### PR TITLE
Ajout d'un sélecteur de situation dans la section documentation

### DIFF
--- a/mon-entreprise/source/components/RuleLink.tsx
+++ b/mon-entreprise/source/components/RuleLink.tsx
@@ -8,6 +8,7 @@ import { SitePathsContext } from './utils/SitePathsContext'
 export default function RuleLink(
 	props: {
 		dottedName: DottedName
+		documentationState?: object
 		displayIcon?: boolean
 	} & Omit<React.ComponentProps<Link>, 'to'>
 ) {
@@ -17,6 +18,7 @@ export default function RuleLink(
 		<EngineRuleLink
 			{...props}
 			engine={engine}
+			documentationState={props.documentationState}
 			documentationPath={sitePaths.documentation.index}
 		/>
 	)

--- a/mon-entreprise/source/components/SearchButton.tsx
+++ b/mon-entreprise/source/components/SearchButton.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState, useContext } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import Overlay from './Overlay'
 import { EngineContext } from 'Components/utils/EngineContext'
 import SearchBar from './SearchBar'
-import { useLocation } from 'react-router'
 
 type SearchButtonProps = {
 	invisibleButton?: boolean

--- a/publicodes/source/components/RuleLink.tsx
+++ b/publicodes/source/components/RuleLink.tsx
@@ -12,6 +12,7 @@ type RuleLinkProps<Name extends string> = Omit<
 	dottedName: Name
 	engine: Engine<Name>
 	documentationPath: string
+	documentationState?: {}
 	displayIcon?: boolean
 	children?: React.ReactNode
 }
@@ -20,15 +21,21 @@ export function RuleLink<Name extends string>({
 	dottedName,
 	engine,
 	documentationPath,
+	documentationState,
 	displayIcon = false,
 	children,
 	...props
 }: RuleLinkProps<Name>) {
 	const rule = engine.getParsedRules()[dottedName]
 	const newPath = documentationPath + '/' + encodeRuleName(dottedName)
-
 	return (
-		<Link to={newPath} {...props}>
+		<Link
+			to={{
+				pathname: newPath,
+				state: documentationState
+			}}
+			{...props}
+		>
 			{children || rule.title}{' '}
 			{displayIcon && rule.icons && <span>{emoji(rule.icons)} </span>}
 		</Link>


### PR DESCRIPTION
https://deploy-preview-1063--syso.netlify.app/simulateurs/comparaison-r%C3%A9gimes-sociaux

Dans le code création d'une abstraction `comparaisonEngines` qui permet de gérer une liste de moteurs avec des situations amendées.

- [ ] Utiliser `comparaisonEngines` sur le simulateur de chômage partiel