### PR TITLE
Accélère la navigation sur le publicode studio

### DIFF
--- a/source/Provider.tsx
+++ b/source/Provider.tsx
@@ -4,7 +4,7 @@ import { TrackerProvider } from 'Components/utils/withTracker'
 import { createBrowserHistory } from 'history'
 import { AvailableLangs } from 'i18n'
 import i18next from 'i18next'
-import React, { useEffect, useMemo } from 'react'
+import React, { createContext, useEffect, useMemo } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { Provider as ReduxProvider } from 'react-redux'
 import { Router } from 'react-router-dom'
@@ -41,8 +41,12 @@ if (
 	})
 }
 
+type SiteName = 'mon-entreprise' | 'infrance' | 'publicodes'
+
+export const SiteNameContext = createContext<SiteName | null>(null)
+
 export type ProviderProps = {
-	basename: string
+	basename: SiteName
 	language: AvailableLangs
 	children: React.ReactNode
 	tracker?: Tracker
@@ -119,13 +123,15 @@ export default function Provider({
 				color={iframeCouleur && decodeURIComponent(iframeCouleur)}
 			>
 				<TrackerProvider value={tracker!}>
-					<SitePathProvider value={sitePaths as any}>
-						<I18nextProvider i18n={i18next}>
-							<Router history={history}>
-								<>{children}</>
-							</Router>
-						</I18nextProvider>
-					</SitePathProvider>
+					<SiteNameContext.Provider value={basename}>
+						<SitePathProvider value={sitePaths as any}>
+							<I18nextProvider i18n={i18next}>
+								<Router history={history}>
+									<>{children}</>
+								</Router>
+							</I18nextProvider>
+						</SitePathProvider>
+					</SiteNameContext.Provider>
 				</TrackerProvider>
 			</ThemeColorsProvider>
 		</ReduxProvider>

--- a/source/components/ui/PublicodeHighlighter.tsx
+++ b/source/components/ui/PublicodeHighlighter.tsx
@@ -1,3 +1,4 @@
+import { LinkRenderer } from 'Components/utils/markdown'
 import React from 'react'
 import emoji from 'react-easy-emoji'
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -11,11 +12,11 @@ export default ({ source }: { source: string }) => (
 		<SyntaxHighlighter language="yaml" style={style}>
 			{source}
 		</SyntaxHighlighter>
-		<a
+		<LinkRenderer
 			href={`https://publi.codes/studio?code=${encodeURIComponent(source)}`}
 			css="position: absolute; bottom: 5px; right: 10px; color: white !important;"
 		>
 			{emoji('⚡')} Lancer le calcul
-		</a>
+		</LinkRenderer>
 	</div>
 )

--- a/source/components/utils/markdown.tsx
+++ b/source/components/utils/markdown.tsx
@@ -1,27 +1,49 @@
 import PublicodeHighlighter from 'Components/ui/PublicodeHighlighter'
-import React from 'react'
+import React, { useContext } from 'react'
 import emoji from 'react-easy-emoji'
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown'
 import { useLocation } from 'react-router-dom'
 import { HashLink as Link } from 'react-router-hash-link'
+import { SiteNameContext } from '../../Provider'
 
-function LinkRenderer({ href, children }: { href: string; children: string }) {
-	if (!href.startsWith('http')) {
-		return <Link to={href}>{children}</Link>
+const internalURLs = {
+	'mon-entreprise.fr': 'mon-entreprise',
+	'mycompanyinfrance.fr': 'infrance',
+	'publi.codes': 'publicodes'
+} as const
+
+export function LinkRenderer({
+	href,
+	children,
+	...otherProps
+}: Omit<React.ComponentProps<'a'>, 'ref'>) {
+	const siteName = useContext(SiteNameContext)
+	if (href && !href.startsWith('http')) {
+		return (
+			<Link to={href} {...otherProps}>
+				{children}
+			</Link>
+		)
 	}
 
 	// Convert absolute links that reload the full app into in-app links handled
 	// by react-router.
-	const domain = 'mon-entreprise.fr'
-	if (
-		href.startsWith(`https://${domain}`) &&
-		(location.hostname === 'localhost' || location.hostname === domain)
-	) {
-		return <Link to={href.replace(`https://${domain}`, '')}>{children}</Link>
+	for (const domain of Object.keys(internalURLs)) {
+		if (
+			href &&
+			href.startsWith(`https://${domain}`) &&
+			internalURLs[domain] === siteName
+		) {
+			return (
+				<Link to={href.replace(`https://${domain}`, '')} {...otherProps}>
+					{children}
+				</Link>
+			)
+		}
 	}
 
 	return (
-		<a target="_blank" href={href}>
+		<a target="_blank" href={href} {...otherProps}>
 			{children}
 		</a>
 	)


### PR DESCRIPTION
Ne recharge pas l'application complète mais utilise React Router pour faire un lien in-app. Une fois le premier chargement effectué, les navigations suivantes sont instantanées.