### PR TITLE
WIP : page d'accueil de la documentation

### DIFF
--- a/mon-entreprise/source/rules/couverture-legislative.json
+++ b/mon-entreprise/source/rules/couverture-legislative.json
@@ -1,0 +1,104 @@
+[
+	[
+		"📃 Formes de travail",
+		[
+			[
+				"Salariés et assimilés",
+				[
+					{
+						"rule": "contrat salarié . CDI",
+						"label": "CDI Contrat à Durée Indéterminée"
+					},
+					{
+						"rule": "contrat salarié . CDD",
+						"label": "CDD Contrat à Durée Déterminée"
+					},
+					"CDIC CDI de chantier",
+					"CUI Contrat unique d'insertion",
+					"CTT Contrat de Travail Temporaire (intérim)",
+					{
+						"rule": "contrat salarié . apprentissage",
+						"label": "Contrat d’apprentissage"
+					},
+					{
+						"rule": "contrat salarié . professionnalisation",
+						"label": "Contrat de professionnalisation"
+					},
+					{
+						"rule": "contrat salarié . stage",
+						"label": "Convention de stage"
+					},
+					"Doctorat",
+					"Travailleurs à domicile",
+					"Assistants maternels et familiaux"
+				]
+			],
+			[
+				"Indépendants",
+				[
+					{ "label": "Auto-entrepreneurs", "simulator": "auto-entrepreneur" },
+					"Artisan, commerçant",
+					"Professions libérales",
+					[
+						"Professions libérales réglementées",
+						["médecin", "auxiliaire", "sage-femme", "avocat", "notaire", "etc."]
+					],
+					"Dirigeants assimilés salarié",
+					"Agriculteurs",
+					{ "rule": "artiste-auteur", "simulator": "artiste-auteur" },
+					"Marins",
+					"Conjoint collaborateur"
+				]
+			],
+			[
+				"Fonction publique",
+				[
+					"Titulaires",
+					[
+						"Non titulaires",
+						["contractuels", "auxiliaires", "vacataires", "etc."]
+					],
+					"Élus",
+					"Militaires"
+				]
+			]
+		]
+	],
+	[
+		"🏢 Formes sociales",
+		[
+			"Micro-entreprise",
+			"Entreprise individuelle (EI, EIRL)",
+			"Sociétés anonymes avec un gérant indépendant (SARL, EURL)",
+			"Sociétés anonymes avec un président assimilé salarié (SA, SAS, SASU)",
+			"Entreprises d'exercice libéral (SELARL, SELAFA, SELCA, SELAS, SELASU)",
+			"Sociétés civiles (SCI, SCP, SCCV, SEP)",
+			"Sociétés de personnes (SNC, SCS)",
+			"Coopératives (SCOP, SCIC, SCA)",
+			"Exploitations agricoles (EARL, GAEC, SCEA)",
+			"Societas europaea (SE)",
+			"Associations (loi 1901, AARPI)",
+			"Sociétés d'économie mixte (SAEM, SAEML, SAIEM)",
+			"Sociétés d'investissement et titrisation (SIIC, FCT, ST)",
+			"Groupements (GIE, GIP, GFF, GFI)",
+			"Établissements publics (EPA, EPIC)",
+			"Fondations, fonds de dotation"
+		]
+	],
+	"🦿 Aides",
+	"☂ Cotisations sociales",
+	[
+		"📚 Conventions collectives",
+		[
+			{ "rule": "contrat salarié . convention collective . HCR" },
+			"Optique",
+			"Sportifs",
+			"Intermittents du spectacle",
+			"BTP"
+		]
+	],
+	"💶 Rémunération",
+	"⏲ Conditions de travail",
+	"🏛 Fiscalité société",
+	"👨‍👩‍👧‍👦 Fiscalité particulier"
+]

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Documentation.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Documentation.tsx
@@ -5,12 +5,21 @@ import { EngineContext } from 'Components/utils/EngineContext'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import { Documentation, getDocumentationSiteMap } from 'publicodes'
-import React, { useCallback, useContext, useMemo } from 'react'
+import React, { useCallback, useContext, useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Redirect, useLocation } from 'react-router-dom'
+import { Redirect, useLocation, Link } from 'react-router-dom'
 import { RootState } from 'Reducers/rootReducer'
