### PR TITLE
Mécanisme recalcul

### DIFF
--- a/publicode/rules/dirigeant.yaml
+++ b/publicode/rules/dirigeant.yaml
@@ -1006,9 +1006,12 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
   formule:
     multiplication:
       assiette: cotisations . maladie
-      # TODO : ceci n'est pas bon (le plafond est sur le revenu exonéré, et est proratisé en début / fin d'éxo)
       taux: taux
-      plafond: 3042 heures/an * SMIC horaire
+      # TODO : Le plafond est proratisé en début / fin d'exonération
+      plafond:
+        recalcul:
+          avec:
+            indépendant . revenu net de cotisations: 3042 heures/an * SMIC horaire
 
 dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   question: Bénéficiez-vous du dispositif d'exonération "âge"

--- a/publicode/rules/impôt.yaml
+++ b/publicode/rules/impôt.yaml
@@ -90,8 +90,9 @@ impôt . revenu imposable . abattement contrat court:
       - méthode de calcul . taux neutre
       - contrat salarié
       - contrat salarié . CDD
-      - contrat salarié . CDD . durée contrat <= 2
-  formule: 50% * contrat salarié . SMIC temps plein . net imposable * 1 mois
+      - contrat salarié . CDD . durée contrat <= 2 mois
+  formule:
+    arrondi: 50% * contrat salarié . SMIC temps plein . net imposable * 1 mois
   note: Cet abattement s'applique aussi pour les conventions de stage ou les contrats de mission (intérim) de moins de 2 mois.
   références:
     Bofip - dispositions spécifiques aux contrats courts: https://bofip.impots.gouv.fr/bofip/11252-PGP.html?identifiant=BOI-IR-PAS-20-20-30-10-20180515

--- a/publicode/rules/salarié.yaml
+++ b/publicode/rules/salarié.yaml
@@ -1217,9 +1217,13 @@ contrat salarié . SMIC temps plein:
     décret: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037833206
 
 contrat salarié . SMIC temps plein . net imposable:
-  description: Montant du SMIC net imposable
-  formule: 1247.55 €/mois
-  note: Ce montant est codé en dur, il faudrait le calculer à partir du montant du SMIC brut
+  titre: SMIC net imposable
+  description: Montant du SMIC net imposable pour un temps plein.
+  formule:
+    recalcul:
+      règle: rémunération . net imposable . base
+      avec:
+        rémunération . brut de base: SMIC temps plein
   références:
     barème PAS: https://bofip.impots.gouv.fr/bofip/11255-PGP.html
 
@@ -1753,10 +1757,11 @@ contrat salarié . statut JEI . exonération de cotisations:
   unité: €/mois
 
   formule:
-    # TODO - le plafonnement à 4,5 SMIC, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,
-    # il faut fournir un mécanisme "exonération" capable de recalculer une règle en introduisant un plafond
     encadrement:
-      plafond: 1634.39 €/mois
+      plafond:
+        recalcul:
+          avec:
+            rémunération . brut de base: 4.5 * SMIC
       valeur:
         somme:
           - allocations familiales

--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -96,6 +96,14 @@ arrondi:
   description: |
     On arrondi à l'euro le plus proche
 
+recalcul:
+  type: numeric
+  description: >-
+    Relance le calcul d'une règle dans une situation différente de la situation
+    courante. Permet par exemple de calculer le montant des cotisations au
+    niveau du SMIC, même si le salaire est plus élevé dans la situation
+    actuelle.
+
 ##########################################
 # Ce qu'on appelle aujourd'hui des RuleProp
 # Et qui deviendront des mécanismes classiques normalement par la suite #TODO

