### PR TITLE
Liens internes tuto publicode

### DIFF
--- a/source/components/ui/Typography.css
+++ b/source/components/ui/Typography.css
@@ -68,6 +68,7 @@ h6 {
 	color: var(--darkColor);
 	font-family: 'Montserrat', sans-serif;
 	font-weight: 600;
+	scroll-margin-top: 1rem; /* Add a margin for anchor links */
 }
 
 button {

--- a/source/components/utils/markdown.tsx
+++ b/source/components/utils/markdown.tsx
@@ -2,7 +2,8 @@ import PublicodeHighlighter from 'Components/ui/PublicodeHighlighter'
 import React from 'react'
 import emoji from 'react-easy-emoji'
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown'
-import { Link } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
+import { HashLink as Link } from 'react-router-hash-link'
 
 function LinkRenderer({ href, children }: { href: string; children: string }) {
 	if (!href.startsWith('http')) {
@@ -60,4 +61,90 @@ export const Markdown = ({
 		}}
 		{...otherProps}
 	/>
+)
+
+export const MarkdownWithAnchorLinks = ({
+	renderers = {},
+	...otherProps
+}: MarkdownProps) => (
+	<Markdown
+		renderers={{
+			heading: HeadingWithAnchorLink,
+			...renderers
+		}}
+		{...otherProps}
+	/>
+)
+
+function HeadingWithAnchorLink({
+	level,
+	children
+}: {
+	level: number
+	children: React.ReactNode
+}) {
+	const { pathname } = useLocation()
+	const headingId = React.Children.toArray(children)
+		.map((child: any) => child.props?.value)
+		.join(' ')
+		.toLowerCase()
+		.replace(emojiesRegex, '')
+		.replace(/:|,/g, '')
+		.trim()
+		.replace(/\s+/g, '-')
+
+	const childrenWithAnchor = headingId ? (
+		<>
+			<Link className="anchor-link" to={`${pathname}#${headingId}`}>
+				#
+			</Link>
+			{children}
+		</>
+	) : (
+		children
+	)
+	return (
+		<Heading
+			id={headingId}
+			level={level}
+			css={`
+				position: relative;
+
+				.anchor-link {
+					display: none;
+					position: absolute;
+					top: 0;
+					left: 0;
+					transform: translateX(-100%);
+					padding-right: 6px;
+					color: var(--lighterTextColor);
+					text-decoration: none;
+					font-size: 0.8em;
+				}
+
+				&:hover .anchor-link {
+					display: block;
+				}
+			`}
+		>
+			{childrenWithAnchor}
+		</Heading>
+	)
+}
+
+function Heading({ level, children, ...otherProps }) {
+	return React.createElement(`h${level}`, otherProps, children)
+}
+
+// https://stackoverflow.com/a/41164587/1652064
+const emojiesRegex = new RegExp(
+	`(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|
+[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]
+|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|
+\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|\ud83c[\ude32-\ude3a]|\ud83c[\ude50-\ude51]
+|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|
+\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|
+\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|
+\u2935|[\u2190-\u21ff])`.replace(/\r?\n/g, ''),
+	'g'
 )

--- a/source/engine/mecanisms.yaml
+++ b/source/engine/mecanisms.yaml
@@ -201,9 +201,9 @@ arrondi:
             décimales: 1
 
 régularisation:
-  description: >-
-    Permet de régulariser progressivement un calcul de cotisation en fonction de
-    variables numérique mensuelle cumulée.
+  description: |
+    Permet de régulariser progressivement un calcul de cotisation en fonction du
+    cumul de variables numériques mensuelles.
 
     Ce mécanisme spécifique est utilisé pour le calcul des cotisations
     mensuelles, afin de "lisser" un plafond ou un calcul sur plusieurs mois.
@@ -217,6 +217,7 @@ régularisation:
     jour de l’année.
 
     Par exemple, pour la cotisation suivante : 
+
     ```yaml
       cotisation: 
         formule: 
@@ -225,26 +226,26 @@ régularisation:
             plafond: 2000 €/mois
             taux: 10%
     ```
+
     Avec un brut de 1000 € en janvier et 3500 € en février et 1000€ en mars, le cumul sera le
     suivant :
 
-    ```
-            brut   plafond   cotisation
-       JAN  1000   2000      1000 * 10% = 100 €
-       FEV  4500   4000      4000 * 10% = 400 € 
-       MAR  5500   6000      5500 * 10% = 550 € 
-    ```
-      
-    On regarde ensuite le cumul des valeurs déjà versée les mois précédent, pour
-    ne garder que la différence entre les deux montant. Dans notre exemple, on
-    abouti aux valeurs suivantes :
+    |     | brut   | plafond | cotisation         |
+    | --- | ------ | ------- |------------------- |
+    | JAN | 1000 € | 2000 €  | 1000 × 10% = 100 € |
+    | FEV | 4500 € | 4000 €  | 4000 × 10% = 400 € |
+    | MAR | 5500 € | 6000 €  | 5500 × 10% = 550 € |
 
-    ```
-            cotisation cumul  cotis régularisée
-       JAN  100 €             100 €    
-       FEV  400 €             400 € - 100 € = 300 €
-       MAR  550 €             550 € - 300 € = 150 €
-    ```
+      
+    On regarde ensuite le cumul des valeurs déjà versées les mois précédents, pour
+    ne garder que la différence entre les deux montants. Dans notre exemple, on
+    aboutit aux valeurs suivantes :
+
+    |     | cotisation cumul | cotisation régularisée |
+    | --- | ---------------- | ---------------------- |
+    | JAN |  100 €           |  100 €                 |
+    | FEV |  400 €           |  400 € - 100 € = 300 € |
+    | MAR |  550 €           |  550 € - 300 € = 150 € |
 
   arguments:
     règle: règle à régulariser

--- a/source/sites/mon-entreprise.fr/pages/Nouveautés/Nouveautés.tsx
+++ b/source/sites/mon-entreprise.fr/pages/Nouveautés/Nouveautés.tsx
@@ -1,5 +1,5 @@
 import MoreInfosOnUs from 'Components/MoreInfosOnUs'
-import { Markdown } from 'Components/utils/markdown'
+import { MarkdownWithAnchorLinks } from 'Components/utils/markdown'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/withSitePaths'
 import React, { useContext, useEffect } from 'react'
@@ -77,7 +77,7 @@ export default function Nouveautés() {
 					))}
 				</Sidebar>
 				<MainBlock>
