### PR TITLE
Organismes complémentaires

### DIFF
--- a/publicode/rules/salarié.yaml
+++ b/publicode/rules/salarié.yaml
@@ -827,6 +827,8 @@ contrat salarié . cotisations . assiette:
         somme:
           - frais professionnels . part déductible
           - stage . gratification minimale
+          - prévoyance . part déductible
+          - retraite supplémentaire . part déductible
 
 contrat salarié . cotisations . assiette . salariale:
   titre: Assiette des cotisations sociales
@@ -1017,6 +1019,10 @@ contrat salarié . rémunération . brut:
   titre: Rémunération brute
   unité par défaut: €/mois
   formule:
+    # Pour les frais professionnels, et les cotisations de prévoyance facultative
+    # et de retraite complémentaire on ne ré-intègre ici que la part employeur
+    # (car la part salarié est déjà comptabilisé dans `rémunération . brut de
+    # base` dont elle vient en déduction).
     somme:
       - rémunération . brut de base
       - avantages en nature . montant
@@ -1025,6 +1031,8 @@ contrat salarié . rémunération . brut:
       - heures supplémentaires
       - heures complémentaires
       - frais professionnels
+      - prévoyance . employeur
+      - retraite supplémentaire . employeur
 
 contrat salarié . rémunération . heures supplémentaires:
   titre: rémunération heures supplémentaires
@@ -1060,6 +1068,8 @@ contrat salarié . avantages sociaux:
 
   formule:
     somme:
+      - prévoyance . employeur
+      - retraite supplémentaire . employeur
       - prévoyance obligatoire cadre
       - complémentaire santé .employeur
 
@@ -1213,6 +1223,17 @@ contrat salarié . plafond sécurité sociale:
   unité: €/mois
   formule: plafond sécurité sociale temps plein * temps de travail . quotité de travail
 
+contrat salarié . plafond sécurité sociale . renonciation proratisation:
+  description: >-
+    D'un commun accord, l'employeur et l'employé peuvent renoncer à la réduction
+    du plafond de la sécurité sociale (applicable pour les salariés à temps
+    partiel), notamment afin d'augmenter le montant des cotisations vieillesse.
+  par défaut: non
+  applicable si: temps de travail . quotité de travail < 100%
+  remplace:
+    - règle: plafond sécurité sociale
+      par: plafond sécurité sociale temps plein
+
 contrat salarié . SMIC temps plein:
   unité: €/mois
 
@@ -1320,6 +1341,8 @@ contrat salarié . rémunération . net imposable:
           - prime d'impatriation
           - exonération d'impôt des stagiaires et apprentis
           - heures supplémentaires et complémentaires défiscalisées
+          - retraite supplémentaire . exonération fiscale
+          - prévoyance . exonération fiscale
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
 
@@ -1968,6 +1991,48 @@ contrat salarié . retraite complémentaire . taux salarié tranche 1:
 contrat salarié . retraite complémentaire . taux salarié tranche 2:
   formule: 8.64%
 
+contrat salarié . retraite supplémentaire:
+  formule:
+    somme:
+      - employeur
+      - salarié
+
+contrat salarié . retraite supplémentaire . employeur:
+  titre: Retraite supplémentaire employeur
+  formule: 0€/mois
+
+contrat salarié . retraite supplémentaire . salarié:
+  formule: 0€/mois
+
+contrat salarié . retraite supplémentaire . part déductible:
+  formule:
+    allègement:
+      assiette: retraite supplémentaire . employeur
+      abbatement: plafond d'exonération sociale employeur
+
+contrat salarié . retraite supplémentaire . plafond d'exonération sociale employeur:
+  formule:
+    encadrement:
+      valeur: 5% * cotisations . assiette
+      plafond: 5% * plafond sécurité sociale
+  références:
+    Article D242-1: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037456320&cidTexte=LEGITEXT000006073189&dateTexte=20180930
+
+contrat salarié . retraite supplémentaire . exonération fiscale:
+  titre: retraite supplémentaire exonérée d'impôt
+  formule:
+    encadrement:
+      valeur: retraite supplémentaire
+      plafond:
+        multiplication:
+          taux: 8%
+          assiette:
+            encadrement:
+              valeur: rémunération . brut
+              plafond: 8 * plafond sécurité sociale temps plein
+  références:
+    Bopfip § 120: https://bofip.impots.gouv.fr/bofip/5956-PGP.html
+
 contrat salarié . AGS:
   description: Cotisation au Régime de Garantie des Salaires
   cotisation:
