### PR TITLE
🔨 Add synonyms to the main rules related to indépendant

### DIFF
--- a/source/rules/dirigeant.yaml
+++ b/source/rules/dirigeant.yaml
@@ -353,6 +353,9 @@ dirigeant . auto-entrepreneur . net après impôt:
   formule: revenu net après impôt
 
 dirigeant . rémunération totale:
+  synonymes:
+    - résultat d'exploitation
+    - bénéfices
   question: Quel montant pensez-vous dégager pour votre rémunération ?
   résumé: Dépensé par l'entreprise
   unité par défaut: €/an
@@ -418,6 +421,8 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ACRE .
           plafond: 100%
 
 dirigeant . indépendant . revenu net de cotisations:
+  synonymes:
+    - résultat comptable
   formule:
     somme:
       - revenu professionnel
@@ -431,6 +436,9 @@ dirigeant . indépendant . revenu net de cotisations:
     Cerfa 2033-sd: https://www.impots.gouv.fr/portail/files/formulaires/2033-sd/2020/2033-sd_2983.pdf
 
 dirigeant . indépendant . résultat fiscal:
+  synonymes:
+    - net imposable
+    - assiette fiscale
   résumé: Assiette du calcul de l'impôt
   description: Il s'agit du net imposable, assiette sur laquelle l'impôt est calculé.
   formule:

--- a/source/rules/entreprise-établissement.yaml
+++ b/source/rules/entreprise-établissement.yaml
@@ -97,6 +97,9 @@ entreprise . charges dont rémunération dirigeant:
   formule: charges + dirigeant . rémunération totale
 
 entreprise . charges:
+  synonymes:
+    - charges d'exploitation
+    - charges de fonctionnement
   titre: charges de fonctionnement
   résumé: Toutes les dépenses nécessaires à l'entreprise
   question: Quelles sont les charges de l'entreprise ?


### PR DESCRIPTION
# Pourquoi?

L'usage est de retrouver la règle afférente à ce qu'on trouve mentionné dans une référence (surtout quand on lit la loi et le bofip, mais aussi articles web qui ont une qualité suffisante).

Peut-être plus tard, se donner la liberté d'utiliser la valeur via un des synonymes, ce qui peut être utile pour être le plus cohérent possible.  
Par exemple dans le cas des entreprises: en construisant des règles à partir de la "top line" (c'est à dire du CA), je pense qu'il est légitime d'utiliser des termes comptables: "CA", "charges", "résultat" ou "bénéfices" (comme par exemple "résultat comptable"). Alors qu'une même valeur peut être désignée par un terme différent dans un contexte plutôt fiscal: "revenu brut", "revenu net", "revenu net de <something>" (par ex "revenu net de costisations" qui est exactement la meme valeur que le "résultat comptable").

Je laisse cette idée murir dans mon esprit, à voir plus tard.

# L'implémentation

Là j'ai mis bêtement une clé `synonymes` dans les règles car apparemment on a le droit d'ajouter des clés arbitraires. Ceci dit, je ne suis pas encore sûr de la nécessité d'avoir qqch de structuré (tant que c'est simplement pour du search et de la lecture humaine, pas besoin).

Donc n'hésitez pas à me dire @mquandalle @johangirod si vous pensez que je devrais inscrire ces termes autrement. Dans `note` peut-etre?