### PR TITLE
Emojis des simulateurs indépendant et auto-entrepreneur

### DIFF
--- a/source/sites/mon-entreprise.fr/pages/Simulateurs/Home.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Simulateurs/Home.tsx
@@ -50,7 +50,7 @@ export default function Simulateurs() {
 							pathname: sitePaths.simulateurs.indépendant
 						}}
 					>
-						<div className="ui__ big box-icon">{emoji('🃏')}</div>
+						<div className="ui__ big box-icon">{emoji('👩‍🔧')}</div>
 						<Trans i18nKey="simulateurs.accueil.indépendant">
 							<h3>Indépendant</h3>
 							<p className="ui__ notice" css="flex: 1">
@@ -66,7 +66,7 @@ export default function Simulateurs() {
 							pathname: sitePaths.simulateurs['auto-entrepreneur']
 						}}
 					>
-						<div className="ui__ big box-icon">{emoji('🧢')}</div>
+						<div className="ui__ big box-icon">{emoji('🚶‍♂️')}</div>
 						<Trans i18nKey="simulateurs.accueil.auto">
 							<h3>Auto-entrepreneur</h3>
 							<p className="ui__ notice" css="flex: 1">


### PR DESCRIPTION
Agnès nous a fait un retour concernant les emojis des simulateurs indépendant et auto-entrepreneur, qui donnent l'impression aux personnes concernées qu'on ne les « prends pas au sérieux ». Ça avait aussi été ma première impression lorsque j'étais arrivé sur cette page. (Je devine que le thème est d'illustrer différents niveaux de protection sociale par différents chapeaux, ce qui est une chouette idée, mais il faut bien avouer que ça n'est pas forcément limpide).

J'ai changé un peu au hasard, je suis pas super fort en emojis 😅

https://deploy-preview-908--syso.netlify.com/simulateurs

(si on veut rester dans le thème des chapeaux sont aussi disponibles : 🎩 🧢 👒, peut-être moins gênants que le l'icône du joker 🃏)