--- a/source/engine/mecanismViews/Recalcul.tsx
+++ b/source/engine/mecanismViews/Recalcul.tsx
@@ -1,0 +1,41 @@
+import RuleLink from 'Components/RuleLink'
+import { makeJsx } from 'Engine/evaluation'
+import React from 'react'
+import { Trans } from 'react-i18next'
+import { DottedName } from 'Types/rule'
+import { Node } from './common'
+
+export default function Recalcul(nodeValue, explanation) {
+	return (
+		<Node
+			classes="mecanism recalcul"
+			name="recalcul"
+			value={nodeValue}
+			unit={explanation.unit}
+			child={
+				<>
+					{explanation.règle && (
+						<Trans i18nKey="calcul-avec">
+							Calcul de <RuleLink dottedName={explanation.règle} /> avec :
+						</Trans>
+					)}
+					<ul>
+						{Object.keys(explanation.amendedSituation).map(dottedName => (
+							<li
+								key={dottedName}
+								css={`
+									.node.inlineExpression {
+										display: inline !important;
+									}
+								`}
+							>
+								<RuleLink dottedName={dottedName as DottedName} /> ={' '}
+								{makeJsx(explanation.amendedSituation[dottedName])}
+							</li>
+						))}
+					</ul>
+				</>
+			}
+		/>
+	)
+}

