### PR TITLE
Mécanismes chaînés

### DIFF
--- a/source/engine/mecanisms/arrondi.tsx
+++ b/source/engine/mecanisms/arrondi.tsx
@@ -7,6 +7,7 @@ import {
 import { Node } from 'Engine/mecanismViews/common'
 import { mapTemporal, pureTemporal, temporalAverage } from 'Engine/temporal'
 import { EvaluatedRule } from 'Engine/types'
+import { serializeUnit } from 'Engine/units'
 import { has } from 'ramda'
 import React from 'react'
 import { Trans } from 'react-i18next'
@@ -101,5 +102,18 @@ export default (recurse, k, v) => {
 		name: 'arrondi',
 		type: 'numeric',
 		unit: explanation.value.unit
+	}
+}
+
+export function unchainRoundMecanism(recurse, rawNode) {
+	const { arrondi, ...valeur } = rawNode
+	const arrondiValue = recurse(arrondi)
+
+	if (serializeUnit(arrondiValue.unit) === 'décimales') {
+		return { arrondi: { valeur, décimales: arrondiValue.nodeValue } }
+	} else if (arrondiValue.nodeValue === true) {
+		return { arrondi: { valeur } }
+	} else {
+		return valeur
 	}
 }

--- a/source/rules/artiste-auteur.yaml
+++ b/source/rules/artiste-auteur.yaml
@@ -12,19 +12,13 @@ artiste-auteur . revenus . traitements et salaires:
 
 artiste-auteur . revenus . BNC:
   formule:
-    encadrement:
-      plancher: 0 €/an
-      valeur:
+    allègement:
+      assiette: recettes
+      abattement:
         variations:
           - si: micro-bnc
-            alors:
-              somme:
-                - recettes
-                - (- charges forfaitaires)
-          - sinon:
-              somme:
-                - recettes
-                - (- frais réels)
+            alors: charges forfaitaires
+          - sinon: frais réels
 
 artiste-auteur . revenus . BNC . micro-bnc:
   applicable si:

--- a/source/rules/conventions-collectives/spectacle-vivant.yaml
+++ b/source/rules/conventions-collectives/spectacle-vivant.yaml
@@ -29,14 +29,12 @@ contrat salarié . convention collective . SVP . FCAP:
   # TODO :
   note: les minimum et maximum sont fixé par entreprise, et non par salarié
   formule:
-    encadrement:
-      valeur:
-        produit:
-          plafonnée à: plafond sécurité sociale
-          assiette: rémunération . brut
-          taux: 0.1%
-      plancher: 80 €.employés/an / entreprise . effectif
-      plafond: 300 €.employés/an / entreprise . effectif
+    produit:
+      plafonnée à: plafond sécurité sociale
+      assiette: rémunération . brut
+      taux: 0.1%
+    plancher: 80 €.employés/an / entreprise . effectif
+    plafond: 300 €.employés/an / entreprise . effectif
 
   références:
     Titre V de IDCC 3090: https://www.legifrance.gouv.fr/affichIDCC.do;?idSectionTA=KALISCTA000028157274&cidTexte=KALITEXT000028157267&idConvention=KALICONT000028157262

--- a/source/rules/conventions-collectives/sport.yaml
+++ b/source/rules/conventions-collectives/sport.yaml
@@ -21,12 +21,10 @@ contrat salarié . convention collective . sport . cotisations . financement du 
   # TODO
   note: se calcule sur la masse salariale
   formule:
-    encadrement:
-      plancher: 3 €.employé/an / entreprise . effectif
-      valeur:
-        produit:
-          assiette: cotisations . assiette
-          taux: 0.06%
+    produit:
+      assiette: cotisations . assiette
+      taux: 0.06%
+    plancher: 3 €.employé/an / entreprise . effectif
 
 contrat salarié . convention collective . sport . cotisations . prévoyance:
   remplace:
@@ -114,17 +112,15 @@ contrat salarié . convention collective . sport . cotisations . formation profe
 
 contrat salarié . convention collective . sport . cotisations . formation professionnelle . plan de formation:
   formule:
-    encadrement:
-      plancher: versement minimum
-      valeur:
-        produit:
-          assiette: cotisations . assiette
-          taux:
-            variations:
-              - si: entreprise . effectif < 20
-                alors: 1.45%
-              - si: entreprise . effectif >= 20
-                alors: 0.90%
+    produit:
+      assiette: cotisations . assiette
+      taux:
+        variations:
+          - si: entreprise . effectif < 20
+            alors: 1.45%
+          - si: entreprise . effectif >= 20
+            alors: 0.90%
+    plancher: versement minimum
 
 contrat salarié . convention collective . sport . cotisations . formation professionnelle . plan de formation . versement minimum:
   applicable si: entreprise . effectif < 10