@@ -2436,11 +2501,37 @@ contrat salarié . participation effort de construction:
       assiette: cotisations . assiette
       taux: 0.45%
 
-  # TODO cas agricole, et autres statuts spécifiques
-# TODO: cette contribution est un minimum légal (méconnu semble-t-il), il faudrait pouvoir
-# indiquer le taux appliqué par l'entreprise
-#
+contrat salarié . prévoyance:
+  formule:
+    somme:
+      - employeur
+      - salarié
 
+contrat salarié . prévoyance . employeur:
+  titré: Prévoyance employeur
+  formule: 0 €/mois
+
+contrat salarié . prévoyance . salarié:
+  formule: 0 €/mois
+
+contrat salarié . prévoyance . part déductible:
+  formule:
+    allègement:
+      assiette: prévoyance . employeur
+      abbatement: plafond exonération sociale employeur
+
+contrat salarié . prévoyance . plafond exonération sociale employeur:
+  formule:
+    encadrement:
+      valeur:
+        somme:
+          - 6% * plafond sécurité sociale
+          - 1.5% * cotisations . assiette
+      plafond: 12% * plafond sécurité sociale
+
+# TODO: À fusionner avec `contrat salarié . prévoyance`. Pour l'instant pas
+# gênant d'avoir deux cotisations séparées car `contrat salarié . prévoyance`
+# est toujours nulle (pas de question associée)
 contrat salarié . prévoyance obligatoire cadre:
   titre: Prévoyance obligatoire pour les cadres
   cotisation:
@@ -2452,9 +2543,26 @@ contrat salarié . prévoyance obligatoire cadre:
   formule:
     multiplication:
       assiette: cotisations . assiette
-      taux: 1.5%
       plafond: plafond sécurité sociale
-      # TODO attention : il semblerait que ce 1.5% englobe aussi la complémentaire santé ! La confusion serait entretenue par les organismes de prévoyance...
+      taux: 1.5%
+      # TODO attention : il semblerait que ce 1.5% englobe aussi la
+      # complémentaire santé ! La confusion serait entretenue par les organismes
+      # de prévoyance...
+
+contrat salarié . prévoyance . exonération fiscale:
+  titre: prévoyance exonérée d'impôt
+  formule:
+    encadrement:
+      valeur: prévoyance
+      plafond:
+        encadrement:
+          valeur:
+            somme:
+              - 5% * plafond sécurité sociale temps plein
+              - 2% * rémunération . brut
+          plafond: 2% * 8 * plafond sécurité sociale temps plein
+  références:
+    Bopfip § 120: https://bofip.impots.gouv.fr/bofip/5956-PGP.html
 
 contrat salarié . taxe d'apprentissage:
   cotisation:

--- a/source/locales/rules-en.yaml
+++ b/source/locales/rules-en.yaml
@@ -1927,6 +1927,18 @@ contrat salarié . participation effort de construction:
 contrat salarié . plafond sécurité sociale:
   titre.en: social security ceiling
   titre.fr: plafond sécurité sociale