--- a/source/engine/mecanisms/arrondi.tsx
+++ b/source/engine/mecanisms/arrondi.tsx
@@ -21,7 +21,7 @@ export default (recurse, k, v) => {
 		const child = evaluateNode(cache, situation, parsedRules, node.explanation)
 		const nodeValue =
 			child.nodeValue === null ? null : Math.round(child.nodeValue)
-		return { ...node, nodeValue, explanation: child }
+		return { ...node, unit: child.unit, nodeValue, explanation: child }
 	}
 
 	return {

--- a/source/engine/mecanisms/encadrement.tsx
+++ b/source/engine/mecanisms/encadrement.tsx
@@ -62,6 +62,9 @@ const evaluate = (cache, situation, parsedRules, node) => {
 	let evaluateAttribute = evaluateNode.bind(null, cache, situation, parsedRules)
 	const valeur = evaluateAttribute(node.explanation.valeur)
 	let plafond = evaluateAttribute(node.explanation.plafond)
+	if (val(plafond) === false) {
+		plafond = objectShape.plafond
+	}
 	let plancher = evaluateAttribute(node.explanation.plancher)
 	if (valeur.unit) {
 		try {

--- a/source/engine/parse.js
+++ b/source/engine/parse.js
@@ -35,6 +35,7 @@ import {
 	mecanismOneOf,
 	mecanismOnePossibility,
 	mecanismProduct,
+	mecanismRecalcul,
 	mecanismReduction,
 	mecanismSum,
 	mecanismSynchronisation
@@ -103,6 +104,7 @@ Cela vient probablement d'une erreur dans l'indentation
 		...statelessParseFunction,
 		'une possibilité': mecanismOnePossibility(rule.dottedName),
 		'inversion numérique': mecanismInversion(rule.dottedName),
+		recalcul: mecanismRecalcul(rule.dottedName),
 		filter: () =>
 			parseReferenceTransforms(
 				rules,

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -217,6 +217,7 @@ autoentrepreneur:
   titre: Auto-entrepeneur
 back: Resume simulation
 barème: scale
+calcul-avec: 'Calculation from <1></1>with :'
 cancelExample: Back to your situation
 car dépend de: because it depends on
 cible: target

--- a/source/locales/rules-en.yaml
+++ b/source/locales/rules-en.yaml
@@ -713,16 +713,10 @@ contrat salarié . SMIC temps plein:
   titre.en: full-time mimimum wage (SMIC)
   titre.fr: SMIC temps plein
 contrat salarié . SMIC temps plein . net imposable:
-  description.en: Amount of the net taxable minimum wage (SMIC net imposable)
-  description.fr: Montant du SMIC net imposable
-  note.en: >-
-    [automatic] This amount is hard-coded, it should be calculated from the
-    amount of the gross minimum wage.
-  note.fr: >-
-    Ce montant est codé en dur, il faudrait le calculer à partir du montant du
-    SMIC brut
-  titre.en: net taxable
-  titre.fr: net imposable
+  description.en: '[automatic] Amount of the net taxable SMIC for a full-time employee.'
+  description.fr: Montant du SMIC net imposable pour un temps plein.
+  titre.en: '[automatic] minimum net taxable income'
+  titre.fr: SMIC net imposable
 contrat salarié . aides employeur:
   description.en: >
     Some aids can be requested by the employer to help hires.

--- a/test/mécanismes/arrondi.yaml
+++ b/test/mécanismes/arrondi.yaml
@@ -1,5 +1,11 @@
 cotisation retraite:
 
+demie part:
+  formule:
+    arrondi: 50% * 100.2€
+  exemples:
+    - valeur attendue: 50
+
 Arrondi:
   formule:
     arrondi: cotisation retraite

--- a/test/mécanismes/encadrement.yaml
+++ b/test/mécanismes/encadrement.yaml
@@ -1,21 +1,38 @@
-Plafonnement:
+plafonnement:
   formule:
     encadrement:
       valeur: 1000 €
       plafond: 250 €
 
   exemples:
-    - nom:
-      situation:
-      valeur attendue: 250
+    - valeur attendue: 250
 
-Plancher:
+plafonnement inactif:
+  formule:
+    encadrement:
+      valeur: 1000 €
+      plafond: false
+
+  exemples:
+    - valeur attendue: 1000
+
+plafonnement reference inactive:
+  formule:
+    encadrement:
+      valeur: 1000 €
+      plafond: plafond
+
+  exemples:
+    - valeur attendue: 1000
+
+plafonnement reference inactive . plafond:
+  formule: non
+
+plancher:
   formule:
     encadrement:
       valeur: 1000 €
       plancher: 2500 €
 
   exemples:
-    - nom:
-      situation:
-      valeur attendue: 2500
+    - valeur attendue: 2500

--- a/test/mécanismes/recalcul.yaml
+++ b/test/mécanismes/recalcul.yaml
@@ -1,0 +1,28 @@
+salaire brut:
+  formule: 2000€
+
+salaire net:
+  formule: 0.5 * salaire brut
+
+SMIC brut:
+  formule: 1000€
+
+SMIC net:
+  formule:
+    recalcul:
+      règle: salaire net
+      avec:
+        salaire brut: SMIC brut
+  exemples:
+    - valeur attendue: 500
+
+Recalcule règle courante:
+  formule:
+    encadrement:
+      valeur: 10% * salaire brut
+      plafond:
+        recalcul:
+          avec:
+            salaire brut: 100€
+  exemples:
+    - valeur attendue: 10

--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -190,7 +190,7 @@ exports[`calculate simulations-rémunération-dirigeant: Indépendant -  échell
 
 exports[`calculate simulations-salarié:  JEI 1`] = `"[3440,0,0,3000,2353,2187]"`;
 
-exports[`calculate simulations-salarié:  JEI 2`] = `"[26710,0,0,20000,15969,10681]"`;
+exports[`calculate simulations-salarié:  JEI 2`] = `"[26635,0,0,20000,15969,10681]"`;
 
 exports[`calculate simulations-salarié:  JEI 3`] = `"[4517,0,0,4000,3141,2741]"`;
 


### PR DESCRIPTION
En travaillant sur l'implémentation du quotient familial, j'ai découvert que l'implémentation de son plafonnement nécessite de lancer un nouveau calcul avec des paramètres différents, cf. https://bofip.impots.gouv.fr/bofip/2494-PGP

Je ré-ouvre donc l'issue consacrée à un mécanisme de "sous-simulation" (ex #764) car il y a maintenant 3 cas d'usages :

* Calculer le SMIC net imposable (sans le coder en dur)
* Calculer le plafonnement de l'exonération JEI (correspondant à 4,5 SMIC)
* Calculer le plafonnement du quotient familial

Ce mécanisme permet de calculer un objectif en amendant localement certaines variables (contrairement au mécanisme `remplace` dont le but est précisément de remplacer globalement une variable).