### PR TITLE
Récapitulatif d'aide à la déclaration indépendant: vue et impression

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"react-router-dom": "^5.1.1",
 		"react-spring": "=8.0.27",
 		"react-syntax-highlighter": "^10.1.1",
+		"react-to-print": "^2.5.1",
 		"react-transition-group": "^2.2.1",
 		"react-virtualized": "^9.20.0",
 		"react-virtualized-select": "^3.1.3",

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -864,7 +864,9 @@ path:
     exemples: /examples
     index: /documentation
   gérer:
-    déclaration-indépendant: /declaration-aid-independent
+    déclaration-indépendant:
+      index: /declaration-aid-independent
+      récapitulatif: /summary
     embaucher: /hiring
     index: /manage
     sécuritéSociale: /social-security

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -4,6 +4,7 @@
 <0>Oui</0>: <0>Yes</0>
 A quoi servent mes cotisations ?: What's included in my contributions?
 Accueil: Home
+Aide à la déclaration de revenus au titre de l'année 2019: Help with your 2019 income tax return
 Alors: Then
 Année d'activité: Years of activity
 Assimilé salarié: '"Assimilé-salarié"'
@@ -106,6 +107,7 @@ Retour à mon activité: Back to my business
 Revenir à la documentation: Go back to documentation
 Revenu (incluant les dépenses liées à l'activité): Revenue (including expenses related to the activity)
 Revenu disponible: Disposable income
+Récapitulatif: Summary
 Rémunération du dirigeant: Director's remuneration
 Répartition du chiffre d'affaires: Breakdown of turnover
 Résultat: Result

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -67,7 +67,7 @@ Mon entreprise: My company
 Mon revenu: My income
 Montant: Amount
 Montant des cotisations: Amount of contributions
-"Nom de l'entreprise ou SIREN ": Company name or SIREN code
+'Nom de l''entreprise ou SIREN ': Company name or SIREN code
 Non: 'No'
 Nous n'avons rien trouvé: We didn't find any matching registered company.
 Oui: 'Yes'
@@ -101,6 +101,7 @@ Responsabilité limitée: Limited liability
 Ressources utiles: Helpful resources
 Retour: Back
 Retour à la création: Back to creation
+Retour à ma déclaration: Back to my statement
 Retour à mon activité: Back to my business
 Revenir à la documentation: Go back to documentation
 Revenu (incluant les dépenses liées à l'activité): Revenue (including expenses related to the activity)
@@ -138,14 +139,14 @@ Votre forme juridique: Your legal status
 aide: aid or subsidy
 aide-déclaration-indépendant:
   description: >-
-    <0>Help with your 2019 income tax return </0><1>This tool is a tax
-    (income) and social security (ISD) declaration aid for self-employed
-    workers. It allows you to find out the amount of social security charges
-    deductible from your net fiscal result.</1><2><0>This tool is for you if you
-    are in any of the following cases :</0><1><0>you contribute to the general
-    scheme for self-employed persons</0><1>your business is in the actual tax
-    system and in accrual accounting</1></1><2>It does not concern you if you
-    are in one of the following cases:</2><3><0>you are a regulated liberal
+    <0>Help with your 2019 income tax return </0><1>This tool is a tax (income)
+    and social security (ISD) declaration aid for self-employed workers. It
+    allows you to find out the amount of social security charges deductible from
+    your net fiscal result.</1><2><0>This tool is for you if you are in any of
+    the following cases :</0><1><0>you contribute to the general scheme for
+    self-employed persons</0><1>your business is in the actual tax system and in
+    accrual accounting</1></1><2>It does not concern you if you are in one of
+    the following cases:</2><3><0>you are a regulated liberal
     profession</0><1>you are a liberal profession contributing to the
     CIPAV</1><2>your company is domiciled in the DOMs</2></3></2><3>What is your
     professional income in 2019?</3><4>Indicate your net fiscal result before

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendants.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendants.tsx
@@ -1,18 +1,12 @@
 import { setSimulationConfig, updateSituation } from 'Actions/actions'
-import RuleLink from 'Components/RuleLink'
 import 'Components/TargetSelection.css'
 import Warning from 'Components/ui/WarningBlock'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import useDisplayOnIntersecting from 'Components/utils/useDisplayOnIntersecting'
-import { SitePathsContext } from 'Components/utils/withSitePaths'
-import { formatValue } from 'Engine/format'
 import InputComponent from 'Engine/RuleInput'
-import React, { useCallback, useContext, useEffect, useState } from 'react'
-import emoji from 'react-easy-emoji'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Trans } from 'react-i18next'
-import Skeleton from 'react-loading-skeleton'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link } from 'react-router-dom'
 import { RootState } from 'Reducers/rootReducer'
 import {
 	flatRulesSelector,
@@ -24,23 +18,9 @@ import styled from 'styled-components'
 import { DottedName, Rule } from 'Types/rule'
 import Animate from 'Ui/animate'
 import { useRule } from '../Simulateurs/ArtisteAuteur'
+import { simulationConfig } from './AideDéclarationIndépendantsSimulationConfig'
+import { Results } from './AideDéclarationIndépentantsResult'
 import { CompanySection } from './Home'
-
-const simulationConfig = {
-	objectifs: [
-		'aide déclaration revenu indépendant 2019 . revenu net fiscal',
-		'aide déclaration revenu indépendant 2019 . CSG déductible',
-		'aide déclaration revenu indépendant 2019 . cotisations sociales déductible',
-		'aide déclaration revenu indépendant 2019 . CFP',
-		'aide déclaration revenu indépendant 2019 . total charges sociales déductible',
-		'aide déclaration revenu indépendant 2019 . assiette sociale'
-	] as Array<DottedName>,
-	situation: {
-		dirigeant: 'indépendant',
-		'aide déclaration revenu indépendant 2019': true
-	},
-	'unités par défaut': ['€/an']
-}
 
 const lauchComputationWhenResultsInViewport = () => {
 	const dottedName = 'dirigeant . rémunération totale'
@@ -189,7 +169,7 @@ export default function AideDéclarationIndépendant() {
 					</Animate.fromTop>
 
 					<div ref={resultsRef}>
-						<Results />
+						<Results récapitulatif={true} />
 					</div>
 				</>
 			)}
@@ -282,78 +262,6 @@ function SimpleField({ dottedName, question, summary }: SimpleFieldProps) {
 				/>
 			</Question>
 		</Animate.fromTop>
-	)
-}
-
-function Results() {
-	const results = simulationConfig.objectifs.map(dottedName =>
-		useRule(dottedName)
-	)
-	const onGoingComputation = !results.filter(node => node.nodeValue != null)
-		.length
-	const sitePaths = useContext(SitePathsContext)
-	return (
-		<div
-			className="ui__ card lighter-bg"
-			css="margin-top: 3rem; padding: 1rem 0"
-		>
-			<h1 css="text-align: center; margin-bottom: 2rem">
-				<Trans i18nKey="aide-déclaration-indépendant.results.title">
-					Aide à la déclaration {emoji('📄')}
-				</Trans>
-			</h1>
-			{onGoingComputation && (
-				<h2>
-					<small>
-						<Trans i18nKey="aide-déclaration-indépendant.results.ongoing">
-							Calcul en cours...
-						</Trans>
-					</small>
-				</h2>
-			)}
-			<>
-				<Animate.fromTop>
-					{results.map(r => (
-						<React.Fragment key={r.title}>
-							<h4>
-								{r.title} <small>{r.summary}</small>
-							</h4>
-							{r.description && <p className="ui__ notice">{r.description}</p>}
-							<p className="ui__ lead" css="margin-bottom: 1rem;">
-								<RuleLink dottedName={r.dottedName}>
-									{r.nodeValue != null ? (
-										formatValue({
-											value: r.nodeValue || 0,
-											language: 'fr',
-											unit: '€',
-											maximumFractionDigits: 0
-										})
-									) : (
-										<Skeleton width={80} />
-									)}
-								</RuleLink>
-							</p>
-						</React.Fragment>
-					))}
-					{!onGoingComputation && (
-						<div css="text-align: center">
-							<button className="ui__ simple button">
-								{emoji('🔗')} Obtenir le lien
-							</button>
-							<Link
-								className="ui__ simple button"
-								to={sitePaths.gérer.déclarationIndépendant.récapitulatif}
-							>
-								{emoji('📋')} Récapitulatif
-							</Link>
-							<button className="ui__ simple button">
-								{emoji('🖨')} Imprimer
-							</button>
-						</div>
-					)}
-				</Animate.fromTop>
-			</>
-		</div>
 	)
 }
 

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendants.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendants.tsx
@@ -4,16 +4,17 @@ import 'Components/TargetSelection.css'
 import Warning from 'Components/ui/WarningBlock'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import useDisplayOnIntersecting from 'Components/utils/useDisplayOnIntersecting'