@@ -132,17 +128,15 @@ contrat salarié . convention collective . sport . cotisations . formation profe
 
 contrat salarié . convention collective . sport . cotisations . formation professionnelle . professionnalisation:
   formule:
-    encadrement:
-      plancher: versement minimum
-      valeur:
-        produit:
-          assiette: cotisations . assiette
-          taux:
-            variations:
-              - si: entreprise . effectif < 20
-                alors: 0.15%
-              - si: entreprise . effectif >= 20
-                alors: 0.50%
+    produit:
+      assiette: cotisations . assiette
+      taux:
+        variations:
+          - si: entreprise . effectif < 20
+            alors: 0.15%
+          - si: entreprise . effectif >= 20
+            alors: 0.50%
+    plancher: versement minimum
 
 contrat salarié . convention collective . sport . cotisations . formation professionnelle . professionnalisation . versement minimum:
   applicable si: entreprise . effectif < 10
@@ -238,9 +232,8 @@ contrat salarié . convention collective . sport . primes . manifestation 1:
 contrat salarié . convention collective . sport . primes . manifestation 1 . franchise:
   titre: franchise manifestation 1
   formule:
-    encadrement:
-      valeur: manifestation 1
-      plafond: 70% * plafond journalier sécurité sociale
+    valeur: manifestation 1
+    plafond: 70% * plafond journalier sécurité sociale
 
 contrat salarié . convention collective . sport . primes . manifestation 2:
   question: Quelle prime pour la deuxième manifestation ?
@@ -251,9 +244,8 @@ contrat salarié . convention collective . sport . primes . manifestation 2:
 contrat salarié . convention collective . sport . primes . manifestation 2 . franchise:
   titre: franchise manifestation 2
   formule:
-    encadrement:
-      valeur: manifestation 2
-      plafond: 70% * plafond journalier sécurité sociale
+    valeur: manifestation 2
+    plafond: 70% * plafond journalier sécurité sociale
 
 contrat salarié . convention collective . sport . primes . manifestation 3:
   question: Quelle prime pour la troisième manifestation ?
@@ -264,9 +256,8 @@ contrat salarié . convention collective . sport . primes . manifestation 3:
 contrat salarié . convention collective . sport . primes . manifestation 3 . franchise:
   titre: franchise manifestation 3
   formule:
-    encadrement:
-      valeur: manifestation 3
-      plafond: 70% * plafond journalier sécurité sociale
+    valeur: manifestation 3
+    plafond: 70% * plafond journalier sécurité sociale
 
 contrat salarié . convention collective . sport . primes . manifestation 4:
   question: Quelle prime pour la quatrième manifestation ?
@@ -277,9 +268,8 @@ contrat salarié . convention collective . sport . primes . manifestation 4:
 contrat salarié . convention collective . sport . primes . manifestation 4 . franchise:
   titre: franchise manifestation 4
   formule:
-    encadrement:
-      valeur: manifestation 4
-      plafond: 70% * plafond journalier sécurité sociale
+    valeur: manifestation 4
+    plafond: 70% * plafond journalier sécurité sociale
 
 contrat salarié . convention collective . sport . primes . manifestation 5:
   question: Quelle prime pour la cinquième manifestation ?
@@ -290,9 +280,8 @@ contrat salarié . convention collective . sport . primes . manifestation 5:
 contrat salarié . convention collective . sport . primes . manifestation 5 . franchise:
   titre: franchise manifestation 5
   formule:
-    encadrement:
-      valeur: manifestation 5
-      plafond: 70% * plafond journalier sécurité sociale
+    valeur: manifestation 5
+    plafond: 70% * plafond journalier sécurité sociale
 
 contrat salarié . convention collective . sport . primes . autres manifestations:
   question: Quelles primes pour les autres manifestations ?

--- a/source/rules/dirigeant.yaml
+++ b/source/rules/dirigeant.yaml
@@ -251,12 +251,10 @@ dirigeant . auto-entrepreneur . impôt:
 
 dirigeant . auto-entrepreneur . impôt . abattement:
   formule:
-    encadrement:
-      valeur:
-        produit:
-          assiette: base des cotisations
-          taux: taux
-      plancher: 305 €/an
+    produit:
+      assiette: base des cotisations
+      taux: taux
+    plancher: 305 €/an
   références:
     Légifrance: https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000006199553&cidTexte=LEGITEXT000006069577
 
