### PR TITLE
RFC : variables temporelles ⌛ 

### DIFF
--- a/source/components/PaySlipSections.js
+++ b/source/components/PaySlipSections.js
@@ -50,12 +50,14 @@ export let SalaireNetSection = ({ getRule }) => {
 	let avantagesEnNature = getRule(
 		'contrat salarié . rémunération . avantages en nature'
 	)
+	let impôt = getRule('impôt')
+	let netImposable = getRule('contrat salarié . rémunération . net imposable')
 	return (
 		<div className="payslip__salarySection">
 			<h4 className="payslip__salaryTitle">
 				<T>Salaire net</T>
 			</h4>
-			<Line rule={getRule('contrat salarié . rémunération . net imposable')} />
+			{netImposable && <Line rule={netImposable} />}
 			{avantagesEnNature.nodeValue && (
 				<>
 					{/* Salaire net de cotisations */}
@@ -74,11 +76,14 @@ export let SalaireNetSection = ({ getRule }) => {
 				</>
 			)}
 			<Line rule={getRule('contrat salarié . rémunération . net')} />
-
-			<Line negative rule={getRule('impôt')} />
-			<Line
-				rule={getRule('contrat salarié . rémunération . net après impôt')}
-			/>
+			{impôt && (
+				<>
+					<Line negative rule={impôt} />
+					<Line
+						rule={getRule('contrat salarié . rémunération . net après impôt')}
+					/>
+				</>
+			)}
 		</div>
 	)
 }

--- a/source/components/SchemeComparaison.tsx
+++ b/source/components/SchemeComparaison.tsx
@@ -1,8 +1,5 @@
 import { setSituationBranch } from 'Actions/actions'
-import {
-	defineDirectorStatus,
-	isAutoentrepreneur
-} from 'Actions/companyStatusActions'
+import { defineDirectorStatus, isAutoentrepreneur } from 'Actions/companyStatusActions'
 import classnames from 'classnames'
 import { T } from 'Components'
 import Conversation from 'Components/conversation/Conversation'
@@ -19,10 +16,7 @@ import emoji from 'react-easy-emoji'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { RootState } from 'Reducers/rootReducer'
-import {
-	analysisWithDefaultsSelector,
-	branchAnalyseSelector
-} from 'Selectors/analyseSelectors'
+import { analysisWithDefaultsSelector, branchAnalyseSelector } from 'Selectors/analyseSelectors'
 import { DottedName } from 'Types/rule'
 import Animate from 'Ui/animate'
 import InfoBulle from 'Ui/InfoBulle'
@@ -375,13 +369,13 @@ export default function SchemeComparaison({
 							<div className="AS">
 								<RuleValueLink
 									branch="assimilé"
-									rule="contrat salarié . rémunération . net"
+									rule="revenus net de cotisations"
 								/>
 							</div>
 							<div className="indep">
 								<RuleValueLink
 									branch="indépendant"
-									rule="indépendant . revenu net de cotisations"
+									rule="revenus net de cotisations"
 								/>
 							</div>
 							<div className="auto">
@@ -390,7 +384,7 @@ export default function SchemeComparaison({
 								) : (
 									<RuleValueLink
 										branch="auto-entrepreneur"
-										rule="auto-entrepreneur . revenu net de cotisations"
+										rule="revenus net de cotisations"
 									/>
 								)}
 							</div>
@@ -416,7 +410,7 @@ export default function SchemeComparaison({
 							</div>
 							<div className="indep">
 								{getRule('indépendant', 'protection sociale . retraite')
-									.applicable !== false ? (
+									.isApplicable !== false ? (
 									<span>
 										<RuleValueLink
 											branch="indépendant"
@@ -441,7 +435,7 @@ export default function SchemeComparaison({
 								) : getRule(
 										'auto-entrepreneur',
 										'protection sociale . retraite'
-								  ).applicable !== false ? (
+								  ).isApplicable !== false ? (
 									<span>
 										<RuleValueLink
 											branch="auto-entrepreneur"
@@ -522,6 +516,9 @@ export default function SchemeComparaison({
 							</div>
 							<div className="indep">
 								<span>
+								{getRule('indépendant', 'protection sociale . santé . indemnités journalières')
+									.isApplicable !== false ? (
+									<span>
 									<RuleValueLink
 										appendText={
 											<>
@@ -531,6 +528,13 @@ export default function SchemeComparaison({
 										branch="indépendant"
 										rule="protection sociale . santé . indemnités journalières"
 									/>
+									</span>
+								) : (
+									<span className="ui__ notice">
+										<T>Pas implémenté</T>
+									</span>
+								)}
+									
 								</span>
 							</div>
 							<div className="auto">

--- a/source/components/SearchBar.worker.js
+++ b/source/components/SearchBar.worker.js
@@ -28,6 +28,6 @@ onmessage = function(event) {
 
 	if (event.data.input) {
 		let results = fuse.search(event.data.input)
-		postMessage( results )
+		postMessage(results)
 	}
 }

--- a/source/components/StackedBarChart.tsx
+++ b/source/components/StackedBarChart.tsx
@@ -87,6 +87,7 @@ export default function StackedBarChart({ data }: StackedBarChartProps) {
 	const [intersectionRef, displayChart] = useDisplayOnIntersecting({
 		threshold: 0.5
 	})
+	data = data.filter(datum => datum.nodeValue != undefined)
 	const percentages = roundedPercentages(data.map(d => d.nodeValue))
 	const dataWithPercentage = data.map((data, index) => ({
 		...data,

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -21,6 +21,8 @@ questions:
     ACRE: entreprise . ACRE
   liste noire:
     - entreprise . charges
+  non prioritaires:
+    - entreprise . catégorie d'activité . débit de tabac
 
 situation:
   dirigeant: 'indépendant'

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -2,7 +2,7 @@ objectifs:
   - icône: 👩‍💼
     nom: Mon revenu
     objectifs:
-      - entreprise . rémunération totale du dirigeant
+      - dirigeant . rémunération totale
       - dirigeant . indépendant . cotisations et contributions
       - dirigeant . indépendant . revenu net de cotisations
       - dirigeant . indépendant . revenu professionnel

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -23,6 +23,9 @@ questions:
     - entreprise . charges
   non prioritaires:
     - entreprise . catégorie d'activité . débit de tabac
+    - entreprise . ZFU
+    - dirigeant . indépendant . cotisations et contributions . exonérations . âge
+    - dirigeant . indépendant . cotisations et contributions . exonérations . invalidité
 
 situation:
   dirigeant: 'indépendant'

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -11,7 +11,7 @@ objectifs:
 
 questions:
   uniquement:
-    - entreprise . rémunération totale du dirigeant
+    - dirigeant . rémunération totale
     - entreprise . charges
     - entreprise . catégorie d'activité
     - entreprise . catégorie d'activité . service ou vente

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -3,7 +3,7 @@ titre: |
 
 objectifs:
   - revenu net après impôt
-  - revenu net de cotisations
+  - revenus net de cotisations
   - protection sociale . retraite
   - protection sociale . retraite . trimestres validés par an
   - protection sociale . santé . indemnités journalières

--- a/source/engine/evaluateRule.js
+++ b/source/engine/evaluateRule.js
@@ -35,6 +35,7 @@ export const evaluateApplicability = (
 				: mergeAll([
 						...parentDependencies.map(parent => parent.missingVariables),
 						notApplicable?.missingVariables || {},
+						disabled?.missingVariables || {},
 						applicable?.missingVariables || {}
 				  ])
 
@@ -81,9 +82,7 @@ export default (cache, situationGate, parsedRules, node) => {
 			formulaMissingVariables
 		)
 	cache.parseLevel--
-	if (node.dottedName.startsWith('sum')) {
-		// console.log(node.dottedName, missingVariables, node)
-	}
+
 	return {
 		...node,
 		...applicabilityEvaluation,

--- a/source/engine/parseReference.js
+++ b/source/engine/parseReference.js
@@ -291,9 +291,12 @@ export let parseReferenceTransforms = (
 	parsedRules
 ) => parseResult => {
 	const referenceName = parseResult.variable.fragments.join(' . ')
-	let node = parseReference(rules, rule, parsedRules, parseResult.filter)(
-		referenceName
-	)
+	let node = parseReference(
+		rules,
+		rule,
+		parsedRules,
+		parseResult.filter
+	)(referenceName)
 
 	return {
 		...node,

--- a/source/engine/parseRule.js
+++ b/source/engine/parseRule.js
@@ -6,7 +6,7 @@ import { parse } from 'Engine/parse'
 import { evolve, map } from 'ramda'
 import React from 'react'
 import { coerceArray } from '../utils'
-import { evaluateNode, makeJsx } from './evaluation'
+import { evaluateNode, makeJsx, mergeAllMissing } from './evaluation'
 import { Node } from './mecanismViews/common'
 import { disambiguateRuleReference, findParentDependencies } from './rules'
 
@@ -136,7 +136,12 @@ export default (rules, rule, parsedRules) => {
 			)
 			const nodeValue = isDisabledBy.some(x => !!x.nodeValue)
 			const explanation = { ...node.explanation, isDisabledBy }
-			return { ...node, explanation, nodeValue }
+			return {
+				...node,
+				explanation,
+				nodeValue,
+				missingVariables: mergeAllMissing(isDisabledBy)
+			}
 		},
 		jsx: (nodeValue, { isDisabledBy }) => {
 			return (

--- a/source/engine/rules.js
+++ b/source/engine/rules.js
@@ -243,12 +243,14 @@ export let findParentDependencies = (rules, rule) => {
 		reject(isNil),
 		filter(
 			//Find the first "calculable" parent
-			({ question, unit, formule }) =>
+			({ question, unit, formule, dottedName }) =>
 				(question && !unit && !formule) ||
 				(question && formule?.['une possibilité'] !== undefined) ||
 				(typeof formule === 'string' && formule.includes(' = ')) ||
 				formule === 'oui' ||
-				formule === 'non'
+				formule === 'non' ||
+				formule?.['une de ces conditions'] ||
+				formule?.['toutes ces conditions']
 		)
 	)(parentDependencies)
 }

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1,3 +1,6 @@
+année courante: 
+  formule: 2019
+
 période:
   par défaut: mois
   une possibilité:
@@ -3230,24 +3233,23 @@ revenu net après impôt:
   formule: revenu net de cotisations - impôt
 
 entreprise . date de création:
-  question: Quand avez-vous crée votre entreprise ?
-  formule:
-    une possibilité:
-      choix obligatoire: oui
-      possibilités:
-        - avant 2018
-        - avant 2019
-        - après 2019
-  par défaut: après 2019
+  question: En quelle année avez-vous crée votre entreprise ?
+  par défaut: 2019
+  suggestions:
+    2019: 2019
+    2018: 2018
+    2017: 2017
+  unité: " "
+  contrôles:
+    - si: date de création > 2020
+      niveau: avertissement
+      message: Nous ne pouvons voir aussi loin dans le futur
+    - si: date de création < 1900
+      niveau: avertissement
+      message: Il s'agit d'une très vieille entreprise ! Êtes-vous sûr de ne pas vous être trompé dans la saisie ?
 
-entreprise . date de création . avant 2018:
-  titre: avant le 1er janvier 2018
-
-entreprise . date de création . avant 2019:
-  titre: avant le 1er janvier 2019
-
-entreprise . date de création . après 2019:
-  titre: après le 1er janvier 2019
+entreprise . année d'activité:
+  formule: année courante - date de création 
 
 entreprise . chiffre d'affaires:
   titre: chiffre d'affaires (H.T.)
@@ -3793,11 +3795,11 @@ dirigeant . indépendant . rattachement CIPAV:
           - entreprise . catégorie d'activité . libérale règlementée
       - toutes ces conditions:
           - dirigeant = 'indépendant'
-          - entreprise . date de création = 'avant 2019'
+          - entreprise . date de création < 2019
           - entreprise . catégorie d'activité = 'libérale'
       - toutes ces conditions:
           - dirigeant = 'auto-entrepreneur'
-          - entreprise . date de création = 'avant 2018'
+          - entreprise . date de création < 2018 
           - entreprise . catégorie d'activité = 'libérale'
 
   rend non applicable:
@@ -3805,7 +3807,7 @@ dirigeant . indépendant . rattachement CIPAV:
     - dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
   période: aucune
 
-? dirigeant . indépendant . libérale règlementée . maladie
+? dirigeant . indépendant . rattachement CIPAV . maladie
 : période: flexible
   remplace: cotisations et contributions . cotisations . maladie
   titre: maladie libérale règlementée
@@ -4075,6 +4077,53 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
         1.1: 0%
         1.4: 3.1%
 
+entreprise . ZFU:
+  question: Votre entreprise est-elle localisée dans une zone franche urbaine (ZFU) ?
+  par défaut: non
+
+dirigeant . indépendant . exonération ZFU:
+  période: aucune
+  applicable si: entreprise . date de création < 2015
+  non applicable si: rattachement CIPAV
+  formule: entreprise . ZFU = oui
+  remplace:
+    règle: cotisations et contributions . cotisations . maladie
+    par: taux * cotisations et contributions . cotisations . maladie
+  
+
+dirigeant . indépendant . exonération ZFU . taux:
+  titre: taux exonération ZFU
+  formule:
+    variations:
+      - si: entreprise . effectif < 5
+        alors:     
+          barème linéaire:
+            assiette: entreprise . année d'activité
+            retourne seulement le taux: oui
+            tranches:
+            - en-dessous de: 9
+              taux: 0%
+            - de: 10 
+              à: 15
+              taux: 40%
+            - de: 16
+              à: 17
+              taux: 60%
+            - de: 18
+              à: 19
+              taux: 80%
+            - au-dessus de: 20
+              taux: 100%
+      - sinon:
+          variations:
+            - si: entreprise . année d'activité = 6
+              alors: 40%
+            - si: entreprise . année d'activité = 7
+              alors: 60%
+            - si: entreprise . année d'activité = 8
+              alors: 80%
+            - sinon: 100%
+
 dirigeant:
   question: Quel est le régime social du dirigeant ?
   par défaut: non
@@ -4308,6 +4357,12 @@ entreprise . ACRE:
     *Conditions d'obtention*:
     - Pour les entreprises créées après le 1er janvier 2019, la réduction est automatique, sauf si vous avez déjà obtenu l'ACCRE dans les trois années précédentes
     - Pour les entreprises créées avant le 1er janvier 2019, la réduction de cotisation s'appelait ACCRE était soumise à conditions et n'était pas automatique : il fallait en faire la demande.
+  applicable si:
+    une de ces conditions: 
+      - toutes ces conditions: 
+          - dirigeant = 'auto-entrepreneur'
+          - entreprise . année d'activité < 4
+      - entreprise . année d'activité < 2
   question: Votre entreprise bénéficie-t'elle de l'ACRE (anciennement ACCRE) ?
   par défaut: non
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1646,7 +1646,7 @@ contrat salarié . réduction ACRE . taux:
   formule:
     barème continu:
       assiette: cotisations . assiette
-      multiplicateur: plafond sécurité sociale temps plein
+      multiplicateur: plafond sécurité sociale * entreprise . ACRE . prorata
       points:
         0: 100%
         0.75: 100%
@@ -3218,7 +3218,7 @@ entreprise . date de création:
     2019: 2019
     2018: 2018
     2017: 2017
-  unité: " "
+  type: date
   contrôles:
     - si: date de création > 2020
       niveau: avertissement
@@ -3342,25 +3342,28 @@ entreprise . charges:
   par défaut: 0
   unité: €
 
-dirigeant . indépendant . cotisations et contributions . réduction ACRE:
+dirigeant . indépendant . cotisations et contributions . exonérations . réduction ACRE . taux ACRE:
+  période: flexible
+  formule:
+    barème continu:
+      assiette: revenu professionnel
+      multiplicateur: plafond sécurité sociale temps plein * entreprise . ACRE . prorata
+      points:
+        0: 100%
+        0.75: 100%
+        1: 0%
+      retourne seulement le taux: oui
+
+dirigeant . indépendant . cotisations et contributions . exonérations . réduction ACRE:
   applicable si: entreprise . ACRE
   période: flexible
   formule:
     multiplication:
       assiette: cotisations - cotisations . retraite complémentaire
       taux: taux ACRE
+      facteur: prorata
 
-dirigeant . indépendant . cotisations et contributions . réduction ACRE . taux ACRE:
-  période: flexible
-  formule:
-    barème continu:
-      assiette: revenu professionnel
-      multiplicateur: plafond sécurité sociale temps plein
-      points:
-        0: 100%
-        0.75: 100%
-        1: 0%
-      retourne seulement le taux: oui
+
 
 dirigeant . indépendant . revenu net de cotisations:
   formule: 
@@ -3769,7 +3772,7 @@ dirigeant . indépendant . cotisations et contributions:
       - CSG et CRDS
       - formation professionnelle
       - conjoint collaborateur . cotisations
-      - (- réduction ACRE)
+      - (- exonérations . réduction ACRE)
   unité: €
   période: flexible
 
@@ -4057,7 +4060,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
           taux: 8%
 
 dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
-  non applicable si: exonérations . âge
   formule:
     multiplication:
       assiette: assiette
@@ -4174,31 +4176,77 @@ entreprise . ZFU:
   par défaut: non
 
 dirigeant . indépendant . cotisations et contributions . exonérations:
-dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
-  période: aucune
-  applicable si: 
-    toutes ces conditions:
-      - entreprise . date de création < 2015
-      - entreprise . ZFU
-  remplace:
-    règle: cotisations . maladie
-    par: taux * cotisations . maladie
+  somme:
+    - réduction ACRE
+    - ZFU
+    - invalidité
+    - âge
+  
+  note: La loi dit qu'il ne peut pas y avoir deux exonérations sur le même risque active pendant la même période. Pour l'instant, nous ne vérifions pas cette hypothèse.
 
+dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
+  période: flexible
+  applicable si: entreprise . ZFU
+  formule:
+    prorata temporis:
+      assiette: cotisations . maladie
+      début d'effet: entreprise . date de création
+      variations:
+        si: entreprise . effectif < 5 
+        alors:
+          tranches:
+            - avant: 10 ans
+              taux: 100%
+            - entre: 10 ans
+              et: 15 ans
+              taux: 60%
+            - entre: 15 ans
+              et: 17 ans
+              taux: 40%
+            - entre: 18 ans
+              et: 20 ans
+              taux: 20%
+        sinon: 
+          tranches:
+            - avant: 5 ans
+              taux: 100%
+            - entre: 5 ans
+              et: 6 ans
+              taux: 60%
+            - entre: 6 ans
+              et: 7 ans
+              taux: 40%
+            - entre: 7 ans
+              et: 8 ans
+              taux: 20%
+              
 dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   question: Bénéficiez-vous du dispositif d'exonération "âge" 
   description: Ce dispositif a été arrêté en 2015, mais est toujours actifs pour les personnes qui en bénéficiait avant son abbrogation.
   applicable si: entreprise . date de création < 2016
   par défaut: non
+  formule: cotisations . invalidité et décès
 
 dirigeant . indépendant . cotisations et contributions . exonérations . invalidité:
   question: Êtes-vous titulaire d’une pension d’invalidité ? 
   description:  Les personnes titulaires d’une pension d’invalidité versée par un régime des travailleurs non-salariés non agricoles bénéficient d’une exonération totale des cotisations maladie et retraite complémentaire.
+  période: flexible
   par défaut: non
-  rend non applicable: 
-    - cotisations . maladie
-    - cotisations . indemnités journalières maladie
-    - cotisations . retraite complémentaire
-  
+  formule:
+    prorata temporis:
+      assiette: 
+        somme:
+          - cotisations . maladie
+          - cotisations . indemnités journalières maladie
+          - cotisations . retraite complémentaire
+      début d'effet: début d'effet
+        
+
+dirigeant . indépendant . cotisations et contributions . exonérations . invalidité . début d'effet:
+  question: Depuis quand êtes vous titulaire de cette pension ?
+  description: Les personnes titulaires d’une pension d’invalidité versée par un régime des travailleurs non-salariés non agricoles bénéficient d’une exonération totale des cotisations maladie et retraite complémentaire.
+  par défaut: 2019
+  type: date
 
 
 situation personnelle . IJSS:
@@ -4265,38 +4313,6 @@ situation personnelle . IJSS . total:
   
 
 
-dirigeant . indépendant . cotisations et contributions . exonérations . ZFU . taux:
-  titre: taux exonération ZFU
-  formule:
-    variations:
-      - si: entreprise . effectif < 5
-        alors:     
-          barème linéaire:
-            assiette: entreprise . année d'activité
-            retourne seulement le taux: oui
-            tranches:
-            - en-dessous de: 9
-              taux: 0%
-            - de: 10 
-              à: 15
-              taux: 40%
-            - de: 16
-              à: 17
-              taux: 60%
-            - de: 18
-              à: 19
-              taux: 80%
-            - au-dessus de: 20
-              taux: 100%
-      - sinon:
-          variations:
-            - si: entreprise . année d'activité = 6
-              alors: 40%
-            - si: entreprise . année d'activité = 7
-              alors: 60%
-            - si: entreprise . année d'activité = 8
-              alors: 80%
-            - sinon: 100%
 
 situation personnelle . domiciliation fiscale à l'étranger:
   description: |
@@ -4566,27 +4582,17 @@ entreprise . ACRE:
     une de ces conditions: 
       - toutes ces conditions: 
           - dirigeant = 'auto-entrepreneur'
-          - entreprise . année d'activité < 4
-      - entreprise . année d'activité < 2
+          - entreprise . année d'activité < 3
+      - entreprise . année d'activité < 1
   question: Votre entreprise bénéficie-t-elle de l'ACRE (anciennement ACCRE) ?
   par défaut: non
 
-entreprise . ACRE . année:
-  question: Quel est l'âge de l'entreprise ?
+entreprise . ACRE . prorata:
+  période: flexible
   formule:
-    une possibilité:
-      choix obligatoire: oui
-      possibilités:
-        - moins d'un an
-        - moins de deux ans
-        - moins de trois ans
-  par défaut: moins d'un an
-
-entreprise . ACRE . année . moins d'un an:
-
-entreprise . ACRE . année . moins de deux ans:
-
-entreprise . ACRE . année . moins de trois ans:
+    prorata temporis:
+      début d'effet: entreprise . date de création
+      durée: 1 an
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
   période: flexible
@@ -4598,19 +4604,29 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ré
   période: flexible
   description: Ce taux peut dans certains cas réduire le montant des cotisations sociales de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
   formule:
-    variations:
-      - si: entreprise . ACRE . année = 'moins d'un an'
-        alors: 75%
-      - si: entreprise . ACRE . année = 'moins de deux ans'
-        alors: 50%
-      - si: entreprise . ACRE . année = 'moins de trois ans'
-        alors: 25%
+    prorata temporis:
+      début d'effet: 
+        début du trimestre: entreprise . date de création
+      durée: 3 ans
+      tranches: 
+        - avant: 1 an
+          taux: 75%
+        - entre: 1 an
+          et: 2 ans
+          taux: 50%
+        - entre: 2 ans
+          et: 3 ans
+          taux: 25%
   références:
-    Fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/je-beneficie-dexonerations/accre.html
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
+
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
-  formule: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
-  période: flexible
+  période: année
+  formule: 
+    prorata temporis: 
+      assiette: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
+      début d'effet: entreprise . date de création
+      durée: 3 ans
 
 dirigeant . auto-entrepreneur . impôt:
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3407,7 +3407,7 @@ dirigeant . indépendant . revenu professionnel:
         - entreprise . chiffre d'affaires minimum
 
 dirigeant . indépendant . conjoint collaborateur:
-  non applicable si: entreprise . rattachement libéral règlementé
+  non applicable si: dirigeant . indépendant . rattachement CIPAV
   question: Avez-vous un conjoint collaborateur ?
   description: |
     Permet au conjoint du dirigeant d'être couvert par la protection sociale moyennant le paiement de cotisations sociales supplémantaires. 
@@ -3780,11 +3780,12 @@ dirigeant . indépendant . cotisations et contributions:
   unité: €
   période: flexible
 
-entreprise . rattachement libéral règlementé:
+dirigeant . indépendant . rattachement CIPAV:
   description: |
     Les entreprises libérales non règlementées créées étaient rattachées aux règlementées pour le calcul des cotisations sociales. Depuis 2018 ce n'est plus le cas pour les auto-entrepreneurs (2019 pour les entreprise individuelles). Elles sont maintenant rattachées aux artisans-commerçants, donc dépendent de la sécurité sociale des indépendants.
   références:
     article de loi (chercher "travailleurs indépendants créant leur activité"): https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/texte#JORFARTI000036339157
+  note: pour l'instant, nous n'avons retenu que la CIPAV pour les calculs
   formule:
     une de ces conditions:
       - toutes ces conditions:
@@ -3804,17 +3805,9 @@ entreprise . rattachement libéral règlementé:
     - dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
   période: aucune
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
-  période: flexible
-  formule:
-    variations:
-      - si: entreprise . rattachement libéral règlementé
-        alors: libérale règlementée
-
-      - sinon: artisans commerçants libéraux
-
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée
+? dirigeant . indépendant . libérale règlementée . maladie
 : période: flexible
+  remplace: cotisations et contributions . cotisations . maladie
   titre: maladie libérale règlementée
   formule:
     barème continu:
@@ -3826,7 +3819,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
 
 dirigeant . indépendant . cotisations et contributions . cotisations . maladie . assiette:
   titre: assiette maladie
-
   période: flexible
   formule:
     variations:
@@ -3849,7 +3841,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
 
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
+? dirigeant . indépendant . cotisations et contributions . cotisations . maladie
 : période: flexible
   formule:
     barème:
@@ -3869,7 +3861,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
 
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable
+? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux variable
 : période: flexible
   formule:
     variations:
@@ -3877,7 +3869,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
         alors: taux RSA
       - sinon: taux
 
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA
+? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA
 : période: flexible
   formule:
     multiplication:
@@ -3886,21 +3878,21 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
   note: |
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable
+? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA part variable
 : période: flexible
   formule:
     multiplication:
       assiette: 5%
       taux: revenu professionnel / seuil supérieur de réduction
 
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction
+? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . seuil supérieur de réduction
 : période: flexible
   formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
       taux: 110%
 
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux
+? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux
 : période: flexible
   formule:
     barème continu:
@@ -3919,31 +3911,32 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
+dirigeant . indépendant . rattachement CIPAV . retraite de base:
+  période: flexible
+  remplace: cotisations et contributions . cotisations . retraite de base
+  formule: 
+    multiplication:
+      assiette: cotisations et contributions . cotisations . retraite de base . assiette
+      multiplicateur:
+      composantes:
+        - nom: tranche 1
+          plafond: plafond sécurité sociale temps plein
+          taux: 8.23%
+        - nom: tranche 2
+          plafond: 5 * plafond sécurité sociale temps plein
+          taux: 1.87%
+
 dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base:
-  période: année
+  période: flexible
   formule:
-    variations:
-      - si: entreprise . rattachement libéral règlementé
-        alors:
-          multiplication:
-            assiette: assiette
-            multiplicateur:
-            composantes:
-              - nom: tranche 1
-                plafond: plafond sécurité sociale temps plein
-                taux: 8.23%
-              - nom: tranche 2
-                plafond: 5 * plafond sécurité sociale temps plein
-                taux: 1.87%
-      - sinon:
-          barème:
-            assiette: assiette
-            multiplicateur: plafond sécurité sociale temps plein
-            tranches:
-              - en-dessous de: 1
-                taux: 17.75%
-              - au-dessus de: 1
-                taux: 0.6%
+    barème:
+      assiette: assiette
+      multiplicateur: plafond sécurité sociale temps plein
+      tranches:
+        - en-dessous de: 1
+          taux: 17.75%
+        - au-dessus de: 1
+          taux: 0.6%
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base . assiette
 : période: flexible
@@ -3959,50 +3952,51 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
+? dirigeant . indépendant . rattachement CIPAV . retraite complémentaire:
+  période: année
+  remplace: cotisations et contributions . cotisations . retraite complémentaire
+  formule:
+    barème linéaire:
+      assiette: revenu professionnel
+      tranches:
+        - en-dessous de: 26580
+          montant: 1315
+        - de: 26581
+          à: 49280
+          montant: 2630
+        - de: 49281
+          à: 57850
+          montant: 3945
+        - de: 57851
+          à: 66400
+          montant: 6575
+        - de: 66401
+          à: 83060
+          montant: 9205
+        - de: 83061
+          à: 103180
+          montant: 14465
+        - de: 103181
+          à: 123300
+          montant: 15780
+        - au-dessus de: 123300
+          montant: 17095
+
+
 ? dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire
 : période: année
   unité: €
-  note: Pour les professions libérales, nous avons retenu un des 8 régimes de retraite, celui de la CIPAV, la caisse interprofessionnelle.
   formule:
-    variations:
-      - si: entreprise . rattachement libéral règlementé
-        alors:
-          barème linéaire:
-            assiette: revenu professionnel
-            tranches:
-              - en-dessous de: 26580
-                montant: 1315
-              - de: 26581
-                à: 49280
-                montant: 2630
-              - de: 49281
-                à: 57850
-                montant: 3945
-              - de: 57851
-                à: 66400
-                montant: 6575
-              - de: 66401
-                à: 83060
-                montant: 9205
-              - de: 83061
-                à: 103180
-                montant: 14465
-              - de: 103181
-                à: 123300
-                montant: 15780
-              - au-dessus de: 123300
-                montant: 17095
-      - sinon:
-          barème:
-            assiette: revenu professionnel
-            tranches:
-              - en-dessous de: 37960
-                taux: 7%
-              - de: 37960
-                à: 162096
-                taux: 8%
-              - au-dessus de: 162096
-                taux: 0%
+    barème:
+      assiette: revenu professionnel
+      tranches:
+        - en-dessous de: 37960
+          taux: 7%
+        - de: 37960
+          à: 162096
+          taux: 8%
+        - au-dessus de: 162096
+          taux: 0%
 
 dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
   formule:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4149,6 +4149,34 @@ dirigeant . indépendant . exonération ZFU . taux:
               alors: 80%
             - sinon: 100%
 
+situation personnelle . domicilié à l'étranger:
+  description: |
+    Ces assurés ne sont pas redevables de la CSG/CRDS mais, en contrepartie ils sont redevables de la cotisation maladie sur la base d’un taux de 14,5%. Contrairement aux autres assurés commerçants/artisans ils ne bénéficient pas de la réduction du taux de la cotisation maladie en fonction du revenu déclaré.
+  question: Le travailleur est-il fiscalement domicilié à l'étranger ?
+  par défaut: non
+  rend non applicable: 
+    - dirigeant . indépendant . cotisations et contributions . CSG et CRDS
+    - contrat salarié . CSG
+    - contrat salarié . CRDS
+    - impôt
+  références: 
+    urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-csg-crds/qui-en-est-redevable.html
+
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie domicilié à l'étranger:
+  applicable si: situation personnelle . domicilié à l'étranger
+  période: flexible
+  remplace: maladie
+  formule: 
+    multiplication: 
+      assiette: maladie . assiette
+      taux: 14.5%
+
+contrat salarié . maladie . taux domicilié à l'étranger:
+  applicable si: situation personnelle . domicilié à l'étranger
+  période: aucune
+  remplace: taux salarié
+  formule: 5.50%
+
 dirigeant:
   question: Quel est le régime social du dirigeant ?
   par défaut: non

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3406,6 +3406,168 @@ dirigeant . indépendant . revenu professionnel:
         - entreprise . chiffre d'affaires
         - entreprise . chiffre d'affaires minimum
 
+dirigeant . indépendant . conjoint collaborateur:
+  non applicable si: entreprise . rattachement libéral règlementé
+  question: Avez-vous un conjoint collaborateur ?
+  description: |
+    Permet au conjoint du dirigeant d'être couvert par la protection sociale moyennant le paiement de cotisations sociales supplémantaires. 
+    Pour en bénéficier, l'époux(se) ou partenaire de Pacs du dirigeant doit:
+    - exercer une activité professionnelle régulière et habituelle dans l'entreprise 
+    - faire l'objet d'une mention au RCS pour les commerçants ou au répertoire des métiers (RM) pour les artisans 
+    - ne pas être rémunéré 
+    - ne pas être associé de la société.
+  par défaut: non
+  références: 
+    secu-independant.fr: https://www.secu-independants.fr/cotisations/conjoint/conjoint-collaborateur/?reg=lorraine&pro=artisan&act=retraite&ae=non#c46535
+    service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F33429
+  
+dirigeant . indépendant . conjoint collaborateur . assiette :
+  question: Sur quelle base le conjoint cotise-t'il ?
+  description: |
+    Le conjoint collaborateur dispose de trois choix d’assiette pour le calcul de ces cotisations :
+    - 1/3 du Plafond de Sécurité Sociale
+    - Option sur le revenu du chef avec partage ( ½ ou 1/3)
+    - Option sur le revenu du chef sans partage ( ½ ou 1/3)
+  par défaut: forfaitaire
+  formule:   
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - forfaitaire
+        - revenu sans partage
+        - revenu avec partage
+dirigeant . indépendant . conjoint collaborateur . assiette . forfaitaire:
+  description: Le conjoint collaborateur paiera des cotisations équivalentes à un revenu professionnel forfaitaire, fixé à 1/3 du plafond de la sécurité sociale.
+  formule: assiette = 'forfaitaire'
+  
+dirigeant . indépendant . conjoint collaborateur . assiette . revenu avec partage:
+  description: |
+    Le conjoint collaborateur et le gérant paieront des cotisations sociales chacun sur une part du revenu professionnel.
+    **Cette option baisse le montant des cotisations à payer pour le gérant, mais elle diminue également ses contreparties sociales (retraite, indémnité journalière, indemnité décès, etc)**
+  période: flexible
+  formule: assiette = 'revenu avec partage'
+  remplace: 
+    règle: revenu professionnel
+    par: revenu professionnel - cotisations . assiette
+    dans: 
+      - cotisations et contributions . cotisations . retraite de base
+      - cotisations et contributions . cotisations . retraite complémentaire
+      - cotisations et contributions . cotisations . invalidité et décès
+dirigeant . indépendant . conjoint collaborateur . assiette . revenu sans partage:
+  description: Le conjoint collaborateur paiera des cotisations sociales calculées sur une base d'un pourcentage du revenu professionnel du gérant de l'entreprise (un tiers ou la moitié).
+  formule: assiette = 'revenu sans partage'
+
+dirigeant . indépendant . conjoint collaborateur . assiette . pourcentage: 
+  question: À quel pourcentage du revenu le conjoint cotise-t'il ?
+  par défaut: tiers
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - tiers
+        - moitié
+        
+dirigeant . indépendant . conjoint collaborateur . assiette . pourcentage . tiers: 
+  formule: pourcentage = 'tiers'
+  titre: '1/3'
+
+dirigeant . indépendant . conjoint collaborateur . assiette . pourcentage . moitié: 
+  formule: pourcentage = 'moitié'
+  titre: '1/2'
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . assiette:
+  période: flexible
+  titre: assiette conjoint collaborateur
+  formule: 
+    multiplication:
+        assiette: revenu professionnel
+        taux: 1 / 3
+        variations: 
+          - si: assiette . forfaitaire
+            alors: 
+              assiette: plafond sécurité sociale temps plein 
+          - si: assiette . pourcentage . moitié
+            alors: 
+              taux: 50%
+          - sinon: rien
+
+dirigeant . indépendant . conjoint collaborateur . cotisations: 
+  titre: Cotisations conjoint collaborateur
+  période: flexible
+  formule: 
+    somme:
+      - retraite de base
+      - retraite complémentaire
+      - invalidité et décès
+      - indemnités journalières maladie
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . assiette retraite:
+  période: flexible
+  formule: 
+    le maximum de: 
+      - cotisations . assiette
+      - 5.25% * plafond sécurité sociale temps plein
+      - 200 * SMIC horaire
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . retraite de base:
+  période: flexible
+  formule: 
+    barème:
+      assiette: assiette retraite
+      multiplicateur: plafond sécurité sociale temps plein
+      tranches:
+        - en-dessous de: 1
+          taux: 17.75%
+        - au-dessus de: 1
+          taux: 0.6%
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire:
+  période: flexible
+  formule:
+    barème:
+      assiette: retraite complémentaire . assiette
+      tranches:
+        - en-dessous de: 37960
+          taux: 7%
+        - de: 37960
+          à: 162096
+          taux: 8%
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire . assiette:
+  période: flexible
+  titre: assiette retraite complémentaire
+  formule: 
+    le minimum de:
+      - variations:
+          - si: entreprise . catégorie d'activité = 'artisanale'
+            alors: 4 * plafond sécurité sociale temps plein
+          - sinon: 3 * plafond sécurité sociale temps plein
+      - assiette retraite
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et décès . assiette:
+  titre: assiette invalidité et décès
+  période: flexible
+  formule: 
+    le maximum de:
+      - cotisations . assiette
+      - 20% * plafond sécurité sociale temps plein
+dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et décès:
+  période: flexible
+  formule:
+    multiplication:
+      assiette: assiette 
+      plafond: plafond sécurité sociale temps plein
+      taux: 1.3%
+
+dirigeant . indépendant . conjoint collaborateur . cotisations . indemnités journalières maladie:
+  période: flexible
+  formule: 
+    multiplication:
+      assiette: plafond sécurité sociale temps plein
+      facteur: 40%
+      taux: 0.85%
+
+
 entreprise . catégorie d'activité:
   question: Quelle est votre catégorie d'activité ?
   description: Votre catégorie d'activité va déterminer une grande partie des calculs de cotisation, contribution et impôt.
@@ -3613,6 +3775,7 @@ dirigeant . indépendant . cotisations et contributions:
       - cotisations
       - CSG et CRDS
       - formation professionnelle
+      - conjoint collaborateur . cotisations
       - (- réduction ACRE)
   unité: €
   période: flexible
@@ -3842,12 +4005,13 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
                 taux: 0%
 
 dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
-  période: flexible
   formule:
     multiplication:
       assiette: assiette
       plafond: plafond sécurité sociale temps plein
       taux: 1.3%
+  période: flexible
+
 
       # TODO invalidité décès pour les libéraux
       # 3 classes, 76, 228, 380€
@@ -3895,10 +4059,12 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
       assiette: plafond sécurité sociale temps plein
       taux:
         variations:
+          - si: conjoint collaborateur
+            alors: 0.34%
           - si: entreprise . catégorie d'activité = 'artisanale'
             alors: 0.29%
           - sinon: 0.25%
-  note: Pour les commerçants et professions libérales, le taux passe à 0,34 % si votre conjoint a le statut de conjoint collaborateur.
+
   références:
     fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23459
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2836,6 +2836,7 @@ contrat salarié . taxe sur les salaires . barème:
 
 contrat salarié . régime des impatriés:
   question: Le salarié bénéficie-t-il du régime des impatriés ?
+  non applicable si: situation personnelle . domicilié à l'étranger
   par défaut: non
   description: |
     Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été appelé par une entreprise étrangère à occuper un emploi dans une entreprise établie en France ayant un lien avec la première ou si vous avez été directement recruté à l’étranger par une entreprise établie en France, vous pouvez bénéficier du régime des impatriés.
@@ -3986,7 +3987,10 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
 
 
 dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire . taux spécifique PLNR :
-  non applicable si: rattachement CIPAV
+  applicable si: 
+    toutes ces conditions: 
+      - entreprise . catégorie d'activité = 'libérale'
+      - rattachement CIPAV = non
   titre: taux spécifique profession libérale non reglementée
   question:
     Avez-vous opté pour des taux spécifique de cotisation retraite complémentaire ?
@@ -3994,6 +3998,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
     Les professions libérales non règlementées qui ont débuté leur activité à compter du 1er janvier 2019 ou ceux qui ont débuté leur activité avant la date du 1er janvier 2019  et ont opté pour le régime général des travailleurs indépendants  ont la possibilité d’opter pour des taux spécifique de la cotisation retraite complémentaire.
   références:
     Guide PL urssaf (page 10): https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Guide-Professions-liberales.pdf
+
 dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire . taux spécifique PLNR . taux:
   titre: retraite complémentaire (taux PLNR)
   description: la retraite complémentaire avec taux spécifiques
@@ -4151,8 +4156,8 @@ dirigeant . indépendant . exonération ZFU . taux:
 
 situation personnelle . domicilié à l'étranger:
   description: |
-    Ces assurés ne sont pas redevables de la CSG/CRDS mais, en contrepartie ils sont redevables de la cotisation maladie sur la base d’un taux de 14,5%. Contrairement aux autres assurés commerçants/artisans ils ne bénéficient pas de la réduction du taux de la cotisation maladie en fonction du revenu déclaré.
-  question: Le travailleur est-il fiscalement domicilié à l'étranger ?
+    Ces assurés ne sont pas redevables de la CSG/CRDS mais, en contrepartie ils sont redevables de la cotisation maladie sur la base d’un taux plus elevé.
+  question: La résidence fiscale de l'assuré est-elle domicilié à l'étranger ?
   par défaut: non
   rend non applicable: 
     - dirigeant . indépendant . cotisations et contributions . CSG et CRDS
@@ -4165,6 +4170,7 @@ situation personnelle . domicilié à l'étranger:
 dirigeant . indépendant . cotisations et contributions . cotisations . maladie domicilié à l'étranger:
   applicable si: situation personnelle . domicilié à l'étranger
   période: flexible
+  description: En contrepartie de l'exonération de CSG, les cotisants ont un taux maladie plus elevé. Contrairement aux autres assurés commerçants/artisans ils ne bénéficient pas de la réduction du taux de la cotisation maladie en fonction du revenu déclaré.
   remplace: maladie
   formule: 
     multiplication: 
@@ -4199,7 +4205,7 @@ dirigeant . assimilé salarié:
       par: oui
   rend non applicable:
     - contrat salarié . convention collective
-    - contrat salarié . rémunération . primes
+    - contrat salarié . rémunération . primes . activité
     - contrat salarié . chômage
     - contrat salarié . réduction générale
     - contrat salarié . allocations familiales . taux réduit

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -109,7 +109,6 @@ contrat salarié . CDD . CPF :
     destinataire: OPCA
     dû par: employeur
     branche: formation
-  période: flexible
 
   non applicable si:
     une de ces conditions:
@@ -260,7 +259,6 @@ contrat salarié . CDD . compensation pour congés non pris . salaire journalier
   formule: assiette mensuelle / période . jours ouvrés moyen par mois
 
 contrat salarié . CDD . prime de fin de contrat:
-  période: flexible
   indemnité:
     destinataire: salarié
 
@@ -326,7 +324,6 @@ contrat salarié . ATMP:
     branche: accidents du travail et maladies professionnelles
     destinataire: URSSAF
     responsable: CARSAT
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -590,7 +587,6 @@ contrat salarié . CDD . contrat jeune vacances:
   par défaut: non
 
 contrat salarié . CDD . indemnités salarié CDD:
-  période: flexible
   description: Cotisations employeur spécifiques au CDD
   formule:
     somme:
@@ -604,7 +600,6 @@ contrat salarié . CDD . surcoût:
     financières en contrepartie de la souplesse apportée par ce contrat; elles sont au nombre de 4.
 
     Certaines sont versées en fin de contrat, d'autres avec chaque salaire mensuel; elles sont ici ramenées à leur coût mensuel.
-  période: flexible
   formule:
     somme: #TODO à l'avenir, exprimer une somme par requête de type : obligation applicable au CDD
       - indemnités salarié CDD
@@ -701,7 +696,6 @@ contrat salarié . stage:
     - régime des impatriés
 
 contrat salarié . stage . gratification minimale:
-  période: flexible
   formule: 15% * plafond sécurité sociale temps plein
   références:
     Gratification minimale: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131
@@ -715,7 +709,6 @@ contrat salarié . exonération d'impôt des stagiaires et apprentis:
     une de ces conditions:
       - apprentissage
       - stage
-  période: flexible
   formule: SMIC
 
 contrat salarié . CDD:
@@ -740,7 +733,6 @@ contrat salarié . cotisations . assiette:
   description: |
     L'assiette des cotisations sociales est la base de calcul d'un grand nombre de cotisations sur le travail salarié. Elle comprend notamment les rémunérations en espèces (salaire de base, indemnité, primes...) et les avantages en nature (logement, véhicule...).
   référence: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/la-base-de-calcul.html
-  période: flexible
   formule:
     allègement:
       assiette: rémunération . brut
@@ -755,7 +747,6 @@ contrat salarié . cotisations . assiette . salariale:
     Les apprentis bénéficient d'une exonération de cotisations sociales jusqu'à 79% du SMIC.
   références:
     URSSAF: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-a-la/le-contrat-dapprentissage/exonerations.html
-  période: flexible
   formule:
     variations:
       - si: apprentissage
@@ -774,7 +765,6 @@ contrat salarié . rémunération . brut de base:
     C'est le salaire *brut* régulier inscrit dans le contrat de travail. Il ne change jamais entre les mois et ne peut pas être modifié sans signature des deux parties.
 
     Il ne comprend pas les indemnités, avantages sociaux, avantages en nature et primes...
-  période: flexible
   unité: €
   suggestions:
     salaire médian: 2300
@@ -829,7 +819,6 @@ contrat salarié . rémunération . brut de base . équivalent temps plein:
   question: Quel est le salaire en équivalent temps plein ?
   unité: €
   formule: brut de base / temps de travail . quotité de travail
-  période: flexible
   suggestions:
     salaire médian: 2300
     SMIC: 1522
@@ -850,7 +839,6 @@ contrat salarié . rémunération . assiette de vérification du SMIC:
   description: >
     C'est le salaire pris en compte pour vérifier que le SMIC est atteint.
   unité: €
-  période: flexible
   formule:
     somme:
       - brut de base
@@ -859,7 +847,6 @@ contrat salarié . rémunération . assiette de vérification du SMIC:
 
 contrat salarié . rémunération . primes:
   unité: €
-  période: flexible
   formule:
     somme:
       - base
@@ -867,7 +854,6 @@ contrat salarié . rémunération . primes:
 contrat salarié . rémunération . primes . base:
   formule: 0
 contrat salarié . rémunération . primes . activité:
-  période: flexible
   unité: €
   titre: primes d'activité
   description: >
@@ -881,13 +867,11 @@ contrat salarié . rémunération . primes . activité:
 
 contrat salarié . rémunération . primes . activité . base:
   titre: primes d'activité
-  période: flexible
   unité: €
   question: Quel est le montant des primes liées à l'activité du salarié ?
   par défaut: 0
 
 contrat salarié . rémunération . primes . activité . conventionnelles:
-  période: flexible
   unité: €
   formule: 0
 
@@ -895,7 +879,6 @@ contrat salarié . rémunération . brut:
   description: Toutes les sommes versées au salarié sous forme monétaire en échange de son travail.
   titre: Rémunération brute
   unité: €
-  période: flexible
   formule:
     somme:
       - rémunération . brut de base
@@ -908,7 +891,6 @@ contrat salarié . rémunération . heures supplémentaires:
   titre: rémunération heures supplémentaires
   description: La rémunération relative aux heures supplémentaires
   unité: €
-  période: flexible
   formule:
     multiplication:
       assiette: taux horaire
@@ -922,7 +904,6 @@ contrat salarié . avantages sociaux:
     Ce sont les avantages sociaux payés par l'employeur. Ils sont spécifiques à l'entreprise, et fournis par des structures privées (mutuelle, assurance...).
     Ils sont soumis à l'impôt sur le revenu.
   unité: €
-  période: flexible
   formule:
     somme:
       - prévoyance obligatoire cadre
@@ -939,7 +920,6 @@ contrat salarié . rémunération . avantages en nature:
 
 contrat salarié . rémunération . avantages en nature . montant:
   titre: Avantages en nature (montant)
-  période: flexible
   description: >
     Les avantages en nature sont soumis aux cotisations et à l'impôt sur le revenu. Ils sont pris en compte pour vérifier que le salaire minimum est atteint.
 
@@ -967,7 +947,6 @@ contrat salarié . rémunération . avantages en nature . autres:
   par défaut: non
 
 contrat salarié . rémunération . avantages en nature . autres . montant:
-  période: flexible
   question: >
     Quel est le montant de ces autres avantages ?
   par défaut: 0
@@ -1029,7 +1008,6 @@ contrat salarié . rémunération . avantages en nature . nourriture:
 
 contrat salarié . rémunération . avantages en nature . nourriture . montant:
   titre: nourriture
-  période: flexible
   unité: €
   formule:
     multiplication:
@@ -1054,7 +1032,6 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
     2 par jour: 42
 
 contrat salarié . indemnités salarié:
-  période: flexible
   formule:
     somme:
       - CDD . indemnités salarié CDD
@@ -1087,7 +1064,6 @@ plafond journalier sécurité sociale:
   unité: €
 
 contrat salarié . plafond sécurité sociale:
-  période: flexible
   acronyme: PSS
   formule: plafond sécurité sociale temps plein * temps de travail . quotité de travail
 
@@ -1118,7 +1094,6 @@ SMIC horaire:
 contrat salarié . SMIC contractuel:
   description: >
     Valeur du SMIC pro-ratisé pour prendre en compte le temps partiel et utilisé pour la détermination du salaire minimum
-  période: flexible
   formule: SMIC temps plein * temps de travail . quotité de travail
 
 contrat salarié . SMIC:
@@ -1126,7 +1101,6 @@ contrat salarié . SMIC:
     Plusieurs réductions de cotisations ([réduction générale](/documentation/contrat-salarié/réduction-générale), taux réduit d'[allocations familiales](/documentation/contrat-salarié/allocations-familiales/taux-réduit) et de [maladie](/documentation/contrat-salarié/maladie/taux-employeur/taux-réduit), réduction outre-mer) reposent sur un paramètre SMIC faisant l'objet de plusieurs ajustements pour prendre en compte le temps de travail effectif.
 
     Les heures supplémentaires sont prises en compte sans tenir compte de la majoration.
-  période: flexible
   formule: temps de travail * SMIC horaire
   références:
     Détermination du SMIC: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale/le-calcul-de-la-reduction/etape-1--determination-du-coeffi/determination-du-smic-a-prendre.html
@@ -1134,7 +1108,6 @@ contrat salarié . SMIC:
 contrat salarié . cotisations . salariales:
   titre: cotisations salariales
   unité: €
-  période: flexible
   formule:
     somme:
       - vieillesse [salarié]
@@ -1152,7 +1125,6 @@ contrat salarié . cotisations . salariales:
 
 contrat salarié . cotisations . patronales:
   titre: cotisations patronales
-  période: flexible
   unité: €
   formule:
     somme:
@@ -1187,7 +1159,6 @@ contrat salarié . rémunération . net de cotisations:
   titre: Salaire net de cotisations
   type: rémunération
   unité: €
-  période: flexible
   formule: brut - cotisations . salariales
 
 contrat salarié . rémunération . net imposable:
@@ -1196,7 +1167,6 @@ contrat salarié . rémunération . net imposable:
   unité: €
   description: |
     C'est la base utilisée pour calculer l'impôt sur le revenu.
-  période: flexible
   formule:
     allègement:
       assiette: base
@@ -1211,7 +1181,6 @@ contrat salarié . rémunération . net imposable:
 
 contrat salarié . rémunération . net imposable . base:
   unité: €
-  période: flexible
   description: Le net imposable avant les exonérations et déductions
   formule:
     somme:
@@ -1221,8 +1190,7 @@ contrat salarié . rémunération . net imposable . base:
       - CRDS
 
 ? contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées
-: période: flexible
-  unité: €
+: unité: €
   formule:
     le minimum de:
       - plafond brut
@@ -1239,7 +1207,6 @@ contrat salarié . rémunération . net imposable . base:
 contrat salarié . prime d'impatriation:
   description: La prime d'impatriation est une partie de la rémunération exonérée d'impôt sur le revenu.
   applicable si: régime des impatriés
-  période: flexible
   unité: €
   formule:
     multiplication:
@@ -1261,7 +1228,6 @@ contrat salarié . rémunération . net:
     Aussi appelé salaire net à payer (c'était du moins le cas avant l'impôt à la source).
 
     Cette somme peut varier en fonction de décisions politiques (augmentation ou diminution des cotisations) alors que le salaire brut est contractuel (pour le changer, il faut signer un avenant au contrat).
-  période: flexible
   formule: rémunération . net de cotisations - avantages en nature . montant
 
 contrat salarié . rémunération . net après impôt:
@@ -1270,7 +1236,6 @@ contrat salarié . rémunération . net après impôt:
   question: Quel est le revenu net du salarié après impôt ?
   type: salaire
   unité: €
-  période: flexible
   description: |
     Le 1er janvier 2019, l'impôt sur le revenu est prélevé à la source et apparaît donc sur la fiche de paie.
 
@@ -1575,7 +1540,6 @@ contrat salarié . prix du travail:
   titre: Coût total
   résumé: Dépensé par l'entreprise
   question: Quel est le coût total de cette embauche ?
-  période: flexible
   description: |
     Coût total d'embauche d'un salarié en incluant, en plus des éléments de rémunération, les aides différées et les coûts de medecine du travail
     > C'est donc aussi une mesure de la valeur apportée par le salarié à l'entreprise : l'employeur est prêt à verser cette somme en contrepartie du travail fourni.
@@ -1594,7 +1558,6 @@ contrat salarié . rémunération . total:
   résumé: Dépensé par l'entreprise
   type: salaire
   unité: €
-  période: flexible
   description: |
     C'est le total que l'employeur doit verser pour employer un salarié.
   formule:
@@ -1603,7 +1566,6 @@ contrat salarié . rémunération . total:
       - cotisations . patronales
 
 contrat salarié . cotisations . patronales . réductions de cotisations:
-  période: flexible
   unité: €
   formule:
     somme:
@@ -1614,8 +1576,7 @@ contrat salarié . cotisations . patronales . réductions de cotisations:
       - déduction heures supplémentaires
 
 ? contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires
-: période: flexible
-  applicable si: entreprise . effectif < 20
+: applicable si: entreprise . effectif < 20
   titre: déduction forfaitaire pour heures supplémentaires
   formule:
     multiplication:
@@ -1630,7 +1591,6 @@ contrat salarié . réduction ACRE:
     toutes ces conditions:
       - dirigeant = 'assimilé salarié'
       - entreprise . ACRE
-  période: flexible
   formule:
     multiplication:
       assiette:
@@ -1642,7 +1602,6 @@ contrat salarié . réduction ACRE:
 
 contrat salarié . réduction ACRE . taux:
   titre: taux ACRE
-  période: flexible
   formule:
     barème continu:
       assiette: cotisations . assiette
@@ -1660,7 +1619,6 @@ contrat salarié . cotisations . salariales . réduction heures supplémentaires
   aide:
     type: réduction de cotisations
   unité: €
-  période: flexible
   formule: rémunération . heures supplémentaires * taux des cotisations réduites
   références:
     Code de la sécurité sociale - Article D241-21: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000038056813&cidTexte=LEGITEXT000006073189
@@ -1684,7 +1642,6 @@ contrat salarié . cotisations . salariales . réduction heures supplémentaires
     Circulaire DSS/5B/2019/71: http://circulaire.legifrance.gouv.fr/pdf/2019/04/cir_44492.pdf
 
 contrat salarié . cotisations:
-  période: flexible
   description: Total des cotisations patronales et salariales
   formule:
     somme:
@@ -1693,13 +1650,11 @@ contrat salarié . cotisations:
 
 contrat salarié . cotisations . salariales . conventionnelles:
   titre: cotisations salariales conventionnelles
-  période: flexible
   description: Cotisations spécifiques à la convention collective
   formule: 0
 
 contrat salarié . cotisations . patronales . conventionnelles:
   titre: cotisations patronales conventionnelles
-  période: flexible
   description: Cotisations spécifiques à la convention collective
   formule: 0
 
@@ -1707,7 +1662,6 @@ contrat salarié . aides employeur:
   titre: aides à l'embauche
   résumé: Pour l'employeur, différées dans le temps
   icônes: 🎁
-  période: flexible
   description: |
     Ces aides sont appelées différées, car elles ne consistent pas en une simple réduction des cotisations mensuelles : elles interviendront a posteriori par exemple sous forme de crédit d'impôt.
 
@@ -1748,7 +1702,6 @@ entreprise:
     Le contrat lie une entreprise, identifiée par un code SIREN, et un employé.
 
 entreprise . prélèvements obligatoires:
-  période: flexible
   formule:
     somme:
       - CVAE
@@ -1756,7 +1709,6 @@ entreprise . prélèvements obligatoires:
 
 entreprise . prélèvements obligatoires . CVAE:
   titre: Cotisation sur la valeur ajoutée des entreprises
-  période: flexible
   formule: 0
   note: Cette contribution concerne les entreprises ou travailleurs indépendants qui réalisent plus de  500 000 € de chiffre d'affaires. Elle n'est pour l'instant **pas intégrée dans nos calculs**.
   références:
@@ -1765,7 +1717,6 @@ entreprise . prélèvements obligatoires . CVAE:
 entreprise . prélèvements obligatoires . CFE:
   titre: Cotisation foncière des entreprises
   formule: 0
-  période: flexible
   note: Cette cotisation n'est pas due pour la première année d'une entreprise, ni pour un chiffre d'affaires inférieur à 5000€. La CFE n'est **pas encore intégrée** dans nos calculs.
   références:
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23547
@@ -1868,7 +1819,6 @@ contrat salarié . temps de travail:
     somme:
       - temps contractuel
       - heures supplémentaires
-  période: flexible
   description: En France, la base légale du travail est de 35h/semaine. Mais un grand nombre de dispositions existantes permettent de faire varier ce nombre. Vous pouvez les retrouver sur la page [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/N458) dédiée.
 
 contrat salarié . temps de travail . temps contractuel:
@@ -2020,7 +1970,6 @@ contrat salarié . réduction générale:
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
   applicable si: cotisations . assiette <= plafond de l'assiette
-  période: flexible
   formule:
     le minimum de:
       - assiette
@@ -2046,7 +1995,6 @@ contrat salarié . réduction générale:
       valeur attendue: 0
 
 contrat salarié . réduction générale . écart au plafond de l'assiette:
-  période: flexible
   formule: plafond de l'assiette - cotisations . assiette
 
 contrat salarié . réduction générale . multiplicateur:
@@ -2061,7 +2009,6 @@ contrat salarié . réduction générale . paramètre T:
 
 contrat salarié . réduction générale . assiette:
   titre: Assiette de la réduction générale
-  période: flexible
   formule:
     somme:
       - allocations familiales
@@ -2076,7 +2023,6 @@ contrat salarié . réduction générale . assiette:
     changements 2019: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/la-reduction-generale-des-cotisa.html
 
 contrat salarié . réduction générale . assiette . part de la cotisation ATMP:
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2087,7 +2033,6 @@ contrat salarié . réduction générale . assiette . part de la cotisation ATMP
     Code de la sécurité sociale - Mise à jour du taux: https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=B2573099C91B1ACDA218B214D650C071.tplgfr25s_3?idArticle=JORFARTI000037884643&cidTexte=JORFTEXT000037884638&dateTexte=29990101&categorieLien=id
 
 contrat salarié . réduction générale . plafond de l'assiette:
-  période: flexible
   formule: 1.6 * SMIC
 
 contrat salarié . contribution d'équilibre général:
@@ -2096,7 +2041,6 @@ contrat salarié . contribution d'équilibre général:
     branche: retraite
     type de retraite: complémentaire
     destinataire: AGIRC-ARRCO
-  période: flexible
   formule:
     barème:
       assiette: cotisations . assiette
@@ -2130,7 +2074,6 @@ contrat salarié . contribution d'équilibre technique:
     type de retraite: complémentaire
     destinataire: AGIRC-ARRCO
   applicable si: cotisations . assiette > plafond sécurité sociale
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2152,7 +2095,6 @@ contrat salarié . retraite complémentaire:
     destinataire: AGIRC-ARRCO
   description: |
     Cotisations de retraite complémentaire.
-  période: flexible
   formule:
     barème:
       assiette: cotisations . assiette
@@ -2197,7 +2139,6 @@ contrat salarié . AGS:
   references:
     calcul: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31409
 
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2205,7 +2146,6 @@ contrat salarié . AGS:
       taux: 0.15%
 
 contrat salarié . allocations familiales:
-  période: flexible
   cotisation:
     dû par: employeur
     branche: famille
@@ -2227,12 +2167,10 @@ contrat salarié . allocations familiales . taux:
     calcul: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil.html
 
 contrat salarié . allocations familiales . taux réduit:
-  période: flexible
   formule: cotisations . assiette < plafond de réduction
 
 contrat salarié . allocations familiales . taux réduit . plafond de réduction:
   titre: Plafond de la réduction des allocations familiales
-  période: flexible
   formule: SMIC * 3.5
 
 contrat salarié . APEC:
@@ -2248,7 +2186,6 @@ contrat salarié . APEC:
 
   applicable si: statut cadre
 
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2271,7 +2208,6 @@ contrat salarié . chômage:
     calcul: http://www.pole-emploi.fr/employeur/taux-des-contributions-de-l-assurance-chomage-et-cotisations-ags-@/article.jspz?id=61567
     urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/lassurance-chomage-et-lags/les-taux.html
     changements 2017: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/contributions-patronales-dassura.html
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2310,7 +2246,6 @@ contrat salarié . complémentaire santé:
     branche: santé
   références:
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F20739
-  période: flexible
   formule:
     multiplication:
       assiette: forfait
@@ -2353,7 +2288,6 @@ contrat salarié . complémentaire santé . part salarié:
 
 contrat salarié . complémentaire santé . forfait:
   titre: Forfait de complémentaire santé entreprise
-  période: flexible
   description: |
     L'employeur a l'obligation de proposer une offre de complémentaire santé. Il doit prendre en charge la moitié du montant,
     ce que nous avons retenu pour cette simulation, ou davantage. Le montant est libre, tant qu'elle couvre un panier légal de soins.
@@ -2419,7 +2353,6 @@ contrat salarié . contribution au dialogue social:
     - https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-contribution-patronale-au-dia.html
     - https://www.service-public.fr/professionnels-entreprises/vosdroits/F33308
 
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2427,7 +2360,6 @@ contrat salarié . contribution au dialogue social:
 
 contrat salarié . assiette CSG et CRDS:
   note: Cette assiette est complexe, cette version n'est qu'une simplification.
-  période: flexible
   références:
     calcul: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-csg-crds/les-revenus-salariaux-soumis-a-l.html
     abattement: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-csg-crds/abattement-et-deductions/les-revenus-exclus-de-labattemen.html
@@ -2438,7 +2370,6 @@ contrat salarié . assiette CSG et CRDS:
       - avantages sociaux
 
 contrat salarié . assiette CSG et CRDS . assiette abattue:
-  période: flexible
   formule:
     barème:
       assiette: cotisations . assiette
@@ -2451,7 +2382,6 @@ contrat salarié . assiette CSG et CRDS . assiette abattue:
           taux: 100%
 
 contrat salarié . CSG . assiette heures supplémentaires défiscalisées:
-  période: flexible
   formule:
     multiplication:
       assiette: rémunération . net imposable . heures supplémentaires défiscalisées
@@ -2460,7 +2390,6 @@ contrat salarié . CSG . assiette heures supplémentaires défiscalisées:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
 
 contrat salarié . CSG . assiette CSG déductible:
-  période: flexible
   unité: €
   formule: assiette CSG et CRDS - assiette heures supplémentaires défiscalisées
 
@@ -2471,7 +2400,6 @@ contrat salarié . CSG:
   description: |
     Contribution sociale généralisée.
     Prélèvement obligatoire qui participe au financement de la sécurité sociale.
-  période: flexible
   formule:
     multiplication:
       composantes:
@@ -2509,7 +2437,6 @@ contrat salarié . CRDS:
     impôt: oui
     dû par: salarié
   description: Contribution pour le remboursement de la dette sociale
-  période: flexible
   formule:
     multiplication:
       assiette: assiette CSG et CRDS
@@ -2525,7 +2452,6 @@ contrat salarié . FNAL:
     branche: famille
   références:
     calcul: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-contribution-au-fonds-nationa.html
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2568,7 +2494,6 @@ contrat salarié . formation professionnelle:
     - taux de **0,70 %** pour le franchissement en année **N+3**  (1,3 % pour les entreprises de travail temporaire)
     - taux de **0,90 %** pour le franchissement en année **N+4** (1,3 % pour les entreprises de travail temporaire)
     - taux de **1 %** pour le franchissement en année **N+5** (1,3 % pour les entreprises de travail temporaire)
-  période: flexible
   non applicable si:
     toutes ces conditions:
       - entreprise . effectif < 11
@@ -2596,7 +2521,6 @@ contrat salarié . maladie:
     fiche: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-maladie---maternit.html
     Décret n° 2017-1891 relatif au taux des cotisations d'assurance maladie: https://www.legifrance.gouv.fr/eli/decret/2017/12/30/CPAS1732212D/jo/texte
     Réduction 2019: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/une-reduction-des-cotisations-pa.html
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2627,7 +2551,6 @@ contrat salarié . maladie . taux employeur:
       - sinon: 13%
 
 contrat salarié . maladie . taux employeur . taux réduit:
-  période: flexible
   formule: cotisations . assiette < plafond de réduction employeur
 
 contrat salarié . maladie . taux salarié:
@@ -2639,7 +2562,6 @@ contrat salarié . maladie . taux salarié:
       - sinon: 0%
 
 contrat salarié . maladie . plafond de réduction employeur:
-  période: flexible
   formule: 2.5 * SMIC
 
 contrat salarié . médecine du travail:
@@ -2673,7 +2595,6 @@ contrat salarié . participation effort de construction:
     L'employeur a le choix entre verser cet impôt à un "organisme du 1% patronal" agréé, investir la somme dans le logement de ses salariés, ou accorder à eux et leur famille des prêts de construction à taux réduit.
 
   applicable si: entreprise . effectif >= 20
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2692,7 +2613,6 @@ contrat salarié . prévoyance obligatoire cadre:
   références:
     minimum: http://www.axios.fr/150-tranche-a-evitez-une-erreur-a-160-000-euros
   applicable si: statut cadre
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2715,7 +2635,6 @@ contrat salarié . taxe d'apprentissage:
     csa: http://www.opcalia.com/employeurs/financer-la-formation-et-lapprentissage/taxe-dapprentissage/contribution-supplementaire-a-lapprentissage-csa/
 
   note: Taxe complexe, comportant notamment des exonérations non prises en compte ici.
-  période: flexible
   formule:
     somme:
       - base
@@ -2723,7 +2642,6 @@ contrat salarié . taxe d'apprentissage:
 
 contrat salarié . taxe d'apprentissage . assiette:
   titre: assiette de la taxe d'apprentissage
-  période: flexible
   description: Le salaire des apprentis est partiellement exonéré dans la base de calcul de la taxe d'apprentissage.
   formule:
     variations:
@@ -2740,7 +2658,6 @@ contrat salarié . taxe d'apprentissage . assiette:
 
 contrat salarié . taxe d'apprentissage . base:
   titre: taxe d'apprentissage de base
-  période: flexible
   formule:
     multiplication:
       assiette: assiette
@@ -2756,7 +2673,6 @@ contrat salarié . taxe d'apprentissage . contribution supplémentaire:
       - entreprise . effectif >= 250
       - entreprise . ratio alternants < 5%
 
-  période: flexible
   formule:
     multiplication:
       assiette: assiette
@@ -2794,7 +2710,6 @@ contrat salarié . taxe d'apprentissage . csa au taux majoré:
       - entreprise . ratio alternants < 1%
 
 contrat salarié . taxe sur les salaires . assiette de base:
-  période: flexible
   formule:
     somme:
       - cotisations . assiette
@@ -2803,7 +2718,6 @@ contrat salarié . taxe sur les salaires . assiette de base:
     assiette: http://bofip.impots.gouv.fr/bofip/6690-PGP.html
 
 contrat salarié . taxe sur les salaires . assiette:
-  période: flexible
   formule:
     allègement:
       assiette: assiette de base
@@ -2865,7 +2779,6 @@ contrat salarié . régime des impatriés:
     Article 155B du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006307476&dateTexte=&categorieLien=cid
 
 entreprise . taxe sur les salaires . barème:
-  période: flexible
   formule: contrat salarié . taxe sur les salaires . barème * effectif
 
 entreprise . taxe sur les salaires . abattement associations:
@@ -2892,7 +2805,6 @@ contrat salarié . taxe sur les salaires:
     une de ces conditions:
       - entreprise . association non lucrative
       - entreprise . établissement bancaire
-  période: flexible
   formule: entreprise . taxe sur les salaires / entreprise . effectif
 
   note: Cette implémentation de la taxe sur les salaires est spécifique aux associations à but non lucratif, elle est donc largement simplifiée. Plein d'autres organisations sont concernées, en fonction de la TVA qu'elles paient. Les associations y sont assujetties automatiquement.
@@ -2924,7 +2836,6 @@ contrat salarié . versement transport:
   cotisation:
     branche: transport
     dû par: employeur
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2940,7 +2851,6 @@ contrat salarié . vieillesse:
     destinataire: CNAV
     # CTP: 100
   description: Cotisation au régime de retraite de base des salariés.
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2999,7 +2909,6 @@ contrat salarié . forfait social:
     Fiche URSSAF: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/le-forfait-social.html
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31532
     Code du travail - Article L137-15: https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000019950196&cidTexte=LEGITEXT000006073189
-  période: flexible
   formule:
     multiplication:
       assiette: avantages sociaux
@@ -3012,7 +2921,6 @@ impôt:
   icônes: 🏛️
   description: Cet ensemble de formules est un modèle ultra-simplifié de l'impôt sur le revenu, qui ne prend en compte que l'abattement 10%, le barème et la décôte.
   titre: impôts sur le revenu
-  période: flexible
   unité: €
   formule:
     somme:
@@ -3085,7 +2993,6 @@ impôt . méthode de calcul . prélèvement à la source:
 impôt . revenu imposable:
   description: |
     C'est le revenu à prendre en compte pour calculer l'impôt avec un taux moyen d'imposition (neutre ou personnalisé).
-  période: flexible
   formule:
     allègement:
       assiette:
@@ -3104,7 +3011,7 @@ impôt . revenu imposable . abattement contrat court:
       - contrat salarié
       - contrat salarié . CDD
       - contrat salarié . CDD . durée contrat <= 2
-  formule: 50% * contrat salarié . SMIC temps plein . net imposable [mois]
+  formule: 50% * contrat salarié . SMIC temps plein . net imposable [mensuel]
   note: Cet abattement s'applique aussi pour les conventions de stage ou les contrats de mission (intérim) de moins de 2 mois.
   références:
     Bofip - dispositions spécifiques aux contrats courts: https://bofip.impots.gouv.fr/bofip/11252-PGP.html?identifiant=BOI-IR-PAS-20-20-30-10-20180515
@@ -3113,14 +3020,12 @@ impôt . revenu abattu:
   description: |
     L'impôt est calculé sur un revenu abattu : il est diminué (par exemple de 10%) pour prendre en compte une estimation des *frais professionnels* de l'activité rémunérée.
     Par exemple, on peut considérer qu'un salarié use ses chaussures pour aller au travail. Ces chaussures, il les a acheté avec son argent, donc du revenu sur lequel il a injustement payé de l'impôt.
-  période: flexible
   formule:
     somme:
       - revenu abattu par défaut
       - dirigeant . auto-entrepreneur . impôt . revenu imposable
 
 impôt . revenu abattu par défaut:
-  période: flexible
   description: Dans le cas général, l'impôt est calculé après l'application d'un abattement forfaitaire fixe. Chacun peut néanmoins opter pour la déclaration de ses *frais réels*, qui viendront remplacer ce forfait par défaut.
   formule:
     allègement:
@@ -3234,19 +3139,16 @@ entreprise . chiffre d'affaires:
   titre: chiffre d'affaires (H.T.)
   question: Quel est votre chiffre d'affaires envisagé ?
   résumé: Le montant des ventes réalisées
-  période: flexible
   unité: €
   formule: dirigeant . rémunération totale + charges
 
 entreprise . chiffre d'affaires minimum:
   description: Le montant minimum des ventes (H.T) à réaliser pour atteindre le seuil de rentabilité.
-  période: flexible
   question: Quel est votre chiffre d'affaires minimum envisagé ?
   unité: €
   formule: chiffre d'affaires
 
 entreprise . chiffre d'affaires de société:
-  période: flexible
   formule:
     somme:
       - dirigeant . rémunération totale / rémunération du dirigeant
@@ -3260,12 +3162,10 @@ entreprise . rémunération du dirigeant:
   par défaut: 1
 
 entreprise . bénéfice:
-  période: flexible
   formule: chiffre d'affaires - charges dont rémunération dirigeant
 
 entreprise . résultat net:
   résumé: Ce qu'il reste après impôt sur les sociétés
-  période: flexible
   formule: bénéfice - impôt sur les sociétés
 
 entreprise . impôt sur les sociétés:
@@ -3285,7 +3185,6 @@ entreprise . impôt sur les sociétés:
     fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23575
 
 entreprise . charges dont rémunération dirigeant:
-  période: flexible
   formule: charges + dirigeant . rémunération totale
 
 dirigeant . rémunération totale:
@@ -3296,7 +3195,6 @@ dirigeant . rémunération totale:
     Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
 
     On peut aussi considérer que c'est la valeur monétaire du travail du dirigeant.
-  période: flexible
   formule:
     variations:
       - si: indépendant
@@ -3338,12 +3236,10 @@ entreprise . charges:
 
   références:
     Charges déductibles ou non du résultat fiscal d'une entreprise: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31973
-  période: flexible
   par défaut: 0
   unité: €
 
 dirigeant . indépendant . cotisations et contributions . exonérations . réduction ACRE . taux ACRE:
-  période: flexible
   formule:
     barème continu:
       assiette: revenu professionnel
@@ -3371,7 +3267,6 @@ dirigeant . indépendant . revenu net de cotisations:
       - revenu professionnel
       - situation personnelle . IJSS . défiscalisées
       - (- cotisations et contributions . CSG et CRDS [non déductible])
-  période: flexible
   résumé: Avant impôt
   question: Quel revenu avant impôt voulez-vous toucher ?
   description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
@@ -3387,7 +3282,6 @@ dirigeant . indépendant . revenu professionnel:
 
     Il faut donc voir ce calcul comme *le montant qui devra de toute façon être payé* à court terme après 2 ans d'exercice.
 
-  période: flexible
   unité: €
   formule:
     inversion numérique:
@@ -3435,7 +3329,6 @@ dirigeant . indépendant . conjoint collaborateur . assiette . revenu avec parta
   description: |
     Le conjoint collaborateur et le gérant paieront des cotisations sociales chacun sur une part du revenu professionnel.
     **Cette option baisse le montant des cotisations à payer pour le gérant, mais elle diminue également ses contreparties sociales (pension de retraite, indemnité décès, etc)**
-  période: flexible
   formule: assiette = 'revenu avec partage'
   remplace: 
     règle: revenu professionnel
@@ -3467,7 +3360,6 @@ dirigeant . indépendant . conjoint collaborateur . assiette . pourcentage . moi
   titre: '1/2'
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . assiette:
-  période: flexible
   titre: assiette conjoint collaborateur
   formule: 
     multiplication:
@@ -3484,7 +3376,6 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . assiette:
 
 dirigeant . indépendant . conjoint collaborateur . cotisations: 
   titre: Cotisations conjoint collaborateur
-  période: flexible
   formule: 
     somme:
       - retraite de base
@@ -3493,7 +3384,6 @@ dirigeant . indépendant . conjoint collaborateur . cotisations:
       - indemnités journalières maladie
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . assiette retraite:
-  période: flexible
   formule: 
     le maximum de: 
       - cotisations . assiette
@@ -3501,7 +3391,6 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . assiette retra
       - 200 * SMIC horaire
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite de base:
-  période: flexible
   formule: 
     barème:
       assiette: assiette retraite
@@ -3513,7 +3402,6 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite de ba
           taux: 0.6%
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire:
-  période: flexible
   formule:
     barème:
       assiette: retraite complémentaire . assiette
@@ -3525,7 +3413,6 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite compl
           taux: 8%
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire . assiette:
-  période: flexible
   titre: assiette retraite complémentaire
   formule: 
     le minimum de:
@@ -3537,13 +3424,11 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite compl
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et décès . assiette:
   titre: assiette invalidité et décès
-  période: flexible
   formule: 
     le maximum de:
       - cotisations . assiette
       - 20% * plafond sécurité sociale temps plein
 dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et décès:
-  période: flexible
   formule:
     multiplication:
       assiette: assiette 
@@ -3551,7 +3436,6 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et
       taux: 1.3%
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . indemnités journalières maladie:
-  période: flexible
   formule: 
     multiplication:
       assiette: plafond sécurité sociale temps plein
@@ -3753,7 +3637,6 @@ dirigeant . indépendant:
   formule: dirigeant = 'indépendant'
 
 dirigeant . indépendant . cotisations et contributions . cotisations:
-  période: flexible
   références:
     assiettes et taux: https://www.secu-independants.fr/baremes/cotisations-et-contributions
   formule:
@@ -3774,7 +3657,6 @@ dirigeant . indépendant . cotisations et contributions:
       - conjoint collaborateur . cotisations
       - (- exonérations . réduction ACRE)
   unité: €
-  période: flexible
 
 
 dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac: 
@@ -3783,12 +3665,10 @@ dirigeant . indépendant . cotisations et contributions . cotisations . déducti
   description: |
     Si vous exercez une activité de débit de tabac simultanément à une activité commerciale, vous avez la possibilité d’opter pour le calcul de votre cotisation d’assurance vieillesse sur le seul revenu tiré de votre activité commerciale (en effet, les remises pour débit de tabac sont soumises par ailleurs à un prélèvement vieillesse particulier). Nous attirons cependant votre attention sur le fait qu’en cotisant sur une base moins importante, excluant les revenus de débit de tabac, vos droits à retraite pour l’assurance vieillesse des commerçants en seront diminués.
   unité: €
-  période: flexible
   par défaut: non
 
 dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac . revenus déduits: 
   titre: revenu professionnel (avec déduction tabac) 
-  période: flexible
   applicable si: déduction tabac
   unité: €
   remplace: 
@@ -3840,8 +3720,7 @@ dirigeant . indépendant . PLNR régime général:
   par défaut: non
 
 ? dirigeant . rattachement CIPAV . maladie
-: période: flexible
-  remplace: indépendant . cotisations et contributions . cotisations . maladie
+: remplace: indépendant . cotisations et contributions . cotisations . maladie
   titre: maladie libérale règlementée
   formule:
     barème continu:
@@ -3853,7 +3732,6 @@ dirigeant . indépendant . PLNR régime général:
 
 dirigeant . indépendant . cotisations et contributions . cotisations . maladie . assiette:
   titre: assiette maladie
-  période: flexible
   formule:
     variations:
       - si: situation personnelle . RSA
@@ -3868,7 +3746,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
 : titre: Maladie 2
   description: Cotisations pour les indemnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
-  période: flexible
   formule:
     multiplication:
       assiette: maladie . assiette
@@ -3876,8 +3753,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
       plafond: 5 * plafond sécurité sociale temps plein
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . maladie
-: période: flexible
-  formule:
+: formule:
     barème:
       assiette: assiette
       multiplicateur: plafond sécurité sociale temps plein
@@ -3896,16 +3772,14 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux variable
-: période: flexible
-  formule:
+: formule:
     variations:
       - si: situation personnelle . RSA
         alors: taux RSA
       - sinon: taux
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA
-: période: flexible
-  formule:
+: formule:
     multiplication:
       assiette: taux RSA part variable + 1.35%
       plafond: 6.35%
@@ -3913,22 +3787,19 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA part variable
-: période: flexible
-  formule:
+: formule:
     multiplication:
       assiette: 5%
       taux: revenu professionnel / seuil supérieur de réduction
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . seuil supérieur de réduction
-: période: flexible
-  formule:
+: formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
       taux: 110%
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux
-: période: flexible
-  formule:
+: formule:
     barème continu:
       retourne seulement le taux: oui
       assiette: revenu professionnel
@@ -3946,7 +3817,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
 dirigeant . rattachement CIPAV . retraite de base:
-  période: flexible
   remplace: indépendant . cotisations et contributions . cotisations . retraite de base
   formule: 
     multiplication:
@@ -3961,7 +3831,6 @@ dirigeant . rattachement CIPAV . retraite de base:
           taux: 1.87%
 
 dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base:
-  période: flexible
   formule:
     barème:
       assiette: assiette
@@ -3973,8 +3842,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
           taux: 0.6%
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base . assiette
-: période: flexible
-  titre: assiette retraite de base
+: titre: assiette retraite de base
   formule:
     variations:
       - si: situation personnelle . RSA
@@ -4034,7 +3902,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
   titre: retraite complémentaire (taux PLNR)
   description: la retraite complémentaire avec taux spécifiques
   remplace: retraite complémentaire
-  période: flexible
   formule: 
     barème:
       assiette: revenu professionnel
@@ -4065,14 +3932,12 @@ dirigeant . indépendant . cotisations et contributions . cotisations . invalidi
       assiette: assiette
       plafond: plafond sécurité sociale temps plein
       taux: 1.3%
-  période: flexible
 
 
       # TODO invalidité décès pour les libéraux
       # 3 classes, 76, 228, 380€
 ? dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette
-: période: flexible
-  titre: assiette invalidité et décès
+: titre: assiette invalidité et décès
   formule:
     variations:
       - si: situation personnelle . RSA
@@ -4085,7 +3950,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . invalidi
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
-  période: flexible
   formule:
     multiplication:
       assiette: assiette
@@ -4122,7 +3986,6 @@ dirigeant . indépendant . revenus étrangers:
   par défaut: non
 
 dirigeant . indépendant . revenus étrangers . montant:
-  période: flexible
   unité: €
   titre: revenus perçu à l'étranger
   question: Quel est leur montant ?
@@ -4130,7 +3993,6 @@ dirigeant . indépendant . revenus étrangers . montant:
 
 
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette:
-  période: flexible
   formule:
     somme:
       - revenu professionnel
@@ -4142,7 +4004,6 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
 
 
 dirigeant . indépendant . cotisations et contributions . formation professionnelle:
-  période: flexible
   formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
@@ -4161,8 +4022,7 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-indépendant/transfert-du-recouvrement-de-la.html
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . allocations familiales
-: période: flexible
-  formule:
+: formule:
     barème continu:
       assiette: revenu professionnel
       multiplicateur: plafond sécurité sociale temps plein
@@ -4261,7 +4121,6 @@ situation personnelle . IJSS:
 
 situation personnelle . IJSS . montant:
   non applicable si: ALD
-  période: flexible
   titre: indemnités journalières fiscalisées
   par défaut: 0
   question: Quel était leur montant total brut ?
@@ -4285,10 +4144,8 @@ situation personnelle . IJSS . ALD . autres indemnités . montant:
   question: Quel était le montant de vos autres indemnités ?
   par défaut: 0
   unité: €
-  période: flexible
 
 situation personnelle . IJSS . défiscalisées:
-  période: flexible
   applicable si: ALD
   titre: indemnités journalières défiscalisées
   question: Quel était le montant de vos indemnités ALD ?
@@ -4297,7 +4154,6 @@ situation personnelle . IJSS . défiscalisées:
 
 situation personnelle . IJSS . fiscalisées:
   titre: indemnités journalières fiscalisées
-  période: flexible
   formule: 
     somme: 
       - IJSS . montant
@@ -4305,7 +4161,6 @@ situation personnelle . IJSS . fiscalisées:
 
 situation personnelle . IJSS . total:
   titre: total indemnités journalières
-  période: flexible
   formule:
     somme: 
       - fiscalisées
@@ -4330,7 +4185,6 @@ situation personnelle . domiciliation fiscale à l'étranger:
 dirigeant . indépendant . cotisations et contributions . cotisations . maladie domiciliation fiscale étranger:
   applicable si: situation personnelle . domiciliation fiscale à l'étranger
   titre: Maladie (domiciliation fiscale à l'étranger)
-  période: flexible
   description: En contrepartie de l'exonération de CSG, les cotisants ont un taux maladie plus elevé. Contrairement aux autres assurés commerçants/artisans ils ne bénéficient pas de la réduction du taux de la cotisation maladie en fonction du revenu déclaré.
   remplace: maladie
   formule: 
@@ -4395,7 +4249,6 @@ dirigeant . auto-entrepreneur:
 
 dirigeant . auto-entrepreneur . base des cotisations:
   formule: entreprise . chiffre d'affaires
-  période: flexible
   contrôles:
     - si: base des cotisations > plafond
       message: Seuil de chiffre d'affaires dépassé. [En savoir plus](/documentation/auto-entrepreneur/plafond)
@@ -4428,7 +4281,6 @@ dirigeant . auto-entrepreneur . revenu net de cotisations:
   question: Quel revenu avant impôt voulez-vous toucher ?
   description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
   formule: dirigeant . rémunération totale - cotisations et contributions
-  période: flexible
   unité: €
 
 dirigeant . auto-entrepreneur . cotisations et contributions:
@@ -4441,12 +4293,10 @@ dirigeant . auto-entrepreneur . cotisations et contributions:
       - entreprise . prélèvements obligatoires
   références:
     Imposition du micro-entrepreneur: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23267
-  période: flexible
 
 dirigeant . auto-entrepreneur . cotisations et contributions . TFC:
   titre: Taxes pour frais de chambre
   unité: €
-  période: flexible
   note: |
     Nous n'avons pas intégré les exceptions suivantes :
 
@@ -4461,7 +4311,6 @@ dirigeant . auto-entrepreneur . cotisations et contributions . TFC:
 
 dirigeant . auto-entrepreneur . cotisations et contributions . TFC . commerce:
   titre: taxe pour frais de chambre de commerce
-  période: flexible
   unité: €
   applicable si: entreprise . catégorie d'activité = 'commerciale ou industrielle'
   formule:
@@ -4477,7 +4326,6 @@ dirigeant . auto-entrepreneur . cotisations et contributions . TFC . commerce:
           - sinon: 0.044%
 
 dirigeant . auto-entrepreneur . cotisations et contributions . TFC . métiers:
-  période: flexible
   unité: €
   titre: taxe pour frais de chambre des métiers
   applicable si: entreprise . catégorie d'activité = 'artisanale'
@@ -4493,7 +4341,6 @@ dirigeant . auto-entrepreneur . cotisations et contributions . TFC . métiers:
 ? dirigeant . auto-entrepreneur . cotisations et contributions . contribution formation professionnelle
 : titre: Contribution à la formation professionnelle
   unité: €
-  période: flexible
   références:
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23459
   formule:
@@ -4519,7 +4366,6 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
     L'auto-entreprise est un régime simplifié : plutôt qu'une fiche de paie complexe, toutes les cotisations sont groupées dans un *forfait* dont le taux dépend de la catégorie d'activité.
 
     Depuis janvier 2019, toute nouvelle auto-entreprise peut bénéficier de l'ACRE, une réduction de cotisations, dégressive sur 3 ans.
-  période: flexible
   unité: €
   formule:
     barème:
@@ -4538,7 +4384,6 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
   unité: €
   # L'ACOSS ne veut pas communiquer sur le pourcentage des cotisations fléchés pour la retraite complémentaire pour les PL
   non applicable si: entreprise . catégorie d'activité = 'libérale'
-  période: flexible
   formule:
     multiplication:
       assiette: base des cotisations
@@ -4683,7 +4528,6 @@ dirigeant . auto-entrepreneur . impôt . versement libératoire . montant:
     - 1,7% si l’activité est une activité de services relevant des bénéfices industriels et commerciaux (BIC)
     - 2,2% pour les autres prestations de services relevants des bénéfices non commerciaux (BNC)
   unité: €
-  période: flexible
 
   formule:
     multiplication:
@@ -4702,12 +4546,10 @@ dirigeant . auto-entrepreneur . impôt . versement libératoire . montant:
 
 dirigeant . auto-entrepreneur . impôt . revenu imposable:
   non applicable si: versement libératoire
-  période: flexible
   formule: revenu abattu
 
 dirigeant . auto-entrepreneur . impôt . revenu abattu:
   titre: revenu abattu auto-entrepreneur
-  période: flexible
   formule:
     allègement:
       assiette: base des cotisations
@@ -4715,7 +4557,6 @@ dirigeant . auto-entrepreneur . impôt . revenu abattu:
 
 revenus net de cotisations:
   résumé: Avant impôt
-  période: flexible
   question: Quel revenu avant impôt voulez-vous toucher ?
   description: |
     Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
@@ -4728,7 +4569,6 @@ revenus net de cotisations:
 revenu net après impôt:
   unité: €
   résumé: Versé sur le compte bancaire
-  période: flexible
   question: Quel revenu voulez-vous toucher ?
   description: |
     Il s'agit du revenu net de charges, cotisations et d'impôts.
@@ -4765,7 +4605,6 @@ protection sociale . retraite:
     INSEE: https://www.insee.fr/fr/statistiques/fichier/3549496/REVPMEN18_F1.21_niv-pauv-pers-agees.pdf
 
   unité: €
-  période: flexible
   formule:
     somme:
       - base
@@ -4787,7 +4626,6 @@ protection sociale . retraite:
 protection sociale . retraite . base:
   titre: pension de retraite de base
   unité: €
-  période: flexible
   formule:
     multiplication:
       plafond: plafond sécurité sociale temps plein
@@ -4799,7 +4637,6 @@ protection sociale . retraite . base:
 
 protection sociale . retraite . base . taux de la pension:
   description: Le taux appliqué, avec décote ou surcote en fonction du nombre de trimestres cotisés.
-  période: flexible
   formule:
     variations:
       - si: trimestres validés par an = 0
@@ -5239,7 +5076,6 @@ contrat salarié . lodeom . réduction outre-mer:
           - éligible barème compétitivité renforcée
           - éligible barème innovation et croissance
 
-  période: flexible
 
   formule:
     le minimum de:
@@ -5349,11 +5185,9 @@ contrat salarié . lodeom . réduction outre-mer:
       valeur attendue: 0
 
 contrat salarié . lodeom . plafond de l'assiette:
-  période: flexible
   formule: borne supérieure * SMIC
 
 contrat salarié . lodeom . écart au plafond de l'assiette:
-  période: flexible
   formule: plafond de l'assiette - cotisations . assiette
 
 contrat salarié . lodeom . éligible barème compétitivité:
@@ -5437,7 +5271,6 @@ contrat salarié . lodeom . borne supérieure:
 
 contrat salarié . lodeom . multiplicateur:
   note: pour le barème 1 le dénominateur vaut 0,9
-  période: flexible
   formule: (borne inférieure * paramètre T) / (borne supérieure - borne inférieure)
 
 contrat salarié . lodeom . paramètre T:
@@ -5483,7 +5316,6 @@ contrat salarié . convention collective . HCR . montant forfaitaire d'un repas:
 
 ? contrat salarié . convention collective . HCR . majoration heures supplémentaires
 : remplace: temps de travail . heures supplémentaires . majoration
-  période: flexible
   formule:
     barème:
       assiette: temps de travail . heures supplémentaires
@@ -5505,7 +5337,6 @@ contrat salarié . convention collective . SVP:
 
 contrat salarié . convention collective . SVP . cotisations patronales:
   titre: cotisations conventionnelles
-  période: flexible
   remplace: cotisations . patronales . conventionnelles
   formule:
     somme:
@@ -5540,7 +5371,6 @@ contrat salarié . convention collective . SVP . FCAP:
     Note explicative AUDIENS: http://www.cheque-intermittents.com/wp-content/uploads/2015/05/FCAP-SVP-EXPLIC_final.pdf
 
 contrat salarié . convention collective . SVP . prévoyance:
-  période: flexible
   formule:
     multiplication:
       plafonnée à: plafond sécurité sociale
@@ -5563,7 +5393,6 @@ contrat salarié . convention collective . sport . cotisations:
 
 contrat salarié . convention collective . sport . cotisations . patronales:
   titre: cotisations conventionnelles
-  période: flexible
   remplace:
     - règle: cotisations . patronales . conventionnelles
   formule:
@@ -5583,7 +5412,6 @@ contrat salarié . convention collective . sport . cotisations . patronales:
           taux: 0.06%
 
 contrat salarié . convention collective . sport . cotisations . prévoyance:
-  période: flexible
   remplace:
     - règle: cotisations . salariales . conventionnelles
       par: prévoyance [salarié]
@@ -5607,8 +5435,7 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
     Article 10.8 de la CCNS (IDCC 2511): https://www.legifrance.gouv.fr/affichIDCCArticle.do;?idArticle=KALIARTI000033304755&cidTexte=KALITEXT000017577657&dateTexte=29990101&categorieLien=id
 
 ? contrat salarié . convention collective . sport . cotisations . régime frais de santé
-: période: flexible
-  remplace: contrat salarié . complémentaire santé . forfait
+: remplace: contrat salarié . complémentaire santé . forfait
   formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
@@ -5634,7 +5461,6 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
               alors: 1.17%
             - si: option . R3
               alors: 1.32%
-  période: flexible
   référence:
     unamens.fr: https://www.umanens.fr/reglementation-couverture-sante-obligatoire/ccn-sport
     unamens (notice pdf): https://www.umanens.fr/documents/doc-offres-2018/sport/juin-2019/CCN_SPORT_PLAQ_EMPLOYEUR_2019.pdf
@@ -5660,7 +5486,6 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
 
 ? contrat salarié . convention collective . sport . cotisations . formation professionnelle
 : remplace: contrat salarié . formation professionnelle
-  période: flexible
   formule:
     somme:
       - plan de formation
@@ -5671,8 +5496,7 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
     Article 8.6 de la CCNS (IDCC2511): https://www.legifrance.gouv.fr/affichIDCCArticle.do;?idArticle=KALIARTI000034406905&cidTexte=KALITEXT000017577657&dateTexte=29990101&categorieLien=id
 
 ? contrat salarié . convention collective . sport . cotisations . formation professionnelle . plan de formation
-: période: flexible
-  formule:
+: formule:
     le maximum de:
       - versement minimum
       - multiplication:
@@ -5690,8 +5514,7 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
   formule: 30 €
 
 ? contrat salarié . convention collective . sport . cotisations . formation professionnelle . professionnalisation
-: période: flexible
-  formule:
+: formule:
     le maximum de:
       - versement minimum
       - multiplication:
@@ -5713,7 +5536,6 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
     toutes ces conditions:
       - CDI
       - entreprise . effectif >= 20
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -5721,15 +5543,13 @@ contrat salarié . convention collective . sport . cotisations . prévoyance:
 
 ? contrat salarié . convention collective . sport . cotisations . formation professionnelle . CIF CDD
 : applicable si: CDD
-  période: flexible
   formule:
     multiplication:
       assiette: cotisations . assiette
       taux: 1%
 
 ? contrat salarié . convention collective . sport . cotisations . assiette franchisée
-: période: flexible
-  formule:
+: formule:
     allègement:
       assiette: cotisations . assiette
       abattement: franchise
@@ -5920,7 +5740,6 @@ contrat salarié . intermittents du spectacle . formation professionnelle:
           taux: 2.10%
 
 contrat salarié . intermittents du spectacle . caisse des congés spectacle:
-  période: flexible
   formule:
     multiplication:
       assiette: rémunération . brut
@@ -6073,7 +5892,6 @@ contrat salarié . intermittents du spectacle . artiste . acteur de complément:
 
 ? contrat salarié . intermittents du spectacle . artiste . acteur de complément . assiette forfaitaire
 : applicable si: rémunération . brut < 6% * plafond sécurité sociale temps plein
-  période: flexible
   remplace:
     - contrat salarié . cotisations . assiette forfaitaire
     - règle: nombre jours travaillés
@@ -6088,7 +5906,6 @@ contrat salarié . cotisations . assiette forfaitaire:
 
 contrat salarié . cotisations . assiette forfaitaire . montant:
   titre: assiette forfaitaire de cotisations
-  période: flexible
   non applicable si: rémunération réelle
   remplace:
     - règle: cotisations . assiette

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3781,15 +3781,21 @@ dirigeant . indépendant . cotisations et contributions . cotisations . déducti
     Si vous exercez une activité de débit de tabac simultanément à une activité commerciale, vous avez la possibilité d’opter pour le calcul de votre cotisation d’assurance vieillesse sur le seul revenu tiré de votre activité commerciale (en effet, les remises pour débit de tabac sont soumises par ailleurs à un prélèvement vieillesse particulier). Nous attirons cependant votre attention sur le fait qu’en cotisant sur une base moins importante, excluant les revenus de débit de tabac, vos droits à retraite pour l’assurance vieillesse des commerçants en seront diminués.
   unité: €
   période: flexible
-  par défaut: 0
+  par défaut: non
+
+dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac . revenus déduits: 
+  titre: revenu professionnel (avec déduction tabac) 
+  période: flexible
+  applicable si: déduction tabac
+  unité: €
   remplace: 
     règle: revenu professionnel
     dans: 
       - retraite de base
       - retraite complémentaire
       - invalidité et décès
-      - conjoint collaborateur . cotisations . assiette
-    par: revenu professionnel - déduction tabac
+      - conjoint collaborateur
+  formule: revenu professionnel - déduction tabac
     
 
 dirigeant . rattachement CIPAV:
@@ -4127,6 +4133,7 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
     somme:
       - revenu professionnel
       - cotisations
+      - conjoint collaborateur . cotisations
       - (- revenus étrangers . montant)
       - (- situation personnelle . IJSS . fiscalisées)
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4050,6 +4050,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
           taux: 8%
 
 dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
+  non applicable si: exonérations . âge
   formule:
     multiplication:
       assiette: assiette
@@ -4161,18 +4162,28 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
         1.4: 3.1%
 
 entreprise . ZFU:
-  question: Votre entreprise est-elle localisée dans une zone franche urbaine (ZFU) ?
+  question: Votre entreprise bénéficie-t'elle du dispositif zone franche urbaine (ZFU) ?
   par défaut: non
 
-dirigeant . indépendant . exonération ZFU:
+dirigeant . indépendant . cotisations et contributions . exonérations:
+dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
   période: aucune
   applicable si: entreprise . date de création < 2015
   non applicable si: rattachement CIPAV
   formule: entreprise . ZFU = oui
   remplace:
-    règle: cotisations et contributions . cotisations . maladie
-    par: taux * cotisations et contributions . cotisations . maladie
-  
+    règle: cotisations . maladie
+    par: taux * cotisations . maladie
+
+dirigeant . indépendant . cotisations et contributions . exonérations . âge:
+  question: Bénéficiez-vous du dispositif d'exonération "âge" 
+  description: Ce dispositif a été arrêté en 2015, mais est toujours actifs pour les personnes qui en bénéficiait avant son abbrogation.
+  applicable si: entreprise . date de création < 2016
+  par défaut: non
+
+dirigeant . indépendant . cotisations et contributions . exonérations . âge . effet:
+  applicable si: âge
+
 situation personnelle . IJSS:
   description: |
     En cas de maladie, maternité, ou accident, le régime général de Sécurité sociale ainsi que les régimes spéciaux assurent le versement de prestations « en espèces ». Ce sont les indemnités journalières de Sécurité sociale (IJSS),
@@ -4236,7 +4247,7 @@ situation personnelle . IJSS . total:
   
 
 
-dirigeant . indépendant . exonération ZFU . taux:
+dirigeant . indépendant . cotisations et contributions . exonérations . ZFU . taux:
   titre: taux exonération ZFU
   formule:
     variations:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2836,7 +2836,7 @@ contrat salarié . taxe sur les salaires . barème:
 
 contrat salarié . régime des impatriés:
   question: Le salarié bénéficie-t-il du régime des impatriés ?
-  non applicable si: situation personnelle . domicilié à l'étranger
+  non applicable si: situation personnelle . domiciliation fiscale à l'étranger
   par défaut: non
   description: |
     Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été appelé par une entreprise étrangère à occuper un emploi dans une entreprise établie en France ayant un lien avec la première ou si vous avez été directement recruté à l’étranger par une entreprise établie en France, vous pouvez bénéficier du régime des impatriés.
@@ -3212,7 +3212,7 @@ impôt . CEHR:
     Bofip.impots.gouv.fr: http://bofip.impots.gouv.fr/bofip/7804-PGP
 
 entreprise . date de création:
-  question: En quelle année avez-vous crée votre entreprise ?
+  question: En quelle année avez-vous créé votre entreprise ?
   par défaut: 2019
   suggestions:
     2019: 2019
@@ -3431,7 +3431,7 @@ dirigeant . indépendant . conjoint collaborateur . assiette . forfaitaire:
 dirigeant . indépendant . conjoint collaborateur . assiette . revenu avec partage:
   description: |
     Le conjoint collaborateur et le gérant paieront des cotisations sociales chacun sur une part du revenu professionnel.
-    **Cette option baisse le montant des cotisations à payer pour le gérant, mais elle diminue également ses contreparties sociales (retraite, indémnité journalière, indemnité décès, etc)**
+    **Cette option baisse le montant des cotisations à payer pour le gérant, mais elle diminue également ses contreparties sociales (pension de retraite, indemnité décès, etc)**
   période: flexible
   formule: assiette = 'revenu avec partage'
   remplace: 
@@ -3776,7 +3776,7 @@ dirigeant . indépendant . cotisations et contributions:
 
 dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac: 
   applicable si: entreprise . catégorie d'activité . débit de tabac
-  question: Quels est le montant des revenus issus de la vente de tabac que souhaitez-vous exonérer de cotisation vieillesse ?
+  question: Quel est le montant des revenus issus de la vente de tabac que vous souhaitez exonérer de cotisation vieillesse ?
   description: |
     Si vous exercez une activité de débit de tabac simultanément à une activité commerciale, vous avez la possibilité d’opter pour le calcul de votre cotisation d’assurance vieillesse sur le seul revenu tiré de votre activité commerciale (en effet, les remises pour débit de tabac sont soumises par ailleurs à un prélèvement vieillesse particulier). Nous attirons cependant votre attention sur le fait qu’en cotisant sur une base moins importante, excluant les revenus de débit de tabac, vos droits à retraite pour l’assurance vieillesse des commerçants en seront diminués.
   unité: €
@@ -3787,6 +3787,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . déducti
     dans: 
       - retraite de base
       - retraite complémentaire
+      - invalidité et décès
     par: revenu professionnel - déduction tabac
     
 
@@ -3816,6 +3817,17 @@ dirigeant . rattachement CIPAV:
     - dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
     - dirigeant . indépendant . conjoint collaborateur
   période: aucune
+
+dirigeant . indépendant . PLNR régime général:
+  applicable si: 
+    toutes ces conditions: 
+      - entreprise . catégorie d'activité = 'libérale'
+      - entreprise . catégorie d'activité . libérale règlementée = non
+      - entreprise . date de création < 2019
+  question: Avez-vous opté pour le rattachement au régime général des indépendant ?
+  description: En tant que profession libéral non reglementée, vous pouvez choisir d'être rattaché au régime général plutôt que la CIPAV
+  par défaut: non
+  rend non applicable: rattachement CIPAV
 
 ? dirigeant . rattachement CIPAV . maladie
 : période: flexible
@@ -4036,8 +4048,6 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
         - de: 37960
           à: 162096
           taux: 8%
-        - au-dessus de: 162096
-          taux: 0%
 
 dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
   formule:
@@ -4055,12 +4065,12 @@ dirigeant . indépendant . cotisations et contributions . cotisations . invalidi
   titre: assiette invalidité et décès
   formule:
     variations:
-      - si: situation personnelle . RSA != oui
-        alors:
+      - si: situation personnelle . RSA
+        alors: revenu professionnel
+      - sinon: 
           le maximum de:
             - 11.5% * plafond sécurité sociale temps plein
             - revenu professionnel
-      - sinon: revenu professionnel
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
@@ -4077,18 +4087,16 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
             impôt sur le revenu: déductible
           taux: 6.8%
         - attributs:
-            nom: indemnités journalières
+            nom: revenus de remplacement
             impôt sur le revenu: non déductible
           assiette: situation personnelle . IJSS . total
           taux: 2.9%
         - attributs:
-            nom: indemnités journalières
+            nom: revenus de remplacement
             impôt sur le revenu: déductible
           assiette: situation personnelle . IJSS . total
           taux: 3.8%
 
-  note: 
-    Lorsque le revenu fiscal de reference de l'année N-1 est inferieur à un seuil, il y a exonération / taux réduit de la CSG, ce qui n'est pas encore implémenté
   références:
     fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/les-contributions-csg-crds/taux-de-la-csg-crds.html
     IJSS (amelie.fr): https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie
@@ -4129,11 +4137,12 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
       assiette: plafond sécurité sociale temps plein
       taux:
         variations:
-          - si: conjoint collaborateur
-            alors: 0.34%
           - si: entreprise . catégorie d'activité = 'artisanale'
             alors: 0.29%
+          - si: conjoint collaborateur
+            alors: 0.34%
           - sinon: 0.25%
+  note: Le taux n'est pas majoré pour les artisans avec conjoint collaborateur
 
   références:
     fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23459
@@ -4170,7 +4179,7 @@ situation personnelle . IJSS:
     Les indemnités complémentaires aux indemnités journalières de la Sécurité sociale versées dans le cadre d’un contrat de prévoyance ne constituent pas des revenus de remplacement.
 
     Note: Les prestations d’invalidité versées par les régimes d’invalidité-décès ne sont pas concernées
-  question: Avez-vous touché des indemnité journalières de sécurité sociale (maladie, maternité, paternité, etc.) ?
+  question: Avez-vous touché des indemnités journalières de sécurité sociale (maladie, maternité, paternité, etc.) ?
   par défaut: non
 
 situation personnelle . IJSS . montant:
@@ -4260,10 +4269,10 @@ dirigeant . indépendant . exonération ZFU . taux:
               alors: 80%
             - sinon: 100%
 
-situation personnelle . domicilié à l'étranger:
+situation personnelle . domiciliation fiscale à l'étranger:
   description: |
     Ces assurés ne sont pas redevables de la CSG/CRDS mais, en contrepartie ils sont redevables de la cotisation maladie sur la base d’un taux plus elevé.
-  question: La résidence fiscale de l'assuré est-elle domicilié à l'étranger ?
+  question: La résidence fiscale de l'assuré est-elle domiciliée à l'étranger ?
   par défaut: non
   rend non applicable: 
     - dirigeant . indépendant . cotisations et contributions . CSG et CRDS
@@ -4273,8 +4282,9 @@ situation personnelle . domicilié à l'étranger:
   références: 
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-csg-crds/qui-en-est-redevable.html
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie domicilié à l'étranger:
-  applicable si: situation personnelle . domicilié à l'étranger
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie domiciliation fiscale étranger:
+  applicable si: situation personnelle . domiciliation fiscale à l'étranger
+  titre: Maladie (domiciliation fiscale à l'étranger)
   période: flexible
   description: En contrepartie de l'exonération de CSG, les cotisants ont un taux maladie plus elevé. Contrairement aux autres assurés commerçants/artisans ils ne bénéficient pas de la réduction du taux de la cotisation maladie en fonction du revenu déclaré.
   remplace: maladie
@@ -4283,8 +4293,9 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
       assiette: maladie . assiette
       taux: 14.5%
 
-contrat salarié . maladie . taux domicilié à l'étranger:
-  applicable si: situation personnelle . domicilié à l'étranger
+contrat salarié . maladie . taux domiciliation fiscale étranger:
+  titre: taux salarié (domiciliation fiscale à l'étranger)
+  applicable si: situation personnelle . domiciliation fiscale à l'étranger
   période: aucune
   remplace: taux salarié
   formule: 5.50%
@@ -4528,7 +4539,7 @@ entreprise . ACRE:
           - dirigeant = 'auto-entrepreneur'
           - entreprise . année d'activité < 4
       - entreprise . année d'activité < 2
-  question: Votre entreprise bénéficie-t'elle de l'ACRE (anciennement ACCRE) ?
+  question: Votre entreprise bénéficie-t-elle de l'ACRE (anciennement ACCRE) ?
   par défaut: non
 
 entreprise . ACRE . année:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1605,7 +1605,7 @@ contrat salarié . réduction ACRE . taux:
   formule:
     barème continu:
       assiette: cotisations . assiette
-      multiplicateur: plafond sécurité sociale * entreprise . ACRE . prorata
+      multiplicateur: plafond sécurité sociale
       points:
         0: 100%
         0.75: 100%
@@ -3243,7 +3243,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . réduc
   formule:
     barème continu:
       assiette: revenu professionnel
-      multiplicateur: plafond sécurité sociale temps plein * entreprise . ACRE . prorata
+      multiplicateur: plafond sécurité sociale temps plein
       points:
         0: 100%
         0.75: 100%
@@ -3252,13 +3252,14 @@ dirigeant . indépendant . cotisations et contributions . exonérations . réduc
 
 dirigeant . indépendant . cotisations et contributions . exonérations . réduction ACRE:
   applicable si: entreprise . ACRE
-  période: flexible
-  formule:
-    multiplication:
-      assiette: cotisations - cotisations . retraite complémentaire
-      taux: taux ACRE
-      facteur: prorata
-
+  formule: 
+    variable temporelle:
+      début: entreprise . date de création
+      durée: 1 an
+      montant:
+        multiplication:
+          assiette: cotisations - cotisations . retraite complémentaire
+          taux: taux ACRE
 
 
 dirigeant . indépendant . revenu net de cotisations:
@@ -4044,42 +4045,49 @@ dirigeant . indépendant . cotisations et contributions . exonérations:
   
   note: La loi dit qu'il ne peut pas y avoir deux exonérations sur le même risque active pendant la même période. Pour l'instant, nous ne vérifions pas cette hypothèse.
 
-dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
-  période: flexible
-  applicable si: entreprise . ZFU
+dirigeant . indépendant . cotisations et contributions . exonérations . ZFU . taux:
   formule:
-    prorata temporis:
-      assiette: cotisations . maladie
-      début d'effet: entreprise . date de création
+    variable temporelle:
+      début: entreprise . date de création
       variations:
         si: entreprise . effectif < 5 
         alors:
-          tranches:
-            - avant: 10 ans
-              taux: 100%
+          périodes:
+            - pendant: 10 ans
+              montant: 100%
             - entre: 10 ans
               et: 15 ans
-              taux: 60%
+              montant: 60%
             - entre: 15 ans
               et: 17 ans
-              taux: 40%
+              montant: 40%
             - entre: 18 ans
               et: 20 ans
-              taux: 20%
+              montant: 20%
         sinon: 
-          tranches:
-            - avant: 5 ans
-              taux: 100%
+          périodes:
+            - pendant: 5 ans
+              montant: 100%
             - entre: 5 ans
               et: 6 ans
-              taux: 60%
+              montant: 60%
             - entre: 6 ans
               et: 7 ans
-              taux: 40%
+              montant: 40%
             - entre: 7 ans
               et: 8 ans
-              taux: 20%
-              
+              montant: 20%
+
+dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
+  applicable si: entreprise . ZFU
+  période: année
+  formule:
+    le minimum de:
+      - 120% * SMIC [mensuel]
+      - multiplication:
+          assiette: cotisations . maladie
+          taux: taux
+                  
 dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   question: Bénéficiez-vous du dispositif d'exonération "âge" 
   description: Ce dispositif a été arrêté en 2015, mais est toujours actifs pour les personnes qui en bénéficiait avant son abbrogation.
@@ -4090,16 +4098,15 @@ dirigeant . indépendant . cotisations et contributions . exonérations . âge:
 dirigeant . indépendant . cotisations et contributions . exonérations . invalidité:
   question: Êtes-vous titulaire d’une pension d’invalidité ? 
   description:  Les personnes titulaires d’une pension d’invalidité versée par un régime des travailleurs non-salariés non agricoles bénéficient d’une exonération totale des cotisations maladie et retraite complémentaire.
-  période: flexible
   par défaut: non
   formule:
-    prorata temporis:
-      assiette: 
+    variable temporelle:
+      début d'effet: début d'effet
+      montant:
         somme:
           - cotisations . maladie
           - cotisations . indemnités journalières maladie
           - cotisations . retraite complémentaire
-      début d'effet: début d'effet
         
 
 dirigeant . indépendant . cotisations et contributions . exonérations . invalidité . début d'effet:
@@ -4432,46 +4439,32 @@ entreprise . ACRE:
   question: Votre entreprise bénéficie-t-elle de l'ACRE (anciennement ACCRE) ?
   par défaut: non
 
-entreprise . ACRE . prorata:
-  période: flexible
-  formule:
-    prorata temporis:
-      début d'effet: entreprise . date de création
-      durée: 1 an
-
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
-  période: flexible
   formule: 100% - réduction ACRE
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . réduction ACRE:
   titre: réduction ACRE
   applicable si: entreprise . ACRE
-  période: flexible
   description: Ce taux peut dans certains cas réduire le montant des cotisations sociales de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
   formule:
-    prorata temporis:
-      début d'effet: 
+    variable temporelle:
+      début: 
         début du trimestre: entreprise . date de création
-      durée: 3 ans
-      tranches: 
-        - avant: 1 an
-          taux: 75%
+      périodes: 
+        - pendant: 1 an
+          montant: 75%
         - entre: 1 an
           et: 2 ans
-          taux: 50%
+          montant: 50%
         - entre: 2 ans
           et: 3 ans
-          taux: 25%
+          montant: 25%
   références:
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
   période: année
-  formule: 
-    prorata temporis: 
-      assiette: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
-      début d'effet: entreprise . date de création
-      durée: 3 ans
+  formule: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
 
 dirigeant . auto-entrepreneur . impôt:
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3985,6 +3985,31 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
           montant: 17095
 
 
+dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire . taux spécifique PLNR :
+  non applicable si: rattachement CIPAV
+  titre: taux spécifique profession libérale non reglementée
+  question:
+    Avez-vous opté pour des taux spécifique de cotisation retraite complémentaire ?
+  description: |
+    Les professions libérales non règlementées qui ont débuté leur activité à compter du 1er janvier 2019 ou ceux qui ont débuté leur activité avant la date du 1er janvier 2019  et ont opté pour le régime général des travailleurs indépendants  ont la possibilité d’opter pour des taux spécifique de la cotisation retraite complémentaire.
+  références:
+    Guide PL urssaf (page 10): https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Guide-Professions-liberales.pdf
+dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire . taux spécifique PLNR . taux:
+  titre: retraite complémentaire (taux PLNR)
+  description: la retraite complémentaire avec taux spécifiques
+  remplace: retraite complémentaire
+  période: flexible
+  formule: 
+    barème:
+      assiette: revenu professionnel
+      multiplicateur: plafond sécurité sociale temps plein
+      tranches:
+        - de: 1
+          à: 4
+          taux: 14%
+
+
+    
 ? dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire
 : période: année
   unité: €

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3788,6 +3788,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . déducti
       - retraite de base
       - retraite complémentaire
       - invalidité et décès
+      - conjoint collaborateur . cotisations . assiette
     par: revenu professionnel - déduction tabac
     
 
@@ -3797,6 +3798,7 @@ dirigeant . rattachement CIPAV:
   références:
     article de loi (chercher "travailleurs indépendants créant leur activité"): https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/texte#JORFARTI000036339157
   note: pour l'instant, nous n'avons retenu que la CIPAV pour les calculs
+  non applicable si: indépendant . PLNR régime général
   formule:
     une de ces conditions:
       - toutes ces conditions:
@@ -3827,7 +3829,6 @@ dirigeant . indépendant . PLNR régime général:
   question: Avez-vous opté pour le rattachement au régime général des indépendant ?
   description: En tant que profession libéral non reglementée, vous pouvez choisir d'être rattaché au régime général plutôt que la CIPAV
   par défaut: non
-  rend non applicable: rattachement CIPAV
 
 ? dirigeant . rattachement CIPAV . maladie
 : période: flexible
@@ -4185,6 +4186,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . âge .
   applicable si: âge
 
 situation personnelle . IJSS:
+  titre: indemnités journalières de sécurité sociale
   description: |
     En cas de maladie, maternité, ou accident, le régime général de Sécurité sociale ainsi que les régimes spéciaux assurent le versement de prestations « en espèces ». Ce sont les indemnités journalières de Sécurité sociale (IJSS),
     Les indemnités complémentaires aux indemnités journalières de la Sécurité sociale versées dans le cadre d’un contrat de prévoyance ne constituent pas des revenus de remplacement.

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -817,7 +817,7 @@ contrat salarié . rémunération . brut de base:
         - équivalent temps plein
         - entreprise . chiffre d'affaires
         - entreprise . chiffre d'affaires minimum
-        - entreprise . rémunération totale du dirigeant
+        - dirigeant . rémunération totale
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement
@@ -3258,7 +3258,7 @@ entreprise . chiffre d'affaires:
   résumé: Le montant des ventes réalisées
   période: flexible
   unité: €
-  formule: rémunération totale du dirigeant + charges
+  formule: dirigeant . rémunération totale + charges
 
 entreprise . chiffre d'affaires minimum:
   description: Le montant minimum des ventes (H.T) à réaliser pour atteindre le seuil de rentabilité.
@@ -3271,7 +3271,7 @@ entreprise . chiffre d'affaires de société:
   période: flexible
   formule:
     somme:
-      - rémunération totale du dirigeant / rémunération du dirigeant
+      - dirigeant . rémunération totale / rémunération du dirigeant
       - charges
 
 entreprise . rémunération du dirigeant:
@@ -3308,9 +3308,9 @@ entreprise . impôt sur les sociétés:
 
 entreprise . charges dont rémunération dirigeant:
   période: flexible
-  formule: charges + rémunération totale du dirigeant
+  formule: charges + dirigeant . rémunération totale
 
-entreprise . rémunération totale du dirigeant:
+dirigeant . rémunération totale:
   question: Quel montant pensez-vous dégager pour votre rémunération ?
   résumé: Dépensé par l'entreprise
   unité: €
@@ -3321,17 +3321,21 @@ entreprise . rémunération totale du dirigeant:
   période: flexible
   formule:
     variations:
-      - si: dirigeant . indépendant
-        alors: revenu net de cotisations + dirigeant . indépendant . cotisations et contributions
-      - si: dirigeant . auto-entrepreneur
+      - si: indépendant
+        alors: 
+          somme:
+            - indépendant . revenu net de cotisations
+            - indépendant . cotisations et contributions
+            - (- situation personnelle . IJSS . total)
+      - si: auto-entrepreneur
         alors:
           inversion numérique:
             avec:
-              - dirigeant . auto-entrepreneur . revenu net de cotisations
+              - auto-entrepreneur . revenu net de cotisations
               - revenu net après impôt
               - entreprise . chiffre d'affaires
               - entreprise . chiffre d'affaires minimum
-      - si: dirigeant = 'assimilé salarié'
+      - si: assimilé salarié
         alors: contrat salarié . rémunération . total
 
 entreprise . charges:
@@ -3381,7 +3385,11 @@ dirigeant . indépendant . cotisations et contributions . réduction ACRE . taux
       retourne seulement le taux: oui
 
 dirigeant . indépendant . revenu net de cotisations:
-  formule: revenu professionnel - cotisations et contributions . CSG et CRDS [non déductible]
+  formule: 
+    somme: 
+      - revenu professionnel
+      - situation personnelle . IJSS . défiscalisées
+      - (- cotisations et contributions . CSG et CRDS [non déductible])
   période: flexible
   résumé: Avant impôt
   question: Quel revenu avant impôt voulez-vous toucher ?
@@ -3404,7 +3412,7 @@ dirigeant . indépendant . revenu professionnel:
     inversion numérique:
       avec:
         - dirigeant . indépendant . revenu net de cotisations
-        - entreprise . rémunération totale du dirigeant
+        - dirigeant . rémunération totale
         - revenu net après impôt
         - entreprise . chiffre d'affaires
         - entreprise . chiffre d'affaires minimum
@@ -4064,12 +4072,27 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
         - attributs:
             impôt sur le revenu: non déductible
           taux: 2.9%
-
         - attributs:
             impôt sur le revenu: déductible
           taux: 6.8%
+        - attributs:
+            nom: indemnités journalières
+            impôt sur le revenu: non déductible
+          assiette: situation personnelle . IJSS . total
+          taux: 2.9%
+        - attributs:
+            nom: indemnités journalières
+            impôt sur le revenu: déductible
+          assiette: situation personnelle . IJSS . total
+          taux: 3.8%
+
+  note: 
+    Lorsque le revenu fiscal de reference de l'année N-1 est inferieur à un seuil, il y a exonération / taux réduit de la CSG, ce qui n'est pas encore implémenté
   références:
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/les-contributions-csg-crds/taux-de-la-csg-crds.html
+    IJSS (amelie.fr): https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie
+    IJSS (service-public.fr): https://www.service-public.fr/particuliers/vosdroits/F2971
+
 
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette:
   période: flexible
@@ -4077,6 +4100,7 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
     somme:
       - revenu professionnel
       - cotisations
+      - (- situation personnelle . IJSS . fiscalisées)
 
 dirigeant . indépendant . cotisations et contributions . formation professionnelle:
   période: flexible
@@ -4120,6 +4144,68 @@ dirigeant . indépendant . exonération ZFU:
     règle: cotisations et contributions . cotisations . maladie
     par: taux * cotisations et contributions . cotisations . maladie
   
+situation personnelle . IJSS:
+  description: |
+    En cas de maladie, maternité, ou accident, le régime général de Sécurité sociale ainsi que les régimes spéciaux assurent le versement de prestations « en espèces ». Ce sont les indemnités journalières de Sécurité sociale (IJSS),
+    Les indemnités complémentaires aux indemnités journalières de la Sécurité sociale versées dans le cadre d’un contrat de prévoyance ne constituent pas des revenus de remplacement.
+
+    Note: Les prestations d’invalidité versées par les régimes d’invalidité-décès ne sont pas concernées
+  question: Avez-vous touché des indemnité journalières de sécurité sociale (maladie, maternité, paternité, etc.) ?
+  par défaut: non
+
+situation personnelle . IJSS . montant:
+  non applicable si: ALD
+  période: flexible
+  titre: indemnités journalières fiscalisées
+  par défaut: 0
+  question: Quel était leur montant total brut ?
+  unité: €
+
+situation personnelle . IJSS . ALD:
+  question: Avez-vous touché des indemnités dans le cas d'une affection longue durée (ALD) dite "exonérante" ?
+  description: 
+    L'affection longue durée (ALD) est mise en place par la loi du 13 août 2004 relative à l'assurance maladie. Ce statut offre aux personnes malades chroniques qui remplissent certaines conditions une prise en charge spécifique de leurs soins médicaux.
+    L'affection longue durée est une maladie de longue durée, présentant un caractère grave ou chronique et nécessitant un traitement long dont le coût est élevé.
+    La liste des ALD dites "exonérante" est disponible sur le site [ameli.fr](https://www.ameli.fr/assure/droits-demarches/maladie-accident-hospitalisation/affection-longue-duree-ald/affection-longue-duree-ald)
+    Les indemnité versée dans le cadre d'une ALD dites "éxonérante" ne sont pas imposable. 
+  par défaut: non
+
+
+situation personnelle . IJSS . ALD . autres indemnités:
+  question: Avez-vous également touché des indemnités non liées à votre ALD (maternité, paternité, autre maladie) ?
+  par défaut: non
+
+situation personnelle . IJSS . ALD . autres indemnités . montant:
+  question: Quel était le montant de vos autres indemnités ?
+  par défaut: 0
+  unité: €
+  période: flexible
+
+situation personnelle . IJSS . défiscalisées:
+  période: flexible
+  applicable si: ALD
+  titre: indemnités journalières défiscalisées
+  question: Quel était le montant de vos indemnités ALD ?
+  par défaut: 0
+  unité: €
+
+situation personnelle . IJSS . fiscalisées:
+  titre: indemnités journalières fiscalisées
+  période: flexible
+  formule: 
+    somme: 
+      - IJSS . montant
+      - ALD . autres indemnités . montant
+
+situation personnelle . IJSS . total:
+  titre: total indemnités journalières
+  période: flexible
+  formule:
+    somme: 
+      - fiscalisées
+      - défiscalisées
+  
+
 
 dirigeant . indépendant . exonération ZFU . taux:
   titre: taux exonération ZFU
@@ -4265,7 +4351,7 @@ dirigeant . auto-entrepreneur . revenu net de cotisations:
   résumé: Avant impôt
   question: Quel revenu avant impôt voulez-vous toucher ?
   description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
-  formule: entreprise . rémunération totale du dirigeant - cotisations et contributions
+  formule: dirigeant . rémunération totale - cotisations et contributions
   période: flexible
   unité: €
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3798,7 +3798,6 @@ dirigeant . rattachement CIPAV:
   références:
     article de loi (chercher "travailleurs indépendants créant leur activité"): https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/texte#JORFARTI000036339157
   note: pour l'instant, nous n'avons retenu que la CIPAV pour les calculs
-  non applicable si: indépendant . PLNR régime général
   formule:
     une de ces conditions:
       - toutes ces conditions:
@@ -3828,6 +3827,7 @@ dirigeant . indépendant . PLNR régime général:
       - entreprise . date de création < 2019
   question: Avez-vous opté pour le rattachement au régime général des indépendant ?
   description: En tant que profession libéral non reglementée, vous pouvez choisir d'être rattaché au régime général plutôt que la CIPAV
+  rend non applicable: rattachement CIPAV
   par défaut: non
 
 ? dirigeant . rattachement CIPAV . maladie
@@ -4169,9 +4169,10 @@ entreprise . ZFU:
 dirigeant . indépendant . cotisations et contributions . exonérations:
 dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
   période: aucune
-  applicable si: entreprise . date de création < 2015
-  non applicable si: rattachement CIPAV
-  formule: entreprise . ZFU = oui
+  applicable si: 
+    toutes ces conditions:
+      - entreprise . date de création < 2015
+      - entreprise . ZFU
   remplace:
     règle: cotisations . maladie
     par: taux * cotisations . maladie
@@ -4182,8 +4183,16 @@ dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   applicable si: entreprise . date de création < 2016
   par défaut: non
 
-dirigeant . indépendant . cotisations et contributions . exonérations . âge . effet:
-  applicable si: âge
+dirigeant . indépendant . cotisations et contributions . exonérations . invalidité:
+  question: Êtes-vous titulaire d’une pension d’invalidité ? 
+  description:  Les personnes titulaires d’une pension d’invalidité versée par un régime des travailleurs non-salariés non agricoles bénéficient d’une exonération totale des cotisations maladie et retraite complémentaire.
+  par défaut: non
+  rend non applicable: 
+    - cotisations . maladie
+    - cotisations . indemnités journalières maladie
+    - cotisations . retraite complémentaire
+  
+
 
 situation personnelle . IJSS:
   titre: indemnités journalières de sécurité sociale

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3729,6 +3729,11 @@ entreprise . catégorie d'activité . libérale règlementée:
         - Sage-femme
         - Vétérinaire
 
+entreprise . catégorie d'activité . débit de tabac:
+  applicable si: catégorie d'activité = 'commerciale ou industrielle'
+  question: Votre entreprise est-elle un débit de tabac ?
+  par défaut: non
+
 entreprise . rattachée à la CIPAV:
   # TODO implémenter un nouveau mécanisme
   # TODO consolider la formule :
@@ -3790,6 +3795,23 @@ dirigeant . indépendant . cotisations et contributions:
       - (- réduction ACRE)
   unité: €
   période: flexible
+
+
+dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac: 
+  applicable si: entreprise . catégorie d'activité . débit de tabac
+  question: Quels est le montant des revenus issus de la vente de tabac que souhaitez-vous exonérer de cotisation vieillesse ?
+  description: |
+    Si vous exercez une activité de débit de tabac simultanément à une activité commerciale, vous avez la possibilité d’opter pour le calcul de votre cotisation d’assurance vieillesse sur le seul revenu tiré de votre activité commerciale (en effet, les remises pour débit de tabac sont soumises par ailleurs à un prélèvement vieillesse particulier). Nous attirons cependant votre attention sur le fait qu’en cotisant sur une base moins importante, excluant les revenus de débit de tabac, vos droits à retraite pour l’assurance vieillesse des commerçants en seront diminués.
+  unité: €
+  période: flexible
+  par défaut: 0
+  remplace: 
+    règle: revenu professionnel
+    dans: 
+      - retraite de base
+      - retraite complémentaire
+    par: revenu professionnel - déduction tabac
+    
 
 dirigeant . indépendant . rattachement CIPAV:
   description: |
@@ -3954,12 +3976,12 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
   titre: assiette retraite de base
   formule:
     variations:
-      - si: situation personnelle . RSA != oui
-        alors:
+      - si: situation personnelle . RSA
+        alors: revenu professionnel
+      - sinon: 
           le maximum de:
             - 11.5% * plafond sécurité sociale temps plein
             - revenu professionnel
-      - sinon: revenu professionnel
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
@@ -4118,7 +4140,9 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
       - cotisations
       - (- revenus étrangers . montant)
       - (- situation personnelle . IJSS . fiscalisées)
-  
+
+
+
 dirigeant . indépendant . cotisations et contributions . formation professionnelle:
   période: flexible
   formule:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -4093,6 +4093,22 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
     IJSS (amelie.fr): https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie
     IJSS (service-public.fr): https://www.service-public.fr/particuliers/vosdroits/F2971
 
+dirigeant . indépendant . revenus étrangers: 
+  description: |
+    Les revenus étrangers sont des revenus déclarés par les travailleurs indépendants pour des revenus perçus au titre de l’exercice d’une activité non salariée dans un autre Etat de l’UE, EEE ou en Suisse à l’étranger.  
+    Ces revenus ne sont soumis qu’aux cotisations et sont intégrés à l’assiette sociale. Par contre, ces revenus sont identifiés spécifiquement afin de les déduire de l’assiette de la CSG/CRDS. 
+    Pour savoir si ces revenus sont soumis à l'impôt sur le revenu, référez-vous à la notice explicative sur le site [impots.gouv.fr](https://www.impots.gouv.fr/portail/international-particulier/imposition-des-revenus-de-source-etrangere)
+
+  question: Avez-vous perçu des revenus à l'étranger dans le cadre de votre activité ? 
+  par défaut: non
+
+dirigeant . indépendant . revenus étrangers . montant:
+  période: flexible
+  unité: €
+  titre: revenus perçu à l'étranger
+  question: Quel est leur montant ?
+  par défaut: 0
+
 
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette:
   période: flexible
@@ -4100,8 +4116,9 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
     somme:
       - revenu professionnel
       - cotisations
+      - (- revenus étrangers . montant)
       - (- situation personnelle . IJSS . fiscalisées)
-
+  
 dirigeant . indépendant . cotisations et contributions . formation professionnelle:
   période: flexible
   formule:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3211,28 +3211,6 @@ impôt . CEHR:
     Article 223 sexies du Code général des impôts: https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000025049019&cidTexte=LEGITEXT000006069577
     Bofip.impots.gouv.fr: http://bofip.impots.gouv.fr/bofip/7804-PGP
 
-revenu net de cotisations:
-  résumé: Avant impôt
-  période: flexible
-  question: Quel revenu avant impôt voulez-vous toucher ?
-  description: |
-    Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
-  formule:
-    somme:
-      - contrat salarié . rémunération . net
-      - dirigeant . indépendant . revenu net de cotisations
-      - dirigeant . auto-entrepreneur . revenu net de cotisations
-
-revenu net après impôt:
-  unité: €
-  résumé: Versé sur le compte bancaire
-  période: flexible
-  question: Quel revenu voulez-vous toucher ?
-  description: |
-    Il s'agit du revenu net de charges, cotisations et d'impôts.
-    Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
-  formule: revenu net de cotisations - impôt
-
 entreprise . date de création:
   question: En quelle année avez-vous crée votre entreprise ?
   par défaut: 2019
@@ -3418,7 +3396,6 @@ dirigeant . indépendant . revenu professionnel:
         - entreprise . chiffre d'affaires minimum
 
 dirigeant . indépendant . conjoint collaborateur:
-  non applicable si: dirigeant . indépendant . rattachement CIPAV
   question: Avez-vous un conjoint collaborateur ?
   description: |
     Permet au conjoint du dirigeant d'être couvert par la protection sociale moyennant le paiement de cotisations sociales supplémantaires. 
@@ -3429,7 +3406,7 @@ dirigeant . indépendant . conjoint collaborateur:
     - ne pas être associé de la société.
   par défaut: non
   références: 
-    secu-independant.fr: https://www.secu-independants.fr/cotisations/conjoint/conjoint-collaborateur/?reg=lorraine&pro=artisan&act=retraite&ae=non#c46535
+    secu-indépendant.fr: https://www.secu-independants.fr/cotisations/conjoint/conjoint-collaborateur/?reg=lorraine&pro=artisan&act=retraite&ae=non#c46535
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F33429
   
 dirigeant . indépendant . conjoint collaborateur . assiette :
@@ -3681,7 +3658,7 @@ entreprise . catégorie d'activité . libérale règlementée:
 
         - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant.
         - assurez-vous que le statut auto-entrepreneur est bien compatible avec votre profession règlementée
-        - pour les praticiens et auxiliaires médicaux (PAM), [les spécificités de calcul des cotisations](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) et la [CURPS](https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) ne sont pas encore intégrées.
+        - pour les praticiens et auxiliaires médicaux (PAM), [les spécificités de calcul des cotisations](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) et la [CURPS](https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) ne sont pas encore intégrées.
 
   références:
     Liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales
@@ -3813,7 +3790,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . déducti
     par: revenu professionnel - déduction tabac
     
 
-dirigeant . indépendant . rattachement CIPAV:
+dirigeant . rattachement CIPAV:
   description: |
     Les entreprises libérales non règlementées créées étaient rattachées aux règlementées pour le calcul des cotisations sociales. Depuis 2018 ce n'est plus le cas pour les auto-entrepreneurs (2019 pour les entreprise individuelles). Elles sont maintenant rattachées aux artisans-commerçants, donc dépendent de la sécurité sociale des indépendants.
   références:
@@ -3835,16 +3812,18 @@ dirigeant . indépendant . rattachement CIPAV:
 
   rend non applicable:
     - protection sociale . retraite
+    - protection sociale . santé . indemnités journalières
     - dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
+    - dirigeant . indépendant . conjoint collaborateur
   période: aucune
 
-? dirigeant . indépendant . rattachement CIPAV . maladie
+? dirigeant . rattachement CIPAV . maladie
 : période: flexible
-  remplace: cotisations et contributions . cotisations . maladie
+  remplace: indépendant . cotisations et contributions . cotisations . maladie
   titre: maladie libérale règlementée
   formule:
     barème continu:
-      assiette: revenu professionnel
+      assiette: indépendant . revenu professionnel
       multiplicateur: plafond sécurité sociale temps plein
       points:
         0: 1.5%
@@ -3944,12 +3923,12 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
-dirigeant . indépendant . rattachement CIPAV . retraite de base:
+dirigeant . rattachement CIPAV . retraite de base:
   période: flexible
-  remplace: cotisations et contributions . cotisations . retraite de base
+  remplace: indépendant . cotisations et contributions . cotisations . retraite de base
   formule: 
     multiplication:
-      assiette: cotisations et contributions . cotisations . retraite de base . assiette
+      assiette: indépendant . cotisations et contributions . cotisations . retraite de base . assiette
       multiplicateur:
       composantes:
         - nom: tranche 1
@@ -3985,12 +3964,12 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-? dirigeant . indépendant . rattachement CIPAV . retraite complémentaire:
+dirigeant . rattachement CIPAV . retraite complémentaire:
   période: année
-  remplace: cotisations et contributions . cotisations . retraite complémentaire
+  remplace: indépendant . cotisations et contributions . cotisations . retraite complémentaire
   formule:
     barème linéaire:
-      assiette: revenu professionnel
+      assiette: indépendant . revenu professionnel
       tranches:
         - en-dessous de: 26580
           montant: 1315
@@ -4111,7 +4090,7 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
   note: 
     Lorsque le revenu fiscal de reference de l'année N-1 est inferieur à un seuil, il y a exonération / taux réduit de la CSG, ce qui n'est pas encore implémenté
   références:
-    fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/les-contributions-csg-crds/taux-de-la-csg-crds.html
+    fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/les-contributions-csg-crds/taux-de-la-csg-crds.html
     IJSS (amelie.fr): https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie
     IJSS (service-public.fr): https://www.service-public.fr/particuliers/vosdroits/F2971
 
@@ -4158,8 +4137,8 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
 
   références:
     fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23459
-    fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
-    brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-independant/transfert-du-recouvrement-de-la.html
+    fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
+    brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-indépendant/transfert-du-recouvrement-de-la.html
 
 ? dirigeant . indépendant . cotisations et contributions . cotisations . allocations familiales
 : période: flexible
@@ -4587,7 +4566,7 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ré
       - si: entreprise . ACRE . année = 'moins de trois ans'
         alors: 25%
   références:
-    Fiche URSSAF: https://www.urssaf.fr/portail/home/independant/je-beneficie-dexonerations/accre.html
+    Fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/je-beneficie-dexonerations/accre.html
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
   formule: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
@@ -4677,6 +4656,28 @@ dirigeant . auto-entrepreneur . impôt . revenu abattu:
     allègement:
       assiette: base des cotisations
       abattement: abattement
+
+revenus net de cotisations:
+  résumé: Avant impôt
+  période: flexible
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: |
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
+  formule:
+    somme:
+      - contrat salarié . rémunération . net
+      - dirigeant . indépendant . revenu net de cotisations
+      - dirigeant . auto-entrepreneur . revenu net de cotisations
+
+revenu net après impôt:
+  unité: €
+  résumé: Versé sur le compte bancaire
+  période: flexible
+  question: Quel revenu voulez-vous toucher ?
+  description: |
+    Il s'agit du revenu net de charges, cotisations et d'impôts.
+    Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
+  formule: revenus net de cotisations - impôt
 
 protection sociale:
   description: >

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -545,7 +545,7 @@ contrat salarié . CDD . surcoût:
 
     Certaines sont versées en fin de contrat, d'autres avec chaque salaire
     mensuel; elles sont ici ramenées à leur coût mensuel.
-assimilé salarié:
+dirigeant . assimilé salarié:
   description.en: >
     Some company managers (this is particularly the case for SASUs) are
     considered by the social security system as equivalent to employees. They
@@ -998,9 +998,6 @@ contrat salarié . indemnités salarié:
   titre.en: Employee benefits
   titre.fr: indemnités salarié
 contrat salarié . statut cadre:
-  titre.en: cadre status
-  titre.fr: statut cadre
-contrat salarié . statut cadre . choix statut cadre:
   question.en: Does the employee have the "cadre" status?
   question.fr: Le salarié a-t-il le statut cadre ?
   description.en: >-
@@ -2411,13 +2408,13 @@ entreprise . charges:
 
     A l'inverse, un téléphone portable à moins de 500€ peut être assimilé à une
     charge sans immobilisation.
-indépendant . cotisations et contributions . réduction ACRE:
+dirigeant . indépendant . cotisations et contributions . réduction ACRE:
   titre.en: ACRE reduction
   titre.fr: réduction ACRE
-indépendant . cotisations et contributions . réduction ACRE . taux ACRE:
+dirigeant . indépendant . cotisations et contributions . réduction ACRE . taux ACRE:
   titre.en: ACRE rate
   titre.fr: taux ACRE
-indépendant . revenu net de cotisations:
+dirigeant . indépendant . revenu net de cotisations:
   résumé.en: Before taxes
   résumé.fr: Avant impôt
   question.en: What pre-tax income do you want to receive?
@@ -2430,7 +2427,7 @@ indépendant . revenu net de cotisations:
     l'impôt sur le revenu.
   titre.en: net contribution income
   titre.fr: revenu net de cotisations
-indépendant . revenu professionnel:
+dirigeant . indépendant . revenu professionnel:
   titre.en: Professional income
   titre.fr: revenu professionnel (net imposable)
   description.en: >
@@ -2715,10 +2712,10 @@ indépendant:
   question.fr: Activité à la sécurité sociale des indépendants ?
   titre.en: self employed
   titre.fr: indépendant
-indépendant . cotisations et contributions . cotisations:
+dirigeant . indépendant . cotisations et contributions . cotisations:
   titre.en: social contributions
   titre.fr: cotisations
-indépendant . cotisations et contributions:
+dirigeant . indépendant . cotisations et contributions:
   titre.en: all contributions
   titre.fr: cotisations et contributions
 entreprise . rattachement libéral règlementé:
@@ -2736,16 +2733,16 @@ entreprise . rattachement libéral règlementé:
     donc dépendent de la sécurité sociale des indépendants.
   titre.en: linked with regulated liberal
   titre.fr: rattachement libéral règlementé
-indépendant . cotisations et contributions . cotisations . maladie:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
   titre.en: health insurance
   titre.fr: maladie
-indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée:
   titre.en: health insurance for regulated liberal
   titre.fr: maladie libérale règlementée
-indépendant . cotisations et contributions . cotisations . maladie . assiette:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . assiette:
   titre.en: health insurance basis
   titre.fr: assiette maladie
-indépendant . cotisations et contributions . cotisations . indemnités journalières maladie:
+dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie:
   titre.en: health insurance 2
   titre.fr: Maladie 2
   description.en: >-
@@ -2757,49 +2754,49 @@ indépendant . cotisations et contributions . cotisations . indemnités journali
     santé des artisans, commerçants, industriels et conjoints collaborateurs
     nécessite un arrêt de travail, une part de leur ancien revenu leur sera
     versé.
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux:
   titre.en: 'craftsmen, traders, liberal'
   titre.fr: artisans commerçants libéraux
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable:
   titre.en: variable rate
   titre.fr: taux variable
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA:
   titre.en: RSA rate
   titre.fr: taux RSA
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable:
   titre.en: variable part RSA rate
   titre.fr: taux RSA part variable
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction:
   titre.en: upper reduction threshold
   titre.fr: seuil supérieur de réduction
-indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux:
+dirigeant . indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux:
   titre.en: rate
   titre.fr: taux
-indépendant . cotisations et contributions . cotisations . retraite de base:
+dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base:
   titre.en: pension
   titre.fr: retraite de base
-indépendant . cotisations et contributions . cotisations . retraite de base . assiette:
+dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base . assiette:
   titre.en: pension basis
   titre.fr: assiette retraite de base
-indépendant . cotisations et contributions . cotisations . retraite complémentaire:
+dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire:
   titre.en: supplementary pension
   titre.fr: retraite complémentaire
-indépendant . cotisations et contributions . cotisations . invalidité et décès:
+dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
   titre.en: disability and death
   titre.fr: invalidité et décès
-indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette:
+dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette:
   titre.en: disability and death basis
   titre.fr: assiette invalidité et décès
-indépendant . cotisations et contributions . CSG et CRDS:
+dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
   titre.en: CSG and CRDS
   titre.fr: CSG et CRDS
-indépendant . cotisations et contributions . CSG et CRDS . assiette:
+dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette:
   titre.en: basis
   titre.fr: assiette
-indépendant . cotisations et contributions . formation professionnelle:
+dirigeant . indépendant . cotisations et contributions . formation professionnelle:
   titre.en: professional training
   titre.fr: formation professionnelle
-indépendant . cotisations et contributions . cotisations . allocations familiales:
+dirigeant . indépendant . cotisations et contributions . cotisations . allocations familiales:
   titre.en: family allowances
   titre.fr: allocations familiales
 auto-entrepreneur:
@@ -2818,7 +2815,7 @@ auto-entrepreneur:
     cotisations sociales par un prélèvement unique mensuel.
   titre.en: auto-entrepreneur
   titre.fr: auto-entrepreneur
-auto-entrepreneur . base des cotisations:
+dirigeant . auto-entrepreneur . base des cotisations:
   contrôles.en:
     - si: base des cotisations > plafond
       message: >-
@@ -2833,7 +2830,7 @@ auto-entrepreneur . base des cotisations:
       niveau: avertissement
   titre.en: contribution basis
   titre.fr: base des cotisations
-auto-entrepreneur . plafond:
+dirigeant . auto-entrepreneur . plafond:
   description.en: >
     The status of microentrepreneur applies as long as the annual turnover
     (actually collected during the calendar year) does not exceed a certain
@@ -2853,7 +2850,7 @@ auto-entrepreneur . plafond:
     individuelle](/simulateurs/indépendant).
   titre.en: upper limit
   titre.fr: plafond
-auto-entrepreneur . revenu net de cotisations:
+dirigeant . auto-entrepreneur . revenu net de cotisations:
   résumé.en: Before taxes
   résumé.fr: Avant impôt
   question.en: What pre-tax income do you want to receive?
@@ -2866,22 +2863,22 @@ auto-entrepreneur . revenu net de cotisations:
     l'impôt sur le revenu.
   titre.en: Net contribution income
   titre.fr: revenu net de cotisations
-auto-entrepreneur . cotisations et contributions:
+dirigeant . auto-entrepreneur . cotisations et contributions:
   titre.en: Contributions
   titre.fr: cotisations et contributions
-auto-entrepreneur . cotisations et contributions . TFC:
+dirigeant . auto-entrepreneur . cotisations et contributions . TFC:
   titre.en: Chamber taxes
   titre.fr: Taxes pour frais de chambre
-auto-entrepreneur . cotisations et contributions . TFC . commerce:
+dirigeant . auto-entrepreneur . cotisations et contributions . TFC . commerce:
   titre.en: Chamber of Trades taxes
   titre.fr: taxe pour frais de chambre de commerce
-auto-entrepreneur . cotisations et contributions . TFC . métiers:
+dirigeant . auto-entrepreneur . cotisations et contributions . TFC . métiers:
   titre.en: Chamber of Crafts taxes
   titre.fr: taxe pour frais de chambre des métiers
-auto-entrepreneur . cotisations et contributions . contribution formation professionnelle:
+dirigeant . auto-entrepreneur . cotisations et contributions . contribution formation professionnelle:
   titre.en: Contribution to vocational training
   titre.fr: Contribution à la formation professionnelle
-auto-entrepreneur . cotisations et contributions . cotisations:
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
   description.en: >
     Social security contributions give the self-employed entrepreneur access to
     a minimum social protection: a pension, health care, social security, social
@@ -2910,7 +2907,7 @@ auto-entrepreneur . cotisations et contributions . cotisations:
     l'ACRE, une réduction de cotisations, dégressive sur 3 ans.
   titre.en: contributions
   titre.fr: cotisations
-auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire:
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire:
   description.en: >-
     The total amount that is allocated to the supplementary pension, useful to
     estimate the total amount of the retirement pension for auto-entrepreneurs
@@ -2919,7 +2916,7 @@ auto-entrepreneur . cotisations et contributions . cotisations . retraite compl�
     estimer le montant total de la pension de retraite des auto-entrepreneurs
   titre.en: supplementary pension
   titre.fr: retraite complémentaire
-auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation:
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation:
   description.en: >
     The social contributions of the self-employed are simplified: there is no
     than a single line whose rate depends on the category of activity.
@@ -2984,11 +2981,11 @@ entreprise . ACRE . année . moins de deux ans:
 entreprise . ACRE . année . moins de trois ans:
   titre.en: less than three years
   titre.fr: moins de trois ans
-auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
   titre.en: |
     "ACRE" rate
   titre.fr: taux ACRE
-auto-entrepreneur . cotisations et contributions . cotisations . réduction ACRE:
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . réduction ACRE:
   titre.en: |
     "ACRE" reduction
   titre.fr: réduction ACRE
@@ -2999,16 +2996,16 @@ auto-entrepreneur . cotisations et contributions . cotisations . réduction ACRE
   description.fr: >-
     Ce taux peut dans certains cas réduire le montant des cotisations sociales
     de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
-auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
   titre.en: ACRE upper limit
   titre.fr: plafond ACRE
-auto-entrepreneur . impôt:
+dirigeant . auto-entrepreneur . impôt:
   titre.en: tax
   titre.fr: impôt
-auto-entrepreneur . impôt . abattement:
+dirigeant . auto-entrepreneur . impôt . abattement:
   titre.en: allowance
   titre.fr: abattement
-auto-entrepreneur . impôt . abattement . taux inversé:
+dirigeant . auto-entrepreneur . impôt . abattement . taux inversé:
   description.en: >-
     This is the rate to be applied to determine what remains after the
     application of
@@ -3018,10 +3015,10 @@ auto-entrepreneur . impôt . abattement . taux inversé:
     l'abattement
   titre.en: inverted rate
   titre.fr: taux inversé
-auto-entrepreneur . impôt . abattement . taux:
+dirigeant . auto-entrepreneur . impôt . abattement . taux:
   titre.en: tax allowance rate
   titre.fr: taux d'abattement de l'impôt
-auto-entrepreneur . impôt . versement libératoire:
+dirigeant . auto-entrepreneur . impôt . versement libératoire:
   description.en: >
     With the option for the discharge payment, the income tax is paid at the
     same time as your contributions (per month or per quarter) with the
@@ -3055,7 +3052,7 @@ auto-entrepreneur . impôt . versement libératoire:
       niveau: info
   titre.en: discharge payment
   titre.fr: versement libératoire
-auto-entrepreneur . impôt . versement libératoire . montant:
+dirigeant . auto-entrepreneur . impôt . versement libératoire . montant:
   titre.en: discharge payment for auto-entrepreneur
   titre.fr: versement libératoire auto-entrepreneur
   description.en: >
@@ -3086,10 +3083,10 @@ auto-entrepreneur . impôt . versement libératoire . montant:
 
     - 2,2% pour les autres prestations de services relevants des bénéfices non
     commerciaux (BNC)
-auto-entrepreneur . impôt . revenu imposable:
+dirigeant . auto-entrepreneur . impôt . revenu imposable:
   titre.en: taxable income
   titre.fr: revenu imposable
-auto-entrepreneur . impôt . revenu abattu:
+dirigeant . auto-entrepreneur . impôt . revenu abattu:
   titre.en: reduced income
   titre.fr: revenu abattu auto-entrepreneur
 protection sociale:

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -2320,7 +2320,7 @@ entreprise . impôt sur les sociétés:
 entreprise . charges dont rémunération dirigeant:
   titre.en: expenses of which executive compensation
   titre.fr: charges dont rémunération dirigeant
-entreprise . rémunération totale du dirigeant:
+dirigeant . rémunération totale:
   question.en: How much do you think you will make available for your remuneration?
   question.fr: Quel montant pensez-vous dégager pour votre rémunération ?
   résumé.en: Spent by the company

--- a/source/selectors/analyseSelectors.ts
+++ b/source/selectors/analyseSelectors.ts
@@ -1,11 +1,39 @@
-import { collectMissingVariablesByTarget, getNextSteps } from 'Engine/generateQuestions'
-import { collectDefaults, disambiguateExampleSituation, findRuleByDottedName } from 'Engine/rules'
+import {
+	collectMissingVariablesByTarget,
+	getNextSteps
+} from 'Engine/generateQuestions'
+import {
+	collectDefaults,
+	disambiguateExampleSituation,
+	findRuleByDottedName
+} from 'Engine/rules'
 import { analyse, analyseMany, parseAll } from 'Engine/traverse'
-import { add, defaultTo, difference, dissoc, equals, head, intersection, isEmpty, isNil, last, length, map, mergeDeepWith, negate, pick, pipe, sortBy, split, takeWhile, zipWith } from 'ramda'
+import {
+	add,
+	defaultTo,
+	difference,
+	dissoc,
+	equals,
+	head,
+	intersection,
+	isEmpty,
+	isNil,
+	last,
+	length,
+	map,
+	mergeDeepWith,
+	negate,
+	pick,
+	pipe,
+	sortBy,
+	split,
+	takeWhile,
+	zipWith
+} from 'ramda'
 import { useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
-import { DottedName } from "Types/rule"
+import { DottedName } from 'Types/rule'
 import { mapOrApply } from '../utils'
 // create a "selector creator" that uses deep equal instead of ===
 const createDeepEqualSelector = createSelectorCreator(defaultMemoize, equals)
@@ -281,8 +309,10 @@ export let nextStepsSelector = createSelector(
 
 		nextSteps = sortBy(
 			question =>
-				similarity(question, lastStepWithAnswer) +
-				notPriority.indexOf(question),
+				notPriority.includes(question)
+					? notPriority.indexOf(question)
+					: similarity(question, lastStepWithAnswer),
+
 			nextSteps
 		)
 

--- a/source/storage/persistEverything.js
+++ b/source/storage/persistEverything.js
@@ -1,4 +1,3 @@
-
 import type { Store } from 'redux'
 import { omit } from 'ramda'
 import { debounce } from '../utils'

--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -114,7 +114,7 @@ exports[`calculate simulations-rémunération-dirigeant: Assimilé salarié - é
 
 exports[`calculate simulations-rémunération-dirigeant: Auto-entrepreneur - activités 1`] = `"[15580,15580,6600,4,18,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant: Auto-entrepreneur - activités 2`] = `"[15560,15560,0,4,18,0]"`;
+exports[`calculate simulations-rémunération-dirigeant: Auto-entrepreneur - activités 2`] = `"[15560,15560,0,4,0,0]"`;
 
 exports[`calculate simulations-rémunération-dirigeant: Auto-entrepreneur - activités 3`] = `"[15444,15444,7047,4,14,0]"`;
 
@@ -148,7 +148,7 @@ exports[`calculate simulations-rémunération-dirigeant: Auto-entrepreneur - éc
 
 exports[`calculate simulations-rémunération-dirigeant: Indépendant - activités 1`] = `"[13772,13772,10085,4,21,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant: Indépendant - activités 2`] = `"[14563,14571,0,4,21,0]"`;
+exports[`calculate simulations-rémunération-dirigeant: Indépendant - activités 2`] = `"[14563,14571,0,4,0,0]"`;
 
 exports[`calculate simulations-rémunération-dirigeant: Indépendant - activités 3`] = `"[13761,13761,10077,4,21,0]"`;
 
@@ -166,7 +166,7 @@ exports[`calculate simulations-rémunération-dirigeant: Indépendant - période
 
 exports[`calculate simulations-rémunération-dirigeant: Indépendant - périodes 3`] = `"[2927,3397,2422,4,56,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant: Indépendant - échelle de rémunération 1`] = `"[0,0,36807,3,21,0]"`;
+exports[`calculate simulations-rémunération-dirigeant: Indépendant - échelle de rémunération 1`] = `"[null,null,36807,3,21,0]"`;
 
 exports[`calculate simulations-rémunération-dirigeant: Indépendant - échelle de rémunération 2`] = `"[631,631,481,3,21,0]"`;
 

--- a/test/regressions/simulations-indépendant.yaml
+++ b/test/regressions/simulations-indépendant.yaml
@@ -15,8 +15,8 @@ période:
     période: mois
 
 inversions:
-  - entreprise . rémunération totale du dirigeant: 2000
-  - entreprise . rémunération totale du dirigeant: 50000
+  - dirigeant . rémunération totale: 2000
+  - dirigeant . rémunération totale: 50000
   - revenu net après impôt: 10000
   - revenu net après impôt: 50000
   - revenu net après impôt: 10000

--- a/test/regressions/simulations-rémunération-dirigeant.yaml
+++ b/test/regressions/simulations-rémunération-dirigeant.yaml
@@ -1,38 +1,38 @@
 échelle de rémunération:
-  - entreprise . rémunération totale du dirigeant: 1000
-  - entreprise . rémunération totale du dirigeant: 2000
-  - entreprise . rémunération totale du dirigeant: 5000
-  - entreprise . rémunération totale du dirigeant: 10000
-  - entreprise . rémunération totale du dirigeant: 20000
-  - entreprise . rémunération totale du dirigeant: 50000
-  - entreprise . rémunération totale du dirigeant: 100000
+  - dirigeant . rémunération totale: 1000
+  - dirigeant . rémunération totale: 2000
+  - dirigeant . rémunération totale: 5000
+  - dirigeant . rémunération totale: 10000
+  - dirigeant . rémunération totale: 20000
+  - dirigeant . rémunération totale: 50000
+  - dirigeant . rémunération totale: 100000
 
 périodes:
-  - entreprise . rémunération totale du dirigeant: 200
+  - dirigeant . rémunération totale: 200
     période: mois
-  - entreprise . rémunération totale du dirigeant: 500
+  - dirigeant . rémunération totale: 500
     période: mois
-  - entreprise . rémunération totale du dirigeant: 5000
+  - dirigeant . rémunération totale: 5000
     période: mois
 
 avec charges:
-  - entreprise . rémunération totale du dirigeant: 10000
+  - dirigeant . rémunération totale: 10000
     entreprise . charges: 2000
-  - entreprise . rémunération totale du dirigeant: 20000
+  - dirigeant . rémunération totale: 20000
     entreprise . charges: 15000
 
 activités:
-  - entreprise . rémunération totale du dirigeant: 20000
+  - dirigeant . rémunération totale: 20000
     entreprise . catégorie d'activité: libérale
-  - entreprise . rémunération totale du dirigeant: 20000
+  - dirigeant . rémunération totale: 20000
     entreprise . catégorie d'activité: libérale
     entreprise . catégorie d'activité . libérale règlementée: true
-  - entreprise . rémunération totale du dirigeant: 20000
+  - dirigeant . rémunération totale: 20000
     entreprise . catégorie d'activité: artisanale
-  - entreprise . rémunération totale du dirigeant: 20000
+  - dirigeant . rémunération totale: 20000
     entreprise . catégorie d'activité: commerciale ou industrielle
     entreprise . catégorie d'activité . service ou vente: vente
-  - entreprise . rémunération totale du dirigeant: 20000
+  - dirigeant . rémunération totale: 20000
     entreprise . catégorie d'activité: commerciale ou industrielle
     entreprise . catégorie d'activité . service ou vente: service
     entreprise . catégorie d'activité . restauration ou hébergement: true


### PR DESCRIPTION
Dans le cadre de l'implémentation des exonérations, nous arrivons à une limite du moteur : ces dernières sont définies à partir d'une date de début d'effet et eventuellement une date de fin d'effet. Elles ne doivent pas être pris en compte pour le calcul des cotisations en dehors de leur période d'effet.


  ## Première idée

Cette introduction de la temporalité dans le moteur nous a apparu dans un premier temps trop hasardeuse, et nous étions partis avec @mquandalle sur une solution se basant sur une surcouche au moteur. Cette dernière ferait une simulation par combinaison de dispositifs actif sur l'année, qu'elle sommerait ensuite, pondéré par la période d'effet.

Néanmoins, cette solution souffre de deux inconvénients majeurs
- L'introduction d'une nouvelle couche de calcul "hors moteur", et donc potentiellement "hors explications" et "hors règles" pour un mécanisme plutôt commun dans les dispositifs legislatifs
- La complexité à gerer plusieurs dispositifs actifs sur plusieurs période différentes (avec une complexité en n² p/r au nombre de dispositifs)

## Une extension de la définition de "période"

L'idée est d'étendre la notion de période de simulation : "année" / "mois", pour la rendre plus précise. Une période, c'est une date de début et une date de fin. Lorsque l'on clique sur "année" sur les simulateurs, on initialise la période à l'année courante : 
```yaml
- période . début: 01/01/2019
- période . fin: 31/12/2019
```

> Si jamais l'entreprise a été crée en cours d'année, alors la période de calcul des cotisations est ajustée : 
```yaml
- période . début: entreprise . date de création
- période . fin: 31/12/2019
```
On peut donc imaginer simuler des cotisations (et salaire) sur des période diverses : quelques semaines, quelques jours, plusieurs mois, plusieurs années... 

La clé `période: flexible` dans les variables ferait donc echo au fait que la valeur de cette variable est naturellement proratisée à la période de simulation. On peut d'ailleurs considérer que c'est le comportement par défaut, et supprimer le besoin d'expliciter à chaque fois la période d'une variable

### La période de simulation, entrée du moteur
Période devient une entrée de premier niveau pour le moteur de calcul. On veut pouvoir remettre à zéro une situation sans forcément changer la période à calculer.

### Les variables sont pro-ratisées par défaut :
On étend la gestion des périodes. Mois / année étaient proratisée dans une variable "flexible". Ce sera également le cas pour des périodes plus précises :

```yaml
plafond de la sécurité sociale:
  période: mois
  formule: 2800 €
  test: 
    - période:
        début: 01/01/2020
        fin: 11/02/2020
      valeur attendue: 3900€
```

<details>
  <summary>VOIR L'ANCIENNE PROPOSITION</summary>
  
  ## Proposition d'un nouveau mécanisme : `prorata temporis`

Le mécanisme prorata temporis fonctionne en faisant calculant le prorata temporel entre la période de la variable et la période précisée en paramètre.
    
### Syntaxe de base :
```yaml
période: flexible
formule: 
  prorata temporis:
    assiette: réduction . montant
    début d'effet: réduction . début d'effet
    durée: 1 an
```
#### Exemple 1
```yaml
situation:
  réduction . montant: 1000 €
  réduction . début d'effet: 02/02/2018
  période . début: 01/01/2019
  période . fin: 31/12/2019
valeur attendue: 90.41 € (1000 * 33 / 365)
```
#### Exemple 2
```yaml
situation:
  réduction . montant: 100 €
  réduction . début d'effet: 02/02/2018
  période . début: 01/01/2020
  période . fin: 01/02/2020
valeur attendue: 0 € (1000 * 0 / 365)
```
#### Exemple 3
```yaml
situation:
  réduction . montant: 500 €
  réduction . début d'effet: 10/01/2018
  période . début: 01/01/2018
  période . fin: 31/01/2018
valeur attendue: 338,71 € (500 * 21 / 31)
```
### Syntaxe dévelopée
Dans le cas d'exonération degressive (ZFU, ACRE), on voudrait pouvoir spécifier d'un coup différent taux pour chaque année. Je propose la syntaxe suivante : 
        
```yaml
prorata temporis:
  assiette: cotisations . maladie
  début d'effet: entreprise . date de création
  tranches:
    - avant: 10 ans
      taux: 100%
    - entre: 10 ans
      et: 15 ans
      taux: 60%
    - entre: 15 ans
      et: 17 ans
      taux: 40%
    - entre: 18 ans
      et: 20 ans
      taux: 20%
```
        
</details>

## Nouvelle proposition : mécanisme `variable temporelle`

### Syntaxe par défaut

```yaml
aide:
  période: mois
  formule:
    variable temporelle:
      début: date d'effet
      montant: 310 €
```
- 0 pour la période de simulation avant `date d'effet` 
- 310 €/mois pour la période de simulation après `date d'effet` 

```yaml 
situation: 
  date d'effet: 20/01/2020
période: 
  début: 01/01/2020
  fin: 31/01/2020
valeur attendue: 110 €
```

### Avec durée

```yaml
aide:
  période: année
  formule:
    variable temporelle:
      début: date d'effet
      durée: 1 an
      montant: 3650 €
```

- 0 pour la période de simulation avant `date d'effet` 
- 310 €/mois pour la période de simulation entre `date d'effet` et `date d'effet + 1 an`
- 0 après


```yaml 
situation: 
  date d'effet: 02/01/2019
période:
  début: 01/01/2020
  fin: 31/12/2020
valeur attendue: 330 €
```


### Avec périodes

```yaml
taux exonération:
  période: aucune
  formule:
    variable temporelle:
      début: date d'effet
      périodes: 
        - pendant: 1 an
          montant: 100%
        - entre: 1 an
          et: 2 ans
          montant: 50%
```

- 0 pour la période de simulation avant `date d'effet` 
- 100% pour la période de simulation entre `date d'effet` et `date d'effet + 1 an`
- 50% pour la période de simulation entre `date d'effet + 1 an` et `date d'effet + 2 an`
- 0 après


```yaml 
situation: 
  date d'effet: 11/02/2018
période:
  début: 01/02/2019
  fin: 31/12/2019
valeur attendue: 67.86% 
```
*67.86% = 100% * (10 / 28) + 50% * (18 / 28)*



### Implications et questionnement
- Ajout du type 'date' au moteur
- Ajout des calculs sur les dates
- Ajout d'une période de simulation
- Peut-on se servir des variables temporelles pour modeliser les changements legislatifs au cours du temps ?
- Le mot clé "période" sur les variables est ambigu. Il correspond d'avantage au concept d'unité. Il faudrait reflechir si il est possible de l'eliminer complètement (cf #734) 