-import SearchBar from 'Components/SearchBar'
+import emoji from 'react-easy-emoji'
+import couvertureLegislative from '../../../rules/couverture-legislative.json'
+import styled from 'styled-components'
+import animate from 'Components/ui/animate'
+import RuleLink from 'Components/RuleLink'
+import useSimulatorsData, { simulateurs } from './Simulateurs/metadata'
+
+type CouvertureLegislative = Array<Category>
+type Category = string | [string, Array<Node>]
+type Node = string | { rule: string; simulator?: simulateurs }
 
 export default function RulePage() {
 	const currentSimulation = useSelector(
@@ -69,13 +78,122 @@ function BackToSimulation() {
 }
 
 function DocumentationLanding() {
+	const sitePaths = useContext(SitePathsContext)
+	const { pathname } = useLocation()
+	const [currentlyOpenAccordeon, setCurrentlyOpenAccordeon] = useState()
 	return (
 		<>
+			<ScrollToTop key={pathname} />
 			<h1>
-				<Trans i18nKey="page.documentation.title">Documentation</Trans>
+				<Trans i18nKey="page.documentation.title">
+					Couverture législative <>{emoji('⚖')}</>
+				</Trans>
 			</h1>
-			<p>Explorez toutes les règles de la documentation</p>
-			<SearchBar showListByDefault={true} />
+			<p>
+				Cette page référence les dispositifs existants dans la législation
+				française en matière de droit de la sécurité sociale, droit fiscal, et
+				plus partiellement en droit du travail. Cette liste n'est pas exhaustive
+				mais permet d'avoir un aperçu synthétique des sujets couverts et de ceux
+				non couverts par{' '}
+				<Link to={sitePaths.simulateurs.index}>nos simulateurs</Link>.
+			</p>
+			<hr />
+			<div className="ui__ card light-border">
+				{(couvertureLegislative as CouvertureLegislative).map(cat => {
+					const title = Array.isArray(cat) ? cat[0] : cat
+					const isOpen = currentlyOpenAccordeon === title
+					return (
+						<CategorySection key={title} className={isOpen ? 'isOpen' : ''}>
+							<h3
+								onClick={() => setCurrentlyOpenAccordeon(isOpen ? null : title)}
+							>
+								{emoji(title)}
+							</h3>
+							{isOpen && (
+								<animate.fromTop>
+									<ul>
+										{Array.isArray(cat) &&
+											cat[1]?.map((node, i) => (
+												<li key={i}>
+													<Node node={node} />
+												</li>
+											))}
+									</ul>
+								</animate.fromTop>
+							)}
+						</CategorySection>
+					)
+				})}
+			</div>
 		</>
 	)
+}
+
+const CategorySection = styled.div`
+	border-top: 2px solid var(--lighterColor);
+
+	&:first-child {
+		border-top: none;
+	}
+
+	h3 {
+		cursor: pointer;
+	}
+
+	h3:after {
+		display: block;
+		content: '↓';
+		float: right;
+		transition: transform 0.4s ease-in-out;
+	}
+
+	&.isOpen h3:after {
+		transform: rotate(180deg);
+	}
+`
+
+function Node({ node, level = 1 }) {
+	const isCategory = Array.isArray(node)
+	const simulatorsData = useSimulatorsData()
+	if (isCategory && level < 2) {
+		return (
+			<p>
+				<strong>{node[0]}</strong>
+				<ul>
+					{node[1].map((node, i) => (
+						<li key={i}>
+							<Node node={node} level={level + 1} />
+						</li>
+					))}
+				</ul>
+			</p>
+		)
+	} else if (isCategory && level == 2) {
+		return (
+			<>
+				{node[0]} (
+				{node[1].map((node, i) => (
+					<React.Fragment key={i}>
+						{i + 1 !== node[1].length && ', '}
+						<Node node={node} level={level + 1} />
+					</React.Fragment>
+				))}
+				)
+			</>
+		)
+	} else {
+		const { rule, label, simulator } =
+			typeof node === 'string' ? { label: node } : node
+		return (
+			<>
+				{rule ? <RuleLink dottedName={rule}>{label}</RuleLink> : label}
+				{simulator && (
+					<>
+						{' '}
+						<Link to={simulatorsData[simulator].path}>→ Simulateur</Link>
+					</>
+				)}
+			</>
+		)
+	}
 }

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/Home.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/Home.tsx
@@ -93,12 +93,15 @@ export default function Simulateurs() {
 						</li>
 						<li>
 							<strong>Améliorés en continu</strong> afin d'augmenter le nombre
-							de dispositifs pris en compte
+							de{' '}
+							<Link to={sitePaths.documentation.index}>
+								dispositifs pris en compte
+							</Link>
 						</li>
 						<li>
 							<strong>Intégrable facilement et gratuitement</strong> sur
 							n'importe quel site internet.{' '}
-							<Link to={sitePaths.integration.iframe}>En savoir plus</Link>.
+							<Link to={sitePaths.integration.iframe}>En savoir plus</Link>
 						</li>
 					</ul>
 				</Trans>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/metadata.tsx
@@ -35,7 +35,7 @@ import SalariéSimulation from './SalariéSimulation'
 import SchemeComparaisonPage from './SchemeComparaison'
 import ÉconomieCollaborative from './ÉconomieCollaborative'
 
-const simulateurs = [
+export const simulateurs = [
 	'salarié',
 	'auto-entrepreneur',
 	'indépendant',


### PR DESCRIPTION
Reprendre le contenu de #714 comme page d'accueil de la documentation.

Preview: https://deploy-preview-1082--syso.netlify.app/documentation
Closes #714

Questions :
- renommer `/documentation` en `/legislation` ?
- utiliser une page par section plutôt qu'un composant accordéon pour le référencement ? ou bien garder l'accordéon mais mettre la section ouverte dans l'URL ?