-					<Markdown
+					<MarkdownWithAnchorLinks
 						source={data[selectedRelease].description}
 						escapeHtml={false}
 						renderers={{ text: TextRenderer }}

--- a/source/sites/publi.codes/Landing.tsx
+++ b/source/sites/publi.codes/Landing.tsx
@@ -1,4 +1,4 @@
-import { Markdown } from 'Components/utils/markdown'
+import { MarkdownWithAnchorLinks } from 'Components/utils/markdown'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import publicodeReadme from 'Engine/README.md'
 import React, { useEffect } from 'react'
@@ -17,14 +17,14 @@ export default function Landing() {
 			display: none !important;
 		}`
 		document.body.appendChild(css)
-	})
+	}, [])
 	return (
 		<div className="app-content ui__ container" css="margin: 2rem 0">
 			<ScrollToTop />
 			<Header />
 			<br />
 			<br />
-			<Markdown source={publicodeReadme} />
+			<MarkdownWithAnchorLinks source={publicodeReadme} />
 		</div>
 	)
 }

--- a/source/sites/publi.codes/Mécanismes.tsx
+++ b/source/sites/publi.codes/Mécanismes.tsx
@@ -32,6 +32,7 @@ const Mecanism = ({ name, description, exemples }: MecanismProp) => (
 	</React.Fragment>
 )
 export default function Landing() {
+	const { pathname } = useLocation()
 	useEffect(() => {
 		var css = document.createElement('style')
 		css.type = 'text/css'
@@ -53,7 +54,7 @@ export default function Landing() {
 			<ul>
 				{Object.keys(mecanisms).map(name => (
 					<li key={name}>
-						<Link to={useLocation().pathname + '#' + name}>{name}</Link>
+						<Link to={pathname + '#' + name}>{name}</Link>
 					</li>
 				))}
 			</ul>


### PR DESCRIPTION
Retouche la documentation publicode pour supporter les liens internes (de manière générique pourra être utilisé sur toutes les pages Markdown) et améliore l'affichage de l'explication du mécanisme `régularisation`.