### PR TITLE
Prise en compte des heures supplémentaires dans le paramètre SMIC des réductions

### DIFF
--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -742,7 +742,7 @@ contrat salarié . rémunération . brut de base:
   contrôles:
     - si:
         toutes ces conditions:
-          - rémunération . assiette de vérification du SMIC [mensuel] < SMIC [mensuel]
+          - rémunération . assiette de vérification du SMIC [mensuel] < SMIC contractuel [mensuel]
           - assimilé salarié != oui
           - stage != oui
           - apprentissage != oui
@@ -1059,9 +1059,21 @@ SMIC horaire:
     décret: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037833206
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F2300
 
-contrat salarié . SMIC:
+contrat salarié . SMIC contractuel:
+  description: >
+    Valeur du SMIC pro-ratisé pour prendre en compte le temps partiel et utilisé pour la détermination du salaire minimum
   période: flexible
   formule: SMIC temps plein * temps de travail . quotité de travail
+
+contrat salarié . SMIC:
+  description: |
+    Plusieurs réductions de cotisations ([réduction générale](/documentation/contrat-salarié/réduction-générale), taux réduit d'[allocations familiales](/documentation/contrat-salarié/allocations-familiales/taux-réduit) et de [maladie](/documentation/contrat-salarié/maladie/taux-employeur/taux-réduit), réduction outre-mer) reposent sur un paramètre SMIC faisant l'objet de plusieurs ajustements pour prendre en compte le temps de travail effectif.
+
+    Les heures supplémentaires sont prises en compte sans tenir compte de la majoration.
+  période: flexible
+  formule: temps de travail * SMIC horaire
+  références:
+    Détermination du SMIC: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale/le-calcul-de-la-reduction/etape-1--determination-du-coeffi/determination-du-smic-a-prendre.html
 
 contrat salarié . cotisations . salariales:
   titre: cotisations salariales

--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -208,15 +208,15 @@ exports[`calculate simulations-salarié: cdd 1`] = `"[2494,0,0,2000,1561,1477]"`
 
 exports[`calculate simulations-salarié: cdd 2`] = `"[2494,0,0,2000,1561,1477]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires 1`] = `"[2642,0,0,2000,1636,1551]"`;
+exports[`calculate simulations-salarié: heures supplémentaires 1`] = `"[2599,0,0,2000,1636,1551]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires 2`] = `"[3349,0,0,2000,2009,1914]"`;
+exports[`calculate simulations-salarié: heures supplémentaires 2`] = `"[3123,0,0,2000,2009,1914]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires 3`] = `"[2713,0,0,2000,1636,1551]"`;
+exports[`calculate simulations-salarié: heures supplémentaires 3`] = `"[2669,0,0,2000,1636,1551]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires 4`] = `"[2623,0,0,2000,1627,1543]"`;
+exports[`calculate simulations-salarié: heures supplémentaires 4`] = `"[2580,0,0,2000,1627,1543]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires 5`] = `"[3291,0,0,2000,1970,1885]"`;
+exports[`calculate simulations-salarié: heures supplémentaires 5`] = `"[3043,0,0,2000,1970,1885]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu 1`] = `"[4076,0,0,3000,2353,2168]"`;
 


### PR DESCRIPTION
À l'occasion de l'implémentation de la réduction LODEOM hier #581, nous nous sommes rendu compte que nous ne prenions pas en compte le nombre d'heures supplémentaires effectuées dans la pro-ratisation du paramètre SMIC utilisé dans le calcul des réductions. Cette erreur nous conduisait en pratique à sous-estimer le montant de la réduction générale de cotisations sur les heures supplémentaires et donc à surestimer le prix total du travail.

cc @laem 

C'est aussi l'occasion de constater que le snapshot testing #739 fonctionne comme prévu :)