### PR TITLE
Ajoute la CC Compta

### DIFF
--- a/source/locales/rules-en.yaml
+++ b/source/locales/rules-en.yaml
@@ -1625,6 +1625,20 @@ contrat salarié . convention collective . SVP . prévoyance:
     c'est donc cette dernière qui est prise en compte
   titre.en: insurance
   titre.fr: prévoyance
+contrat salarié . convention collective . compta:
+  description.en: >-
+    [automatic] This collective agreement concerns chartered accountants
+    registered with the Order, statutory auditors registered with the company,
+    as well as approved management centres and approved associations (AGC).
+  description.fr: >-
+    Cette convention collective concerne les experts comptables inscrits à
+    l'ordre, les commissaires aux comptes inscrits à la compagnie, ainsi que les
+    centres de gestion agréés et les associations agréées (AGC).
+  titre.en: '[automatic] Chartered Accountants and Statutory Auditors'
+  titre.fr: Experts-comptables et commissaires aux comptes
+contrat salarié . convention collective . compta . majoration heures supplémentaires:
+  titre.en: '[automatic] overtime increase'
+  titre.fr: majoration heures supplémentaires
 contrat salarié . convention collective . droit commun:
   titre.en: common law
   titre.fr: droit commun

--- a/source/rules/conventions-collectives/experts-comptables.yaml
+++ b/source/rules/conventions-collectives/experts-comptables.yaml
@@ -1,0 +1,22 @@
+contrat salarié . convention collective . compta:
+  formule: convention collective = 'compta'
+  titre: Experts-comptables et commissaires aux comptes
+  icônes: 🧮
+  description: >-
+    Cette convention collective concerne les experts comptables inscrits à
+    l'ordre, les commissaires aux comptes inscrits à la compagnie, ainsi que les
+    centres de gestion agréés et les associations agréées (AGC).
+  références:
+    Légifrance: https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635826
+    Synthèse Dicotravail: https://www.dicotravail.com/convention-collective/experts-comptables-jo-3020-idcc-787/
+
+contrat salarié . convention collective . compta . majoration heures supplémentaires:
+  remplace: temps de travail . heures supplémentaires . majoration
+  formule:
+    barème:
+      assiette: temps de travail . heures supplémentaires
+      multiplicateur: période . semaines par mois
+      tranches:
+        - taux: 10%
+          plafond: 4 heures/semaine
+        - taux: 25%

--- a/source/rules/index.ts
+++ b/source/rules/index.ts
@@ -9,6 +9,7 @@ import artisteAuteur from './artiste-auteur.yaml'
 import base from './base.yaml'
 import chômagePartiel from './chômage-partiel.yaml'
 import CCBatiment from './conventions-collectives/bâtiment.yaml'
+import CCCompta from './conventions-collectives/experts-comptables.yaml'
 import CCHotels from './conventions-collectives/hôtels-cafés-restaurants.yaml'
 import CCOptique from './conventions-collectives/optique.yaml'
 import CCSpectacleVivant from './conventions-collectives/spectacle-vivant.yaml'
@@ -43,6 +44,7 @@ const rules: Rules = {
 	...CCOptique,
 	...CCSpectacleVivant,
 	...CCSport,
+	...CCCompta,
 	...situationPersonnelle,
 	...chômagePartiel
 }

--- a/source/rules/salarié.yaml
+++ b/source/rules/salarié.yaml
@@ -3579,6 +3579,7 @@ contrat salarié . convention collective:
         - BTP
         - sport
         - SVP
+        - compta
         - optique
   contrôles:
     - si:

--- a/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -338,9 +338,11 @@ exports[`calculate simulations-salarié:  heures supplémentaires et complément
 
 exports[`calculate simulations-salarié:  heures supplémentaires et complémentaires 5`] = `"[3025,0,0,2000,1970,1932]"`;
 
-exports[`calculate simulations-salarié:  heures supplémentaires et complémentaires 6`] = `"[3336,0,2446,2000,1919,1889]"`;
+exports[`calculate simulations-salarié:  heures supplémentaires et complémentaires 6`] = `"[3041,0,0,2000,1978,1939]"`;
 
-exports[`calculate simulations-salarié:  heures supplémentaires et complémentaires 7`] = `"[3286,0,2286,2000,1889,1859]"`;
+exports[`calculate simulations-salarié:  heures supplémentaires et complémentaires 7`] = `"[3336,0,2446,2000,1919,1889]"`;
+
+exports[`calculate simulations-salarié:  heures supplémentaires et complémentaires 8`] = `"[3286,0,2286,2000,1889,1859]"`;
 
 exports[`calculate simulations-salarié:  impôt sur le revenu 1`] = `"[4076,0,0,3000,2353,2168]"`;
 

--- a/test/regressions/simulations-salarié.yaml
+++ b/test/regressions/simulations-salarié.yaml
@@ -151,6 +151,9 @@ heures supplémentaires et complémentaires:
     contrat salarié . temps de travail . heures supplémentaires: 30
     contrat salarié . convention collective: 'HCR'
   - contrat salarié . rémunération . brut de base: 2000
+    contrat salarié . temps de travail . heures supplémentaires: 30
+    contrat salarié . convention collective: 'compta'
+  - contrat salarié . rémunération . brut de base: 2000
     contrat salarié . temps de travail . temps partiel: oui
     contrat salarié . temps de travail . temps partiel . heures par semaine: 24
     contrat salarié . temps de travail . heures complémentaires: 20


### PR DESCRIPTION
Suite à un retour utilisateur, ajoute la convention collective des experts comptables. 
Seul le barème de majoration des heures supplémentaires est intégré pour l'instant, je ne vois pas d'autres éléments à intégrer (https://www.dicotravail.com/convention-collective/experts-comptables-jo-3020-idcc-787/)