### PR TITLE
Ne plus servir la version legacy du bundle pour Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,33 +299,6 @@
 		<% } %>
 		<!-- End Matomo Code -->
 
-		<script>
-			// Add support for nomodule attribute to SAFARI 10.1
-			;(function() {
-				var d = document
-				var c = d.createElement('script')
-				if (!('noModule' in c) && 'onbeforeload' in c) {
-					var s = false
-					d.addEventListener(
-						'beforeload',
-						function(e) {
-							if (e.target === c) {
-								s = true
-							} else if (!e.target.hasAttribute('nomodule') || !s) {
-								return
-							}
-							e.preventDefault()
-						},
-						true
-					)
-					c.type = 'module'
-					c.src = '.'
-					d.head.appendChild(c)
-					c.remove()
-				}
-			})()
-		</script>
-
 		<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
 		<script
 			type="module"


### PR DESCRIPTION
Début de résolution pour le problème de tracking.
Normalement grosse optimisation du volume de données à télécharger sur Safari (un seul bundle au lieu des deux).