### PR TITLE
Supprime l'écrêtement de la CSG/CRDS

### DIFF
--- a/publicode/rules/salarié.yaml
+++ b/publicode/rules/salarié.yaml
@@ -2712,6 +2712,8 @@ contrat salarié . CSG et CRDS . CRDS . taux:
   titre: taux CRDS
   formule: 0.5%
 
+# L'écrêtement de la CSG/CRDS pour les revenus de remplacement a été implémenté
+# dans 992a4da
 contrat salarié . CSG et CRDS . revenus de remplacement:
   titre: CSG et CRDS revenus de remplacement
   description: >-
@@ -2721,24 +2723,19 @@ contrat salarié . CSG et CRDS . revenus de remplacement:
     réduire le montant de la rémunération d’activité et des allocations de
     chômage à un seuil inférieur au Smic brut.
 
+    Cette disposition est suspendue dans le cadre de l'activité partielle suite
+    au covid-19.
   formule:
     somme:
       - revenus de remplacement . CSG déductible
       - revenus de remplacement . CSG non déductible
       - revenus de remplacement . CRDS
+  références:
+    Aménagements covid-19: https://www.legisocial.fr/actualites-sociales/3781-ordonnance-modifiant-regime-activite-partielle-publiee-jo-jour.html
+    Mesures d'urgences pour l'activité partielle: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000041762506&categorieLien=id
 
 contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible:
   titre: CSG déductible revenus de remplacement
-  applicable si: rémunération nette >= SMIC temps plein
-  formule: montant
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible . rémunération nette:
-  formule:
-    somme:
-      - rémunération . net de cotisations
-      - rémunération . revenus de remplacement
-      - (- montant)
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible . montant:
-  titre: CSG déductible
   formule:
     produit:
       assiette: CSG et CRDS . assiette revenu remplacements
@@ -2746,17 +2743,6 @@ contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible . mon
 
 contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible:
   titre: CSG non déductible revenus de remplacement
-  applicable si: rémunération nette >= SMIC temps plein
-  formule: montant
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible . rémunération nette:
-  formule:
-    somme:
-      - rémunération . net de cotisations
-      - rémunération . revenus de remplacement
-      - (- CSG déductible . montant)
-      - (- montant)
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible . montant:
-  titre: CSG non déductible
   formule:
     produit:
       assiette: CSG et CRDS . assiette revenu remplacements
@@ -2764,18 +2750,6 @@ contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible .
 
 contrat salarié . CSG et CRDS . revenus de remplacement . CRDS:
   titre: CRDS revenus de remplacement
-  applicable si: rémunération nette >= SMIC temps plein
-  formule: montant
-contrat salarié . CSG et CRDS . revenus de remplacement . CRDS . rémunération nette:
-  formule:
-    somme:
-      - rémunération . net de cotisations
-      - rémunération . revenus de remplacement
-      - (- CSG déductible . montant)
-      - (- CSG non déductible . montant)
-      - (- montant)
-contrat salarié . CSG et CRDS . revenus de remplacement . CRDS . montant:
-  titre: CRDS
   formule:
     produit:
       assiette: assiette revenu remplacements

--- a/source/locales/rules-en.yaml
+++ b/source/locales/rules-en.yaml
@@ -536,7 +536,7 @@ contrat salarié . CDD . contrat jeune vacances:
   description.fr: >-
     Aussi appelé CDD vendanges. Contrat conclu avec un jeune pendant ses
     vacances scolaires ou universitaires.
-  note.en: '[automatic] That''s not a reason for a fixed-term contract.'
+  note.en: "[automatic] That's not a reason for a fixed-term contract."
   note.fr: Ce n'est pas un motif de CDD.
   question.en: Is it a young holiday contract?
   question.fr: Est-ce un contrat jeune vacances ?
@@ -907,43 +907,30 @@ contrat salarié . CSG et CRDS . non déductible:
 contrat salarié . CSG et CRDS . revenus de remplacement:
   description.en: '[automatic] CSG and CRDS deducted from replacement income.'
   description.fr: La CSG et CRDS prélevées sur les revenus de remplacement.
-  note.en: >-
-    [automatic] The levying of the CSG and the CRDS may not have the effect of
-    reducing the amount of earned income and unemployment benefits to a
-    threshold lower than the gross minimum wage.
   note.fr: >-
     Le prélèvement de la CSG et de la CRDS ne peut pas avoir pour effet de
     réduire le montant de la rémunération d’activité et des allocations de
     chômage à un seuil inférieur au Smic brut.
+
+    Cette disposition est suspendue dans le cadre de l'activité partielle suite
+    au covid-19.
+  note.en: >-
+    The levying of the CSG and the CRDS may not have the effect of reducing the
+    amount of earned income and unemployment benefits to a threshold lower than
+    the gross minimum wage.
+
+    This provision is suspended for partial activity following covid-19.
   titre.en: '[automatic] CSG and CRDS replacement income'
   titre.fr: CSG et CRDS revenus de remplacement
 contrat salarié . CSG et CRDS . revenus de remplacement . CRDS:
   titre.en: '[automatic] CRDS replacement income'
   titre.fr: CRDS revenus de remplacement
