### PR TITLE
Lodeom

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,14 @@
 {
-	"bracketSpacing": true,
-	"useTabs": true,
-	"semi": false,
-	"singleQuote": true
+  "bracketSpacing": true,
+  "useTabs": true,
+  "semi": false,
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": "*.yaml",
+      "options": {
+        "printWidth": 1000
+      }
+    }
+  ]
 }

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -5,6 +5,7 @@ objectifs:
   - contrat salarié . rémunération . brut de base
   - contrat salarié . rémunération . net
   - contrat salarié . rémunération . net après impôt
+  - contrat salarié . lodeom . réduction zone un
 
 objectifs secondaires:
   - contrat salarié . temps de travail
@@ -12,6 +13,9 @@ objectifs secondaires:
 
 questions:
   à l'affiche:
+    LODEOM 1: contrat salarié . lodeom . éligible barème un
+    LODEOM 2: contrat salarié . lodeom . éligible barème deux
+    LODEOM 3: contrat salarié . lodeom . éligible barème trois
     Contrat: contrat salarié
     Cadre: contrat salarié . statut cadre . choix statut cadre
     Heures supplémentaires: contrat salarié . temps de travail . heures supplémentaires
@@ -29,6 +33,7 @@ questions:
     - contrat salarié . complémentaire santé . part employeur
     - contrat salarié . régime des impatriés
 situation:
+  contrat salarié . lodeom . zone un: oui
   contrat salarié . assimilé salarié: non
   indépendant: non
   auto-entrepreneur: non

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -5,7 +5,6 @@ objectifs:
   - contrat salarié . rémunération . brut de base
   - contrat salarié . rémunération . net
   - contrat salarié . rémunération . net après impôt
-  - contrat salarié . lodeom . réduction zone un
 
 objectifs secondaires:
   - contrat salarié . temps de travail
@@ -13,9 +12,6 @@ objectifs secondaires:
 
 questions:
   à l'affiche:
-    LODEOM barème 1: contrat salarié . lodeom . éligible barème un . secteurs d'activité
-    LODEOM barème 2: contrat salarié . lodeom . éligible barème deux
-    LODEOM barème 3: contrat salarié . lodeom . éligible barème trois
     Contrat: contrat salarié
     Cadre: contrat salarié . statut cadre . choix statut cadre
     Heures supplémentaires: contrat salarié . temps de travail . heures supplémentaires
@@ -34,7 +30,6 @@ questions:
     - contrat salarié . régime des impatriés
 situation:
   contrat salarié . assimilé salarié: non
-  contrat salarié . lodeom . zone un: oui
   indépendant: non
   auto-entrepreneur: non
   période: mois

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -13,9 +13,9 @@ objectifs secondaires:
 
 questions:
   à l'affiche:
-    LODEOM 1: contrat salarié . lodeom . éligible barème un
-    LODEOM 2: contrat salarié . lodeom . éligible barème deux
-    LODEOM 3: contrat salarié . lodeom . éligible barème trois
+    LODEOM barème 1: contrat salarié . lodeom . éligible barème un . secteurs d'activité
+    LODEOM barème 2: contrat salarié . lodeom . éligible barème deux
+    LODEOM barème 3: contrat salarié . lodeom . éligible barème trois
     Contrat: contrat salarié
     Cadre: contrat salarié . statut cadre . choix statut cadre
     Heures supplémentaires: contrat salarié . temps de travail . heures supplémentaires
@@ -33,8 +33,8 @@ questions:
     - contrat salarié . complémentaire santé . part employeur
     - contrat salarié . régime des impatriés
 situation:
-  contrat salarié . lodeom . zone un: oui
   contrat salarié . assimilé salarié: non
+  contrat salarié . lodeom . zone un: oui
   indépendant: non
   auto-entrepreneur: non
   période: mois

--- a/source/components/utils/markdown.tsx
+++ b/source/components/utils/markdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import emoji from 'react-easy-emoji'
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown'
 import { Link } from 'react-router-dom'
 
@@ -13,6 +14,7 @@ function LinkRenderer({ href, children }) {
 		return <Link to={href}>{children}</Link>
 	}
 }
