### PR TITLE
Composantes un peu mieux

### DIFF
--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -150,13 +150,15 @@ complément:
 composantes:
   type: numeric
   description: |
-    Beaucoup de cotisations sont composées de deux parties qui partage la méthode de calcul mais diffèrent par des paramètres différents.
+    Beaucoup de cotisations sont composées de deux parties qui se partagent la méthode de calcul mais diffèrent par des paramètres différents.
 
-    Pour ne pas définir deux variables presque redondantes, on utilise le mécanisme de composante. Il se comportera comme une somme dans les calculs, mais son affichage sur les pages /règle sera adapté.
+    Pour ne pas définir deux variables presque redondantes, on utilise le mécanisme de composante. Il se comportera comme une somme dans les calculs, mais une composante de la somme peut être récupérée indépendamment des autres.
 
     Il est même possible, pour les mécanismes `barème` et `multiplication` de garder en commun un paramètre comme l'assiette, puis de déclarer des composantes pour le taux.
 
-    > L'exemple le plus courant de composantes, c'est la distinction part employeur, part salarié (ex. retraite AGIRC).
+    > L'exemple le plus courant de composantes, c'est la distinction part employeur, part salarié dans une cotisation.
+    > Cette dernière a alors une branche labellisée `dû par: employeur` et l'autre labellisée `dû par: salarié`.
+    > Puis, une variable, par exemple `cotisations salariales`, peut appeler non pas `cotisation` mais `cotisation (salarié). Notez que l'on a pas besoin de spécifier `dû par: salarié` mais simplement `salarié`. 
 
 allègement:
   type: numeric

--- a/source/engine/mecanisms/utils.js
+++ b/source/engine/mecanisms/utils.js
@@ -1,6 +1,6 @@
 import Composantes from 'Engine/mecanismViews/Composantes'
 import { add, dissoc, objOf } from 'ramda'
-import { evaluateArrayWithFilter } from 'Engine/evaluation'
+import { evaluateArray } from 'Engine/evaluation'
 
 export let decompose = (recurse, k, v) => {
 	let subProps = dissoc('composantes')(v),
@@ -14,18 +14,10 @@ export let decompose = (recurse, k, v) => {
 			composante: c.nom ? { nom: c.nom } : c.attributs
 		}))
 
-	let filter = situationGate => c =>
-		!situationGate('sys.filter') ||
-		!c.composante ||
-		((!c.composante['dû par'] ||
-			c.composante['dû par'] == situationGate('sys.filter')) &&
-			(!c.composante['impôt sur le revenu'] ||
-				c.composante['impôt sur le revenu'] == situationGate('sys.filter')))
-
 	return {
 		explanation,
 		jsx: Composantes,
-		evaluate: evaluateArrayWithFilter(filter, add, 0),
+		evaluate: evaluateArray(add, 0, true),
 		category: 'mecanism',
 		name: 'composantes',
 		type: 'numeric'

--- a/test/bug-cotisations.test.js
+++ b/test/bug-cotisations.test.js
@@ -5,6 +5,8 @@ import { analyse, analyseMany, parseAll } from '../source/engine/traverse'
 import dedent from 'dedent-js'
 import { safeLoad } from 'js-yaml'
 
+/* These tests were introduced when we discovered that some values were different in the simulation results and in the documentation pages. It was due do side effects introduced by the filter mechanism */
+
 describe('bug-analyse-many', function() {
 	it('complex inversion with composantes', () => {
 		let rawRules = dedent`
@@ -89,7 +91,7 @@ describe('bug-analyse-many', function() {
 			'contrat salarié . cotisations . salariales'
 		)(situationSelector).targets[0]
 
-		console.log(analyseManyValue.nodeValue, analyseValue.nodeValue)
+		//console.log(analyseManyValue.nodeValue, analyseValue.nodeValue)
 		expect(analyseManyValue.nodeValue).to.equal(analyseValue.nodeValue)
 	})
 })

