### PR TITLE
:fire: change l'api de formatValue pour une version plus cohérente

### DIFF
--- a/mon-entreprise/source/components/BarChart.tsx
+++ b/mon-entreprise/source/components/BarChart.tsx
@@ -26,7 +26,11 @@ function ChartItemBar({ style, numberToPlot, unit }: ChartItemBarProps) {
 					color: var(--textColorOnWhite);
 				`}
 			>
-				{formatValue({ nodeValue: numberToPlot, unit, precision: 0, language })}
+				{formatValue(numberToPlot, {
+					displayedUnit: unit,
+					precision: 0,
+					language
+				})}
 			</div>
 		</div>
 	)

--- a/mon-entreprise/source/components/CurrencyInput/CurrencyInput.test.js
+++ b/mon-entreprise/source/components/CurrencyInput/CurrencyInput.test.js
@@ -10,13 +10,9 @@ describe('CurrencyInput', () => {
 		expect(getInput(<CurrencyInput />)).to.have.length(1)
 	})
 
-	it('should accept both . and , as decimal separator', () => {
-		let onChange = spy()
-		const input = getInput(<CurrencyInput onChange={onChange} />)
-		input.simulate('change', { target: { value: '12.1', focus: () => {} } })
-		expect(onChange).to.have.been.calledWith(
-			match.hasNested('target.value', '12.1')
-		)
+	it('should accept , as decimal separator in french', () => {
+		const onChange = spy()
+		const input = getInput(<CurrencyInput language="fr" onChange={onChange} />)
 		input.simulate('change', { target: { value: '12,1', focus: () => {} } })
 		expect(onChange).to.have.been.calledWith(
 			match.hasNested('target.value', '12.1')
@@ -58,7 +54,7 @@ describe('CurrencyInput', () => {
 
 	it('should not accept anything else than number', () => {
 		let onChange = spy()
-		const input = getInput(<CurrencyInput onChange={onChange} />)
+		const input = getInput(<CurrencyInput language="fr" onChange={onChange} />)
 		input.simulate('change', { target: { value: '*1/2abc3', focus: () => {} } })
 		expect(onChange).to.have.been.calledWith(
 			match.hasNested('target.value', '123')
@@ -72,7 +68,9 @@ describe('CurrencyInput', () => {
 
 	it('should not call onChange while the decimal part is being written', () => {
 		let onChange = spy()
-		const input = getInput(<CurrencyInput value="111" onChange={onChange} />)
+		const input = getInput(
+			<CurrencyInput language="fr" value="111" onChange={onChange} />
+		)
 		input.simulate('change', { target: { value: '111,', focus: () => {} } })
 		expect(onChange).not.to.have.been.called
 	})
@@ -98,7 +96,12 @@ describe('CurrencyInput', () => {
 		const clock = useFakeTimers()
 		let onChange = spy()
 		const input = getInput(
-			<CurrencyInput onChange={onChange} debounce={1000} currencySymbol={''} />
+			<CurrencyInput
+				language="fr"
+				onChange={onChange}
+				debounce={1000}
+				currencySymbol={''}
+			/>
 		)
 		input.simulate('change', { target: { value: '1', focus: () => {} } })
 		expect(onChange).not.to.have.been.called
@@ -126,7 +129,9 @@ describe('CurrencyInput', () => {
 
 	it('should not call onChange the value is the same as the current input value', () => {
 		let onChange = spy()
-		const wrapper = mount(<CurrencyInput value={2000} onChange={onChange} />)
+		const wrapper = mount(
+			<CurrencyInput language="fr" value={2000} onChange={onChange} />
+		)
 		const input = wrapper.find('input')
 		input.simulate('change', { target: { value: '2000', focus: () => {} } })
 		wrapper.setProps({ value: '2000' })
@@ -134,7 +139,7 @@ describe('CurrencyInput', () => {
 	})
 
 	it('should adapt its size to its content', () => {
-		const wrapper = mount(<CurrencyInput value={1000} />)
+		const wrapper = mount(<CurrencyInput language="fr" value={1000} />)
 		// It would be better to use `input.offsetWidth` but it's not supported by
 		// Enzyme/JSDOM
 		const getInlineWidth = () =>
@@ -148,25 +153,25 @@ describe('CurrencyInput', () => {
 
 	it('should not call onChange if the value is not a correct number', () => {
 		let onChange = spy()
-		mount(<CurrencyInput onChange={onChange} />)
+		mount(<CurrencyInput language="fr" onChange={onChange} />)
 			.find('input')
 			.simulate('change', {
 				target: { value: '-', focus: () => {} }
 			})
-		mount(<CurrencyInput onChange={onChange} />)
+		mount(<CurrencyInput language="fr" onChange={onChange} />)
 			.find('input')
 			.simulate('change', {
-				target: { value: '.', focus: () => {} }
+				target: { value: ',', focus: () => {} }
 			})
-		mount(<CurrencyInput onChange={onChange} />)
+		mount(<CurrencyInput language="fr" onChange={onChange} />)
 			.find('input')
 			.simulate('change', {
-				target: { value: '.5', focus: () => {} }
+				target: { value: ',5', focus: () => {} }
 			})
-		mount(<CurrencyInput onChange={onChange} />)
+		mount(<CurrencyInput language="fr" onChange={onChange} />)
 			.find('input')
 			.simulate('change', {
-				target: { value: '8.', focus: () => {} }
+				target: { value: '8,', focus: () => {} }
 			})
 		expect(onChange).not.to.have.been.called
 	})

--- a/mon-entreprise/source/components/CurrencyInput/CurrencyInput.tsx
+++ b/mon-entreprise/source/components/CurrencyInput/CurrencyInput.tsx
@@ -65,9 +65,6 @@ export default function CurrencyInput({
 		thousandSeparator,
 		decimalSeparator
 	} = currencyFormat(language)
-	// We display negative numbers iff this was the provided value (but we disallow the user to enter them)
-	const valueHasChanged = currentValue !== initialValue
-
 	// Autogrow the input
 	const valueLength = currentValue.toString().length
 	const width = `${5 + (valueLength - 5) * 0.75}em`
@@ -95,7 +92,7 @@ export default function CurrencyInput({
 					nextValue.current = value.toString().replace(/^0+/, '')
 				}}
 				onChange={handleChange}
-				value={currentValue?.toString().replace('.', decimalSeparator)}
+				value={currentValue ? +currentValue : ''}
 				autoComplete="off"
 			/>
 			{!isCurrencyPrefixed && <>&nbsp;€</>}

--- a/mon-entreprise/source/components/EngineValue.tsx
+++ b/mon-entreprise/source/components/EngineValue.tsx
@@ -32,11 +32,8 @@ export default function Value({
 		expression,
 		{ unit }
 	)
-	const nodeValue = evaluation.nodeValue
-	const value = formatValue({
-		nodeValue,
-		unit:
-			displayedUnit ?? (evaluation as EvaluatedNode<DottedName, number>).unit,
+	const value = formatValue(evaluation, {
+		displayedUnit,
 		language,
 		precision
 	})

--- a/mon-entreprise/source/components/PaySlip.tsx
+++ b/mon-entreprise/source/components/PaySlip.tsx
@@ -3,7 +3,7 @@ import RuleLink from 'Components/RuleLink'
 import { EngineContext, useEvaluation } from 'Components/utils/EngineContext'
 import { formatValue, ParsedRule, ParsedRules } from 'publicodes'
 import React, { Fragment, useContext } from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { DottedName } from 'Rules'
 import './PaySlip.css'
 import { Line, SalaireBrutSection, SalaireNetSection } from './PaySlipSections'
@@ -149,6 +149,7 @@ export default function PaySlip() {
 }
 
 function Cotisation({ dottedName }: { dottedName: DottedName }) {
+	const language = useTranslation().i18n.language
 	const partSalariale = useEvaluation(
 		'contrat salarié . cotisations . salariales'
 	)?.formule.explanation.explanation.find(
@@ -170,12 +171,12 @@ function Cotisation({ dottedName }: { dottedName: DottedName }) {
 			/>
 			<span style={{ backgroundColor: 'var(--lightestColor)' }}>
 				{partPatronale?.nodeValue
-					? formatValue({ ...partPatronale, unit: '€' })
+					? formatValue(partPatronale, { displayedUnit: '€', language })
 					: '–'}
 			</span>
 			<span style={{ backgroundColor: 'var(--lightestColor)' }}>
 				{partSalariale?.nodeValue
-					? formatValue({ ...partSalariale, unit: '€' })
+					? formatValue(partSalariale, { displayedUnit: '€', language })
 					: '–'}
 			</span>
 		</>

--- a/mon-entreprise/source/components/PercentageField.tsx
+++ b/mon-entreprise/source/components/PercentageField.tsx
@@ -29,10 +29,9 @@ export default function PercentageField({ onChange, value, debounce = 0 }) {
 				max="1"
 			/>
 			<span style={{ display: 'inline-block', width: '3em' }}>
-				{formatValue({
-					nodeValue: localValue,
+				{formatValue(localValue, {
 					language,
-					unit: '%'
+					displayedUnit: '%'
 				})}
 			</span>
 		</div>

--- a/mon-entreprise/source/components/TargetSelection.tsx
+++ b/mon-entreprise/source/components/TargetSelection.tsx
@@ -243,14 +243,14 @@ function TargetInputOrValue({
 						language={language}
 					/>
 					<span className="targetInputBottomBorder">
-						{formatValue({ nodeValue: value, language, unit: '€' })}
+						{formatValue(value, { language, displayedUnit: '€' })}
 					</span>
 				</>
 			) : (
 				<span>
 					{value && Number.isNaN(value)
 						? '—'
-						: formatValue({ nodeValue: value, unit: '€', language })}
+						: formatValue(value, { displayedUnit: '€', language })}
 				</span>
 			)}
 			{target.dottedName.includes('prix du travail') && <AidesGlimpse />}
@@ -274,9 +274,8 @@ function TitreRestaurant() {
 				<RuleLink dottedName={titresRestaurant.dottedName}>
 					+{' '}
 					<strong>
-						{formatValue({
-							nodeValue: titresRestaurant.nodeValue,
-							unit: '€',
+						{formatValue(titresRestaurant, {
+							displayedUnit: '€',
 							language
 						})}
 					</strong>{' '}
@@ -304,13 +303,12 @@ function AidesGlimpse() {
 	return (
 		<Animate.fromTop>
 			<div className="aidesGlimpse">
-				<RuleLink dottedName={aides.dottedName}>
+				<RuleLink dottedName={aideLink.dottedName}>
 					<Trans>en incluant</Trans>{' '}
 					<strong>
 						<span>
-							{formatValue({
-								nodeValue: aides.nodeValue,
-								unit: '€',
+							{formatValue(aides, {
+								displayedUnit: '€',
 								language
 							})}
 						</span>

--- a/mon-entreprise/source/components/conversation/AnswerList.tsx
+++ b/mon-entreprise/source/components/conversation/AnswerList.tsx
@@ -107,7 +107,7 @@ function StepsTable({
 									`}
 								>
 									<span className="answerContent">
