### PR TITLE
Webi18n

### DIFF
--- a/source/components/conversation/InputSuggestions.js
+++ b/source/components/conversation/InputSuggestions.js
@@ -1,5 +1,4 @@
 import withColours from 'Components/utils/withColours'
-import { toPairs } from 'ramda'
 import React, { Component } from 'react'
 import { translate } from 'react-i18next'
 import './InputSuggestions.css'
@@ -23,25 +22,31 @@ export default class InputSuggestions extends Component {
 			<div className="inputSuggestions">
 				suggestions:
 				<ul>
-					{toPairs(suggestions).map(([text, value]) => (
-						<li
-							key={value}
-							onClick={() => {
-								onFirstClick(value)
-								if (this.state.suggestion !== value)
-									this.setState({ suggestion: value })
-								else onSecondClick && onSecondClick(value)
-							}}
-							style={{
-								color: colouredBackground
-									? colours.textColour
-									: colours.textColourOnWhite
-							}}>
-							<span title={t('cliquez pour insérer cette suggestion')}>
-								{text}
-							</span>
-						</li>
-					))}
+					{suggestions.map(
+						suggestion => do {
+							let { texte: text, valeur: value } =
+								typeof suggestion === 'object'
+									? suggestion
+									: { texte: suggestion, valeur: suggestion }
+							;<li
+								key={value}
+								onClick={() => {
+									onFirstClick(value)
+									if (this.state.suggestion !== value)
+										this.setState({ suggestion: value })
+									else onSecondClick && onSecondClick(value)
+								}}
+								style={{
+									color: colouredBackground
+										? colours.textColour
+										: colours.textColourOnWhite
+								}}>
+								<span title={t('cliquez pour insérer cette suggestion')}>
+									{text}
+								</span>
+							</li>
+						}
+					)}
 				</ul>
 			</div>
 		)

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -563,10 +563,14 @@
     Durée maximale d'un CDD (service-public.fr): https://www.service-public.fr/professionnels-entreprises/vosdroits/F31211
   format: mois
   suggestions:
-    18 mois: 18
-    1 an: 12
-    6 mois: 6
-    3 mois: 3
+    - texte: 18 mois
+      valeur: 18
+    - texte: 1 an
+      valeur: 12
+    - texte: 6 mois
+      valeur: 6
+    - texte: 3 mois
+      valeur: 3
   # 70% des contrats signés ont concerné, en 2015, des durées inférieures à un mois
   par défaut: 1
 
@@ -577,8 +581,10 @@
   description: Combien de jours de congés ne pourront être pris par l'employé, du fait de la durée de son CDD. En jours ouvrés, par rapport aux 25 jours de congés légaux pour un contrat de douze mois.
   format: jours
   suggestions:
-    3 / 25: 3
-    10 / 25: 10
+    - texte: 2 / 25
+      valeur: 3
+    - texte: 10 / 25
+      valeur: 10
   par défaut: 0
 
 - espace: contrat salarié . CDD
@@ -708,8 +714,10 @@
     Il ne comprend pas les indemnités, avantages sociaux, avantages en nature et primes...
   format: euros
   suggestions:
-    salaire médian: 2300
-    SMIC: 1500
+    - texte: salaire médian
+      valeur: 2300
+    - texte: SMIC
+      valeur: 1500
   contrôles: 
     - si: brut de base < 300
       message: Entrez un salaire mensuel
@@ -784,8 +792,10 @@
   question: Quel est le montant mensuel des avantages en nature ?
   applicable si: contrat salarié . avantages en nature
   suggestions:
-    nourriture: 80
-    véhicule: 260
+    - texte: nourriture
+      valeur: 80
+    - texte: véhicule
+      valeur: 260
   format: euros
   par défaut: 0
 
@@ -1371,10 +1381,10 @@
     De nombreuses cotisations patronales varient selon l'effectif de l'entreprise.
   format: nombre
   suggestions:
-    1: 1
-    20: 20
-    50: 50
-    1000: 1000
+    - 1
+    - 20
+    - 50 
+    - 1000
   par défaut: 1
 
 - espace: entreprise
@@ -1389,8 +1399,8 @@
     Cette fraction détermine la contribution supplémentaire pour l'apprentissage pour les entreprises concernées.
   format: pourcentage
   suggestions:
-    1: 1
-    5: 5
+    - 1
+    - 5
   par défaut: 0
 
 - espace: entreprise
@@ -2095,8 +2105,10 @@
   format: euros
   par défaut: 40
   suggestions:
-    basique: 40
-    élevé: 100
+    - texte: basique
+      valeur: 40
+    - texte: élevé
+      valeur: 100
   contrôles: 
     - si: forfait complémentaire santé < 15
       niveau: avertissement

--- a/source/sites/embauche.gouv.fr/App.js
+++ b/source/sites/embauche.gouv.fr/App.js
@@ -27,6 +27,7 @@ import Integration from './pages/Integration'
 import IntegrationTest from './pages/IntegrationTest'
 import Route404 from './pages/Route404'
 import RulesList from './pages/RulesList'
+import I18n from './pages/I18n'
 
 if (process.env.NODE_ENV === 'production') {
 	Raven.config(
@@ -72,6 +73,7 @@ class EmbaucheRoute extends Component {
 				{inIframe() && <DisableScroll />}
 				<Switch>
 					<Route exact path="/" component={Home} />
+					<Route exact path="/i18n" component={I18n} />
 					<Route path="/contact" component={Contact} />
 					<Route path="/règle/:name" component={RulePage} />
 					<Redirect from="/simu/*" to="/" />


### PR DESCRIPTION
> Désolé, ecore une PR juste commencée

Notre système de traduction de la base de règles n'est pas génial aujourd'hui. Externalize.js génère externalized.yaml avec des traductions de google quand elles n'ont pas été traduites par nos soins. On fait cette opération de mise à jour avec un script nodejs donc. De plus, on gère relativement bien les clefs de premier niveau dans une règle, mais pas les éléments plus complexes, comme les suggestions et les contrôles. La structure de externalized.yaml n'est as adaptée à ces derniers.

Au lieu  de ça, il faudrait créer une page /i18n sur le site qui liste, règle par règle, le nombre d'oublis de traduction.  Les règles traduites seraient une duplication de base.yaml, dans laquelle on traduirait les éléments qu'il faut traduire (nom, titre, description, suggestion.texte,valeur etc.). On doit donc éviter dans la base d'utiliser des clefs d'objet yaml come textes à afficher à l'utilisateur, d'où le commit 2edf324.  On peut utiliser `deep-diff` pour repérer les trous (élément présent dans base.yaml mais pas traduite dans base.en.yaml, et afficher les résultats sur i18n. On améliore la traduction, le script de comparaison se relance, et ainsi de suite. La page /i18n représente l'état de la traduction.

#357

