### PR TITLE
Mécanisme "simulation"

### DIFF
--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1039,8 +1039,11 @@ contrat salarié . SMIC temps plein . net imposable:
   période: mois
   unité: €
   description: Montant du SMIC net imposable
-  formule: 1247,55
-  note: Ce montant est codé en dur, il faudrait le calculer à partir du montant du SMIC brut
+  formule: 
+    simulation:
+      montant: rémunération . net imposable . base
+      situation:
+        rémunération . brut de base: SMIC temps plein
   références:
     barème PAS: https://bofip.impots.gouv.fr/bofip/11255-PGP.html
 


### PR DESCRIPTION
L'idée est d'ajouter un mécanisme pour lancer une sous-simulation avec une situation donnée. Mon cas d'usage est de calculer le montant du `SMIC net imposable` qui est utilisé comme valeur fixe au niveau des impôts et qui est pour l'instant codé en dur au lieu d'être calculé à partir du SMIC brut déjà défini dans la base de règles. L'implémentation de ce mécanisme paraît très simple.

Qu'en pensez-vous @laem @johangirod ? Y-a-t'il d'autres endroits où un tel mécanisme pourrait-être utile ? Peut-on calculer le SMIC net imposable autrement ? 