### PR TITLE
:alien: Ajoute inexistant traduction dans le formulaire des newsletter

### DIFF
--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -599,6 +599,7 @@ newsletter:
     description: |
       Subscribe to our monthly newsletter to receive <2>official advice on starting a business</2> and access new features in advance.
 S'inscrire: Register
+Votre adresse e-mail: Your email address
 
 Renseigner mon entreprise: Find my company
 Simulations personnalisées: Customized simulations


### PR DESCRIPTION
Ajoute inexistant traduction dans le formulaire des newsletter.

Actuellement, https://mycompanyinfrance.fr/ affiche le contenue suivant dans le champ d'email:
![current1](https://user-images.githubusercontent.com/33183880/71786572-754caa00-2feb-11ea-9e91-f114a3b18d04.png)


Quand ça devrait être:
![pr1](https://user-images.githubusercontent.com/33183880/71786574-78479a80-2feb-11ea-8ac0-6500c0b0aab7.png)




