### PR TITLE
Nom de la variable CDD dans les tests de régression

### DIFF
--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -204,9 +204,9 @@ exports[`calculate simulations-salarié: avantages 3`] = `"[2602,0,0,2000,1549,1
 
 exports[`calculate simulations-salarié: cadre 1`] = `"[4122,0,0,3000,2348,2149]"`;
 
-exports[`calculate simulations-salarié: cdd 1`] = `"[2494,0,0,2000,1561,1477]"`;
+exports[`calculate simulations-salarié: cdd 1`] = `"[2514,0,0,2000,1561,1477]"`;
 
-exports[`calculate simulations-salarié: cdd 2`] = `"[2494,0,0,2000,1561,1477]"`;
+exports[`calculate simulations-salarié: cdd 2`] = `"[2605,0,0,2000,1599,1506]"`;
 
 exports[`calculate simulations-salarié: heures supplémentaires 1`] = `"[2599,0,0,2000,1636,1551]"`;
 

--- a/test/regressions/simulations-salarié.yaml
+++ b/test/regressions/simulations-salarié.yaml
@@ -48,11 +48,11 @@ cadre:
     contrat salarié . statut cadre: true
 
 cdd:
-  - contrat salarié . rémunération . brut de base: 2000
-    contrat salarié . cdd: true
-  - contrat salarié . rémunération . brut de base: 2000
-    contrat salarié . cdd: true
-    contrat salarié . cdd . durée contrat: 6
+  - contrat salarié: CDD
+    contrat salarié . rémunération . brut de base: 2000
+  - contrat salarié: CDD
+    contrat salarié . rémunération . brut de base: 2000
+    contrat salarié . CDD . durée contrat: 6
     contrat salarié . CDD . congés non pris: 3
 
 atmp:
@@ -60,12 +60,12 @@ atmp:
     contrat salarié . ATMP . taux collectif ATMP: 0.05
 
 assimilé salarié:
-  - dirigeant: 'assimilé salarié'
+  - dirigeant: assimilé salarié
     contrat salarié . rémunération . brut de base: 5000
-  - dirigeant: 'assimilé salarié'
+  - dirigeant: assimilé salarié
     contrat salarié . rémunération . brut de base: 1500
     entreprise . ACRE: true
-  - dirigeant: 'assimilé salarié'
+  - dirigeant: assimilé salarié
     contrat salarié . rémunération . brut de base: 3000
     entreprise . ACRE: true
 
@@ -87,10 +87,10 @@ impôt sur le revenu:
     impôt . méthode de calcul: taux neutre
   - contrat salarié . rémunération . brut de base: 30000
     impôt . méthode de calcul: taux neutre
-  - contrat salarié . rémunération . brut de base: 3000
-    impôt . méthode de calcul: taux neutre
-    contrat salarié . CDD: true
+  - contrat salarié: CDD
+    contrat salarié . rémunération . brut de base: 3000
     contrat salarié . CDD . durée contrat: 2
+    impôt . méthode de calcul: taux neutre
   - contrat salarié . rémunération . brut de base: 3000
     impôt . méthode de calcul: taux neutre
     établissement . localisation . département: Guadeloupe


### PR DESCRIPTION
Nous utilisions `cdd` au lieu de `CDD` dans deux tests.

Ajouter un `throw error` si on utilise une variable qui n'existe pas dans les règles ?