@@ -392,9 +390,8 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ACRE .
     produit:
       assiette: plafond sécurité sociale temps plein
       taux:
-        encadrement:
-          valeur: entreprise . durée d'activité . en fin d'année / 1 an
-          plafond: 100%
+        valeur: entreprise . durée d'activité . en fin d'année / 1 an
+        plafond: 100%
 
 dirigeant . indépendant . cotisations et contributions . exonérations . ACRE . prorata sur l'année:
   description: |
@@ -472,9 +469,8 @@ dirigeant . indépendant . revenu professionnel:
 dirigeant . indépendant . assiette des cotisations:
   description: Il s'agit de l'assiette des cotisations sociales, nombre forcément positif
   formule:
-    encadrement:
-      plancher: 0
-      valeur: revenu professionnel
+    valeur: revenu professionnel
+    plancher: 0
 
 dirigeant . indépendant . conjoint collaborateur:
   question: Avez-vous un conjoint collaborateur ?
@@ -694,12 +690,10 @@ dirigeant . indépendant . contrats madelin . part déductible fiscalement:
   titre: Part de la cotisation à contrat Madelin qui est déductible fiscalement
   formule:
     somme:
-      - encadrement:
-          valeur: mutuelle . montant
-          plafond: mutuelle . plafond
-      - encadrement:
-          valeur: retraite . montant
-          plafond: retraite . plafond
+      - valeur: mutuelle . montant
+        plafond: mutuelle . plafond
+      - valeur: retraite . montant
+        plafond: retraite . plafond
 
 dirigeant . indépendant . contrats madelin . part non-déductible fiscalement:
   titre: Part de la cotisation à contrat Madelin qui n'est pas déductible fiscalement
@@ -725,19 +719,17 @@ dirigeant . indépendant . contrats madelin . mutuelle . montant:
 dirigeant . indépendant . contrats madelin . mutuelle . plafond:
   unité par défaut: €/an
   formule:
-    encadrement:
-      valeur:
-        somme:
-          - produit:
-              assiette: résultat fiscal
-              taux: 3.75%
-          - produit:
-              assiette: plafond sécurité sociale temps plein
-              taux: 7%
-      plafond:
-        produit:
-          assiette: 8 * plafond sécurité sociale temps plein
-          taux: 3%
+    somme:
+      - produit:
+          assiette: résultat fiscal
+          taux: 3.75%
+      - produit:
+          assiette: plafond sécurité sociale temps plein
+          taux: 7%
+    plafond:
+      produit:
+        assiette: 8 * plafond sécurité sociale temps plein
+        taux: 3%
   références:
     Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029042287&cidTexte=LEGITEXT000006069577&dateTexte=20140530
     Réassurez-moi: https://reassurez-moi.fr/guide/pro/tns/plafond#le_plafond_de_deduction_madelin_pour_une_mutuelle_santenbsp
@@ -849,8 +841,8 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
     barème:
       assiette [ref]:
         encadrement:
-          plancher [ref]: 40% * plafond sécurité sociale temps plein
           valeur: assiette des cotisations
+          plancher [ref]: 40% * plafond sécurité sociale temps plein
       multiplicateur: plafond sécurité sociale temps plein
       tranches:
         - taux: taux variable
@@ -990,8 +982,8 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
     barème:
       assiette [ref]:
         encadrement:
-          plancher [ref]: 11.5% * plafond sécurité sociale temps plein
           valeur: assiette des cotisations
+          plancher [ref]: 11.5% * plafond sécurité sociale temps plein
       multiplicateur: plafond sécurité sociale temps plein
       tranches:
         - taux: 17.75%

--- a/source/rules/exemple-régularisation.yaml
+++ b/source/rules/exemple-régularisation.yaml
@@ -33,15 +33,11 @@ réduction générale . urssaf . coefficient:
 
 réduction générale . urssaf . réduction sans régularisation:
   formule:
-    encadrement:
-      plancher: 0
-      valeur:
-        arrondi:
-          valeur:
-            multiplication:
-              assiette: rémunération
-              taux: coefficient
-          décimales: 2
+    produit:
+      assiette: rémunération
+      taux: coefficient
+    arrondi: 2 décimales
+    plancher: 0
 
 réduction générale . urssaf:
   formule:
@@ -62,15 +58,11 @@ réduction générale . chômage . coefficient:
 
 réduction générale . chômage . réduction sans régularisation:
   formule:
-    encadrement:
-      plancher: 0
-      valeur:
-        arrondi:
-          valeur:
-            multiplication:
-              assiette: rémunération
-              taux: coefficient
-          décimales: 2
+    produit:
+      assiette: rémunération
+      taux: coefficient
+    arrondi: 2 décimales
+    plancher: 0
 
 réduction générale . début:
   non applicable si: réduction sur AC au 1er janvier
@@ -97,24 +89,18 @@ réduction lodeom:
         - SMIC
         - rémunération
       règle:
-        encadrement:
-          plancher: 0
-          valeur:
-            arrondi:
-              décimales: 2
-              valeur:
-                produit:
-                  assiette: rémunération
-                  facteur [ref coefficient]:
-                    arrondi:
-                      décimales: 4
-                      valeur:
-                        grille:
-                          assiette: rémunération
-                          multiplicateur: SMIC
-                          tranches:
-                            - montant: constante
-                              plafond: 1.7
-                            - montant: constante * 1.7 * SMIC / rémunération
-                              plafond: 2.5
-                            - montant: 1.7 * constante * (3.5 * SMIC / rémunération - 1)
+        produit:
+          assiette: rémunération
+          facteur [ref coefficient]:
+            grille:
+              assiette: rémunération
+              multiplicateur: SMIC
+              tranches:
+                - montant: constante
+                  plafond: 1.7
+                - montant: constante * 1.7 * SMIC / rémunération
+                  plafond: 2.5
+                - montant: 1.7 * constante * (3.5 * SMIC / rémunération - 1)
+            arrondi: 4 décimales
+        arrondi: 2 décimales
+        plancher: 0

--- a/source/rules/protection-sociale.yaml
+++ b/source/rules/protection-sociale.yaml
@@ -70,13 +70,11 @@ protection sociale . retraite . base . taux de la pension:
 protection sociale . retraite . trimestres validés par an:
   unité: trimestres validés/an
   formule:
-    encadrement:
-      valeur:
-        somme:
-          - trimestres salarié
-          - trimestres indépendant
-          - trimestres auto-entrepreneur
-      plafond: 4
+    somme:
+      - trimestres salarié
+      - trimestres indépendant
+      - trimestres auto-entrepreneur
+    plafond: 4
 
 protection sociale . retraite . trimestres validés par an . trimestres salarié:
   unité: trimestres validés/an
@@ -91,9 +89,8 @@ protection sociale . retraite . trimestres validés par an . trimestres indépen
       - si: situation personnelle . RSA
         alors: barème trimestres générique
       - sinon:
-          encadrement:
-            plancher: 3
-            valeur: barème trimestres générique
+          valeur: barème trimestres générique
+          plancher: 3
 
 protection sociale . retraite . trimestres validés par an . barème trimestres générique:
   unité: trimestres validés/an
@@ -287,12 +284,10 @@ protection sociale . santé . indemnités journalières . auto-entrepreneur:
       - si: revenu moyen < 3919.20 €/an
         alors: 0 €/jour
       - sinon:
-          encadrement:
-            valeur:
-              produit:
-                assiette: revenu moyen [€/jour]
-                taux: 50%
-            plafond: 55.51 €/jour
+          produit:
+            assiette: revenu moyen [€/jour]
+            taux: 50%
+          plafond: 55.51 €/jour
   reférences:
     - secu-independants.fr: https://www.secu-independants.fr/sante/indemnites-journalieres/montant-de-lindemnite
 
@@ -301,13 +296,11 @@ protection sociale . santé . indemnités journalières . indépendant:
   unité: €/jour
 
   formule:
-    encadrement:
-      valeur:
-        produit:
-          assiette: revenu moyen [€/jour]
-          taux: 50%
-      plancher: 21 €/jour
-      plafond: 55.51 €/jour
+    produit:
+      assiette: revenu moyen [€/jour]
+      taux: 50%
+    plancher: 21 €/jour
+    plafond: 55.51 €/jour
   reférences:
     - secu-independants.fr: https://www.secu-independants.fr/sante/indemnites-journalieres/montant-de-lindemnite
 
@@ -389,13 +382,11 @@ protection sociale . accidents du travail et maladies professionnelles:
 
   applicable si: contrat salarié
   formule:
-    encadrement:
-      valeur:
-        produit:
-          assiette: revenu moyen [€/jour]
-          taux: 60%
-      plafond: 202.78 €/jour
-
+    produit:
+      assiette: revenu moyen [€/jour]
+      taux: 60%
+    plafond:
+      202.78 €/jour
       # TODO
       # - 0.834% * plafond sécurité sociale temps plein [€/an]
 