-contrat salarié . CSG et CRDS . revenus de remplacement . CRDS . montant:
-  titre.en: '[automatic] DRES'
-  titre.fr: CRDS
-contrat salarié . CSG et CRDS . revenus de remplacement . CRDS . rémunération nette:
-  titre.en: '[automatic] take-home pay'
-  titre.fr: rémunération nette
 contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible:
   titre.en: '[automatic] Deductible MSA replacement income'
   titre.fr: CSG déductible revenus de remplacement
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible . montant:
-  titre.en: '[automatic] deductible MSA'
-  titre.fr: CSG déductible
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG déductible . rémunération nette:
-  titre.en: '[automatic] take-home pay'
-  titre.fr: rémunération nette
 contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible:
   titre.en: '[automatic] Non-deductible CSG replacement income'
   titre.fr: CSG non déductible revenus de remplacement
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible . montant:
-  titre.en: '[automatic] non-deductible MSA'
-  titre.fr: CSG non déductible
-contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible . rémunération nette:
-  titre.en: '[automatic] take-home pay'
-  titre.fr: rémunération nette
 contrat salarié . FNAL:
   description.en: >-
     The National Housing Fund (Fnal) is a contribution to ensure the financing
@@ -1153,7 +1140,7 @@ contrat salarié . aides employeur:
     France. Découvrez-les sur le [portail
     officiel](http://www.aides-entreprises.fr).
   résumé.en: Deferred aids available to the employer.
-  résumé.fr: 'Pour l''employeur, différées dans le temps'
+  résumé.fr: "Pour l'employeur, différées dans le temps"
   titre.en: '[automatic] employer assistance'
   titre.fr: aides employeur
 contrat salarié . aides employeur . aide à l'embauche d'apprentis:
@@ -1225,7 +1212,7 @@ contrat salarié . ancienneté:
   titre.en: '[automatic] seniority'
   titre.fr: ancienneté
 contrat salarié . ancienneté . date d'embauche:
-  question.en: '[automatic] What is the employee''s hiring date?'
+  question.en: "[automatic] What is the employee's hiring date?"
   question.fr: Quelle est la date d'embauche du salarié ?
   suggestions.Début 2019.en: '[automatic] Early 2019'
   suggestions.Début 2019.fr: Début 2019
@@ -1471,7 +1458,7 @@ contrat salarié . convention collective:
     Néanmoins, cela permet d'obtenir une première estimation, plus précise
     que le régime général.
   question.en: 'Which "convention collective" is applicable to the company ? [beta] '
-  question.fr: 'Quelle convention collective est applicable à l''entreprise ? [beta] '
+  question.fr: "Quelle convention collective est applicable à l'entreprise ? [beta] "
   titre.en: convention collective
   titre.fr: convention collective
 contrat salarié . convention collective . BTP:
@@ -1573,7 +1560,7 @@ contrat salarié . convention collective . BTP . retraite complémentaire . etam
   titre.fr: etam
 contrat salarié . convention collective . HCR:
   description.en: 'The company is a hotel, café, restaurant or similar.'
-  description.fr: 'L''entreprise est un hôtel, café, restaurant ou assimilé.'
+  description.fr: "L'entreprise est un hôtel, café, restaurant ou assimilé."
   titre.en: '[automatic] hotels, cafés and restaurants HCR'
   titre.fr: 'hôtels, cafés restaurants HCR'
 contrat salarié . convention collective . HCR . majoration heures supplémentaires:
@@ -2202,7 +2189,7 @@ contrat salarié . frais professionnels . titres-restaurant . taux participation
   description.fr: >-
     Part du titre-restaurant payée par l'employeur. Doit être de 50% minimum et
     de 60% maximum.
-  question.en: '[automatic] What is the employer''s paid portion?'
+  question.en: "[automatic] What is the employer's paid portion?"
   question.fr: Quelle est la participation de l'employeur ?
   suggestions.50%.en: '[automatic] 50%'
   suggestions.50%.fr: 50%
@@ -2629,7 +2616,7 @@ contrat salarié . prévoyance . part déductible:
   titre.en: '[automatic] deductible portion'
   titre.fr: part déductible
 contrat salarié . prévoyance . plafond exonération sociale employeur:
-  titre.en: '[automatic] ceiling employer''s social security exemption'
+  titre.en: "[automatic] ceiling employer's social security exemption"
   titre.fr: plafond exonération sociale employeur
 contrat salarié . prévoyance . salarié:
   titre.en: '[automatic] employee'
@@ -2670,7 +2657,7 @@ contrat salarié . retraite supplémentaire . part déductible:
   titre.en: '[automatic] deductible portion'
   titre.fr: part déductible
 contrat salarié . retraite supplémentaire . plafond d'exonération sociale employeur:
-  titre.en: '[automatic] employer''s social security ceiling'
+  titre.en: "[automatic] employer's social security ceiling"
   titre.fr: plafond d'exonération sociale employeur
 contrat salarié . retraite supplémentaire . salarié:
   titre.en: '[automatic] employee'
@@ -3054,7 +3041,7 @@ contrat salarié . rémunération . brut de base:
 
     Il ne comprend pas les indemnités, avantages sociaux, avantages en nature et
     primes...
-  question.en: '[automatic] What''s your gross salary?'
+  question.en: "[automatic] What's your gross salary?"
   question.fr: Quel est votre salaire brut ?
   résumé.en: '[automatic] Reference gross (excluding premiums, allowances and surcharges)'
   résumé.fr: 'Brut de référence (sans les primes, indemnités ni majorations)'
@@ -3107,7 +3094,7 @@ contrat salarié . rémunération . net:
     Cette somme peut varier en fonction de décisions politiques (augmentation ou
     diminution des cotisations) alors que le salaire brut est contractuel (pour
     le changer, il faut signer un avenant au contrat).
-  question.en: '[automatic] What''s your take-home pay?'
+  question.en: "[automatic] What's your take-home pay?"
   question.fr: Quel est votre salaire net ?
   résumé.en: Received by the employee
   résumé.fr: Salaire net avant impôt
@@ -4612,7 +4599,7 @@ dirigeant . rattachement CIPAV:
   note.en: >-
     [automatic] for the time being, we have only retained the CIPAV for the
     calculations.
-  note.fr: 'pour l''instant, nous n''avons retenu que la CIPAV pour les calculs'
+  note.fr: "pour l'instant, nous n'avons retenu que la CIPAV pour les calculs"
   titre.en: CIPAV attachment
   titre.fr: rattachement CIPAV
 dirigeant . rattachement CIPAV . invalidité et décès:
@@ -4975,7 +4962,7 @@ entreprise . catégorie d'activité . restauration ou hébergement:
   titre.fr: restauration ou hébergement
 entreprise . catégorie d'activité . service ou vente:
   question.en: 'Is it a service activity, or the purchase and sale of goods?'
-  question.fr: 'Est-ce une activité de prestation de service, ou de l''achat-vente de biens ?'
+  question.fr: "Est-ce une activité de prestation de service, ou de l'achat-vente de biens ?"
   titre.en: service or sale
   titre.fr: service ou vente
 entreprise . catégorie d'activité . service ou vente . service:
@@ -5094,7 +5081,7 @@ entreprise . chiffre d'affaires minimum:
   titre.en: Minimum turnover
   titre.fr: chiffre d'affaires minimum
 entreprise . date de création:
-  contrôles.0.en: '[automatic] We can''t see that far into the future'
+  contrôles.0.en: "[automatic] We can't see that far into the future"
   contrôles.0.fr: Nous ne pouvons voir aussi loin dans le futur
   contrôles.1.en: >-
     [automatic] This is a very old company! Are you sure you didn't make a
@@ -5311,7 +5298,7 @@ entreprise . établissement bancaire:
     L'entreprise est un établissement bancaire, financier ou d'assurance. Elle
     est non assujettie à la TVA.
   question.en: 'Is it a banking, financial or insurance institution?'
-  question.fr: 'S''agit-il d''un établissement bancaire, financier, d''assurance ?'
+  question.fr: "S'agit-il d'un établissement bancaire, financier, d'assurance ?"
   titre.en: banking institution
   titre.fr: établissement bancaire
 impôt:

--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -200,7 +200,7 @@ exports[`calculate simulations-salarié:  JEI 2`] = `"[26635,0,0,20000,15969,106
 
 exports[`calculate simulations-salarié:  JEI 3`] = `"[4517,0,0,4000,3141,2741]"`;
 
-exports[`calculate simulations-salarié:  activité partielle 1`] = `"[27,1218,0,1560,1197,1197]"`;
+exports[`calculate simulations-salarié:  activité partielle 1`] = `"[27,1218,0,1560,1116,1116]"`;
 
 exports[`calculate simulations-salarié:  activité partielle 2`] = `"[27,2800,0,4000,2594,2354]"`;
 
@@ -214,9 +214,9 @@ exports[`calculate simulations-salarié:  activité partielle 6`] = `"[27,2100,3
 
 exports[`calculate simulations-salarié:  activité partielle 7`] = `"[27,2800,0,4000,2594,2491]"`;
 
-exports[`calculate simulations-salarié:  activité partielle 8`] = `"[227,1400,0,2000,1540,1515]"`;
+exports[`calculate simulations-salarié:  activité partielle 8`] = `"[227,1400,0,2000,1473,1447]"`;
 
-exports[`calculate simulations-salarié:  activité partielle 9`] = `"[1156,700,0,2000,1551,1519]"`;
+exports[`calculate simulations-salarié:  activité partielle 9`] = `"[1156,700,0,2000,1517,1486]"`;
 
 exports[`calculate simulations-salarié:  activité partielle 10`] = `"[327,4200,0,6000,4182,3494]"`;
 


### PR DESCRIPTION
Pour les revenus de remplacement suite à l'ordonnance sur le covid