-										{formatValue({ ...rule, language })}
+										{formatValue(rule, { language })}
 									</span>
 								</span>{' '}
 							</td>

--- a/mon-entreprise/source/components/conversation/Input.js
+++ b/mon-entreprise/source/components/conversation/Input.js
@@ -50,7 +50,7 @@ export default function Input({
 					autoComplete="off"
 				/>
 				<span className="suffix">
-					{formatValue({ nodeValue: value ?? 0, unit, language }).replace(
+					{formatValue({ nodeValue: value ?? 0, unit }, { language }).replace(
 						/[\d,.]*/g,
 						''
 					)}

--- a/mon-entreprise/source/components/conversation/InputSuggestions.tsx
+++ b/mon-entreprise/source/components/conversation/InputSuggestions.tsx
@@ -30,11 +30,13 @@ export default function InputSuggestions({
 			`}
 		>
 			{toPairs(suggestions).map(([text, value]: [string, number]) => {
-				const valueWithUnit: string = formatValue({
-					nodeValue: value,
-					unit,
-					language: i18n.language
-				})
+				const valueWithUnit: string = formatValue(
+					{
+						nodeValue: value,
+						unit
+					},
+					{ language: i18n.language }
+				)
 					.replace(/[\s]/g, '')
 					.replace(/,/, '.')
 				return (

--- a/mon-entreprise/source/components/ui/AnimatedTargetValue.tsx
+++ b/mon-entreprise/source/components/ui/AnimatedTargetValue.tsx
@@ -12,7 +12,7 @@ type AnimatedTargetValueProps = {
 
 const formatDifference = (difference: number, language: string) => {
 	const prefix = difference > 0 ? '+' : ''
-	return prefix + formatValue({ nodeValue: difference, unit: '€', language })
+	return prefix + formatValue(difference, { displayedUnit: '€', language })
 }
 
 export default function AnimatedTargetValue({

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Budget/Budget.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Budget/Budget.tsx
@@ -75,9 +75,8 @@ export default function Budget() {
 										return (
 											<td key={q}>
 												{value
-													? formatValue({
-															nodeValue: value,
-															unit: '€',
+													? formatValue(value, {
+															displayedUnit: '€',
 															language
 													  })
 													: '-'}
@@ -91,10 +90,9 @@ export default function Budget() {
 							<tr>
 								<td>Total</td>
 								<td>
-									{formatValue({
-										nodeValue: sum(Object.values(budget[2020]['T1'])),
+									{formatValue(sum(Object.values(budget[2020]['T1'])), {
 										language,
-										unit: '€'
+										displayedUnit: '€'
 									})}
 								</td>
 								<td>-</td>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Coronavirus.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Coronavirus.tsx
@@ -148,13 +148,10 @@ function ExplanationSection() {
 										<span data-test-id="comparaison-net">
 											Soit{' '}
 											<strong>
-												{formatValue({
-													nodeValue:
-														(net.nodeValue / netHabituel.nodeValue) * 100,
-													unit: '%',
-													language: 'fr',
-													precision: 0
-												})}
+												{formatValue(
+													(net.nodeValue / netHabituel.nodeValue) * 100,
+													{ displayedUnit: '%', precision: 0 }
+												)}
 											</strong>{' '}
 											du revenu net
 										</span>
@@ -170,15 +167,15 @@ function ExplanationSection() {
 										<span data-test-id="comparaison-total">
 											Soit{' '}
 											<strong>
-												{formatValue({
-													nodeValue:
-														(totalEntreprise.nodeValue /
-															totalEntrepriseHabituel.nodeValue) *
+												{formatValue(
+													(totalEntreprise.nodeValue /
+														totalEntrepriseHabituel.nodeValue) *
 														100,
-													unit: '%',
-													language: 'fr',
-													precision: 0
-												})}
+													{
+														displayedUnit: '%',
+														precision: 0
+													}
+												)}
 											</strong>{' '}
 											du coût habituel
 										</span>
@@ -277,10 +274,9 @@ function ValueWithLink(rule: EvaluatedRule<DottedName>) {
 	const { language } = useTranslation().i18n
 	return (
 		<RuleLink dottedName={rule.dottedName}>
-			{formatValue({
-				nodeValue: rule.nodeValue as number,
+			{formatValue(rule, {
 				language,
-				unit: '€',
+				displayedUnit: '€',
 				precision: 0
 			})}
 		</RuleLink>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendant/index.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendant/index.tsx
@@ -440,10 +440,8 @@ function Results() {
 							<p className="ui__ lead" css="margin-bottom: 1rem;">
 								<RuleLink dottedName={r.dottedName}>
 									{r.nodeValue != null ? (
-										formatValue({
-											nodeValue: r.nodeValue || 0,
-											language: 'fr',
-											unit: '€',
+										formatValue(r, {
+											displayedUnit: '€',
 											precision: 0
 										})
 									) : (

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Stats/Stats.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Stats/Stats.tsx
@@ -187,18 +187,14 @@ export default function Stats() {
 				<h2>Avis des visiteurs</h2>
 				<Indicators>
 					<Indicator
-						main={formatValue({
-							nodeValue: stats.feedback.simulator,
-							unit: '%',
-							language: 'fr'
+						main={formatValue(stats.feedback.simulator, {
+							displayedUnit: '%'
 						})}
 						subTitle="Taux de satisfaction sur les simulateurs"
 					/>
 					<Indicator
-						main={formatValue({
-							nodeValue: stats.feedback.content,
-							unit: '%',
-							language: 'fr'
+						main={formatValue(stats.feedback.content, {
+							displayedUnit: '%'
 						})}
 						subTitle="Taux de satisfaction sur le contenu"
 					/>
@@ -319,9 +315,7 @@ function LineChartVisits({ periodicity }: LineChartVisitsProps) {
 				/>
 				<YAxis
 					dataKey="visiteurs"
-					tickFormatter={tickItem =>
-						formatValue({ nodeValue: tickItem, language: 'fr' })
-					}
+					tickFormatter={tickItem => formatValue(tickItem)}
 				/>
 				{periodicity === 'daily' ? (
 					<Legend
@@ -393,10 +387,7 @@ const CustomTooltip = ({
 					value: formatDate(payload[0].payload.date, periodicity)
 				},
 				{
-					value: formatValue({
-						nodeValue: payload[0].payload.visiteurs,
-						language: 'fr'
-					}),
+					value: formatValue(payload[0].payload.visiteurs),
 					unit: ' visiteurs'
 				}
 			]}

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/ÉconomieCollaborative/Activité.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/ÉconomieCollaborative/Activité.tsx
@@ -111,11 +111,10 @@ export default function Activité({
 												defaultChecked={seuilRevenus === 'AUCUN'}
 											/>{' '}
 											<Trans>inférieurs à</Trans>{' '}
-											{formatValue({
-												nodeValue: activité['seuil déclaration'],
+											{formatValue(activité['seuil déclaration'], {
 												precision: 0,
 												language,
-												unit: '€'
+												displayedUnit: '€'
 											})}
 										</label>
 									</li>
@@ -129,11 +128,10 @@ export default function Activité({
 										defaultChecked={seuilRevenus === 'IMPOSITION'}
 									/>{' '}
 									<Trans>inférieurs à</Trans>{' '}
-									{formatValue({
-										nodeValue: activité['seuil pro'],
+									{formatValue(activité['seuil pro'], {
 										precision: 0,
 										language,
-										unit: '€'
+										displayedUnit: '€'
 									})}
 								</label>
 							</li>
@@ -149,11 +147,10 @@ export default function Activité({
 											}
 										/>{' '}
 										<Trans>supérieurs à</Trans>{' '}
-										{formatValue({
-											nodeValue: activité['seuil pro'],
+										{formatValue(activité['seuil pro'], {
 											precision: 0,
 											language,
-											unit: '€'
+											displayedUnit: '€'
 										})}
 									</label>
 								</li>
@@ -170,13 +167,14 @@ export default function Activité({
 										}
 									/>{' '}
 									<Trans>supérieurs à</Trans>{' '}
-									{formatValue({
-										nodeValue:
-											activité['seuil régime général'] || activité['seuil pro'],
-										precision: 0,
-										language,
-										unit: '€'
-									})}
+									{formatValue(
+										activité['seuil régime général'] || activité['seuil pro'],
+										{
+											precision: 0,
+											language,
+											displayedUnit: '€'
+										}
+									)}
 								</label>
 							</li>
 						</ul>

--- a/mon-entreprise/source/sites/publi.codes/Studio.tsx
+++ b/mon-entreprise/source/sites/publi.codes/Studio.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
 const EXAMPLE_CODE = `
-# Bienvenue dans le bac à sable du langage publicode ! 
+# Bienvenue dans le bac à sable du langage publicode !
 # Pour en savoir plus sur le langage, consultez le tutoriel :
 # => https://publi.codes
 
@@ -19,7 +19,7 @@ prix . champignons: 5€/kg
 prix . avocat: 2€/avocat
 
 dépenses primeur:
-  formule: 
+  formule:
     somme:
       - prix . carottes * 1.5 kg
       - prix . champignons * 500g
@@ -186,12 +186,7 @@ export const Results = ({ targets, onClickShare, rules }: ResultsProps) => {
 					) : (
 						<>
 							<p>
-								<strong>
-									{formatValue({
-										...evaluation,
-										language: 'fr'
-									})}
-								</strong>
+								<strong>{formatValue(evaluation)}</strong>
 							</p>
 							<br />
 							{'temporalValue' in evaluation &&
@@ -206,8 +201,7 @@ export const Results = ({ targets, onClickShare, rules }: ResultsProps) => {
 											<code>
 												{formatValue({
 													nodeValue: value,
-													unit: evaluation.unit,
-													language: 'fr'
+													unit: evaluation.unit
 												})}
 											</code>{' '}
 											<br />

--- a/mon-entreprise/source/utils.ts
+++ b/mon-entreprise/source/utils.ts
@@ -72,11 +72,9 @@ export function getSessionStorage() {
 }
 
 export const currencyFormat = (language: string) => ({
-	isCurrencyPrefixed: !!formatValue({
-		language,
-		nodeValue: 12,
-		unit: '€'
-	}).match(/^€/),
-	thousandSeparator: formatValue({ language, nodeValue: 1000 }).charAt(1),
-	decimalSeparator: formatValue({ language, nodeValue: 0.1 }).charAt(1)
+	isCurrencyPrefixed: !!formatValue(12, { language, displayedUnit: '€' }).match(
+		/^€/
+	),
+	thousandSeparator: formatValue(1000, { language }).charAt(1),
+	decimalSeparator: formatValue(0.1, { language }).charAt(1)
 })

--- a/publicodes/source/components/mecanisms/common.tsx
+++ b/publicodes/source/components/mecanisms/common.tsx
@@ -28,7 +28,7 @@ export const NodeValuePointer = ({ data, unit }: NodeValuePointerProps) => (
 			borderRadius: '0.2rem'
 		}}
 	>
-		{formatValue({ nodeValue: data, unit, language: 'fr' })}
+		{formatValue({ nodeValue: data, unit }, { language: 'fr' })}
 	</small>
 )
 

--- a/publicodes/source/components/rule/Rule.tsx
+++ b/publicodes/source/components/rule/Rule.tsx
@@ -41,7 +41,7 @@ export default function Rule({
 					>
 						{rule.nodeValue != null && (
 							<>
-								{formatValue({ ...rule, language })}
+								{formatValue(rule, { language })}
 								<br />
 							</>
 						)}
@@ -49,8 +49,7 @@ export default function Rule({
 							<>
 								<small>
 									Valeur par défaut :{' '}
-									{formatValue({
-										...rule.defaultValue,
+									{formatValue(rule.defaultValue, {
 										language
 									})}
 								</small>

--- a/publicodes/source/format.ts
+++ b/publicodes/source/format.ts
@@ -1,6 +1,6 @@
 import { serializeUnit } from './units'
 import { memoizeWith } from 'ramda'
-import { Evaluation, Unit } from './types'
+import { Unit, EvaluatedNode, Evaluation } from './types'
 import { capitalise0 } from './utils'
 
 const NumberFormat = memoizeWith(
@@ -68,11 +68,8 @@ function formatNumber({
 	if (typeof value !== 'number') {
 		return value
 	}
-	let serializedUnit = unit ? serializeUnit(unit, value, language) : undefined
-	if (serializedUnit === '') {
-		serializedUnit = '%'
-		value *= 100
-	}
+	const serializedUnit = unit ? serializeUnit(unit, value, language) : undefined
+
 	switch (serializedUnit) {
 		case '€':
 			return numberFormatter({
@@ -105,22 +102,31 @@ const booleanTranslations = {
 	en: { true: 'Yes', false: 'No' }
 }
 
-type ValueArg = {
-	nodeValue: Evaluation
-	language: string
-	unit?: string | Unit
+type Options = {
+	language?: string
+	displayedUnit?: string
 	precision?: number
 }
 
-export function formatValue({
-	nodeValue,
-	language,
-	unit,
-	precision = 2
-}: ValueArg) {
+export function formatValue(
+	value: number | { nodeValue: Evaluation; unit?: Unit } | undefined,
+	{ language = 'fr', displayedUnit, precision = 2 }: Options = {}
+) {
+	const nodeValue =
+		typeof value === 'number' || typeof value === 'undefined'
+			? value
+			: value.nodeValue
+	const unit =
+		displayedUnit ??
+		(typeof value === 'number' ||
+		typeof value === 'undefined' ||
+		!('unit' in value)
+			? undefined
+			: value.unit)
+
 	if (
 		(typeof nodeValue === 'number' && Number.isNaN(nodeValue)) ||
-		nodeValue === null
+		nodeValue == null
 	) {
 		return '-'
 	}

--- a/publicodes/source/parse.tsx
+++ b/publicodes/source/parse.tsx
@@ -241,12 +241,9 @@ const statelessParseFunction = {
 		nodeValue: v.nodeValue,
 		unit: v.unit,
 		// eslint-disable-next-line
-		jsx: ({ nodeValue, unit }: EvaluatedRule) => (
+		jsx: (node: EvaluatedRule) => (
 			<span className={v.type}>
-				{formatValue({
-					unit,
-					nodeValue,
-					language: 'fr',
+				{formatValue(node, {
 					// We want to display constants with full precision,
 					// espacilly for percentages like APEC 0,036 %
 					precision: 5

--- a/publicodes/test/format.test.js
+++ b/publicodes/test/format.test.js
@@ -4,58 +4,46 @@ import { formatValue } from '../source/format'
 
 describe('format engine values', () => {
 	it('format currencies', () => {
-		expect(formatValue({ nodeValue: 12, unit: '€', language: 'fr' })).to.equal(
-			'12 €'
-		)
-		expect(
-			formatValue({ nodeValue: 1200, unit: '€', language: 'fr' })
-		).to.equal('1 200 €')
-		expect(formatValue({ nodeValue: 12, unit: '€', language: 'en' })).to.equal(
+		expect(formatValue(12, { displayedUnit: '€' })).to.equal('12 €')
+		expect(formatValue(1200, { displayedUnit: '€' })).to.equal('1 200 €')
+		expect(formatValue(12, { displayedUnit: '€', language: 'en' })).to.equal(
 			'€12'
 		)
+		expect(formatValue(12.1, { displayedUnit: '€', language: 'en' })).to.equal(
+			'€12.10'
+		)
 		expect(
-			formatValue({ nodeValue: 12.1, unit: '€', language: 'en' })
-		).to.equal('€12.10')
-		expect(
-			formatValue({ nodeValue: 12.123, unit: '€', language: 'en' })
+			formatValue(12.123, { displayedUnit: '€', language: 'en' })
 		).to.equal('€12.12')
 	})
 
 	it('format percentages', () => {
-		expect(formatValue({ nodeValue: 10, unit: '%' })).to.equal('10%')
-		expect(formatValue({ nodeValue: 100, unit: '%' })).to.equal('100%')
-		expect(formatValue({ nodeValue: 10.2, unit: '%' })).to.equal('10.2%')
+		expect(formatValue(10, { displayedUnit: '%' })).to.equal('10 %')
+		expect(formatValue(100, { displayedUnit: '%' })).to.equal('100 %')
+		expect(formatValue(10.2, { displayedUnit: '%' })).to.equal('10,2 %')
 	})
 
 	it('format values', () => {
-		expect(formatValue({ unit: '€', nodeValue: 12 })).to.equal('€12')
-		expect(formatValue({ unit: '€', nodeValue: 12.1 })).to.equal('€12.10')
-		expect(formatValue({ unit: '€', nodeValue: 12, language: 'fr' })).to.equal(
-			'12 €'
-		)
-		expect(formatValue({ nodeValue: 1200, language: 'fr' })).to.equal('1 200')
+		expect(formatValue(1200)).to.equal('1 200')
 	})
 })
 
 describe('Units handling', () => {
-	it('translate unit', () => {
-		expect(
-			formatValue({ nodeValue: 1, unit: 'jour', language: 'fr' })
-		).to.equal('1 jour')
-		expect(
-			formatValue({ nodeValue: 1, unit: 'jour', language: 'en' })
-		).to.equal('1 day')
+	it('translate displayedUnit', () => {
+		expect(formatValue(1, { displayedUnit: 'jour', language: 'fr' })).to.equal(
+			'1 jour'
+		)
+		expect(formatValue(1, { displayedUnit: 'jour', language: 'en' })).to.equal(
+			'1 day'
+		)
 	})
 
-	it('pluralize unit', () => {
-		expect(
-			formatValue({ nodeValue: 2, unit: 'jour', language: 'fr' })
-		).to.equal('2 jours')
+	it('pluralize displayedUnit', () => {
+		expect(formatValue(2, { displayedUnit: 'jour' })).to.equal('2 jours')
 		expect(
 			formatValue({
 				nodeValue: 7,
-				unit: parseUnit('jour/semaine'),
-				language: 'fr'
+				unit: parseUnit('jour/semaine')
 			})
 		).to.equal('7 jours / semaine')
 	})


### PR DESCRIPTION
Vu que nous allons bientôt publier la lib, autant nettoyer autant que possible l'api

### Modifications

**Avant**
```ts
formatValue({ 
  nodeValue: Evaluation, 
  unit?: Unit | string, 
  language: string, 
  precision?: number
})
```

**Après**
```ts
formatValue({ 
  nodeValue: Evaluation, 
  unit?: Unit,
} | number, {
  language: string = 'fr',  
  precision?: number
  displayedUnit: 'string'
})
```

Ainsi, formatValue peut être appelée directement avec comme premier paramètre node retourné par evaluate, et comme deuxième paramètre des options de formattage. On peut également l'appeler directement sur un nombre.