--- a/test/mecanisms.test.js
+++ b/test/mecanisms.test.js
@@ -31,11 +31,10 @@ describe('Mécanismes', () =>
 								it(testTexte == null ? '' : testTexte + '', () => {
 									let rules = parseAll(
 											suite
-												.map(
-													item =>
-														item.test != null
-															? R.assoc('nom', item.test, item)
-															: item
+												.map(item =>
+													item.test != null
+														? R.assoc('nom', item.test, item)
+														: item
 												)
 												.map(enrichRule)
 										),
@@ -44,6 +43,13 @@ describe('Mécanismes', () =>
 										analysis = analyse(rules, test)(stateSelector),
 										missing = collectMissingVariables(analysis.targets),
 										target = analysis.targets[0]
+
+									if (typeof valeur === 'string' && valeur[0] === '~') {
+										return expect(target.nodeValue).to.be.closeTo(
+											Number(valeur.substring(1)),
+											1
+										)
+									}
 
 									if (isNumeric(valeur)) {
 										expect(target.nodeValue).to.be.closeTo(valeur, 0.001)

--- a/test/mécanismes/composantes-inversion.yaml
+++ b/test/mécanismes/composantes-inversion.yaml
@@ -1,0 +1,45 @@
+# Composantes + inversion
+- nom: net
+  formule: brut - cotisations
+
+- test: cotisations
+  formule:
+    somme:
+      - cotisation a (salarié)
+      - cotisation b
+  exemples:
+    - nom: test des composantes lors d'une inversion
+      situation:
+        net: 700
+      valeur attendue: ~300
+
+- nom: cotisation a
+  formule:
+    multiplication:
+      assiette: brut
+      composantes:
+        - attributs:
+            dû par: employeur
+          taux: 10%
+        - attributs:
+            dû par: salarié
+          taux: 10%
+
+- nom: cotisation b
+  formule:
+    multiplication:
+      assiette: brut
+      composantes:
+        - attributs:
+            impôt sur le revenu: x
+          taux: 10%
+        - attributs:
+            impôt sur le revenu: y
+          taux: 10%
+
+- nom: brut
+  format: euro
+  formule:
+    inversion numérique:
+      avec:
+        - net

--- a/test/mécanismes/composantes.yaml
+++ b/test/mécanismes/composantes.yaml
@@ -1,3 +1,5 @@
+# l'imbrication des composantes dans les barèmes est testée dans le fichier barème.yaml
+
 - test: Composantes
   formule:
     multiplication:
@@ -7,7 +9,46 @@
         - taux: 2%
 
   exemples:
-    - nom:
-      situation:
+    - situation:
       valeur attendue: 10
 
+- nom: assiette CSG
+  format: euros
+
+- test: composantes nommées
+  formule:
+    multiplication:
+      assiette: assiette CSG
+      composantes:
+        - attributs:
+            impôt sur le revenu: non déductible
+          taux: 2.4%
+
+        - attributs:
+            impôt sur le revenu: déductible
+          taux: 6.8%
+  exemples:
+    - situation:
+        assiette CSG: 1000
+      valeur attendue: 92
+
+- test: sélection des composantes
+  formule: composantes nommées
+  exemples:
+    - situation:
+        assiette CSG: 1000
+      valeur attendue: 92
+
+- test: sélection de la première composantes
+  formule: composantes nommées (non déductible)
+  exemples:
+    - situation:
+        assiette CSG: 2000
+      valeur attendue: 48
+
+- test: sélection de la deuxième composante
+  formule: composantes nommées (déductible)
+  exemples:
+    - situation:
+        assiette CSG: 2000
+      valeur attendue: 136

--- a/test/mécanismes/composantes.yaml
+++ b/test/mécanismes/composantes.yaml
@@ -10,3 +10,4 @@
     - nom:
       situation:
       valeur attendue: 10
+

--- a/test/mécanismes/composantes.yaml
+++ b/test/mécanismes/composantes.yaml
@@ -1,5 +1,3 @@
-# l'imbrication des composantes dans les barèmes est testée dans le fichier barème.yaml
-
 - test: Composantes
   formule:
     multiplication:
@@ -52,3 +50,32 @@
     - situation:
         assiette CSG: 2000
       valeur attendue: 136
+
+- test: autres composantes nommées
+  formule:
+    multiplication:
+      assiette: 100
+      composantes:
+        - attributs:
+            yaya: yoyo
+          taux: 3%
+
+        - attributs:
+            yaya: yiyi
+          taux: 7%
+
+  exemples:
+    - situation:
+      valeur attendue: 10
+
+- test: sélection de yoyo
+  formule: autres composantes nommées (yoyo)
+  exemples:
+    - situation:
+      valeur attendue: 3
+
+- test: sélection de yiyi
+  formule: autres composantes nommées (yiyi)
+  exemples:
+    - situation:
+      valeur attendue: 7


### PR DESCRIPTION
+ de tests et généralisation des composantes à n'importe quels attributs.

L'implémentation est toujours crade (basée sur une réécriture locale de situationGate avec 'sys.filter'), mais c'est compliquée de bien l'implémenter : il faudrait faire passer un paramètre d'évaluateNode en evaluateNode.

- [ ] on peut surement améliorer la perf en évitant de définir la closure situationGate *avant* de vérifier si la variable, en présence d'un filtre ou pas, est déjà cachée ! 
- [ ] dans treatVariableTransform toujours, on attache les attributs de filtre dû par et impôt sur le revenu à la variable, où est-ce utilisé ?