+const TextRenderer = ({ children }) => <>{emoji(children)}</>
 
 type MarkdownProps = ReactMarkdownProps & {
 	source: string
@@ -28,7 +30,7 @@ export const Markdown = ({
 	<ReactMarkdown
 		source={source}
 		className={`markdown ${className}`}
-		renderers={{ ...renderers, link: LinkRenderer }}
+		renderers={{ ...renderers, link: LinkRenderer, text: TextRenderer }}
 		{...otherProps}
 	/>
 )

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -178,8 +178,8 @@ contrat salarié . CDD . compensation pour congés non pris:
     Congés payés et contrat CDD: https://www.easycdd.com/LEGISLATION-CDD/L-embauche-le-suivi-du-contrat-CDD-les-incidents-frequents/Conges-payes-et-contrat-CDD
     assiette de l'indemnité, circulaire DRT 18 du 30 octobre 1990: http://conseillerdusalarie.free.fr/Docs/TextesFrance/19901030Circulaire_DRT_90_18_du_30_octobre_1990_CDD_Travail_temporaire.htm
 
-? contrat salarié . CDD . compensation pour congés non pris . proportion congés non pris
-: unité: '%'
+contrat salarié . CDD . compensation pour congés non pris . proportion congés non pris:
+  unité: '%'
   formule: congés non pris / congés dus en jours ouvrés
 
 contrat salarié . CDD . congés dus en jours ouvrés:
@@ -188,8 +188,8 @@ contrat salarié . CDD . congés dus en jours ouvrés:
 contrat salarié . congés dus par mois:
   formule: 25 jours / 12 mois
 
-? contrat salarié . CDD . compensation pour congés non pris . prime maintient de salaire
-: formule: salaire journalier * congés non pris
+contrat salarié . CDD . compensation pour congés non pris . prime maintient de salaire:
+  formule: salaire journalier * congés non pris
 
 contrat salarié . CDD . compensation pour congés non pris . assiette mensuelle:
   période: mois
@@ -956,8 +956,8 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
       assiette: montant forfaitaire d'un repas
       facteur: repas par mois
 
-? contrat salarié . rémunération . avantages en nature . nourriture . montant forfaitaire d'un repas
-: période: aucune
+contrat salarié . rémunération . avantages en nature . nourriture . montant forfaitaire d'un repas:
+  période: aucune
   unité: €/repas
   formule:
     variations:
@@ -967,8 +967,8 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/taux-et-baremes/avantages-en-nature/nourriture.html
 
-? contrat salarié . rémunération . avantages en nature . nourriture . repas par mois
-: période: mois
+contrat salarié . rémunération . avantages en nature . nourriture . repas par mois:
+  période: mois
   question: >
     Combien de repas par mois sont payés par l'employeur ?
   par défaut: 21
@@ -1151,8 +1151,8 @@ contrat salarié . rémunération . net imposable . base:
       - CSG [non déductible]
       - CRDS
 
-? contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées
-: période: flexible
+contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées:
+  période: flexible
   unité: €
   formule:
     le minimum de:
@@ -1215,8 +1215,8 @@ contrat salarié . rémunération . net après impôt:
 
   formule: net - impôt
 
-? impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique
-: icônes: 🇬🇵🇷🇪 🇲🇶
+impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique:
+  icônes: 🇬🇵🇷🇪 🇲🇶
   formule:
     barème linéaire:
       assiette: revenu imposable [mensuel]
@@ -1544,8 +1544,8 @@ contrat salarié . cotisations . patronales . réductions de cotisations:
       - réduction ACRE
       - déduction heures supplémentaires
 
-? contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires
-: période: flexible
+contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires:
+  période: flexible
   applicable si: entreprise . effectif < 20
   titre: déduction forfaitaire pour heures supplémentaires
   formule:
@@ -1596,8 +1596,8 @@ contrat salarié . cotisations . salariales . réduction heures supplémentaires
   références:
     Code de la sécurité sociale - Article D241-21: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000038056813&cidTexte=LEGITEXT000006073189
 
-? contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites
-: période: aucune
+contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites:
+  période: aucune
   unité: '%'
   description: le taux effectif des cotisations d'assurance vieillesse à la charge du salarié
   formule:
@@ -3234,8 +3234,7 @@ entreprise . rémunération totale du dirigeant:
   question: Quel montant pensez-vous dégager pour votre rémunération ?
   résumé: Dépensé par l'entreprise
   unité: €
-  description:
-    C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
+  description: C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
     Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
 
     On peut aussi considérer que c'est la valeur monétaire du travail du dirigeant.
@@ -3435,8 +3434,8 @@ entreprise . catégorie d'activité . libérale règlementée:
   références:
     Liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales
 
-? entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
-: formule:
+entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée:
+  formule:
     une possibilité:
       choix obligatoire: oui
       possibilités:
@@ -3573,8 +3572,8 @@ indépendant . cotisations et contributions . cotisations . maladie:
 
       - sinon: artisans commerçants libéraux
 
-? indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée:
+  période: flexible
   titre: maladie libérale règlementée
   formule:
     barème continu:
@@ -3599,8 +3598,8 @@ indépendant . cotisations et contributions . cotisations . maladie . assiette:
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-? indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
-: titre: Maladie 2
+indépendant . cotisations et contributions . cotisations . indemnités journalières maladie:
+  titre: Maladie 2
   description: Cotisations pour les indemnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
   période: flexible
   formule:
@@ -3609,8 +3608,8 @@ indépendant . cotisations et contributions . cotisations . maladie . assiette:
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
 
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux:
+  période: flexible
   formule:
     barème:
       assiette: assiette
@@ -3629,16 +3628,16 @@ indépendant . cotisations et contributions . cotisations . maladie . assiette:
 
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable:
+  période: flexible
   formule:
     variations:
       - si: situation personnelle . RSA
         alors: taux RSA
       - sinon: taux
 
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA:
+  période: flexible
   formule:
     multiplication:
       assiette: taux RSA part variable + 1.35%
@@ -3646,22 +3645,22 @@ indépendant . cotisations et contributions . cotisations . maladie . assiette:
   note: |
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable:
+  période: flexible
   formule:
     multiplication:
       assiette: 5%
       taux: revenu professionnel / seuil supérieur de réduction
 
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction:
+  période: flexible
   formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
       taux: 110%
 
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux
-: période: flexible
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux:
+  période: flexible
   formule:
     barème continu:
       retourne seulement le taux: oui
@@ -3705,8 +3704,8 @@ indépendant . cotisations et contributions . cotisations . retraite de base:
               - au-dessus de: 1
                 taux: 0.6%
 
-? indépendant . cotisations et contributions . cotisations . retraite de base . assiette
-: période: flexible
+indépendant . cotisations et contributions . cotisations . retraite de base . assiette:
+  période: flexible
   titre: assiette retraite de base
   formule:
     variations:
@@ -3719,8 +3718,8 @@ indépendant . cotisations et contributions . cotisations . retraite de base:
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-? indépendant . cotisations et contributions . cotisations . retraite complémentaire
-: période: année
+indépendant . cotisations et contributions . cotisations . retraite complémentaire:
+  période: année
   unité: €
   note: Pour les professions libérales, nous avons retenu un des 8 régimes de retraite, celui de la CIPAV, la caisse interprofessionnelle.
   formule:
@@ -3774,8 +3773,8 @@ indépendant . cotisations et contributions . cotisations . invalidité et déc�
 
       # TODO invalidité décès pour les libéraux
       # 3 classes, 76, 228, 380€
-? indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette
-: période: flexible
+indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette:
+  période: flexible
   titre: assiette invalidité et décès
   formule:
     variations:
@@ -3827,8 +3826,8 @@ indépendant . cotisations et contributions . formation professionnelle:
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-independant/transfert-du-recouvrement-de-la.html
 
-? indépendant . cotisations et contributions . cotisations . allocations familiales
-: période: flexible
+indépendant . cotisations et contributions . cotisations . allocations familiales:
+  période: flexible
   formule:
     barème continu:
       assiette: revenu professionnel
@@ -3944,8 +3943,8 @@ auto-entrepreneur . cotisations et contributions . TFC . métiers:
             alors: 0.22%
           - sinon: 0.48%
 
-? auto-entrepreneur . cotisations et contributions . contribution formation professionnelle
-: titre: Contribution à la formation professionnelle
+auto-entrepreneur . cotisations et contributions . contribution formation professionnelle:
+  titre: Contribution à la formation professionnelle
   unité: €
   période: flexible
   références:
@@ -3987,8 +3986,8 @@ auto-entrepreneur . cotisations et contributions . cotisations:
   références:
     La protection sociale du micro-entrepreneur: https://bpifrance-creation.fr/encyclopedie/micro-entreprise-regime-auto-entrepreneur/fiscal-social-comptable/protection-sociale
 
-? auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
-: description: Le montant total qui est alloué à la retraite complémentaire, utile pour estimer le montant total de la pension de retraite des auto-entrepreneurs
+auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire:
+  description: Le montant total qui est alloué à la retraite complémentaire, utile pour estimer le montant total de la pension de retraite des auto-entrepreneurs
   unité: €
   # L'ACOSS ne veut pas communiquer sur le pourcentage des cotisations fléchés pour la retraite complémentaire pour les PL
   non applicable si: entreprise . catégorie d'activité = 'libérale'
@@ -4009,8 +4008,8 @@ auto-entrepreneur . cotisations et contributions . cotisations:
                 - entreprise . catégorie d'activité = 'artisanale'
             alors: 3.50%
 
-? auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation
-: description: |
+auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation:
+  description: |
     Les cotisations sociales de l'auto-entreprise sont simplifiées : il n'y a qu'une ligne unique dont le taux dépend de la catégorie d'activité.
   formule:
     variations:
@@ -4266,8 +4265,8 @@ protection sociale . retraite . trimestres validés par an . trimestres indépen
             - 3
             - barème trimestres générique
 
-? protection sociale . retraite . trimestres validés par an . barème trimestres générique
-: période: aucune
+protection sociale . retraite . trimestres validés par an . barème trimestres générique:
+  période: aucune
   formule:
     barème linéaire:
       unité: trimestres
@@ -4290,8 +4289,8 @@ protection sociale . retraite . trimestres validés par an . trimestres indépen
   références:
     cnav.fr: https://www.legislation.cnav.fr/Pages/bareme.aspx?Nom=salaire_validant_un_trimestre_montant_bar
 
-? protection sociale . retraite . trimestres validés par an . trimestres auto-entrepreneur
-: applicable si: auto-entrepreneur
+protection sociale . retraite . trimestres validés par an . trimestres auto-entrepreneur:
+  applicable si: auto-entrepreneur
   période: aucune
   description: Les seuils de chiffre d'affaires minimum pour la validation des trimestres pour la retraite en auto-entrepreneur. En-dessous du montant minimum, vous n'aurez accès qu'à l'allocation de solidarité.
   formule:
@@ -4417,8 +4416,8 @@ protection sociale . retraite . complémentaire sécurité des indépendants . v
   références:
     secu-independants.fr: https://www.secu-independants.fr/baremes/prestations-vieillesse-et-invalidite-deces
 
-? protection sociale . retraite . complémentaire sécurité des indépendants . points acquis
-: formule: points acquis par mois * mois cotisés
+protection sociale . retraite . complémentaire sécurité des indépendants . points acquis:
+  formule: points acquis par mois * mois cotisés
   période: aucune
 
 protection sociale . retraite . complémentaire sécurité des indépendants . points acquis par mois:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4642,6 +4642,8 @@ contrat salarié . lodeom:
 
 contrat salarié . lodeom . zone un:
   titre: Zone géographique 1 (Guadeloupe, Martinique, La Réunion, Guyane)
+  références:
+    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe.html
   formule:
     une de ces conditions:
       - établissement . localisation . département = 'Guadeloupe'
@@ -4712,6 +4714,8 @@ contrat salarié . lodeom . éligible barème un:
       - si: entreprise . effectif < 11
         alors: oui
       - sinon: secteurs d'activité
+  références:
+    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite.html
 
 contrat salarié . lodeom . éligible barème un . secteurs d'activité:
   question: Votre entreprise appartient-elle à l'un de ces secteurs ?
@@ -4737,6 +4741,8 @@ contrat salarié . lodeom . éligible barème deux:
     - Les entreprises bénéficiaires du régime de perfectionnement actif défini à l’article 256 du règlement (UE) n° 952/2013 du parlement européen et du conseil du 9 octobre 2013 établissant le code des douanes de l’Union
     - En Guyane, les employeurs ayant une activité principale relevant de l’un des secteurs d’activité éligibles à la réduction d’impôt prévue à l’article 199 undecies B du code général des impôts, ou correspondant à l’une des activités suivantes : comptabilité, conseil aux entreprises, ingénierie ou études techniques.
   par défaut: non
+  références:
+    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite-renf.html
 
 contrat salarié . lodeom . éligible barème trois:
   rend non applicable:
@@ -4755,9 +4761,8 @@ contrat salarié . lodeom . éligible barème trois:
     - Si ces conditions sont réunies, l’exonération s’applique aux rémunérations versées aux salariés occupés principalement à la réalisation de projets innovants.
     - Sont donc exclues les fonctions supports : tâches administratives financières, logistiques et de ressources humaines.
   par défaut: non
-
-  #Coefficient = 1,3 × T / 0,9 × (2,2 × Smic calculé pour un an / rémunération annuelle brute – 1)
-  #Coefficient = 1,7 × T × (2,7 × Smic calculé pour un an / rémunération annuelle brute – 1)
+  références:
+    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-innovation-et-croissa.html
 
 contrat salarié . lodeom . borne inférieure:
   formule:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -178,8 +178,8 @@ contrat salarié . CDD . compensation pour congés non pris:
     Congés payés et contrat CDD: https://www.easycdd.com/LEGISLATION-CDD/L-embauche-le-suivi-du-contrat-CDD-les-incidents-frequents/Conges-payes-et-contrat-CDD
     assiette de l'indemnité, circulaire DRT 18 du 30 octobre 1990: http://conseillerdusalarie.free.fr/Docs/TextesFrance/19901030Circulaire_DRT_90_18_du_30_octobre_1990_CDD_Travail_temporaire.htm
 
-contrat salarié . CDD . compensation pour congés non pris . proportion congés non pris:
-  unité: '%'
+? contrat salarié . CDD . compensation pour congés non pris . proportion congés non pris
+: unité: '%'
   formule: congés non pris / congés dus en jours ouvrés
 
 contrat salarié . CDD . congés dus en jours ouvrés:
@@ -188,8 +188,8 @@ contrat salarié . CDD . congés dus en jours ouvrés:
 contrat salarié . congés dus par mois:
   formule: 25 jours / 12 mois
 
-contrat salarié . CDD . compensation pour congés non pris . prime maintient de salaire:
-  formule: salaire journalier * congés non pris
+? contrat salarié . CDD . compensation pour congés non pris . prime maintient de salaire
+: formule: salaire journalier * congés non pris
 
 contrat salarié . CDD . compensation pour congés non pris . assiette mensuelle:
   période: mois
@@ -956,8 +956,8 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
       assiette: montant forfaitaire d'un repas
       facteur: repas par mois
 
-contrat salarié . rémunération . avantages en nature . nourriture . montant forfaitaire d'un repas:
-  période: aucune
+? contrat salarié . rémunération . avantages en nature . nourriture . montant forfaitaire d'un repas
+: période: aucune
   unité: €/repas
   formule:
     variations:
@@ -967,8 +967,8 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant f
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/taux-et-baremes/avantages-en-nature/nourriture.html
 
-contrat salarié . rémunération . avantages en nature . nourriture . repas par mois:
-  période: mois
+? contrat salarié . rémunération . avantages en nature . nourriture . repas par mois
+: période: mois
   question: >
     Combien de repas par mois sont payés par l'employeur ?
   par défaut: 21
@@ -1151,8 +1151,8 @@ contrat salarié . rémunération . net imposable . base:
       - CSG [non déductible]
       - CRDS
 
-contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées:
-  période: flexible
+? contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées
+: période: flexible
   unité: €
   formule:
     le minimum de:
@@ -1215,8 +1215,8 @@ contrat salarié . rémunération . net après impôt:
 
   formule: net - impôt
 
-impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique:
-  icônes: 🇬🇵🇷🇪 🇲🇶
+? impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique
+: icônes: 🇬🇵🇷🇪 🇲🇶
   formule:
     barème linéaire:
       assiette: revenu imposable [mensuel]
@@ -1543,8 +1543,8 @@ contrat salarié . cotisations . patronales . réductions de cotisations:
       - réduction ACRE
       - déduction heures supplémentaires
 
-contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires:
-  période: flexible
+? contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires
+: période: flexible
   applicable si: entreprise . effectif < 20
   titre: déduction forfaitaire pour heures supplémentaires
   formule:
@@ -1595,8 +1595,8 @@ contrat salarié . cotisations . salariales . réduction heures supplémentaires
   références:
     Code de la sécurité sociale - Article D241-21: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000038056813&cidTexte=LEGITEXT000006073189
 
-contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites:
-  période: aucune
+? contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites
+: période: aucune
   unité: '%'
   description: le taux effectif des cotisations d'assurance vieillesse à la charge du salarié
   formule:
@@ -2669,7 +2669,6 @@ contrat salarié . taxe d'apprentissage . base:
           - sinon: 0.68%
 
 contrat salarié . taxe d'apprentissage . contribution supplémentaire:
-
   applicable si:
     toutes ces conditions:
       - entreprise . effectif >= 250
@@ -3435,8 +3434,8 @@ entreprise . catégorie d'activité . libérale règlementée:
   références:
     Liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales
 
-entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée:
-  formule:
+? entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
+: formule:
     une possibilité:
       choix obligatoire: oui
       possibilités:
@@ -3573,8 +3572,8 @@ indépendant . cotisations et contributions . cotisations . maladie:
 
       - sinon: artisans commerçants libéraux
 
-indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée
+: période: flexible
   titre: maladie libérale règlementée
   formule:
     barème continu:
@@ -3599,8 +3598,8 @@ indépendant . cotisations et contributions . cotisations . maladie . assiette:
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-indépendant . cotisations et contributions . cotisations . indemnités journalières maladie:
-  titre: Maladie 2
+? indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
+: titre: Maladie 2
   description: Cotisations pour les indemnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
   période: flexible
   formule:
@@ -3609,8 +3608,8 @@ indépendant . cotisations et contributions . cotisations . indemnités journali
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
 
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
+: période: flexible
   formule:
     barème:
       assiette: assiette
@@ -3629,16 +3628,16 @@ indépendant . cotisations et contributions . cotisations . maladie . artisans c
 
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable
+: période: flexible
   formule:
     variations:
       - si: situation personnelle . RSA
         alors: taux RSA
       - sinon: taux
 
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA
+: période: flexible
   formule:
     multiplication:
       assiette: taux RSA part variable + 1.35%
@@ -3646,22 +3645,22 @@ indépendant . cotisations et contributions . cotisations . maladie . artisans c
   note: |
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable
+: période: flexible
   formule:
     multiplication:
       assiette: 5%
       taux: revenu professionnel / seuil supérieur de réduction
 
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction
+: période: flexible
   formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
       taux: 110%
 
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux
+: période: flexible
   formule:
     barème continu:
       retourne seulement le taux: oui
@@ -3705,8 +3704,8 @@ indépendant . cotisations et contributions . cotisations . retraite de base:
               - au-dessus de: 1
                 taux: 0.6%
 
-indépendant . cotisations et contributions . cotisations . retraite de base . assiette:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . retraite de base . assiette
+: période: flexible
   titre: assiette retraite de base
   formule:
     variations:
@@ -3719,8 +3718,8 @@ indépendant . cotisations et contributions . cotisations . retraite de base . a
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-indépendant . cotisations et contributions . cotisations . retraite complémentaire:
-  période: année
+? indépendant . cotisations et contributions . cotisations . retraite complémentaire
+: période: année
   unité: €
   note: Pour les professions libérales, nous avons retenu un des 8 régimes de retraite, celui de la CIPAV, la caisse interprofessionnelle.
   formule:
@@ -3774,8 +3773,8 @@ indépendant . cotisations et contributions . cotisations . invalidité et déc�
 
       # TODO invalidité décès pour les libéraux
       # 3 classes, 76, 228, 380€
-indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette
+: période: flexible
   titre: assiette invalidité et décès
   formule:
     variations:
@@ -3827,8 +3826,8 @@ indépendant . cotisations et contributions . formation professionnelle:
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-independant/transfert-du-recouvrement-de-la.html
 
-indépendant . cotisations et contributions . cotisations . allocations familiales:
-  période: flexible
+? indépendant . cotisations et contributions . cotisations . allocations familiales
+: période: flexible
   formule:
     barème continu:
       assiette: revenu professionnel
@@ -3944,8 +3943,8 @@ auto-entrepreneur . cotisations et contributions . TFC . métiers:
             alors: 0.22%
           - sinon: 0.48%
 
-auto-entrepreneur . cotisations et contributions . contribution formation professionnelle:
-  titre: Contribution à la formation professionnelle
+? auto-entrepreneur . cotisations et contributions . contribution formation professionnelle
+: titre: Contribution à la formation professionnelle
   unité: €
   période: flexible
   références:
@@ -3987,8 +3986,8 @@ auto-entrepreneur . cotisations et contributions . cotisations:
   références:
     La protection sociale du micro-entrepreneur: https://bpifrance-creation.fr/encyclopedie/micro-entreprise-regime-auto-entrepreneur/fiscal-social-comptable/protection-sociale
 
-auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire:
-  description: Le montant total qui est alloué à la retraite complémentaire, utile pour estimer le montant total de la pension de retraite des auto-entrepreneurs
+? auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
+: description: Le montant total qui est alloué à la retraite complémentaire, utile pour estimer le montant total de la pension de retraite des auto-entrepreneurs
   unité: €
   # L'ACOSS ne veut pas communiquer sur le pourcentage des cotisations fléchés pour la retraite complémentaire pour les PL
   non applicable si: entreprise . catégorie d'activité = 'libérale'
@@ -4009,8 +4008,8 @@ auto-entrepreneur . cotisations et contributions . cotisations . retraite compl�
                 - entreprise . catégorie d'activité = 'artisanale'
             alors: 3.50%
 
-auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation:
-  description: |
+? auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation
+: description: |
     Les cotisations sociales de l'auto-entreprise sont simplifiées : il n'y a qu'une ligne unique dont le taux dépend de la catégorie d'activité.
   formule:
     variations:
@@ -4074,7 +4073,6 @@ auto-entrepreneur . cotisations et contributions . cotisations . réduction ACRE
     Fiche URSSAF: https://www.urssaf.fr/portail/home/independant/je-beneficie-dexonerations/accre.html
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
 auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
-
   formule: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
   période: flexible
 
@@ -4267,8 +4265,8 @@ protection sociale . retraite . trimestres validés par an . trimestres indépen
             - 3
             - barème trimestres générique
 
-protection sociale . retraite . trimestres validés par an . barème trimestres générique:
-  période: aucune
+? protection sociale . retraite . trimestres validés par an . barème trimestres générique
+: période: aucune
   formule:
     barème linéaire:
       unité: trimestres
@@ -4291,8 +4289,8 @@ protection sociale . retraite . trimestres validés par an . barème trimestres 
   références:
     cnav.fr: https://www.legislation.cnav.fr/Pages/bareme.aspx?Nom=salaire_validant_un_trimestre_montant_bar
 
-protection sociale . retraite . trimestres validés par an . trimestres auto-entrepreneur:
-  applicable si: auto-entrepreneur
+? protection sociale . retraite . trimestres validés par an . trimestres auto-entrepreneur
+: applicable si: auto-entrepreneur
   période: aucune
   description: Les seuils de chiffre d'affaires minimum pour la validation des trimestres pour la retraite en auto-entrepreneur. En-dessous du montant minimum, vous n'aurez accès qu'à l'allocation de solidarité.
   formule:
@@ -4418,8 +4416,8 @@ protection sociale . retraite . complémentaire sécurité des indépendants . v
   références:
     secu-independants.fr: https://www.secu-independants.fr/baremes/prestations-vieillesse-et-invalidite-deces
 
-protection sociale . retraite . complémentaire sécurité des indépendants . points acquis:
-  formule: points acquis par mois * mois cotisés
+? protection sociale . retraite . complémentaire sécurité des indépendants . points acquis
+: formule: points acquis par mois * mois cotisés
   période: aucune
 
 protection sociale . retraite . complémentaire sécurité des indépendants . points acquis par mois:
@@ -4635,7 +4633,7 @@ situation personnelle . RSA:
   question: Êtes-vous allocataire du RSA ?
   par défaut: non
 
-contrat salarié . lodeom: 
+contrat salarié . lodeom:
   description: |
     Un ensemble assez complexe de réductions de cotisation est disponible pour les salariés d'outre-mer. 
     Leur fonctionnement est similaire à celui de la réduction générale sur les bas salaires : pour un certain salaire donné, 100% de réduction. 
@@ -4643,14 +4641,14 @@ contrat salarié . lodeom:
 
 contrat salarié . lodeom . zone un:
   titre: Zone géographique 1 (Guadeloupe, Martinique, La Réunion, Guyane)
-  formule: 
+  formule:
     une de ces conditions:
       - établissement . localisation . département = 'Guadeloupe'
       - établissement . localisation . département = 'La Réunion'
       - établissement . localisation . département = 'Martinique'
       - établissement . localisation . département = 'Guyane'
 
-contrat salarié . lodeom . réduction zone un: 
+contrat salarié . lodeom . réduction zone un:
   aide:
     type: réduction de cotisations
     thème: aide bas salaires
@@ -4669,7 +4667,7 @@ contrat salarié . lodeom . réduction zone un:
   formule:
     le minimum de:
       - contrat salarié . réduction générale . assiette
-      - multiplicateur * contrat salarié . réduction générale . écart au plafond de l'assiette
+      - multiplicateur * écart au plafond de l'assiette
   note: Nous utilisons la méthode de calcul officielle de la sécurité sociale. Il serait préférable ici de réduire directement les cotisations concernées, ce qui éviterait au calcul de reposer sur les paramètres `T` publiés chaque année (ils dépendent directement des cotisaitons réduites).
   exemples:
     # Formule de calcul algébrique : (0,2809÷0,6)×(1,6×(1 521,22÷1 530)−1)×1 530
@@ -4692,14 +4690,18 @@ contrat salarié . lodeom . réduction zone un:
 
 contrat salarié . lodeom . plafond de l'assiette:
   période: flexible
-  formule: 1.6 * SMIC
+  formule: borne supérieure * SMIC
+
+contrat salarié . lodeom . écart au plafond de l'assiette:
+  période: flexible
+  formule: plafond de l'assiette - cotisations . assiette
 
 contrat salarié . lodeom . paramètre T:
   formule:
     variations:
       - si:
           toutes ces conditions:
-            - zone un 
+            - zone un
             - entreprise . effectif < 20
         alors: 0.3214
       - si:
@@ -4707,6 +4709,44 @@ contrat salarié . lodeom . paramètre T:
             - zone un
             - entreprise . effectif >= 20
         alors: 0.3254
-      
+
+contrat salarié . lodeom . éligible barème un:
+  titre: Eligibilité au barème de compétitivité
+  question: Êtes-vous éligibles au barème compétitivité ?
+  description: >
+    ### Employeurs éligibles
+
+      - les entreprises de moins de 11 salariés, quel que soit le secteur d’activité ; quel que soit leur effectif,
+      - les entreprises de transport aérien assurant les liaisons entre les départements et régions d’Outre-mer et entre la métropole et ces territoires, ainsi que les dessertes intérieures ;
+      - les entreprises assurant les dessertes maritimes, fluviales ou les liaisons entre départements et régions d’Outre-mer ;
+      - les employeurs relevant des secteurs du bâtiment et des travaux publics, de la presse, de la production audiovisuelle ;
+      - les employeurs des secteurs éligibles aux régimes de compétitivité renforcée ou d’innovation et de croissance, qui ne respectent pas les conditions d’effectifs (moins de 250 salariés) ou de chiffres d’affaires annuel (moins de 50 millions d’euros).
+  par défaut: non
+
+contrat salarié . lodeom . éligible barème deux:
+  question: Êtes-vous éligibles au barème compétitivité renforcée ?
+  par défaut: non
+
+contrat salarié . lodeom . éligible barème trois:
+  question: Êtes-vous éligibles au barème innovation et croissance ?
+  par défaut: non
+
+contrat salarié . lodeom . borne inférieure:
+  formule:
+    variations:
+      - si: éligible barème un
+        alors: 1.3
+      - sinon: 1.7
+
+contrat salarié . lodeom . borne supérieure:
+  formule:
+    variations:
+      - si: éligible barème un
+        alors: 2.2
+      - si: éligible barème deux
+        alors: 2.7
+      - si: éligible barème trois
+        alors: 3.5
+
 contrat salarié . lodeom . multiplicateur:
-  formule: contrat salarié . lodeom . paramètre T / 0.9
+  formule: (borne inférieure * contrat salarié . lodeom . paramètre T) / (borne supérieure - borne inférieure)

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4634,3 +4634,79 @@ situation personnelle . RSA:
   titre: allocataire RSA
   question: Êtes-vous allocataire du RSA ?
   par défaut: non
+
+contrat salarié . lodeom: 
+  description: |
+    Un ensemble assez complexe de réductions de cotisation est disponible pour les salariés d'outre-mer. 
+    Leur fonctionnement est similaire à celui de la réduction générale sur les bas salaires : pour un certain salaire donné, 100% de réduction. 
+    Pour un autre salaire plus élevé, 0% de réduction. Entre les deux, on trace une ligne droite.
+
+contrat salarié . lodeom . zone un:
+  titre: Zone géographique 1 (Guadeloupe, Martinique, La Réunion, Guyane)
+  formule: 
+    une de ces conditions:
+      - établissement . localisation . département = 'Guadeloupe'
+      - établissement . localisation . département = 'La Réunion'
+      - établissement . localisation . département = 'Martinique'
+      - établissement . localisation . département = 'Guyane'
+
+contrat salarié . lodeom . réduction zone un: 
+  aide:
+    type: réduction de cotisations
+    thème: aide bas salaires
+    démarches: non
+
+  applicable si: zone un
+
+  non applicable si:
+    une de ces conditions:
+      - assimilé salarié
+      - cotisations . assiette > plafond de l'assiette
+      - statut JEI
+
+  période: flexible
+
+  formule:
+    le minimum de:
+      - contrat salarié . réduction générale . assiette
+      - multiplicateur * contrat salarié . réduction générale . écart au plafond de l'assiette
+  note: Nous utilisons la méthode de calcul officielle de la sécurité sociale. Il serait préférable ici de réduire directement les cotisations concernées, ce qui éviterait au calcul de reposer sur les paramètres `T` publiés chaque année (ils dépendent directement des cotisaitons réduites).
+  exemples:
+    # Formule de calcul algébrique : (0,2809÷0,6)×(1,6×(1 521,22÷1 530)−1)×1 530
+    - nom: "Maximale dans le cas d'un SMIC"
+      situation:
+        cotisations . assiette: 1521.22
+      valeur attendue: 427.31
+    - nom: 'Salaire proche du SMIC'
+      situation:
+        cotisations . assiette: 1530
+      valeur attendue: 423.2
+    - nom: 'Résiduelle pour un salaire médian'
+      situation:
+        cotisations . assiette: 2300
+      valeur attendue: 62.71
+    - nom: 'Nulle au-dessus du plafond'
+      situation:
+        cotisations . assiette: 2434
+      valeur attendue: 0
+
+contrat salarié . lodeom . plafond de l'assiette:
+  période: flexible
+  formule: 1.6 * SMIC
+
+contrat salarié . lodeom . paramètre T:
+  formule:
+    variations:
+      - si:
+          toutes ces conditions:
+            - zone un 
+            - entreprise . effectif < 20
+        alors: 0.3214
+      - si:
+          toutes ces conditions:
+            - zone un
+            - entreprise . effectif >= 20
+        alors: 0.3254
+      
+contrat salarié . lodeom . multiplicateur:
+  formule: contrat salarié . lodeom . paramètre T / 0.9

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -565,6 +565,7 @@ contrat salarié . assimilé salarié:
     - réduction générale
     - allocations familiales . taux réduit
     - contrat salarié . maladie . taux employeur . taux réduit
+    - lodeom
     - AGS
     - APEC
     - contribution au dialogue social
@@ -645,7 +646,8 @@ contrat salarié . stage:
     - statut JEI
     - réduction générale
     - allocations familiales . taux réduit
-    - contrat salarié . maladie . taux employeur . taux réduit
+    - maladie . taux employeur . taux réduit
+    - lodeom
     - contribution d'équilibre général
     - retraite complémentaire
     - chômage
@@ -1539,7 +1541,7 @@ contrat salarié . cotisations . patronales . réductions de cotisations:
   formule:
     somme:
       - réduction générale
-      - lodeom . réduction zone un
+      - lodeom . réduction outre-mer
       - statut JEI . exonération de cotisations
       - réduction ACRE
       - déduction heures supplémentaires
@@ -1916,6 +1918,7 @@ contrat salarié . statut JEI:
     - réduction générale
     - allocations familiales . taux réduit
     - contrat salarié . maladie . taux employeur . taux réduit
+    - lodeom
 
 contrat salarié . statut JEI . exonération de cotisations:
   titre: Exonération JEI
@@ -4650,7 +4653,7 @@ contrat salarié . lodeom . zone un:
       - établissement . localisation . département = 'Martinique'
       - établissement . localisation . département = 'Guyane'
 
-contrat salarié . lodeom . réduction zone un:
+contrat salarié . lodeom . réduction outre-mer:
   aide:
     type: réduction de cotisations
     thème: aide bas salaires
@@ -4658,17 +4661,12 @@ contrat salarié . lodeom . réduction zone un:
 
   applicable si:
     toutes ces conditions:
+      - cotisations . assiette <= plafond de l'assiette
       - zone un
       - une de ces conditions:
-          - éligible barème un
-          - éligible barème deux
-          - éligible barème trois
-
-  non applicable si:
-    une de ces conditions:
-      - assimilé salarié
-      - cotisations . assiette > plafond de l'assiette
-      - statut JEI
+          - éligible barème compétitivité
+          - éligible barème compétitivité renforcée
+          - éligible barème innovation et croissance
 
   période: flexible
 
@@ -4678,19 +4676,19 @@ contrat salarié . lodeom . réduction zone un:
       - variations:
           - si:
               toutes ces conditions:
-                - éligible barème trois
+                - éligible barème innovation et croissance
                 - cotisations . assiette > borne inférieure
                 - cotisations . assiette < 2.5 * SMIC
             alors: 1.7 * paramètre T * SMIC
           - si:
               toutes ces conditions:
-                - éligible barème trois
+                - éligible barème innovation et croissance
                 - cotisations . assiette > 2.5 * SMIC
             alors: ((borne inférieure * paramètre T) / (borne supérieure - 2.5)) *  écart au plafond de l'assiette
           - sinon: multiplicateur * écart au plafond de l'assiette
   note: Nous utilisons la méthode de calcul officielle de la sécurité sociale. Il serait préférable ici de réduire directement les cotisations concernées, ce qui éviterait au calcul de reposer sur les paramètres `T` publiés chaque année (ils dépendent directement des cotisaitons réduites).
-  référnces: 
-    - https://www.urssaf.fr/portail/home/utile-et-pratique/estimateur-exoneration-lodeom.html?ut=
+  références: 
+    Estimateur URSSAF: https://www.urssaf.fr/portail/home/utile-et-pratique/estimateur-exoneration-lodeom.html?ut=
   exemples:
     # Barème 1
     - nom: "Maximale dans le cas d'un SMIC"
@@ -4718,31 +4716,31 @@ contrat salarié . lodeom . réduction zone un:
     - nom: "Maximale dans le cas d'un SMIC"
       situation:
         zone un: oui
-        éligible barème deux: oui
+        éligible barème compétitivité renforcée: oui
         cotisations . assiette: 1521.22
       valeur attendue: 488.92
     - nom: 'Salaire proche du SMIC'
       situation:
         zone un: oui
-        éligible barème deux: oui
+        éligible barème compétitivité renforcée: oui
         cotisations . assiette: 2565
       valeur attendue: 824.39
     - nom: 'Résiduelle pour un salaire médian'
       situation:
         zone un: oui
-        éligible barème deux: oui
+        éligible barème compétitivité renforcée: oui
         cotisations . assiette: 3900
       valeur attendue: 113.26
     - nom: 'Résiduelle pour un salaire médian'
       situation:
         zone un: oui
-        éligible barème deux: oui
+        éligible barème compétitivité renforcée: oui
         cotisations . assiette: 3000
       valeur attendue: 605.10
     - nom: 'Nulle au-dessus du plafond'
       situation:
         zone un: oui
-        éligible barème deux: oui
+        éligible barème compétitivité renforcée: oui
         cotisations . assiette: 4200
       valeur attendue: 0
 
@@ -4750,32 +4748,32 @@ contrat salarié . lodeom . réduction zone un:
     - nom: "Barème 3 Maximale dans le cas d'un SMIC"
       situation:
         zone un: oui
-        éligible barème trois: oui
+        éligible barème innovation et croissance: oui
         cotisations . assiette: 1521.22
       valeur attendue: 488.92
     - nom: 'Barème 3'
       situation:
         zone un: oui
-        éligible barème trois: oui
+        éligible barème innovation et croissance: oui
         cotisations . assiette: 2565
       valeur attendue: 824.39
     - nom: 'Barème 3'
       situation:
         zone un: oui
-        éligible barème trois: oui
+        éligible barème innovation et croissance: oui
         cotisations . assiette: 2800
       valeur attendue: 831.04
     - nom: 'Barème 3'
       situation:
         zone un: oui
-        éligible barème trois: oui
+        éligible barème innovation et croissance: oui
         cotisations . assiette: 4000
       valeur attendue: 723.60
 
     - nom: 'Barème 3 Nulle au-dessus du plafond'
       situation:
         zone un: oui
-        éligible barème trois: oui
+        éligible barème innovation et croissance: oui
         cotisations . assiette: 5500
       valeur attendue: 0
 
@@ -4787,7 +4785,7 @@ contrat salarié . lodeom . écart au plafond de l'assiette:
   période: flexible
   formule: plafond de l'assiette - cotisations . assiette
 
-contrat salarié . lodeom . éligible barème un:
+contrat salarié . lodeom . éligible barème compétitivité:
   titre: Eligibilité au barème de compétitivité
   applicable si: zone un
   rend non applicable:
@@ -4798,9 +4796,9 @@ contrat salarié . lodeom . éligible barème un:
         alors: oui
       - sinon: secteurs d'activité
   références:
-    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite.html
+    Fiche URSSAF: https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite.html
 
-contrat salarié . lodeom . éligible barème un . secteurs d'activité:
+contrat salarié . lodeom . éligible barème compétitivité . secteurs d'activité:
   question: Votre entreprise appartient-elle à l'un de ces secteurs ?
   description: |
     Pour être éligible au 1er barème de l'exonération LODEOM, dit barème de compétitivité, votre entreprise doit appartenir à l'un des secteurs suivants :
@@ -4813,32 +4811,32 @@ contrat salarié . lodeom . éligible barème un . secteurs d'activité:
     - les secteurs éligibles aux régimes de compétitivité renforcée (barème 2) ou d’innovation et de croissance (barème 3), qui ne respectent pas les conditions d’effectifs (moins de 250 salariés) ou de chiffres d’affaires annuel (moins de 50 millions d’euros).
   par défaut: non
 
-contrat salarié . lodeom . éligible barème deux:
+contrat salarié . lodeom . éligible barème compétitivité renforcée:
   applicable si: zone un
   rend non applicable:
     - réduction générale
-    - éligible barème un
+    - éligible barème compétitivité
   question: Êtes-vous éligibles au barème compétitivité renforcée ?
   description: |
-    - chiffre d'affaire de moins de 50 millions d'euros
+    - Chiffre d'affaire de moins de 50 millions d'euros
     - Les employeurs relevant des secteurs de l’industrie, de la restauration, de l’environnement, de l’agro nutrition, des énergies renouvelables, des nouvelles technologies de l’information et de la communication et des centres d’appel, de la pêche, des cultures marines, de l’aquaculture, de l’agriculture, du tourisme y compris les activités de loisirs s’y rapportant, du nautisme, de l’hôtellerie, de la recherche et du développement ;
     - Les entreprises bénéficiaires du régime de perfectionnement actif défini à l’article 256 du règlement (UE) n° 952/2013 du parlement européen et du conseil du 9 octobre 2013 établissant le code des douanes de l’Union
     - En Guyane, les employeurs ayant une activité principale relevant de l’un des secteurs d’activité éligibles à la réduction d’impôt prévue à l’article 199 undecies B du code général des impôts, ou correspondant à l’une des activités suivantes : comptabilité, conseil aux entreprises, ingénierie ou études techniques.
   par défaut: non
   références:
-    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite-renf.html
+    Fiche URSSAF: https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite-renf.html
 
-contrat salarié . lodeom . éligible barème trois:
+contrat salarié . lodeom . éligible barème innovation et croissance:
   applicable si: zone un
   rend non applicable:
     - réduction générale
-    - éligible barème un
-    - éligible barème deux
+    - éligible barème compétitivité
+    - éligible barème compétitivité renforcée
   question: Êtes-vous éligibles au barème innovation et croissance ?
   description: |
     - Sont éligibles à ce barème les employeurs occupant moins de 250 salariés et ayant réalisé un chiffre d’affaires annuel inférieur à 50 millions d’euros, au titre de la rémunération des salariés concourant essentiellement à la réalisation de projets innovants dans le domaine des technologies de l’information et de la communication.
     - Les projets innovants se définissent comme des projets ayant pour but l’introduction d’un bien, d’un service, d’une méthode de production ou de distribution nouveau ou sensiblement amélioré sur le plan des caractéristiques et de l’usage auquel il est destiné. Ces projets doivent être réalisés dans les domaines suivants :
-      - télécommunication ;
+      - 📱 télécommunication ;
       - informatique, dont notamment programmation, conseil en systèmes et logiciels, tierce maintenance de systèmes et d’applications, gestion d‘installations, traitement des données, hébergement et activités connexes ;
       - édition de portails internet et de logiciels;
       - infographie, notamment conception de contenus visuels et numériques ;
@@ -4847,23 +4845,23 @@ contrat salarié . lodeom . éligible barème trois:
     - Sont donc exclues les fonctions supports : tâches administratives financières, logistiques et de ressources humaines.
   par défaut: non
   références:
-    - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-innovation-et-croissa.html
+    Fiche URSSAF: https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-innovation-et-croissa.html
 
 contrat salarié . lodeom . borne inférieure:
   formule:
     variations:
-      - si: éligible barème un
+      - si: éligible barème compétitivité
         alors: 1.3
       - sinon: 1.7
 
 contrat salarié . lodeom . borne supérieure:
   formule:
     variations:
-      - si: éligible barème un
+      - si: éligible barème compétitivité
         alors: 2.2
-      - si: éligible barème deux
+      - si: éligible barème compétitivité renforcée
         alors: 2.7
-      - si: éligible barème trois
+      - si: éligible barème innovation et croissance
         alors: 3.5
 
 contrat salarié . lodeom . multiplicateur:
@@ -4884,3 +4882,4 @@ contrat salarié . lodeom . paramètre T:
             - zone un
             - entreprise . effectif >= 20
         alors: 0.3254
+  note: La valeur du paramètre `T` dépend du taux FNAL. Une meilleur implémentation consiste à calculer ce paramètre comme une somme de taux.

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4675,25 +4675,108 @@ contrat salarié . lodeom . réduction zone un:
   formule:
     le minimum de:
       - contrat salarié . réduction générale . assiette
-      - multiplicateur * écart au plafond de l'assiette
+      - variations:
+          - si:
+              toutes ces conditions:
+                - éligible barème trois
+                - cotisations . assiette > borne inférieure
+                - cotisations . assiette < 2.5 * SMIC
+            alors: 1.7 * paramètre T * SMIC
+          - si:
+              toutes ces conditions:
+                - éligible barème trois
+                - cotisations . assiette > 2.5 * SMIC
+            alors: ((borne inférieure * paramètre T) / (borne supérieure - 2.5)) *  écart au plafond de l'assiette
+          - sinon: multiplicateur * écart au plafond de l'assiette
   note: Nous utilisons la méthode de calcul officielle de la sécurité sociale. Il serait préférable ici de réduire directement les cotisations concernées, ce qui éviterait au calcul de reposer sur les paramètres `T` publiés chaque année (ils dépendent directement des cotisaitons réduites).
+  référnces: 
+    - https://www.urssaf.fr/portail/home/utile-et-pratique/estimateur-exoneration-lodeom.html?ut=
   exemples:
-    # Formule de calcul algébrique : (0,2809÷0,6)×(1,6×(1 521,22÷1 530)−1)×1 530
+    # Barème 1
     - nom: "Maximale dans le cas d'un SMIC"
       situation:
+        zone un: oui
         cotisations . assiette: 1521.22
-      valeur attendue: 427.31
+      valeur attendue: 488.92
     - nom: 'Salaire proche du SMIC'
       situation:
+        zone un: oui
         cotisations . assiette: 1530
-      valeur attendue: 423.2
+      valeur attendue: 491.74
     - nom: 'Résiduelle pour un salaire médian'
       situation:
+        zone un: oui
         cotisations . assiette: 2300
-      valeur attendue: 62.71
+      valeur attendue: 485.99
     - nom: 'Nulle au-dessus du plafond'
       situation:
-        cotisations . assiette: 2434
+        zone un: oui
+        cotisations . assiette: 3400
+      valeur attendue: 0
+
+    # Barème 2
+    - nom: "Maximale dans le cas d'un SMIC"
+      situation:
+        zone un: oui
+        éligible barème deux: oui
+        cotisations . assiette: 1521.22
+      valeur attendue: 488.92
+    - nom: 'Salaire proche du SMIC'
+      situation:
+        zone un: oui
+        éligible barème deux: oui
+        cotisations . assiette: 2565
+      valeur attendue: 824.39
+    - nom: 'Résiduelle pour un salaire médian'
+      situation:
+        zone un: oui
+        éligible barème deux: oui
+        cotisations . assiette: 3900
+      valeur attendue: 113.26
+    - nom: 'Résiduelle pour un salaire médian'
+      situation:
+        zone un: oui
+        éligible barème deux: oui
+        cotisations . assiette: 3000
+      valeur attendue: 605.10
+    - nom: 'Nulle au-dessus du plafond'
+      situation:
+        zone un: oui
+        éligible barème deux: oui
+        cotisations . assiette: 4200
+      valeur attendue: 0
+
+    # Barème 3
+    - nom: "Barème 3 Maximale dans le cas d'un SMIC"
+      situation:
+        zone un: oui
+        éligible barème trois: oui
+        cotisations . assiette: 1521.22
+      valeur attendue: 488.92
+    - nom: 'Barème 3'
+      situation:
+        zone un: oui
+        éligible barème trois: oui
+        cotisations . assiette: 2565
+      valeur attendue: 824.39
+    - nom: 'Barème 3'
+      situation:
+        zone un: oui
+        éligible barème trois: oui
+        cotisations . assiette: 2800
+      valeur attendue: 831.04
+    - nom: 'Barème 3'
+      situation:
+        zone un: oui
+        éligible barème trois: oui
+        cotisations . assiette: 4000
+      valeur attendue: 723.60
+
+    - nom: 'Barème 3 Nulle au-dessus du plafond'
+      situation:
+        zone un: oui
+        éligible barème trois: oui
+        cotisations . assiette: 5500
       valeur attendue: 0
 
 contrat salarié . lodeom . plafond de l'assiette:
@@ -4706,6 +4789,7 @@ contrat salarié . lodeom . écart au plafond de l'assiette:
 
 contrat salarié . lodeom . éligible barème un:
   titre: Eligibilité au barème de compétitivité
+  applicable si: zone un
   rend non applicable:
     - réduction générale
   formule:
@@ -4730,6 +4814,7 @@ contrat salarié . lodeom . éligible barème un . secteurs d'activité:
   par défaut: non
 
 contrat salarié . lodeom . éligible barème deux:
+  applicable si: zone un
   rend non applicable:
     - réduction générale
     - éligible barème un
@@ -4744,6 +4829,7 @@ contrat salarié . lodeom . éligible barème deux:
     - https://www.urssaf.fr/portail/home/outre-mer/employeur/exoneration-de-cotisations-di-1/employeurs-situes-en-guadeloupe/bareme-dit-de-competitivite-renf.html
 
 contrat salarié . lodeom . éligible barème trois:
+  applicable si: zone un
   rend non applicable:
     - réduction générale
     - éligible barème un
@@ -4783,15 +4869,7 @@ contrat salarié . lodeom . borne supérieure:
 contrat salarié . lodeom . multiplicateur:
   note: pour le barème 1 le dénominateur vaut 0,9
   période: flexible
-  formule:
-    variations:
-      - si:
-          toutes ces conditions:
-            - éligible barème trois
-            - cotisations . assiette > borne inférieure * SMIC
-            - cotisations . assiette < 2.5 * SMIC
-        alors: paramètre T
-      - sinon: (borne inférieure * paramètre T) / (borne supérieure - borne inférieure)
+  formule: (borne inférieure * paramètre T) / (borne supérieure - borne inférieure)
 
 contrat salarié . lodeom . paramètre T:
   formule:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1539,6 +1539,7 @@ contrat salarié . cotisations . patronales . réductions de cotisations:
   formule:
     somme:
       - réduction générale
+      - lodeom . réduction zone un
       - statut JEI . exonération de cotisations
       - réduction ACRE
       - déduction heures supplémentaires
@@ -4654,7 +4655,13 @@ contrat salarié . lodeom . réduction zone un:
     thème: aide bas salaires
     démarches: non
 
-  applicable si: zone un
+  applicable si:
+    toutes ces conditions:
+      - zone un
+      - une de ces conditions:
+          - éligible barème un
+          - éligible barème deux
+          - éligible barème trois
 
   non applicable si:
     une de ces conditions:
@@ -4712,22 +4719,36 @@ contrat salarié . lodeom . paramètre T:
 
 contrat salarié . lodeom . éligible barème un:
   titre: Eligibilité au barème de compétitivité
-  question: Êtes-vous éligibles au barème compétitivité ?
-  description: >
-    ### Employeurs éligibles
+  rend non applicable:
+    - réduction générale
+  formule:
+    variations:
+      - si: entreprise . effectif < 11
+        alors: oui
+      - sinon: secteurs d'activité
 
-      - les entreprises de moins de 11 salariés, quel que soit le secteur d’activité ; quel que soit leur effectif,
-      - les entreprises de transport aérien assurant les liaisons entre les départements et régions d’Outre-mer et entre la métropole et ces territoires, ainsi que les dessertes intérieures ;
-      - les entreprises assurant les dessertes maritimes, fluviales ou les liaisons entre départements et régions d’Outre-mer ;
-      - les employeurs relevant des secteurs du bâtiment et des travaux publics, de la presse, de la production audiovisuelle ;
-      - les employeurs des secteurs éligibles aux régimes de compétitivité renforcée ou d’innovation et de croissance, qui ne respectent pas les conditions d’effectifs (moins de 250 salariés) ou de chiffres d’affaires annuel (moins de 50 millions d’euros).
+contrat salarié . lodeom . éligible barème un . secteurs d'activité:
+  question: Votre entreprise appartient-elle à l'un de ces secteurs ?
+  description: |
+    Pour être éligible au 1er barème de l'exonération LODEOM, dit barème de compétitivité, votre entreprise doit appartenir à l'un des secteurs suivants :
+
+    - ✈ transport aérien assurant les liaisons entre les départements et régions d’Outre-mer et entre la métropole et ces territoires, ainsi que les dessertes intérieures
+    - ⛵ dessertes maritimes, fluviales ou les liaisons entre départements et régions d’Outre-mer 
+    - 🏗 bâtiment et travaux publics
+    - 📰 la presse
+    - 🎥 la production audiovisuelle 
+    - les secteurs éligibles aux régimes de compétitivité renforcée (barème 2) ou d’innovation et de croissance (barème 3), qui ne respectent pas les conditions d’effectifs (moins de 250 salariés) ou de chiffres d’affaires annuel (moins de 50 millions d’euros).
   par défaut: non
 
 contrat salarié . lodeom . éligible barème deux:
+  rend non applicable:
+    - réduction générale
   question: Êtes-vous éligibles au barème compétitivité renforcée ?
   par défaut: non
 
 contrat salarié . lodeom . éligible barème trois:
+  rend non applicable:
+    - réduction générale
   question: Êtes-vous éligibles au barème innovation et croissance ?
   par défaut: non
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4703,20 +4703,6 @@ contrat salarié . lodeom . écart au plafond de l'assiette:
   période: flexible
   formule: plafond de l'assiette - cotisations . assiette
 
-contrat salarié . lodeom . paramètre T:
-  formule:
-    variations:
-      - si:
-          toutes ces conditions:
-            - zone un
-            - entreprise . effectif < 20
-        alors: 0.3214
-      - si:
-          toutes ces conditions:
-            - zone un
-            - entreprise . effectif >= 20
-        alors: 0.3254
-
 contrat salarié . lodeom . éligible barème un:
   titre: Eligibilité au barème de compétitivité
   rend non applicable:
@@ -4743,14 +4729,35 @@ contrat salarié . lodeom . éligible barème un . secteurs d'activité:
 contrat salarié . lodeom . éligible barème deux:
   rend non applicable:
     - réduction générale
+    - éligible barème un
   question: Êtes-vous éligibles au barème compétitivité renforcée ?
+  description: |
+    - chiffre d'affaire de moins de 50 millions d'euros
+    - Les employeurs relevant des secteurs de l’industrie, de la restauration, de l’environnement, de l’agro nutrition, des énergies renouvelables, des nouvelles technologies de l’information et de la communication et des centres d’appel, de la pêche, des cultures marines, de l’aquaculture, de l’agriculture, du tourisme y compris les activités de loisirs s’y rapportant, du nautisme, de l’hôtellerie, de la recherche et du développement ;
+    - Les entreprises bénéficiaires du régime de perfectionnement actif défini à l’article 256 du règlement (UE) n° 952/2013 du parlement européen et du conseil du 9 octobre 2013 établissant le code des douanes de l’Union
+    - En Guyane, les employeurs ayant une activité principale relevant de l’un des secteurs d’activité éligibles à la réduction d’impôt prévue à l’article 199 undecies B du code général des impôts, ou correspondant à l’une des activités suivantes : comptabilité, conseil aux entreprises, ingénierie ou études techniques.
   par défaut: non
 
 contrat salarié . lodeom . éligible barème trois:
   rend non applicable:
     - réduction générale
+    - éligible barème un
+    - éligible barème deux
   question: Êtes-vous éligibles au barème innovation et croissance ?
+  description: |
+    - Sont éligibles à ce barème les employeurs occupant moins de 250 salariés et ayant réalisé un chiffre d’affaires annuel inférieur à 50 millions d’euros, au titre de la rémunération des salariés concourant essentiellement à la réalisation de projets innovants dans le domaine des technologies de l’information et de la communication.
+    - Les projets innovants se définissent comme des projets ayant pour but l’introduction d’un bien, d’un service, d’une méthode de production ou de distribution nouveau ou sensiblement amélioré sur le plan des caractéristiques et de l’usage auquel il est destiné. Ces projets doivent être réalisés dans les domaines suivants :
+      - télécommunication ;
+      - informatique, dont notamment programmation, conseil en systèmes et logiciels, tierce maintenance de systèmes et d’applications, gestion d‘installations, traitement des données, hébergement et activités connexes ;
+      - édition de portails internet et de logiciels;
+      - infographie, notamment conception de contenus visuels et numériques ;
+      - conception d’objets connectés.
+    - Si ces conditions sont réunies, l’exonération s’applique aux rémunérations versées aux salariés occupés principalement à la réalisation de projets innovants.
+    - Sont donc exclues les fonctions supports : tâches administratives financières, logistiques et de ressources humaines.
   par défaut: non
+
+  #Coefficient = 1,3 × T / 0,9 × (2,2 × Smic calculé pour un an / rémunération annuelle brute – 1)
+  #Coefficient = 1,7 × T × (2,7 × Smic calculé pour un an / rémunération annuelle brute – 1)
 
 contrat salarié . lodeom . borne inférieure:
   formule:
@@ -4770,4 +4777,28 @@ contrat salarié . lodeom . borne supérieure:
         alors: 3.5
 
 contrat salarié . lodeom . multiplicateur:
-  formule: (borne inférieure * contrat salarié . lodeom . paramètre T) / (borne supérieure - borne inférieure)
+  note: pour le barème 1 le dénominateur vaut 0,9
+  période: flexible
+  formule:
+    variations:
+      - si:
+          toutes ces conditions:
+            - éligible barème trois
+            - cotisations . assiette > borne inférieure * SMIC
+            - cotisations . assiette < 2.5 * SMIC
+        alors: paramètre T
+      - sinon: (borne inférieure * paramètre T) / (borne supérieure - borne inférieure)
+
+contrat salarié . lodeom . paramètre T:
+  formule:
+    variations:
+      - si:
+          toutes ces conditions:
+            - zone un
+            - entreprise . effectif < 20
+        alors: 0.3214
+      - si:
+          toutes ces conditions:
+            - zone un
+            - entreprise . effectif >= 20
+        alors: 0.3254

--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -224,7 +224,7 @@ exports[`calculate simulations-salarié: impôt sur le revenu 2`] = `"[41765,0,0
 
 exports[`calculate simulations-salarié: impôt sur le revenu 3`] = `"[4076,0,0,3000,2353,2270]"`;
 
-exports[`calculate simulations-salarié: impôt sur le revenu 4`] = `"[4076,0,0,3000,2353,2205]"`;
+exports[`calculate simulations-salarié: impôt sur le revenu 4`] = `"[3915,0,0,3000,2353,2205]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu 5`] = `"[41765,0,0,30000,24267,14656]"`;
 


### PR DESCRIPTION
Prise en compte de LODEOM.

L'idée est de proposer à l'utilisateur, une fois sa zone géographique connue, les trois barèmes. Il peut choisit l'un d'entre eux en examinant les conditions d'éligibilité. Sinon, la réduction générale les remplace.

### D'abord pour Guadeloupe & co

On a bien avancé. Il reste à : 
- [x] gérer l'exception de la pente de la réduction barème 3 en 1/x de 1.7 à 2.5 SMIC. 
- [x] intégrer les réductions dans le calcul principal et attribuer la réduction générale à ceux qui ne sont éligibles à aucun barème Lodeom. 
- [x] intégrer le détail de l'éligibilité des barèmes 2 et 3. 
- [ ] mieux les afficher dans l'UI
- [ ] enlever nos modifications de salarié.yaml qui ne servent qu'à éviter de saisir une ville d'outre-mer


### Avant de merger

- [x] Comprendre pourquoi vscode formate les longs noms de variables avec un `?` en début de ligne


### Puis pour St Bathélemy

- [ ]  Taux T different (leur assiette de réduction est très inférieure) et bornes différentes, plus élargies.

------------

- [ ] Gérer les autres cas particuliers s'il y en a