--- a/source/rules/salarié.yaml
+++ b/source/rules/salarié.yaml
@@ -120,12 +120,11 @@ contrat salarié . frais professionnels . titres-restaurant . montant:
 contrat salarié . frais professionnels . titres-restaurant . part déductible:
   titre: Titres-restaurant (déductible)
   formule:
-    encadrement:
-      valeur: montant .employeur
-      plafond:
-        produit:
-          assiette: titres-restaurant par mois
-          facteur: 5.55 €/titres-restaurant
+    valeur: montant .employeur
+    plafond:
+      produit:
+        assiette: titres-restaurant par mois
+        facteur: 5.55 €/titres-restaurant
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/taux-et-baremes/frais-professionnels/les-titres-restaurant.html
 
@@ -191,9 +190,8 @@ contrat salarié . frais professionnels . indemnité kilométrique vélo . monta
 contrat salarié . frais professionnels . indemnité kilométrique vélo . part déductible:
   titre: indemnité kilométrique vélo (déductible)
   formule:
-    encadrement:
-      valeur: montant
-      plafond: 200 €/an
+    valeur: montant
+    plafond: 200 €/an
 
 contrat salarié . frais professionnels . indemnité kilométrique vélo . distance mensuelle:
   unité: km/mois
@@ -343,13 +341,12 @@ contrat salarié . activité partielle . indemnisation entreprise:
     Dans le cadre de la crise du Coronavirus, le gouvernement a anoncé que
     l'indemnité de chômage partiel sera prise à 100% en charge par l'état.
   formule:
-    encadrement:
-      valeur: indemnités . base
-      plancher: 8.03 €/heure * heures chômées
-      plafond:
-        recalcul:
-          avec:
-            rémunération . brut de base: 4.5 * SMIC
+    valeur: indemnités . base
+    plancher: 8.03 €/heure * heures chômées
+    plafond:
+      recalcul:
+        avec:
+          rémunération . brut de base: 4.5 * SMIC
 
 # TODO : This should be merged with other convention collectives
 contrat salarié . activité partielle . convention syntec:
@@ -384,13 +381,12 @@ contrat salarié . déduction forfaitaire spécifique:
     # pour les journalistes. Nécessite probablement de faire un re-remplacement
     # inverse.
   formule:
-    encadrement:
-      valeur:
-        allègement:
-          assiette: cotisations . assiette
-          abattement: taux
-          plafond: 7600 €/an
-      plancher: cotisations . assiette minimale
+    valeur:
+      allègement:
+        assiette: cotisations . assiette
+        abattement: taux
+        plafond: 7600 €/an
+    plancher: cotisations . assiette minimale
   références:
     Fiche Urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-elements-a-prendre-en-compte/les-frais-professionnels/la-deduction-forfaitaire-specifi.html
 
@@ -1494,15 +1490,14 @@ contrat salarié . plafond sécurité sociale:
   acronyme: PSS
   unité: €/mois
   formule:
-    encadrement:
-      valeur: plafond sécurité sociale temps plein * temps de travail . quotité de travail effective
-      # Note: le plafond de la sécurité sociale est pro-ratisé en fonction de la
-      # quotité de travail effective. Cela pose problème en cas de de chômage
-      # partiel à 100% car le plafond vaut alors 0€ et celui-ci est utilisé
-      # comme "multiplicateur" à plusieurs endroits, ce qui entraîne des
-      # divisions par zéro (si j'ai bien compris le problème, il est possible
-      # que le problème exact soit un peu différent).
-      plancher: 1 €/mois
+    valeur: plafond sécurité sociale temps plein * temps de travail . quotité de travail effective
+    # Note: le plafond de la sécurité sociale est pro-ratisé en fonction de la
+    # quotité de travail effective. Cela pose problème en cas de de chômage
+    # partiel à 100% car le plafond vaut alors 0€ et celui-ci est utilisé
+    # comme "multiplicateur" à plusieurs endroits, ce qui entraîne des
+    # divisions par zéro (si j'ai bien compris le problème, il est possible
+    # que le problème exact soit un peu différent).
+    plancher: 1 €/mois
 
 contrat salarié . plafond sécurité sociale . renonciation proratisation:
   description: >-
@@ -1625,12 +1620,11 @@ contrat salarié . rémunération . net imposable . base:
 
 contrat salarié . rémunération . net imposable . heures supplémentaires et complémentaires défiscalisées:
   formule:
-    encadrement:
-      valeur:
-        somme:
-          - heures supplémentaires
-          - heures complémentaires
-      plafond: plafond brut
+    valeur:
+      somme:
+        - heures supplémentaires
+        - heures complémentaires
+    plafond: plafond brut
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
 
