### PR TITLE
Remplacement dans un remplacement

### DIFF
--- a/source/engine/README.md
+++ b/source/engine/README.md
@@ -297,6 +297,23 @@ somme avec remplacements:
   formule: a + b
 ```
 
+Enfin, il est possible d'accéder à la valeur initiale de la règle modifiée dans
+une formule de remplacement :
+
+```yaml
+temps de trajet:
+  formule: 10 min
+
+bouchons:
+  remplace: temps de trajet
+  formule: temps de trajet * 2
+```
+
+Dans la règle `bouchons`, la variable `temps de trajet` référence la valeur
+initiale de la règle avant sa modification, permettant de l'utiliser dans le
+calcul de la nouvelle valeur. Cette référence initiale est disponible dans tout
+l'espace de nom de `bouchons`.
+
 ## Références de paramètres
 
 Si le mécanisme de remplacement permet de faire des substitutions de règles

--- a/source/engine/parseReference.js
+++ b/source/engine/parseReference.js
@@ -11,7 +11,7 @@ import { disambiguateRuleReference } from './ruleUtils'
 import { areUnitConvertible } from './units'
 const getApplicableReplacements = (
 	filter,
-	contextRuleName,
+	contextRuleName = '',
 	cache,
 	situation,
 	rules,
@@ -34,7 +34,11 @@ const getApplicableReplacements = (
 				!blackListedNames ||
 				blackListedNames.every(name => !contextRuleName.startsWith(name))
 		)
-		.filter(({ referenceNode }) => contextRuleName !== referenceNode.dottedName)
+		// Keep the original value in the context of the replacement rule
+		.filter(
+			({ referenceNode }) =>
+				!contextRuleName.startsWith(referenceNode.dottedName)
+		)
 		// Remove remplacement defined in a not applicable node
 		.filter(({ referenceNode }) => {
 			const referenceRule = rules[referenceNode.dottedName]

--- a/source/rules/salarié.yaml
+++ b/source/rules/salarié.yaml
@@ -380,9 +380,6 @@ contrat salarié . déduction forfaitaire spécifique:
   remplace:
     règle: cotisations . assiette
     sauf dans: contrat salarié . CSG et CRDS
-    # TODO: ajouter pas d'abattement pour l'assurance chômage mais seulement
-    # pour les journalistes. Nécessite probablement de faire un re-remplacement
-    # inverse.
   formule:
     encadrement:
       valeur:
@@ -417,6 +414,18 @@ contrat salarié . déduction forfaitaire spécifique . application:
     retraite et d'assurance chômage.
   titre: application de la DFS
   formule: oui
+
+contrat salarié . déduction forfaitaire spécifique . chômage des journalistes:
+  description: >-
+    Par exception, la déduction forfaitaire spécifique ne s'applique pas à la
+    cotisation chômage pour les journalistes.
+  applicable si: profession spécifique = 'journaliste'
+  remplace:
+    règle: déduction forfaitaire spécifique
+    dans: chômage
+  formule: cotisations . assiette
+  références:
+    Décret relatif à l'assurance chômage: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038829574&categorieLien=id#JORFARTI000038830094
 
 contrat salarié . CDD . taxe forfaitaire sur les CDD d'usage:
   description: |

--- a/test/inversion.test.js
+++ b/test/inversion.test.js
@@ -86,7 +86,7 @@ describe('inversions', () => {
                 - net
         cadre:
         assiette:
-          formule: 67 + brut
+          formule: 67€ + brut
 
       `
 		const result = new Engine({ rules }).evaluate('brut')
