### PR TITLE
Évite la navigation sur les pages de documentation triviales

### DIFF
--- a/source/components/RuleLink.js
+++ b/source/components/RuleLink.js
@@ -19,6 +19,7 @@ const RuleLink = ({
 	title,
 	colours: { colour },
 	style,
+	skipTrivialRule = true,
 	sitePaths,
 	children
 }: Props) => {
@@ -27,7 +28,7 @@ const RuleLink = ({
 
 	return (
 		<Link
-			to={newPath}
+			to={{ pathname: newPath, state: { skipTrivialRule } }}
 			className="rule-link"
 			style={{ color: colour, ...style }}>
 			{children || title || nameLeaf(dottedName)}

--- a/source/components/RulePage.js
+++ b/source/components/RulePage.js
@@ -7,7 +7,7 @@ import {
 	findRulesByName
 } from 'Engine/rules.js'
 import { compose, head } from 'ramda'
-import React from 'react'
+import React, { createContext } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
@@ -23,17 +23,20 @@ import Rule from './rule/Rule'
 import './RulePage.css'
 import SearchButton from './SearchButton'
 
+export const SkipTrivialRuleContext = createContext(false)
+
 export default compose(
 	connect(state => ({
 		valuesToShow: !noUserInputSelector(state),
 		flatRules: flatRulesSelector(state),
 		brancheName: situationBranchNameSelector(state)
 	}))
-)(function RulePage({ flatRules, match, valuesToShow, brancheName }) {
+)(function RulePage({ flatRules, match, location, valuesToShow, brancheName }) {
 	let name = match?.params?.name,
 		decodedRuleName = decodeRuleName(name)
 
 	const renderRule = dottedName => {
+		const skipTrivialRule = Boolean(location?.state?.skipTrivialRule)
 		return (
 			<div id="RulePage">
 				<ScrollToTop key={brancheName + dottedName} />
@@ -42,7 +45,9 @@ export default compose(
 					{brancheName && <span id="situationBranch">{brancheName}</span>}
 					<SearchButton />
 				</div>
-				<Rule dottedName={dottedName} />
+				<SkipTrivialRuleContext.Provider value={skipTrivialRule}>
+					<Rule dottedName={dottedName} />
+				</SkipTrivialRuleContext.Provider>
 			</div>
 		)
 	}

--- a/source/engine/mecanismViews/Somme.js
+++ b/source/engine/mecanismViews/Somme.js
@@ -1,19 +1,45 @@
+import { SkipTrivialRuleContext } from 'Components/RulePage'
+import withSitePaths from 'Components/utils/withSitePaths'
+import { NodeTreeDepthContext } from 'Engine/mecanismViews/common'
+import { encodeRuleName } from 'Engine/rules'
 import { path } from 'ramda'
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
+import { Redirect } from 'react-router-dom'
 import { makeJsx } from '../evaluation'
 import { Node, NodeValuePointer } from './common'
 import './Somme.css'
 
-const SommeNode = ({ explanation, nodeValue, unit }) => (
-	<Node
-		classes="mecanism somme"
-		name="somme"
-		value={nodeValue}
-		unit={unit}
-		child={<Table explanation={explanation} unit={unit} />}
-	/>
-)
-export default SommeNode
+let SommeNode = ({ explanation, nodeValue, unit, sitePaths }) => {
+	let skipTrivialRule = useContext(SkipTrivialRuleContext),
+		nodeTreeDepth = useContext(NodeTreeDepthContext),
+		relevantLines = explanation.filter(({ nodeValue }) => nodeValue > 0)
+
+	if (skipTrivialRule && nodeTreeDepth === 0 && relevantLines.length === 1) {
+		return (
+			<Redirect
+				to={{
+					pathname:
+						sitePaths.documentation.index +
+						'/' +
+						encodeRuleName(relevantLines[0].dottedName),
+					state: { skipTrivialRule: true }
+				}}
+			/>
+		)
+	}
+
+	return (
+		<Node
+			classes="mecanism somme"
+			name="somme"
+			value={nodeValue}
+			unit={unit}
+			child={<Table explanation={explanation} unit={unit} />}
+		/>
+	)
+}
+
+export default withSitePaths(SommeNode)
 
 let Table = ({ explanation, unit }) => (
 	<div className="mecanism-somme__table">

--- a/source/engine/mecanismViews/common.js
+++ b/source/engine/mecanismViews/common.js
@@ -2,7 +2,7 @@ import { default as classNames, default as classnames } from 'classnames'
 import withSitePaths from 'Components/utils/withSitePaths'
 import Value from 'Components/Value'
 import { compose, contains, isNil, pipe, sort, toPairs } from 'ramda'
-import React from 'react'
+import React, { createContext, useContext } from 'react'
 import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -31,47 +31,54 @@ export let NodeValuePointer = ({ data, unit }) => (
 	</span>
 )
 
+export const NodeTreeDepthContext = createContext(0)
+
 // Un élément du graphe de calcul qui a une valeur interprétée (à afficher)
 export function Node({ classes, name, value, child, inline, unit }) {
-	let termDefinition = contains('mecanism', classes) && name
+	let termDefinition = contains('mecanism', classes) && name,
+		nodeTreeDepth = useContext(NodeTreeDepthContext)
 
 	return (
-		<div
-			className={classNames(classes, 'node', { inline })}
-			style={termDefinition ? { borderColor: mecanismColours(name) } : {}}>
-			{name && !inline && (
-				<div className="nodeHead" css="margin-bottom: 1em">
-					<LinkButton
-						className="name"
-						style={termDefinition ? { background: mecanismColours(name) } : {}}
-						data-term-definition={termDefinition}>
-						<Trans>{name}</Trans>
-					</LinkButton>
-				</div>
-			)}
-			{child}{' '}
-			{name ? (
-				!isNil(value) && (
-					<div className="mecanism-result">
-						<span css="font-size: 90%; margin: 0 .6em">=</span>
-						<NodeValuePointer data={value} unit={unit} />
+		<NodeTreeDepthContext.Provider value={nodeTreeDepth + 1}>
+			<div
+				className={classNames(classes, 'node', { inline })}
+				style={termDefinition ? { borderColor: mecanismColours(name) } : {}}>
+				{name && !inline && (
+					<div className="nodeHead" css="margin-bottom: 1em">
+						<LinkButton
+							className="name"
+							style={
+								termDefinition ? { background: mecanismColours(name) } : {}
+							}
+							data-term-definition={termDefinition}>
+							<Trans>{name}</Trans>
+						</LinkButton>
 					</div>
-				)
-			) : (
-				<span
-					css={`
-						@media (max-width: 1200px) {
-							width: 100%;
-							text-align: right;
-						}
-					`}>
-					{value !== true && value !== false && !isNil(value) && (
-						<span className="operator"> =&nbsp;</span>
-					)}
-					<NodeValuePointer data={value} unit={unit} />
-				</span>
-			)}
-		</div>
+				)}
+				{child}{' '}
+				{name ? (
+					!isNil(value) && (
+						<div className="mecanism-result">
+							<span css="font-size: 90%; margin: 0 .6em">=</span>
+							<NodeValuePointer data={value} unit={unit} />
+						</div>
+					)
+				) : (
+					<span
+						css={`
+							@media (max-width: 1200px) {
+								width: 100%;
+								text-align: right;
+							}
+						`}>
+						{value !== true && value !== false && !isNil(value) && (
+							<span className="operator"> =&nbsp;</span>
+						)}
+						<NodeValuePointer data={value} unit={unit} />
+					</span>
+				)}
+			</div>
+		</NodeTreeDepthContext.Provider>
 	)
 }
 


### PR DESCRIPTION
Ajout d'un attribut `skipTrivialRule` au niveau du routeur qui permet d'éviter les pages de documentation ne contenant pas d'information pertinente pour la simulation en cours.

Actuellement utilisé uniquement au niveau de la règle "Aides employeur" qui est une somme de toutes les aides disponibles pour l'employeur. Si tous les éléments de cette somme sont nuls sauf une, on peut naviguer directement vers l'aide non nulle. La page "Aides employeur" reste accessible via le fil d’Ariane.