@@ -1783,16 +1777,15 @@ contrat salarié . cotisations . salariales . réduction heures supplémentaires
   unité: '%'
   description: le taux effectif des cotisations d'assurance vieillesse à la charge du salarié
   formule:
-    encadrement:
-      valeur:
-        produit:
-          assiette:
-            somme:
-              - vieillesse .salarié
-              - retraite complémentaire .salarié
-              - contribution d'équilibre général .salarié
-          facteur: 1 / assiette
-      plafond: 11.31%
+    valeur:
+      produit:
+        assiette:
+          somme:
+            - vieillesse .salarié
+            - retraite complémentaire .salarié
+            - contribution d'équilibre général .salarié
+        facteur: 1 / assiette
+    plafond: 11.31%
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-de-cotisations-sala/modalites-de-calcul-et-de-declar.html
     Circulaire DSS/5B/2019/71: http://circulaire.legifrance.gouv.fr/pdf/2019/04/cir_44492.pdf
@@ -1961,9 +1954,8 @@ contrat salarié . temps de travail . temps partiel . heures par semaine:
 contrat salarié . temps de travail . quotité de travail:
   description: Temps de travail en proportion du temps complet légal.
   formule:
-    encadrement:
-      valeur: temps de travail / (base légale * période . semaines par mois)
-      plafond: 100%
+    valeur: temps de travail / (base légale * période . semaines par mois)
+    plafond: 100%
   unité: '%'
 
 contrat salarié . temps de travail . quotité de travail effective:
@@ -2065,11 +2057,11 @@ contrat salarié . temps de travail . heures complémentaires . seuil légal:
     sont rémunérée avec une majoration de 25%
   unité: heures/mois
   formule:
-    arrondi:
-      produit:
-        assiette: temps partiel . heures par semaine
-        taux: 10%
-        facteur: période . semaines par mois
+    produit:
+      assiette: temps partiel . heures par semaine
+      taux: 10%
+      facteur: période . semaines par mois
+    arrondi: 0 décimales
 
 contrat salarié . statut JEI:
   titre: Statut JEI
@@ -2117,16 +2109,14 @@ contrat salarié . statut JEI . exonération de cotisations:
   unité: €/mois
 
   formule:
-    encadrement:
-      plafond:
-        recalcul:
-          avec:
-            rémunération . brut de base: 4.5 * SMIC
-      valeur:
-        somme:
-          - allocations familiales
-          - maladie .employeur
-          - vieillesse .employeur
+    somme:
+      - allocations familiales
+      - maladie .employeur
+      - vieillesse .employeur
+    plafond:
+      recalcul:
+        avec:
+          rémunération . brut de base: 4.5 * SMIC
 
 contrat salarié . réduction générale:
   description: |
@@ -2138,12 +2128,10 @@ contrat salarié . réduction générale:
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
   non applicable si: cotisations . assiette forfaitaire . montant
   formule:
-    encadrement:
-      valeur:
-        produit:
-          assiette: cotisations . assiette
-          facteur: coefficient
-      plafond: plafond avec application de la DFS
+    produit:
+      assiette: cotisations . assiette
+      facteur: coefficient
+    plafond: plafond avec application de la DFS
   exemples:
     # Formule de calcul algébrique : (0,2809÷0,6)×(1,6×(1 521,22÷1 530)−1)×1 530
     - nom: "Maximale dans le cas d'un SMIC"
@@ -2165,16 +2153,12 @@ contrat salarié . réduction générale:
 
 contrat salarié . réduction générale . coefficient:
   formule:
-    arrondi:
-      décimales: 4
-      valeur:
-        encadrement:
-          valeur:
-            produit:
-              assiette: SMIC / cotisations . assiette * 1.6 - 1
-              facteur: T / 0.6
-          plancher: 0%
-          plafond: T
+    produit:
+      assiette: SMIC / cotisations . assiette * 1.6 - 1
+      facteur: T / 0.6
+    plancher: 0%
+    plafond: T
+    arrondi: 4 décimales
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale/le-calcul-de-la-reduction/etape-1--determination-du-coeffi.html
     Code de la sécurité sociale: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000025103779&cidTexte=LEGITEXT000006073189
@@ -2185,12 +2169,10 @@ contrat salarié . réduction générale . T:
   formule:
     somme:
       - T sécurité sociale et chômage