+import { SitePathsContext } from 'Components/utils/withSitePaths'
 import { formatValue } from 'Engine/format'
 import InputComponent from 'Engine/RuleInput'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import Skeleton from 'react-loading-skeleton'
 import { useDispatch, useSelector } from 'react-redux'
+import { Link } from 'react-router-dom'
 import { RootState } from 'Reducers/rootReducer'
 import {
-	analysisWithDefaultsSelector,
 	flatRulesSelector,
 	nextStepsSelector,
 	ruleAnalysisSelector,
@@ -40,6 +41,7 @@ const simulationConfig = {
 	},
 	'unités par défaut': ['€/an']
 }
+
 const lauchComputationWhenResultsInViewport = () => {
 	const dottedName = 'dirigeant . rémunération totale'
 	const [resultsRef, resultsInViewPort] = useDisplayOnIntersecting({
@@ -70,7 +72,6 @@ const lauchComputationWhenResultsInViewport = () => {
 
 export default function AideDéclarationIndépendant() {
 	const dispatch = useDispatch()
-	const analysis = useSelector(analysisWithDefaultsSelector)
 	const rules = useSelector(flatRulesSelector)
 	const company = useSelector(
 		(state: RootState) => state.inFranceApp.existingCompany
@@ -279,7 +280,6 @@ function SimpleField({ dottedName, question, summary }: SimpleFieldProps) {
 					onChange={update}
 					value={currentValue}
 				/>
-				{/* <Field dottedName={dottedName} onChange={onChange} /> */}
 			</Question>
 		</Animate.fromTop>
 	)
@@ -291,6 +291,7 @@ function Results() {
 	)
 	const onGoingComputation = !results.filter(node => node.nodeValue != null)
 		.length
+	const sitePaths = useContext(SitePathsContext)
 	return (
 		<div
 			className="ui__ card lighter-bg"
@@ -339,6 +340,12 @@ function Results() {
 							<button className="ui__ simple button">
 								{emoji('🔗')} Obtenir le lien
 							</button>
+							<Link
+								className="ui__ simple button"
+								to={sitePaths.gérer.déclarationIndépendant.récapitulatif}
+							>
+								{emoji('📋')} Récapitulatif
+							</Link>
 							<button className="ui__ simple button">
 								{emoji('🖨')} Imprimer
 							</button>

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendants.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendants.tsx
@@ -4,7 +4,7 @@ import Warning from 'Components/ui/WarningBlock'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import useDisplayOnIntersecting from 'Components/utils/useDisplayOnIntersecting'
 import InputComponent from 'Engine/RuleInput'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
@@ -18,6 +18,7 @@ import styled from 'styled-components'
 import { DottedName, Rule } from 'Types/rule'
 import Animate from 'Ui/animate'
 import { useRule } from '../Simulateurs/ArtisteAuteur'
+import { AideDéclarationIndépendantsRécapitulatif } from './AideDéclarationIndépendantsRécapitulatif'
 import { simulationConfig } from './AideDéclarationIndépendantsSimulationConfig'
 import { Results } from './AideDéclarationIndépentantsResult'
 import { CompanySection } from './Home'
@@ -63,6 +64,7 @@ export default function AideDéclarationIndépendant() {
 		updateIncome,
 		currentIncome
 	} = lauchComputationWhenResultsInViewport()
+	const printComponentRef = useRef<HTMLDivElement>(null)
 	return (
 		<>
 			<ScrollToTop />
@@ -169,7 +171,12 @@ export default function AideDéclarationIndépendant() {
 					</Animate.fromTop>
 
 					<div ref={resultsRef}>
-						<Results récapitulatif={true} />
+						<div style={{ display: 'none' }}>
+							<div ref={printComponentRef}>
+								<AideDéclarationIndépendantsRécapitulatif />
+							</div>
+						</div>
+						<Results récapitulatif={true} componentRef={printComponentRef} />
 					</div>
 				</>
 			)}

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
+import { getSessionStorage } from '../../../../utils'
+import { constructLocalizedSitePath } from '../../sitePaths'
+
+type ProviderProps = {
+	situation
+}
+
+export class AideDéclarationIndépendantsRécapitulatif extends Component<
+	ProviderProps
+> {
+	render() {
+		const lang = getSessionStorage()?.getItem('lang')
+		const sitePaths = constructLocalizedSitePath(lang ? lang : 'fr')
+		return (
+			<>
+				<Link to={sitePaths.gérer.déclarationIndépendant.index}>Retour</Link>
+				<h1>Aide à la déclaration de revenus au titre de l'année 2019</h1>
+			</>
+		)
+	}
+}

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
@@ -1,23 +1,142 @@
-import React, { Component } from 'react'
-import { Link } from 'react-router-dom'
-import { getSessionStorage } from '../../../../utils'
-import { constructLocalizedSitePath } from '../../sitePaths'
+import CompanyDetails from 'Components/CompanyDetails'
+import { formatValue } from 'Engine/format'
+import React from 'react'
+import { Trans } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import { RootState } from 'Reducers/rootReducer'
+import { situationSelector } from 'Selectors/analyseSelectors'
+import { Results } from './AideDéclarationIndépentantsResult'
 
-type ProviderProps = {
-	situation
+export function AideDéclarationIndépendantsRécapitulatif() {
+	const situation = useSelector(situationSelector)
+	const siren = useSelector(
+		(state: RootState) => state.inFranceApp.existingCompany?.siren
+	)
+
+	return (
+		<>
+			<h1>
+				<Trans>Aide à la déclaration de revenus au titre de l'année 2019</Trans>
+			</h1>
+
+			<p>
+				Ce document atteste de votre bonne foi concernant votre déclaration
+				selon les éléments transmis.
+			</p>
+
+			<h2>
+				<Trans>Récapitulatif</Trans>
+			</h2>
+
+			<SimpleField
+				label="Rémunération totale"
+				dottedName={'dirigeant . rémunération totale'}
+				unit="€"
+			/>
+
+			{siren && <CompanyDetails siren={siren} />}
+
+			<SimpleField
+				label="Nature de votre activité"
+				dottedName={
+					"aide déclaration revenu indépendant 2019 . nature de l'activité"
+				}
+				unit="text"
+			/>
+
+			<SimpleField
+				label="Vous êtes bénéficiaire du RSA ou de la prime d’activité"
+				dottedName={'situation personnelle . RSA'}
+			/>
+
+			{!situation[
+				"situation personnelle . domiciliation fiscale à l'étranger"
+			] && (
+				<>
+					<SimpleField
+						label="Vous avez perçu des indemnités journalières de maladie, maternité ou paternité au titre de votre activité indépendante"
+						dottedName={'dirigeant . indépendant . IJSS'}
+					/>
+
+					<SimpleField
+						label="Le montant total brut de toutes vos indemnités journalières est de"
+						dottedName={'dirigeant . indépendant . IJSS . total'}
+						unit="€"
+					/>
+
+					<SimpleField
+						label="Le montant brut des indemnités journalières imposables perçues est de"
+						dottedName={'dirigeant . indépendant . IJSS . imposable'}
+						unit="€"
+					/>
+				</>
+			)}
+
+			<SimpleField
+				label="Vous avez un conjoint collaborateur"
+				dottedName={'dirigeant . indépendant . conjoint collaborateur'}
+			/>
+
+			<SimpleField
+				label="Il cotise sur la base"
+				dottedName={
+					'dirigeant . indépendant . conjoint collaborateur . assiette'
+				}
+				unit="text"
+			/>
+
+			<SimpleField
+				label="Vous êtes titulaire d’une pension d’invalidité à titre de travailleur indépendant"
+				dottedName={
+					'dirigeant . indépendant . cotisations et contributions . exonérations . invalidité'
+				}
+			/>
+
+			<SimpleField
+				label="La résidence fiscale est située à l'étranger"
+				dottedName={
+					"situation personnelle . domiciliation fiscale à l'étranger"
+				}
+			/>
+
+			<SimpleField
+				label="Vous avez perçu des revenus à l'étranger dans le cadre de votre activité"
+				dottedName={'dirigeant . indépendant . revenus étrangers'}
+			/>
+
+			<Results récapitulatif={false} />
+		</>
+	)
 }
 
-export class AideDéclarationIndépendantsRécapitulatif extends Component<
-	ProviderProps
-> {
-	render() {
-		const lang = getSessionStorage()?.getItem('lang')
-		const sitePaths = constructLocalizedSitePath(lang ? lang : 'fr')
-		return (
-			<>
-				<Link to={sitePaths.gérer.déclarationIndépendant.index}>Retour</Link>
-				<h1>Aide à la déclaration de revenus au titre de l'année 2019</h1>
-			</>
-		)
-	}
+type SimpleFieldProps = {
+	label?: string
+	dottedName: string
+	unit?: string
+}
+function SimpleField({ label, dottedName, unit }: SimpleFieldProps) {
+	const situation = useSelector(situationSelector)
+	const value = situation[dottedName]
+	return value ? (
+		<p>
+			<span>
+				<Trans>{label}</Trans>
+			</span>{' '}
+			<span>
+				{value !== null &&
+					unit === '€' &&
+					' : ' +
+						formatValue({
+							value: value || 0,
+							language: 'fr',
+							unit: '€',
+							maximumFractionDigits: 0
+						})}
+
+				{value !== null && unit === 'text' && ' : ' + value}
+			</span>
+		</p>
+	) : (
+		<></>
+	)
 }

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
@@ -12,6 +12,7 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 	const siren = useSelector(
 		(state: RootState) => state.inFranceApp.existingCompany?.siren
 	)
+	console.log(situation)
 	const componentRef = useRef<HTMLDivElement>(null)
 	return (
 		<div ref={componentRef}>
@@ -41,7 +42,6 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 				dottedName={
 					"aide déclaration revenu indépendant 2019 . nature de l'activité"
 				}
-				unit="text"
 			/>
 
 			<SimpleField
@@ -82,7 +82,6 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 				dottedName={
 					'dirigeant . indépendant . conjoint collaborateur . assiette'
 				}
-				unit="text"
 			/>
 
 			<SimpleField
@@ -117,7 +116,8 @@ type SimpleFieldProps = {
 function SimpleField({ label, dottedName, unit }: SimpleFieldProps) {
 	const situation = useSelector(situationSelector)
 	const value = situation[dottedName]
-	return value ? (
+	console.log(situation)
+	return value && (value === 'oui' || unit === '€') ? (
 		<p>
 			<span>
 				<Trans>{label}</Trans>
@@ -129,14 +129,12 @@ function SimpleField({ label, dottedName, unit }: SimpleFieldProps) {
 						formatValue({
 							value: value || 0,
 							language: 'fr',
-							unit: '€',
+							unit: unit,
 							maximumFractionDigits: 0
 						})}
 
-				{value !== null && unit === 'text' && ' : ' + value}
+				{value !== null && unit === undefined && ' : ' + value}
 			</span>
 		</p>
-	) : (
-		<></>
-	)
+	) : null
 }

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
@@ -12,6 +12,7 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 	const siren = useSelector(
 		(state: RootState) => state.inFranceApp.existingCompany?.siren
 	)
+	console.log(useSelector((state: RootState) => state.rules))
 	const componentRef = useRef<HTMLDivElement>(null)
 
 	return (
@@ -29,43 +30,30 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 				<Trans>Récapitulatif</Trans>
 			</h2>
 
-			<SimpleField
-				label="Rémunération totale"
-				dottedName={'dirigeant . rémunération totale'}
-				unit="€"
-			/>
+			<SimpleField dottedName={'dirigeant . rémunération totale'} unit="€" />
 
 			{siren && <CompanyDetails siren={siren} />}
 
 			<SimpleField
-				label="Nature de votre activité"
 				dottedName={
 					"aide déclaration revenu indépendant 2019 . nature de l'activité"
 				}
 			/>
 
-			<SimpleField
-				label="Vous êtes bénéficiaire du RSA ou de la prime d’activité"
-				dottedName={'situation personnelle . RSA'}
-			/>
+			<SimpleField dottedName={'situation personnelle . RSA'} />
 
 			{!situation[
 				"situation personnelle . domiciliation fiscale à l'étranger"
 			] && (
 				<>
-					<SimpleField
-						label="Vous avez perçu des indemnités journalières de maladie, maternité ou paternité au titre de votre activité indépendante"
-						dottedName={'dirigeant . indépendant . IJSS'}
-					/>
+					<SimpleField dottedName={'dirigeant . indépendant . IJSS'} />
 
 					<SimpleField
-						label="Le montant total brut de toutes vos indemnités journalières est de"
 						dottedName={'dirigeant . indépendant . IJSS . total'}
 						unit="€"
 					/>
 
 					<SimpleField
-						label="Le montant brut des indemnités journalières imposables perçues est de"
 						dottedName={'dirigeant . indépendant . IJSS . imposable'}
 						unit="€"
 					/>
@@ -73,7 +61,6 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 			)}
 
 			<SimpleField
-				label="Vous avez un conjoint collaborateur"
 				dottedName={'dirigeant . indépendant . conjoint collaborateur'}
 			/>
 
@@ -85,23 +72,18 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 			/>
 
 			<SimpleField
-				label="Vous êtes titulaire d’une pension d’invalidité à titre de travailleur indépendant"
 				dottedName={
 					'dirigeant . indépendant . cotisations et contributions . exonérations . invalidité'
 				}
 			/>
 
 			<SimpleField
-				label="La résidence fiscale est située à l'étranger"
 				dottedName={
 					"situation personnelle . domiciliation fiscale à l'étranger"
 				}
 			/>
 
-			<SimpleField
-				label="Vous avez perçu des revenus à l'étranger dans le cadre de votre activité"
-				dottedName={'dirigeant . indépendant . revenus étrangers'}
-			/>
+			<SimpleField dottedName={'dirigeant . indépendant . revenus étrangers'} />
 
 			<Results récapitulatif={false} componentRef={componentRef} />
 		</div>
@@ -115,24 +97,27 @@ type SimpleFieldProps = {
 }
 function SimpleField({ label, dottedName, unit }: SimpleFieldProps) {
 	const situation = useSelector(situationSelector)
+	const rules = useSelector((state: RootState) => state.rules)
 	const value = situation[dottedName]
 	return value && (value === 'oui' || unit === '€') ? (
 		<p>
 			<span>
-				<Trans>{label}</Trans>
-			</span>{' '}
+				{rules.find(rule => rule.dottedName === dottedName)?.question}
+			</span>
 			<span>
-				{value !== null &&
-					unit === '€' &&
-					' : ' +
+				&nbsp;
+				<strong>
+					{value !== null && unit === '€' ? (
 						formatValue({
 							value: value || 0,
 							language: 'fr',
 							unit: unit,
 							maximumFractionDigits: 0
-						})}
-
-				{value !== null && unit === undefined && ' : ' + value}
+						})
+					) : (
+						<>{value}</>
+					)}
+				</strong>
 			</span>
 		</p>
 	) : null

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
@@ -12,8 +12,8 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 	const siren = useSelector(
 		(state: RootState) => state.inFranceApp.existingCompany?.siren
 	)
-	console.log(situation)
 	const componentRef = useRef<HTMLDivElement>(null)
+
 	return (
 		<div ref={componentRef}>
 			<h1>
@@ -116,7 +116,6 @@ type SimpleFieldProps = {
 function SimpleField({ label, dottedName, unit }: SimpleFieldProps) {
 	const situation = useSelector(situationSelector)
 	const value = situation[dottedName]
-	console.log(situation)
 	return value && (value === 'oui' || unit === '€') ? (
 		<p>
 			<span>

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsRécapitulatif.tsx
@@ -1,6 +1,6 @@
 import CompanyDetails from 'Components/CompanyDetails'
 import { formatValue } from 'Engine/format'
-import React from 'react'
+import React, { useRef } from 'react'
 import { Trans } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
@@ -12,9 +12,9 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 	const siren = useSelector(
 		(state: RootState) => state.inFranceApp.existingCompany?.siren
 	)
-
+	const componentRef = useRef<HTMLDivElement>(null)
 	return (
-		<>
+		<div ref={componentRef}>
 			<h1>
 				<Trans>Aide à la déclaration de revenus au titre de l'année 2019</Trans>
 			</h1>
@@ -104,8 +104,8 @@ export function AideDéclarationIndépendantsRécapitulatif() {
 				dottedName={'dirigeant . indépendant . revenus étrangers'}
 			/>
 
-			<Results récapitulatif={false} />
-		</>
+			<Results récapitulatif={false} componentRef={componentRef} />
+		</div>
 	)
 }
 

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsSimulationConfig.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendantsSimulationConfig.tsx
@@ -1,0 +1,17 @@
+import { DottedName } from 'Types/rule'
+
+export const simulationConfig = {
+	objectifs: [
+		'aide déclaration revenu indépendant 2019 . revenu net fiscal',
+		'aide déclaration revenu indépendant 2019 . CSG déductible',
+		'aide déclaration revenu indépendant 2019 . cotisations sociales déductible',
+		'aide déclaration revenu indépendant 2019 . CFP',
+		'aide déclaration revenu indépendant 2019 . total charges sociales déductible',
+		'aide déclaration revenu indépendant 2019 . assiette sociale'
+	] as Array<DottedName>,
+	situation: {
+		dirigeant: 'indépendant',
+		'aide déclaration revenu indépendant 2019': true
+	},
+	'unités par défaut': ['€/an']
+}

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépentantsResult.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépentantsResult.tsx
@@ -6,14 +6,16 @@ import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import Skeleton from 'react-loading-skeleton'
 import { Link } from 'react-router-dom'
+import ReactToPrint from 'react-to-print'
 import Animate from 'Ui/animate'
 import { useRule } from '../Simulateurs/ArtisteAuteur'
 import { simulationConfig } from './AideDéclarationIndépendantsSimulationConfig'
 
 type ResultsProp = {
 	récapitulatif: boolean
+	componentRef?: any
 }
-export function Results({ récapitulatif }: ResultsProp) {
+export function Results({ récapitulatif, componentRef }: ResultsProp) {
 	const results = simulationConfig.objectifs.map(dottedName =>
 		useRule(dottedName)
 	)
@@ -74,12 +76,20 @@ export function Results({ récapitulatif }: ResultsProp) {
 									{emoji('📋')} Récapitulatif
 								</Link>
 							)}
-							<button
-								className="ui__ simple button"
-								onClick={() => window.print()}
-							>
-								{emoji('🖨')} Imprimer
-							</button>
+							<style>{`@media print {.button.print{display: none;} body {margin: 40px;}}`}</style>
+							{!récapitulatif && (
+								<ReactToPrint
+									trigger={() => (
+										<button
+											className="ui__ simple button print"
+											onClick={() => window.print()}
+										>
+											{emoji('🖨')} Imprimer
+										</button>
+									)}
+									content={() => componentRef.current}
+								/>
+							)}
 						</div>
 					)}
 				</Animate.fromTop>

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépentantsResult.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépentantsResult.tsx
@@ -1,0 +1,89 @@
+import RuleLink from 'Components/RuleLink'
+import { SitePathsContext } from 'Components/utils/withSitePaths'
+import { formatValue } from 'Engine/format'
+import React, { useContext } from 'react'
+import emoji from 'react-easy-emoji'
+import { Trans } from 'react-i18next'
+import Skeleton from 'react-loading-skeleton'
+import { Link } from 'react-router-dom'
+import Animate from 'Ui/animate'
+import { useRule } from '../Simulateurs/ArtisteAuteur'
+import { simulationConfig } from './AideDéclarationIndépendantsSimulationConfig'
+
+type ResultsProp = {
+	récapitulatif: boolean
+}
+export function Results({ récapitulatif }: ResultsProp) {
+	const results = simulationConfig.objectifs.map(dottedName =>
+		useRule(dottedName)
+	)
+	const onGoingComputation = !results.filter(node => node.nodeValue != null)
+		.length
+	const sitePaths = useContext(SitePathsContext)
+	return (
+		<div
+			className="ui__ card lighter-bg"
+			css="margin-top: 3rem; padding: 1rem 0"
+		>
+			<h1 css="text-align: center; margin-bottom: 2rem">
+				<Trans i18nKey="aide-déclaration-indépendant.results.title">
+					Aide à la déclaration
+				</Trans>
+				{emoji('📄')}
+			</h1>
+			{onGoingComputation && (
+				<h2>
+					<small>
+						<Trans i18nKey="aide-déclaration-indépendant.results.ongoing">
+							Calcul en cours...
+						</Trans>
+					</small>
+				</h2>
+			)}
+			<>
+				<Animate.fromTop>
+					{results.map(r => (
+						<React.Fragment key={r.title}>
+							<h4>
+								{r.title} <small>{r.summary}</small>
+							</h4>
+							{r.description && <p className="ui__ notice">{r.description}</p>}
+							<p className="ui__ lead" css="margin-bottom: 1rem;">
+								<RuleLink dottedName={r.dottedName}>
+									{r.nodeValue != null ? (
+										formatValue({
+											value: r.nodeValue || 0,
+											language: 'fr',
+											unit: '€',
+											maximumFractionDigits: 0
+										})
+									) : (
+										<Skeleton width={80} />
+									)}
+								</RuleLink>
+							</p>
+						</React.Fragment>
+					))}
+					{!onGoingComputation && (
+						<div css="text-align: center">
+							{récapitulatif && (
+								<Link
+									className="ui__ simple button"
+									to={sitePaths.gérer.déclarationIndépendant.récapitulatif}
+								>
+									{emoji('📋')} Récapitulatif
+								</Link>
+							)}
+							<button
+								className="ui__ simple button"
+								onClick={() => window.print()}
+							>
+								{emoji('🖨')} Imprimer
+							</button>
+						</div>
+					)}
+				</Animate.fromTop>
+			</>
+		</div>
+	)
+}

--- a/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépentantsResult.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépentantsResult.tsx
@@ -69,27 +69,24 @@ export function Results({ récapitulatif, componentRef }: ResultsProp) {
 					{!onGoingComputation && (
 						<div css="text-align: center">
 							{récapitulatif && (
-								<Link
-									className="ui__ simple button"
-									to={sitePaths.gérer.déclarationIndépendant.récapitulatif}
-								>
-									{emoji('📋')} Récapitulatif
-								</Link>
+								<>
+									<Link
+										className="ui__ simple button"
+										to={sitePaths.gérer.déclarationIndépendant.récapitulatif}
+									>
+										{emoji('📋')} Récapitulatif
+									</Link>
+								</>
 							)}
 							<style>{`@media print {.button.print{display: none;} body {margin: 40px;}}`}</style>
-							{!récapitulatif && (
-								<ReactToPrint
-									trigger={() => (
-										<button
-											className="ui__ simple button print"
-											onClick={() => window.print()}
-										>
-											{emoji('🖨')} Imprimer
-										</button>
-									)}
-									content={() => componentRef.current}
-								/>
-							)}
+							<ReactToPrint
+								trigger={() => (
+									<button className="ui__ simple button print">
+										{emoji('🖨')} Imprimer
+									</button>
+								)}
+								content={() => componentRef.current}
+							/>
 						</div>
 					)}
 				</Animate.fromTop>

--- a/source/sites/mon-entreprise.fr/pages/Gérer/Home.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/Home.tsx
@@ -96,7 +96,7 @@ export default function SocialSecurity() {
 									<Link
 										className="ui__ interactive card box"
 										to={{
-											pathname: sitePaths.gérer.déclarationIndépendant
+											pathname: sitePaths.gérer.déclarationIndépendant.index
 										}}
 									>
 										<div className="ui__ big box-icon">{emoji('✍')}</div>

--- a/source/sites/mon-entreprise.fr/pages/Gérer/index.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/index.tsx
@@ -2,10 +2,8 @@ import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/withSitePaths'
 import React, { useContext } from 'react'
 import { Trans } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import { Route, Switch } from 'react-router'
 import { NavLink, useLocation } from 'react-router-dom'
-import { situationSelector } from 'Selectors/analyseSelectors'
 import AideDéclarationIndépendant from './AideDéclarationIndépendants'
 import { AideDéclarationIndépendantsRécapitulatif } from './AideDéclarationIndépendantsRécapitulatif'
 import Embaucher from './Embaucher'
@@ -15,19 +13,30 @@ import SécuritéSociale from './SécuritéSociale'
 export default function Gérer() {
 	const sitePaths = useContext(SitePathsContext)
 	const location = useLocation()
-	const situation = useSelector(situationSelector)
 	return (
 		<>
 			<ScrollToTop key={location.pathname} />
 			<div css="transform: translateY(2rem)">
-				<NavLink
-					to={sitePaths.gérer.index}
-					exact
-					activeClassName="ui__ hide"
-					className="ui__ simple push-left small button"
-				>
-					← <Trans>Retour à mon activité</Trans>
-				</NavLink>
+				{location.pathname ===
+				'/gérer/aide-declaration-independants/récapitulatif' ? (
+					<NavLink
+						to={sitePaths.gérer.déclarationIndépendant.index}
+						exact
+						activeClassName="ui__ hide"
+						className="ui__ simple push-left small button"
+					>
+						← <Trans>Retour à ma déclaration</Trans>
+					</NavLink>
+				) : (
+					<NavLink
+						to={sitePaths.gérer.index}
+						exact
+						activeClassName="ui__ hide"
+						className="ui__ simple push-left small button"
+					>
+						← <Trans>Retour à mon activité</Trans>
+					</NavLink>
+				)}
 			</div>
 			<Switch>
 				<Route exact path={sitePaths.gérer.index} component={Home} />
@@ -43,9 +52,7 @@ export default function Gérer() {
 				/>
 				<Route
 					path={sitePaths.gérer.déclarationIndépendant.récapitulatif}
-					render={() => (
-						<AideDéclarationIndépendantsRécapitulatif situation={situation} />
-					)}
+					component={AideDéclarationIndépendantsRécapitulatif}
 				/>
 			</Switch>
 		</>

--- a/source/sites/mon-entreprise.fr/pages/Gérer/index.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Gérer/index.tsx
@@ -2,9 +2,12 @@ import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/withSitePaths'
 import React, { useContext } from 'react'
 import { Trans } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { Route, Switch } from 'react-router'
 import { NavLink, useLocation } from 'react-router-dom'
+import { situationSelector } from 'Selectors/analyseSelectors'
 import AideDéclarationIndépendant from './AideDéclarationIndépendants'
+import { AideDéclarationIndépendantsRécapitulatif } from './AideDéclarationIndépendantsRécapitulatif'
 import Embaucher from './Embaucher'
 import Home from './Home'
 import SécuritéSociale from './SécuritéSociale'
@@ -12,6 +15,7 @@ import SécuritéSociale from './SécuritéSociale'
 export default function Gérer() {
 	const sitePaths = useContext(SitePathsContext)
 	const location = useLocation()
+	const situation = useSelector(situationSelector)
 	return (
 		<>
 			<ScrollToTop key={location.pathname} />
@@ -33,8 +37,15 @@ export default function Gérer() {
 				/>
 				<Route path={sitePaths.gérer.embaucher} component={Embaucher} />
 				<Route
-					path={sitePaths.gérer.déclarationIndépendant}
+					exact
+					path={sitePaths.gérer.déclarationIndépendant.index}
 					component={AideDéclarationIndépendant}
+				/>
+				<Route
+					path={sitePaths.gérer.déclarationIndépendant.récapitulatif}
+					render={() => (
+						<AideDéclarationIndépendantsRécapitulatif situation={situation} />
+					)}
 				/>
 			</Switch>
 		</>

--- a/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
@@ -25,6 +25,7 @@ import Animate from 'Ui/animate'
 
 export function useRule(dottedName: DottedName) {
 	const analysis = useSelector(analysisWithDefaultsSelector)
+	console.log(analysis)
 	const getRule = getRuleFromAnalysis(analysis)
 	return getRule(dottedName)
 }

--- a/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
@@ -25,7 +25,6 @@ import Animate from 'Ui/animate'
 
 export function useRule(dottedName: DottedName) {
 	const analysis = useSelector(analysisWithDefaultsSelector)
-	console.log(analysis)
 	const getRule = getRuleFromAnalysis(analysis)
 	return getRule(dottedName)
 }

--- a/source/sites/mon-entreprise.fr/sitePaths.ts
+++ b/source/sites/mon-entreprise.fr/sitePaths.ts
@@ -89,10 +89,16 @@ export const constructLocalizedSitePath = (language: string) => {
 			index: t('path.gérer.index', '/gérer'),
 			embaucher: t('path.gérer.embaucher', '/embaucher'),
 			sécuritéSociale: t('path.gérer.sécuritéSociale', '/sécurité-sociale'),
-			déclarationIndépendant: t(
-				'path.gérer.déclaration-indépendant',
-				'/aide-declaration-independants'
-			)
+			déclarationIndépendant: {
+				index: t(
+					'path.gérer.déclaration-indépendant.index',
+					'/aide-declaration-independants'
+				),
+				récapitulatif: t(
+					'path.gérer.déclaration-indépendant.récapitulatif',
+					'/récapitulatif'
+				)
+			}
 		},
 		simulateurs: {
 			index: t('path.simulateurs.index', '/simulateurs'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9038,6 +9038,13 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.18.0"
 
+react-to-print@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.5.1.tgz#eaaff4248910f179788ab15a593ceb3e07527b8c"
+  integrity sha512-HhuujwTmuGYB+yBq52y1pwiv0aooaLTqksMJ6cGKWy+aT+x6zponitZd54swiAeILndxJ7oO+X1F/93XyfT/JA==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-transition-group@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"


### PR DESCRIPTION
Issue #895 

Vu avec @mquandalle : on propose une page récapitulatif reprenant les éléments saisis par l'utilisateur et avec une mention lui indiquant que ce récap' peut être utilisé comme justificatif (wording à définir). Le bouton `Imprimer` permet de lancer l'impression de ce récapitulatif depuis la page du formulaire. Une nouvelle page est crée pour ce récapitulatif.