+contrat salarié . plafond sécurité sociale . renonciation proratisation:
+  description.en: >-
+    [automatic] By mutual agreement, the employer and the employee may waive the
+    reduction of the social security ceiling (applicable for part-time
+    employees), in particular in order to increase the amount of old-age
+    contributions.
+  description.fr: >-
+    D'un commun accord, l'employeur et l'employé peuvent renoncer à la réduction
+    du plafond de la sécurité sociale (applicable pour les salariés à temps
+    partiel), notamment afin d'augmenter le montant des cotisations vieillesse.
+  titre.en: '[automatic] proration waiver'
+  titre.fr: renonciation proratisation
 contrat salarié . prime d'impatriation:
   description.en: The impatriation bonus is a part of the remuneration exempt from income tax.
   description.fr: >-
@@ -1961,6 +1973,24 @@ contrat salarié . prix du travail:
   résumé.fr: Dépensé par l'entreprise
   titre.en: labor cost
   titre.fr: Coût total
+contrat salarié . prévoyance:
+  titre.en: '[automatic] foresight'
+  titre.fr: prévoyance
+contrat salarié . prévoyance . employeur:
+  titre.en: '[automatic] employer'
+  titre.fr: employeur
+contrat salarié . prévoyance . exonération fiscale:
+  titre.en: '[automatic] tax-exempt pension'
+  titre.fr: prévoyance exonérée d'impôt
+contrat salarié . prévoyance . part déductible:
+  titre.en: '[automatic] deductible portion'
+  titre.fr: part déductible
+contrat salarié . prévoyance . plafond exonération sociale employeur:
+  titre.en: '[automatic] ceiling employer''s social security exemption'
+  titre.fr: plafond exonération sociale employeur
+contrat salarié . prévoyance . salarié:
+  titre.en: '[automatic] employee'
+  titre.fr: salarié
 contrat salarié . prévoyance obligatoire cadre:
   titre.en: mandatory life insurance for "cadres"
   titre.fr: Prévoyance obligatoire pour les cadres
@@ -1984,6 +2014,24 @@ contrat salarié . retraite complémentaire . taux salarié tranche 1:
 contrat salarié . retraite complémentaire . taux salarié tranche 2:
   titre.en: employee rate tranche 2
   titre.fr: taux salarié tranche 2
+contrat salarié . retraite supplémentaire:
+  titre.en: '[automatic] additional pension'
+  titre.fr: retraite supplémentaire
+contrat salarié . retraite supplémentaire . employeur:
+  titre.en: '[automatic] Employer Supplementary Retirement'
+  titre.fr: Retraite supplémentaire employeur
+contrat salarié . retraite supplémentaire . exonération fiscale:
+  titre.en: '[automatic] tax-exempt supplementary pension'
+  titre.fr: retraite supplémentaire exonérée d'impôt
+contrat salarié . retraite supplémentaire . part déductible:
+  titre.en: '[automatic] deductible portion'
+  titre.fr: part déductible
+contrat salarié . retraite supplémentaire . plafond d'exonération sociale employeur:
+  titre.en: '[automatic] employer''s social security ceiling'
+  titre.fr: plafond d'exonération sociale employeur
+contrat salarié . retraite supplémentaire . salarié:
+  titre.en: '[automatic] employee'
+  titre.fr: salarié
 contrat salarié . réduction ACRE:
   titre.en: ACRE reduction
   titre.fr: réduction ACRE


### PR DESCRIPTION
Intégration de la prévoyance et retraite supplémentaire.

Les plafonds d'exonérations sont d'une complexité incroyable. D'une part ils différent dans leur mode de calcul pour la retraite supplémentaire et pour la prévoyance, mais surtout ils différent entre l'exonération fiscale et l'exonération sociale. Les assiettes ne sont pas les mêmes (dans un cas on déduit les cotisations complémentaires, dans l'autre cas non), le plafond de la sécurité sociale utilisé n'est pas le même (dans un cas il est pro-ratisé en fonction de la durée de présence du salarié, dans l'autre non), il y a plusieurs niveaux de plafonnement, etc.