### PR TITLE
Meilleure documentation des barèmes

### DIFF
--- a/source/components/RuleLink.js
+++ b/source/components/RuleLink.js
@@ -29,6 +29,7 @@ const RuleLink = ({
 		<Link
 			to={newPath}
 			className="rule-link"
+			title={title}
 			style={{ color: colour, ...style }}>
 			{children || title || nameLeaf(dottedName)}
 		</Link>

--- a/source/components/rule/Header.js
+++ b/source/components/rule/Header.js
@@ -16,6 +16,7 @@ let RuleHeader = withColours(
 		question,
 		flatRule,
 		flatRules,
+		acronyme,
 		name,
 		title,
 		icon,
@@ -26,9 +27,12 @@ let RuleHeader = withColours(
 			<section id="ruleHeader">
 				<header className="ui__ plain card">
 					<div>
-							<Namespace {...{ dottedName, flatRules, colour: colours.textColour }} />
+						<Namespace
+							{...{ dottedName, flatRules, colour: colours.textColour }}
+						/>
 						<h1 style={{ color: colours.textColour }}>
 							{title || capitalise0(name)}
+							{acronyme && <> ({acronyme})</>}
 						</h1>
 					</div>
 					{icon && <span id="ruleHeader__icon"> {emoji(icon)}</span>}

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -57,7 +57,7 @@ export default compose(
 	const { t } = useTranslation()
 
 	let flatRule = findRuleByDottedName(flatRules, dottedName)
-	let { type, name, title, description, question, icon } = flatRule,
+	let { type, name, acronyme, title, description, question, icon } = flatRule,
 		namespaceRules = findRuleByNamespace(flatRules, dottedName)
 	let displayedRule = analysedExample || analysedRule
 
@@ -116,6 +116,7 @@ export default compose(
 								flatRule,
 								flatRules,
 								name,
+								acronyme,
 								title,
 								icon,
 								valuesToShow

--- a/source/engine/format.js
+++ b/source/engine/format.js
@@ -58,7 +58,7 @@ export function formatValue({
 	if (typeof value !== 'number') {
 		return value
 	}
-	const serializedUnit = serialiseUnit(unit, value)
+	const serializedUnit = serialiseUnit(unit, value, language)
 
 	switch (serializedUnit) {
 		case '€':

--- a/source/engine/format.test.js
+++ b/source/engine/format.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { formatCurrency, formatPercentage, formatValue } from './format'
+import { parseUnit } from 'Engine/units'
 
 describe('format engine values', () => {
 	it('format currencies', () => {
@@ -23,5 +24,25 @@ describe('format engine values', () => {
 			'12 €'
 		)
 		expect(formatValue({ value: 1200, language: 'fr' })).to.equal('1 200')
+	})
+})
+
+describe('Units handling', () => {
+	it('translate unit', () => {
+		expect(formatValue({ value: 1, unit: 'jour', language: 'fr' })).to.equal(
+			'1 jour'
+		)
+		expect(formatValue({ value: 1, unit: 'jour', language: 'en' })).to.equal(
+			'1 day'
+		)
+	})
+
+	it('pluralize unit', () => {
+		expect(formatValue({ value: 2, unit: 'jour', language: 'fr' })).to.equal(
+			'2 jours'
+		)
+		expect(
+			formatValue({ value: 7, unit: parseUnit('jour/semaine'), language: 'fr' })
+		).to.equal('7 jours / semaine')
 	})
 })

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -5,7 +5,7 @@
 @preprocessor esmodule
 
 @{%
-import {string, filteredVariable, variable, temporalVariable,  binaryOperation, unaryOperation, boolean, number, percentage } from './grammarFunctions'
+import {string, filteredVariable, variable, temporalVariable,  binaryOperation, unaryOperation, boolean, number, numberWithUnit, percentage } from './grammarFunctions'
 
 const moo = require("moo");
 
@@ -15,6 +15,9 @@ const word = `${letter}(?:[\-']?${letterOrNumber}+)*`;
 const words = `${word}(?: ${word}|${letterOrNumber}*)*`
 const numberRegExp = '-?(?:[1-9][0-9]+|[0-9])(?:\.[0-9]+)?';
 const percentageRegExp = numberRegExp + '\\%'
+const simpleUnit = `(?:€|[a-z]+)`;
+const dashedSimpleUnits = `${simpleUnit}(?:-${simpleUnit})?`
+const unit = `${dashedSimpleUnits}(?:\/${dashedSimpleUnits})?` 
 
 const lexer = moo.compile({
   percentage: new RegExp(percentageRegExp),
@@ -28,6 +31,7 @@ const lexer = moo.compile({
   multiplicationDivision: ['*','/'],
   temporality: ['annuel' , 'mensuel'],
   words: new RegExp(words),
+  unit: new RegExp(unit),
   string: /'[ \t\.'a-zA-Z\-\u00C0-\u017F0-9 ]+'/,
   dot: ' . ',
   space: { match: /[\s]+/, lineBreaks: true }
@@ -94,6 +98,8 @@ boolean ->
 
 number ->
     %number {% number %}
+  | %number %space %words {% numberWithUnit %}
+  | %number %space %unit {% numberWithUnit %}
   | %percentage {% percentage %}
 
 string -> %string {% string %}

--- a/source/engine/grammarFunctions.js
+++ b/source/engine/grammarFunctions.js
@@ -47,6 +47,13 @@ export let number = ([{ value }]) => ({
 	}
 })
 
+export let numberWithUnit = ([number, , unit]) => ({
+	constant: {
+		nodeValue: parseFloat(number.value),
+		unit: parseUnit(unit.value)
+	}
+})
+
 export let percentage = ([{ value }]) => ({
 	constant: {
 		type: 'percentage',

--- a/source/engine/mecanismViews/Barème.js
+++ b/source/engine/mecanismViews/Barème.js
@@ -102,22 +102,19 @@ let Component = function Barème({
 							))}
 						</tbody>
 					</table>
-					{/* nous avons remarqué que la notion de taux final pour un barème à 2 tranches est moins pertinent pour les règles de calcul des indépendants. Règle empirique à faire évoluer ! */}
+					{/* nous avons remarqué que la notion de taux moyen pour un barème à 2 tranches est moins pertinent pour les règles de calcul des indépendants. Règle empirique à faire évoluer ! */}
 					{showValues &&
 						!explanation.returnRate &&
 						barèmeType === 'marginal' &&
 						explanation.tranches.length > 2 && (
 							<>
 								<b>
-									<Trans>Taux final</Trans> :{' '}
+									<Trans>Taux moyen</Trans> :{' '}
 								</b>
 								<NodeValuePointer
-									data={
-										(nodeValue / lazyEval(explanation['assiette']).nodeValue) *
-										100
-									}
+									data={nodeValue / lazyEval(explanation['assiette']).nodeValue}
+									unit="%"
 								/>
-								%
 							</>
 						)}
 					{explanation.returnRate && (

--- a/source/engine/mecanismViews/BarèmeContinu.js
+++ b/source/engine/mecanismViews/BarèmeContinu.js
@@ -1,11 +1,12 @@
 import { ShowValuesConsumer } from 'Components/rule/ShowValuesContext'
-import { formatPercentage } from 'Engine/format'
+import RuleLink from 'Components/RuleLink'
+import { formatPercentage, formatValue } from 'Engine/format'
 import { sortObjectByKeys } from 'Engine/mecanismViews/common'
 import React from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { BarèmeAttributes } from './Barème'
 import './Barème.css'
-import { Node } from './common'
+import { Node, NodeValuePointer } from './common'
 
 let Comp = function Barème({ nodeValue, explanation, unit }) {
 	return (
@@ -33,7 +34,14 @@ let Comp = function Barème({ nodeValue, explanation, unit }) {
 								<tbody>
 									{sortObjectByKeys(explanation.points).map(([seuil, taux]) => (
 										<tr key={seuil} className="tranche">
-											<td key="tranche">{seuil}</td>
+											<td key="tranche">
+												<SeuilFormatteur
+													value={Number(seuil)}
+													multiplicateur={
+														explanation.multiplicateur.explanation
+													}
+												/>
+											</td>
 											<td key="taux"> {taux}</td>
 										</tr>
 									))}
@@ -58,6 +66,34 @@ let Comp = function Barème({ nodeValue, explanation, unit }) {
 			)}
 		</ShowValuesConsumer>
 	)
+}
+
+function SeuilFormatteur({ value, multiplicateur }) {
+	const { language } = useTranslation().i18n
+	if (value === 0) {
+		return '0'
+	} else {
+		return (
+			<>
+				{formatValue({
+					value,
+					language
+				})}
+				{multiplicateur && (
+					<>
+						&nbsp;
+						<RuleLink {...multiplicateur} title={multiplicateur.name}>
+							{multiplicateur.acronyme}
+						</RuleLink>
+					</>
+				)}{' '}
+				<NodeValuePointer
+					data={value * multiplicateur.nodeValue}
+					unit={multiplicateur.unit}
+				/>
+			</>
+		)
+	}
 }
 
 //eslint-disable-next-line

--- a/source/engine/units.js
+++ b/source/engine/units.js
@@ -18,10 +18,10 @@ let printUnits = (units, count) =>
 		.join('-')
 
 const plural = 2
-export let serialiseUnit = (rawUnit, count = plural) => {
+export let serialiseUnit = (rawUnit, count = plural, lng = undefined) => {
 	if (typeof rawUnit !== 'object') {
 		return typeof rawUnit === 'string'
-			? i18n.t(`units:${rawUnit}`, { count })
+			? i18n.t(`units:${rawUnit}`, { count, lng })
 			: rawUnit
 	}
 	let unit = simplify(rawUnit),

--- a/source/engine/units.js
+++ b/source/engine/units.js
@@ -19,7 +19,7 @@ let printUnits = (units, count) =>
 
 const plural = 2
 export let serialiseUnit = (rawUnit, count = plural, lng = undefined) => {
-	if (typeof rawUnit !== 'object') {
+	if (rawUnit === null || typeof rawUnit !== 'object') {
 		return typeof rawUnit === 'string'
 			? i18n.t(`units:${rawUnit}`, { count, lng })
 			: rawUnit

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -188,7 +188,7 @@ De: From
 à: to
 En-dessous de: Below
 Au-dessus de: Above
-Taux final: Final rate
+Taux moyen: Average rate
 Commencer: Get started
 Passer: Skip
 
@@ -523,7 +523,7 @@ path:
     exemples: '/examples'
   privacy:
     index: '/privacy'
-  integration: 
+  integration:
     index: '/integration'
     iframe: '/iframe'
     library: '/library'

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1022,6 +1022,7 @@ contrat salarié . statut cadre . choix statut cadre:
 plafond sécurité sociale temps plein:
   description: Le plafond de Sécurité sociale est le montant maximum des rémunérations à prendre en compte pour le calcul de certaines cotisations.
   période: mois
+  acronyme: PSS
   formule: 3377
   unité: €
   références:
@@ -1030,6 +1031,7 @@ plafond sécurité sociale temps plein:
 
 contrat salarié . plafond sécurité sociale:
   période: flexible
+  acronyme: PSS
   formule: plafond sécurité sociale temps plein * temps de travail . quotité de travail
 
 contrat salarié . SMIC temps plein:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1545,11 +1545,10 @@ contrat salarié . cotisations . patronales . réductions de cotisations . dédu
   période: flexible
   applicable si: entreprise . effectif < 20
   titre: déduction forfaitaire pour heures supplémentaires
-  unité: €
   formule:
     multiplication:
       assiette: temps de travail . heures supplémentaires
-      facteur: 1.50
+      facteur: 1.50 €/heure
   note: La déduction ne s’applique pas aux heures complémentaires
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-deduction-forfaitaire-patrona/employeurs-concernes.html
@@ -1933,7 +1932,7 @@ contrat salarié . statut JEI . exonération de cotisations:
     # TODO - le plafonnement à 4,5 SMIC, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,
     # il faut fournir un mécanisme "exonération" capable de recalculer une règle en introduisant un plafond
     le minimum de:
-      - 1634.39
+      - 1634.39 €
       - somme:
           - allocations familiales
           - maladie [employeur]
@@ -4594,7 +4593,7 @@ protection sociale . accidents du travail et maladies professionnelles:
           assiette: revenu moyen [mensuel]
           taux: 60%
           facteur: 1 / 30.42
-      - 202.78
+      - 202.78 €
       # TODO
       # - 0.834% * plafond sécurité sociale temps plein [annuel]
 

--- a/test/mécanismes/expressions.yaml
+++ b/test/mécanismes/expressions.yaml
@@ -181,6 +181,23 @@
         salaire de base: 1000
       valeur attendue: 381
 
+- test: litéral avec unité
+  formule: 1 jour
+  unité attendue: jour
+
+- test: litéral avec unité €
+  formule: 2 €
+  unité attendue: €
+
+- test: litéral avec unité complexe
+  formule: 1 €/jour
+  unité attendue: €/jour
+
+- test: inférence d'unité littéraux
+  formule: 2 €/jour * 2 jour
+  valeur attendue: 4
+  unité attendue: €
+
 - nom: catégorie d'activité
   formule:
     une possibilité:


### PR DESCRIPTION
Dans la documentation, ne plus afficher de notion de "multiplicateur" mais directement au niveau des tranches indiquer "5 PASS" avec la valeur calculée correspondante à coté.

Par ailleurs ajout de tests sur la traduction et la pluralisation des unités.