-      - encadrement:
-          valeur: retraite complémentaire . taux employeur tranche 1
-          plafond: 4.72%
-      - encadrement:
-          valeur: contribution d'équilibre général . taux employeur tranche 1
-          plafond: 1.29%
+      - valeur: retraite complémentaire . taux employeur tranche 1
+        plafond: 4.72%
+      - valeur: contribution d'équilibre général . taux employeur tranche 1
+        plafond: 1.29%
 
 contrat salarié . réduction générale . T sécurité sociale et chômage:
   unité: ''
@@ -2335,24 +2317,21 @@ contrat salarié . retraite supplémentaire . part déductible:
 
 contrat salarié . retraite supplémentaire . plafond d'exonération sociale employeur:
   formule:
-    encadrement:
-      valeur: 5% * cotisations . assiette
-      plafond: 5% * plafond sécurité sociale
+    valeur: 5% * cotisations . assiette
+    plafond: 5% * plafond sécurité sociale
   références:
     Article D242-1: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037456320&cidTexte=LEGITEXT000006073189&dateTexte=20180930
 
 contrat salarié . retraite supplémentaire . exonération fiscale:
   titre: retraite supplémentaire exonérée d'impôt
   formule:
-    encadrement:
-      valeur: retraite supplémentaire
-      plafond:
-        produit:
-          taux: 8%
-          assiette:
-            encadrement:
-              valeur: rémunération . brut
-              plafond: 8 * plafond sécurité sociale temps plein
+    valeur: retraite supplémentaire
+    plafond:
+      produit:
+        taux: 8%
+        assiette:
+          valeur: rémunération . brut
+          plafond: 8 * plafond sécurité sociale temps plein
   références:
     Bopfip § 120: https://bofip.impots.gouv.fr/bofip/5956-PGP.html
 
@@ -2962,12 +2941,10 @@ contrat salarié . prévoyance . part déductible:
 
 contrat salarié . prévoyance . plafond exonération sociale employeur:
   formule:
-    encadrement:
-      valeur:
-        somme:
-          - 6% * plafond sécurité sociale
-          - 1.5% * cotisations . assiette
-      plafond: 12% * plafond sécurité sociale
+    somme:
+      - 6% * plafond sécurité sociale
+      - 1.5% * cotisations . assiette
+    plafond: 12% * plafond sécurité sociale
 
 # TODO: À fusionner avec `contrat salarié . prévoyance`. Pour l'instant pas
 # gênant d'avoir deux cotisations séparées car `contrat salarié . prévoyance`
@@ -2992,15 +2969,12 @@ contrat salarié . prévoyance obligatoire cadre:
 contrat salarié . prévoyance . exonération fiscale:
   titre: prévoyance exonérée d'impôt
   formule:
-    encadrement:
-      valeur: prévoyance
-      plafond:
-        encadrement:
-          valeur:
-            somme:
-              - 5% * plafond sécurité sociale temps plein
-              - 2% * rémunération . brut
-          plafond: 2% * 8 * plafond sécurité sociale temps plein
+    valeur: prévoyance
+    plafond:
+      somme:
+        - 5% * plafond sécurité sociale temps plein
+        - 2% * rémunération . brut
+      plafond: 2% * 8 * plafond sécurité sociale temps plein
   références:
     Bopfip § 120: https://bofip.impots.gouv.fr/bofip/5956-PGP.html
 
@@ -3379,33 +3353,31 @@ contrat salarié . lodeom . réduction outre-mer:
           - éligible barème innovation et croissance
 
   formule:
