### PR TITLE
UI groupe de questions

### DIFF
--- a/source/components/conversation/Conversation.tsx
+++ b/source/components/conversation/Conversation.tsx
@@ -8,6 +8,7 @@ import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
 import {
+	currentQuestionGroupSelector,
 	currentQuestionSelector,
 	flatRulesSelector,
 	nextStepsSelector
@@ -25,6 +26,7 @@ export default function Conversation({ customEndMessages }: ConversationProps) {
 	const dispatch = useDispatch()
 	const flatRules = useSelector(flatRulesSelector)
 	const currentQuestion = useSelector(currentQuestionSelector)
+	const currentQuestionGroup = useSelector(currentQuestionGroupSelector)
 	const previousAnswers = useSelector(
 		(state: RootState) => state.simulation?.foldedSteps || []
 	)
@@ -46,15 +48,19 @@ export default function Conversation({ customEndMessages }: ConversationProps) {
 	}
 	const DecoratedInputComponent = FormDecorator(InputComponent)
 
+	console.log({ currentQuestionGroup })
+
 	return flatRules && nextSteps.length ? (
 		<>
 			<Aide />
 			<div tabIndex={0} style={{ outline: 'none' }} onKeyDown={handleKeyDown}>
-				{currentQuestion && (
+				{currentQuestionGroup.length && (
 					<React.Fragment key={currentQuestion}>
-						<Animate.fadeIn>
-							<DecoratedInputComponent dottedName={currentQuestion} />
-						</Animate.fadeIn>
+						{currentQuestionGroup.map(currentQuestionX => (
+							<Animate.fadeIn key={currentQuestionX}>
+								<DecoratedInputComponent dottedName={currentQuestionX} />
+							</Animate.fadeIn>
+						))}
 						<div className="ui__ answer-group">
 							{previousAnswers.length > 0 && (
 								<>

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next'
 import NumberFormat from 'react-number-format'
 import { debounce } from '../../utils'
 import InputSuggestions from './InputSuggestions'
-import SendButton from './SendButton'
 
 // TODO: fusionner Input.js et CurrencyInput.js
 export default function Input({
@@ -52,9 +51,9 @@ export default function Input({
 				<label className="suffix" htmlFor={'step-' + dottedName}>
 					{serializeUnit(unit, value, language)}
 				</label>
-				{onSubmit && (
+				{/* {onSubmit && (
 					<SendButton disabled={value === undefined} onSubmit={onSubmit} />
-				)}
+				)} */}
 			</div>
 		</div>
 	)

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -4,7 +4,6 @@ import { is } from 'ramda'
 import React, { useCallback, useContext } from 'react'
 import { Trans } from 'react-i18next'
 import Explicable from './Explicable'
-import SendButton from './SendButton'
 
 /* Ceci est une saisie de type "radio" : l'utilisateur choisit une réponse dans une liste, ou une liste de listes.
 	Les données @choices sont un arbre de type:
@@ -113,7 +112,7 @@ export default function Question({
 			css="margin-top: 0.6rem; display: flex; align-items: center; flex-wrap: wrap;"
 		>
 			{choiceElements}
-			{onSubmit && <SendButton disabled={!currentValue} onSubmit={onSubmit} />}
+			{/* {onSubmit && <SendButton disabled={!currentValue} onSubmit={onSubmit} />} */}
 		</div>
 	)
 }

--- a/source/components/conversation/conversation.css
+++ b/source/components/conversation/conversation.css
@@ -1,6 +1,5 @@
 .step fieldset {
 	display: flex;
-	justify-content: flex-end;
 	flex-wrap: wrap;
 	align-items: baseline;
 }

--- a/source/selectors/analyseSelectors.ts
+++ b/source/selectors/analyseSelectors.ts
@@ -6,6 +6,7 @@ import {
 	collectDefaults,
 	disambiguateExampleSituation,
 	findRuleByDottedName,
+	parentName,
 	splitName
 } from 'Engine/rules'
 import { analyse, analyseMany, parseAll } from 'Engine/traverse'
@@ -327,4 +328,24 @@ export let nextStepsSelector = createSelector(
 export let currentQuestionSelector = createSelector(
 	[nextStepsSelector, state => state.simulation?.unfoldedStep],
 	(nextSteps, unfoldedStep) => unfoldedStep || head(nextSteps)
+)
+
+export let currentQuestionGroupSelector = createSelector(
+	[
+		currentQuestionSelector,
+		nextStepsSelector,
+		(state: RootState) => state.simulation?.foldedSteps
+	],
+	(currentQuestion, nextSteps, foldedSteps = []) => {
+		const allQuestions = [...nextSteps, ...foldedSteps]
+		if (!foldedSteps.includes(parentName(currentQuestion))) {
+			return [currentQuestion]
+		}
+		return [
+			parentName(currentQuestion),
+			...allQuestions.filter(
+				name => parentName(currentQuestion) === parentName(name)
+			)
+		]
+	}
 )


### PR DESCRIPTION
Lorsqu'un groupe de question porte sur un même sujet (valeur, quantité et participation patronale sur les titres restaurant par exemple), on peut avoir envie de les afficher ensemble pour que l'utilisateur ait une vue complète de la paramétrisation du dispositif.

cf. #220

![Capture d’écran - 2020-02-13 à 16 23 00](https://user-images.githubusercontent.com/1730702/74449883-848e0580-4e7d-11ea-8b8e-135ebee0d0e9.png)

Il a un travail d'UI/UX à faire pour que cette idée puisse marcher.

- [ ] Peut-être afficher les questions et le simulateur côte à côte sur les écrans du bureau qui ont suffisamment de largeur ?
- [ ] Afficher les valeurs par défaut en grisé dans les inputs
- [ ] Espacements