@@ -118,7 +118,7 @@ describe('inversions', () => {
         assiette:
           formule:
             somme:
-              - 1200
+              - 1200€
               - brut
               - taxeOne
         taxeOne:
@@ -127,7 +127,7 @@ describe('inversions', () => {
         taxe:
           formule:
             produit:
-              assiette: 1200
+              assiette: 1200€
               variations:
                 - si: cadre
                   alors:

--- a/test/mécanismes/remplace.yaml
+++ b/test/mécanismes/remplace.yaml
@@ -181,3 +181,18 @@ remplacement non applicable (branche desactivée):
   formule: z
   exemples:
     - valeur attendue: 1
+
+valeur initiale dans le namespace:
+
+valeur initiale dans le namespace . initial:
+  formule: 1000€
+
+valeur initiale dans le namespace . remplacement:
+  remplace: initial
+  formule: 10€
+
+valeur initiale dans le namespace . remplacement . cas particulier:
+  titre: valeur initiale accessible dans l'espace de nom du remplacement
+  formule: initial
+  exemples:
+    - valeur attendue: 1000

--- a/test/rules/co2.yaml
+++ b/test/rules/co2.yaml
@@ -22,12 +22,11 @@ douche . litres d'eau par douche:
   formule: durée de la douche * litres par minute / 1 douche
 
 douche . litres par minute:
-  unité: l/min
   formule:
     variations:
       - si: pomme de douche économe
-        alors: 9
-      - sinon: 18
+        alors: 9 l/min
+      - sinon: 18 l/min
   références:
     économise l'eau: https://www.jeconomiseleau.org/index.php/particuliers/economies-par-usage/la-douche-et-le-bain
 
@@ -39,8 +38,7 @@ eau:
   icônes: 💧
 
 eau . impact par litre froid:
-  unité: kgCO2eq/l
-  formule: 0.000132
+  formule: 0.000132 kgCO2eq/l
 
 chauffage:
   icônes: 🔥
@@ -66,15 +64,14 @@ chauffage . type . électricité:
 # définir ces éléments un par un
 
 chauffage . impact par kWh:
-  unité: kgCO2eq/kWh PCI
   formule:
     variations:
       - si: type = 'gaz'
-        alors: 0.227
+        alors: 0.227 kgCO2eq/kWh
       - si: type = 'fioul'
-        alors: 0.324
+        alors: 0.324 kgCO2eq/kWh
       - si: type = 'électricité'
-        alors: 0.059
+        alors: 0.059 kgCO2eq/kWh
 
   notes: |
     La base carbone de l'ADEME ne permet malheureusement pas de faire des liens profonds vers les chiffres utilisés.
@@ -85,8 +82,7 @@ chauffage . impact par kWh:
     électricité sur Décrypter l'Energie: https://decrypterlenergie.org/decryptage-quel-est-le-contenu-en-co2-du-kwh-electrique
 
 chauffage . énergie consommée par litre:
-  formule: 0.0325
-  unité: kWh
+  formule: 0.0325 kWh/l
   références:
     analyse du prix d'une douche: https://www.econologie.com/forums/plomberie-et-sanitaire/prix-reel-d-un-bain-ou-d-une-douche-pour-l-eau-et-chauffage-t12727.html
 

--- a/test/units.test.js
+++ b/test/units.test.js
@@ -29,10 +29,6 @@ describe('Units', () => {
 			numerators: ['kg', 'm'],
 			denominators: ['s']
 		})
-		expect(parseUnit('kg.m/s')).to.deep.equal({
-			numerators: ['kg', 'm'],
-			denominators: ['s']
-		})
 		expect(parseUnit('€/personne/mois')).to.deep.equal({
 			numerators: ['€'],
 			denominators: ['personne', 'mois']


### PR DESCRIPTION
Lors de la conception du mécanisme `remplace`, nous avons identifié le besoin d'accéder à la valeur initiale avant qu'elle ne soit modifiée. Nous n'avons pas eu à introduire une syntaxe type `.initiale` car cette valeur était utile uniquement dans le formule de la règle de remplacement, et qu'on a donc décidé que les variables dans une règle de remplacement référencent les valeurs avant modification.

Je pense qu'il faudrait étendre cette logique à l'espace de nom complet de la règle de remplacement, c'est à dire que l'on puisse accéder à la valeur initiale d'une règle, disons `assiette des cotisations` non seulement dans la formule d'un remplacement mais aussi dans celle de ses enfants.

Mon cas d'usage est celui d'une exception spécifique pour les journalistes https://github.com/betagouv/mon-entreprise/blob/fd7d485b005cb146fc359010c8c5b516dcebf463/source/rules/salari%C3%A9.yaml#L383-L385 (en gros avec la DFS, l'assiette des cotisations est réduite, ce qui réduit aussi les droits à chômage et retraite. Pour les journalistes, et seulement pour eux, l'usage est de ne pas appliquer la réduction d'assiette à la cotisation chômage, et donc “d'annuler” le remplacement dans ce cas spécifique). Si la règle est certes un peu tordue, je pense qu'on doit pouvoir l'exprimer facilement avec notre logique de remplacement, en l'amendant légèrement comme proposé. @johangirod ?