-    encadrement:
-      valeur:
-        somme:
-          - allocations familiales
-          - FNAL .employeur
-          - maladie .employeur
-          - vieillesse .employeur
-          - produit:
-              assiette: cotisations . assiette
-              taux: ATMP . taux minimum
-          - retraite complémentaire .employeur
-          - contribution d'équilibre général .employeur
-          - chômage .employeur
-      plafond:
-        variations:
-          - si:
-              toutes ces conditions:
-                - éligible barème innovation et croissance
-                - cotisations . assiette > borne inférieure * SMIC
-                - cotisations . assiette < 2.5 * SMIC
-            alors: 1.7 * paramètre T * SMIC
-          - si:
-              toutes ces conditions:
-                - éligible barème innovation et croissance
-                - cotisations . assiette > 2.5 * SMIC
-            alors: ((borne inférieure * paramètre T) / (borne supérieure - 2.5)) *  écart au plafond de l'assiette
-          - sinon: multiplicateur * écart au plafond de l'assiette
+    somme:
+      - allocations familiales
+      - FNAL .employeur
+      - maladie .employeur
+      - vieillesse .employeur
+      - produit:
+          assiette: cotisations . assiette
+          taux: ATMP . taux minimum
+      - retraite complémentaire .employeur
+      - contribution d'équilibre général .employeur
+      - chômage .employeur
+    plafond:
+      variations:
+        - si:
+            toutes ces conditions:
+              - éligible barème innovation et croissance
+              - cotisations . assiette > borne inférieure * SMIC
+              - cotisations . assiette < 2.5 * SMIC
+          alors: 1.7 * paramètre T * SMIC
+        - si:
+            toutes ces conditions:
+              - éligible barème innovation et croissance
+              - cotisations . assiette > 2.5 * SMIC
+          alors: ((borne inférieure * paramètre T) / (borne supérieure - 2.5)) *  écart au plafond de l'assiette
+        - sinon: multiplicateur * écart au plafond de l'assiette
   note: Nous utilisons la méthode de calcul officielle de la sécurité sociale. Il serait préférable ici de réduire directement les cotisations concernées, ce qui éviterait au calcul de reposer sur les paramètres `T` publiés chaque année (ils dépendent directement des cotisaitons réduites).
   références:
     Estimateur URSSAF: https://www.urssaf.fr/portail/home/utile-et-pratique/estimateur-exoneration-lodeom.html?ut=
@@ -3548,9 +3520,8 @@ contrat salarié . cotisations . assiette forfaitaire . montant:
         # Todo : Ce hack est dû à la façon dont est implémenté l'exonération salariale pour les apprentis
         - assiette . salariale
   formule:
-    encadrement:
-      valeur: assiette forfaitaire
-      plancher: minimum
+    valeur: assiette forfaitaire
+    plancher: minimum
   références:
     exception agirc-arco (fiche 3): https://www.agirc-arrco.fr/fileadmin/agircarrco/documents/circulaires/agirc_arrco/2019/2019-1-DRJ_Reglementation__applicable_aux_entreprises.pdf
     CSG et CRDS: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/la-base-de-calcul/assiette-csg-crds.html

--- a/test/mécanismes/arrondi.yaml
+++ b/test/mécanismes/arrondi.yaml
@@ -38,3 +38,25 @@ Arrondi avec precision:
         cotisation retraite: 1200.21
         nombre de décimales: 2
       valeur attendue: 1200.21
+
+arrondi nouvelle ecriture 1:
+  formule:
+    valeur: 30.4167 jours
+    arrondi: oui
+  exemples:
+    - valeur attendue: 30
+      unité attendue: jours
+
+arrondi nouvelle ecriture 2:
+  formule:
+    valeur: 30.4167 jours
+    arrondi: non
+  exemples:
+    - valeur attendue: 30.4167
+
+arrondi nouvelle ecriture 3:
+  formule:
+    valeur: 30.4167
+    arrondi: 2 décimales
+  exemples:
+    - valeur attendue: 30.42

--- a/test/mécanismes/encadrement.yaml
+++ b/test/mécanismes/encadrement.yaml
@@ -7,6 +7,22 @@ plafonnement:
   exemples:
     - valeur attendue: 250
 
+plafond nouvelle ecriture:
+  formule:
+    valeur: 1000 €
+    plafond: 250 €
+
+  exemples:
+    - valeur attendue: 250
+
+plancher nouvelle ecriture:
+  formule:
+    valeur: 1000 €
+    plancher: 2000 €
+
+  exemples:
+    - valeur attendue: 2000
+
 plafonnement inactif:
   formule:
     encadrement:


### PR DESCRIPTION
Support des mécanismes chaînés pour éviter les pyramide de code en `yaml`, ainsi que d'éviter de commencer les définition des règles par des infos de type "arrondi" ou "encadrement" qui ne sont pas leur essence, et perturbent la compréhension de la règle.

Avant

```yaml
réduction générale chômage . réduction sans régularisation:
  formule:
    encadrement:
      plancher: 0
      valeur:
        arrondi:
          valeur:
            produit:
              assiette: rémunération
              taux: coefficient
          décimales: 2
```

Après

```yaml
réduction générale chômage . réduction sans régularisation:
  formule:
    produit:
      assiette: rémunération
      taux: coefficient
    arrondi: 2 décimales
    plancher: 0
```

L'implémentation est une simple transformation du code de la nouvelle forme à l'ancienne, ce qui permet de maintenir la retro-comptabilité.

Ajout aussi d'un mécanisme identité nommé `valeur`, qui résout un problème de syntaxe avec les formules littérales comme :

```yaml
jours par mois:
  valeur: 365 jours / 12 mois
  arrondi: 2 décimales
```