### PR TITLE
Corrige les taux acre pour les auto-entrepreneur

### DIFF
--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -3603,19 +3603,27 @@ dirigeant . auto-entrepreneur . cotisations et contributions . TFC . métiers:
   titre.fr: Contribution à la formation professionnelle
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
   description.en: >
-    [automatic] Social security contributions give the self-employed person
-    access to a minimum social protection: a pension, health care, family
-    allowances, etc.
+    [automatic] Social security contributions give the auto-entrepreneur access
+    to an
+
+    minimum social protection: a pension, health care, social security, health care
+
+    family allowances, etc.
 
 
-    Self-employment is a simplified plan: rather than a complex payslip, all contributions are grouped into a *package* whose rate depends on the activity category.
-  description.fr: >
+    Self-employment is a simplified plan: rather than a pay slip
+
+    complex, all the contributions are grouped in a *package* with the
+
+    rate depends on the activity category.
+  description.fr: |
     Les cotisations sociales donnent à l'auto-entrepreneur accès à une
     protection sociale minimale : une retraite, des soins de santé, des
     allocations familiales, etc.
 
-
-    L'auto-entreprise est un régime simplifié : plutôt qu'une fiche de paie complexe, toutes les cotisations sont groupées dans un *forfait* dont le taux dépend de la catégorie d'activité.
+    L'auto-entreprise est un régime simplifié : plutôt qu'une fiche de paie
+    complexe, toutes les cotisations sont regroupées dans un *forfait* dont le
+    taux dépend de la catégorie d'activité.
   titre.en: contributions
   titre.fr: cotisations
 ? dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE
@@ -3633,28 +3641,22 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
   titre.fr: retraite complémentaire
 ? dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE
 : description.en: >
+    [automatic] This rate corresponds to the contribution reduction that applies
+    to
 
-    l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 25% signifie que
+    the auto-entrepreneur benefiting from Acre. A rate of 75% means that
 
-    l'auto-entrepreneur bénéficie de 25% de réduction sur le montant des cotisations dûes.
-  description.fr: >
+    the auto-entrepreneur has to pay 75% of the original amount of the
+
+    contributions.
+  description.fr: |
     Ce taux correspond à la réduction de cotisations qui s'applique pour
-
-    l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 25% signifie que
-
-    l'auto-entrepreneur bénéficie de 25% de réduction sur le montant des cotisations dûes.
+    l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 75% signifie que
+    l'auto-entrepreneur doit s'acquitter de 75% du montant d'origine des
+    cotisations.
   titre.en: |
     "ACRE" rate
   titre.fr: taux ACRE auto-entrepreneur
-? dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation
-: description.en: >
-    The social contributions of the self-employed are simplified: there is no
-    than a single line whose rate depends on the category of activity.
-  description.fr: >
-    Les cotisations sociales de l'auto-entreprise sont simplifiées : il n'y a
-    qu'une ligne unique dont le taux dépend de la catégorie d'activité.
-  titre.en: contribution rate
-  titre.fr: taux de cotisation
 dirigeant . auto-entrepreneur . impôt:
   titre.en: tax
   titre.fr: impôt
@@ -3812,6 +3814,9 @@ dirigeant . auto-entrepreneur . plafond:
     Les charges ne sont pas déductibles pour le calcul du plafond (comme pour le calcul des cotisations)
   titre.en: upper limit
   titre.fr: plafond
+dirigeant . auto-entrepreneur . vente ou hébergement:
+  titre.en: '[automatic] Sales, catering or accommodation'
+  titre.fr: Vente, restauration ou hébergement
 dirigeant . indépendant:
   titre.en: indépendant
   titre.fr: indépendant

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -109,10 +109,7 @@ dirigeant . auto-entrepreneur . plafond:
   unité: €/an
   formule:
     variations:
-      - si:
-          une de ces conditions:
-            - entreprise . catégorie d'activité . service ou vente = 'vente'
-            - entreprise . catégorie d'activité . restauration ou hébergement
+      - si: vente ou hébergement
         alors: 176200 €/an
       - sinon: 72500 €/an
 
@@ -160,10 +157,7 @@ dirigeant . auto-entrepreneur . cotisations et contributions . TFC . commerce:
       assiette: base des cotisations
       taux:
         variations:
-          - si:
-              une de ces conditions:
-                - entreprise . catégorie d'activité . service ou vente = 'vente'
-                - entreprise . catégorie d'activité . restauration ou hébergement
+          - si: vente ou hébergement
             alors: 0.015%
           - sinon: 0.044%
 
@@ -210,21 +204,41 @@ dirigeant . auto-entrepreneur . cotisations et contributions . contribution form
             alors: 0.2%
           - sinon: 0.1%
 
+dirigeant . auto-entrepreneur . vente ou hébergement:
+  titre: Vente, restauration ou hébergement
+  formule:
+    une de ces conditions:
+      - entreprise . catégorie d'activité . service ou vente = 'vente'
+      - entreprise . catégorie d'activité . restauration ou hébergement
+
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
   description: |
-    Les cotisations sociales donnent à l'auto-entrepreneur accès à une protection sociale minimale : une retraite, des soins de santé, des allocations familiales, etc.
+    Les cotisations sociales donnent à l'auto-entrepreneur accès à une
+    protection sociale minimale : une retraite, des soins de santé, des
+    allocations familiales, etc.
 
-    L'auto-entreprise est un régime simplifié : plutôt qu'une fiche de paie complexe, toutes les cotisations sont groupées dans un *forfait* dont le taux dépend de la catégorie d'activité.
+    L'auto-entreprise est un régime simplifié : plutôt qu'une fiche de paie
+    complexe, toutes les cotisations sont regroupées dans un *forfait* dont le
+    taux dépend de la catégorie d'activité.
 
   formule:
-    barème:
-      assiette: base des cotisations
-      multiplicateur: plafond ACRE
-      tranches:
-        - taux: taux de cotisation * (100% - taux ACRE)
-          plafond: 1
-        - taux: taux de cotisation
-
+    variations:
+      - si: entreprise . ACRE
+        alors:
+          barème:
+            assiette: base des cotisations
+            tranches:
+              - taux: taux de cotisation * taux ACRE
+                plafond: plafond ACRE
+              - taux: taux de cotisation
+      - sinon:
+          produit:
+            assiette: base des cotisations [€/mois]
+            taux [ref taux de cotisation]:
+              variations:
+                - si: vente ou hébergement
+                  alors: 12.8%
+                - sinon: 22%
   références:
     La protection sociale du micro-entrepreneur: https://bpifrance-creation.fr/encyclopedie/micro-entreprise-regime-auto-entrepreneur/fiscal-social-comptable/protection-sociale
 
@@ -237,50 +251,57 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ret
       assiette: base des cotisations
       taux:
         variations:
-          - si:
-              une de ces conditions:
-                - entreprise . catégorie d'activité . service ou vente = 'vente'
-                - entreprise . catégorie d'activité . restauration ou hébergement
+          - si: vente ou hébergement
             alors: 2.04%
-          - si:
-              une de ces conditions:
-                - entreprise . catégorie d'activité = 'commerciale ou industrielle'
-                - entreprise . catégorie d'activité = 'artisanale'
-            alors: 3.50%
-
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux de cotisation:
-  description: |
-    Les cotisations sociales de l'auto-entreprise sont simplifiées : il n'y a qu'une ligne unique dont le taux dépend de la catégorie d'activité.
-  formule:
-    variations:
-      - si:
-          une de ces conditions:
-            - entreprise . catégorie d'activité . service ou vente = 'vente'
-            - entreprise . catégorie d'activité . restauration ou hébergement
-        alors: 12.8%
-      - sinon: 22%
+          - sinon: 3.50%
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
   titre: taux ACRE auto-entrepreneur
   applicable si: entreprise . ACRE
   description: |
     Ce taux correspond à la réduction de cotisations qui s'applique pour
-    l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 25% signifie que
-    l'auto-entrepreneur bénéficie de 25% de réduction sur le montant des cotisations dûes.
+    l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 75% signifie que
+    l'auto-entrepreneur doit s'acquitter de 75% du montant d'origine des
+    cotisations.
+  unité: '%'
   formule:
     variations:
-      - si: entreprise . date de création >= 01/2020
-        alors: 50%
-      - si: entreprise . durée d'activité < 1 an
-        alors: 75%
-      - si: entreprise . durée d'activité < 2 ans
-        alors: 25%
-      - si: entreprise . durée d'activité < 3 ans
-        alors: 10%
+      - si: entreprise . date de création < 01/04/2019
+        alors:
+          grille:
+            assiette: entreprise . durée d'activité
+            tranches:
+              - montant: 25%
+                plafond: 1 an
+              - montant: 50%
+                plafond: 2 ans
+              - montant: 90%
+                plafond: 3 ans
+      - si: entreprise . date de création < 01/04/2020
+        alors:
+          grille:
+            assiette: entreprise . durée d'activité
+            tranches:
+              - montant: 25%
+                plafond: 1 an
+              - montant: 75%
+                plafond: 2 ans
+              - montant: 90%
+                plafond: 3 ans
+      - sinon:
+          grille:
+            assiette: entreprise . durée d'activité
+            tranches:
+              - montant: 50%
+                plafond: 1 an
+              - montant: 75%
+                plafond: 2 ans
+              - montant: 90%
+                plafond: 3 ans
   références:
     Fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/je-beneficie-dexonerations/accre.html
-    FAQ Urssaf depuis 01/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#jai-cree-mon-auto-entreprise-en
-    FAQ Urssaf avant 01/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#quest-ce-qui-change-pour-moi-si
+    FAQ Urssaf depuis 04/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#jai-cree-mon-auto-entreprise-en
+    FAQ Urssaf avant 04/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#quest-ce-qui-change-pour-moi-si
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
   formule: plafond sécurité sociale temps plein / impôt . abattement . taux inversé
@@ -306,10 +327,7 @@ dirigeant . auto-entrepreneur . impôt . abattement . taux:
     variations:
       - si: entreprise . catégorie d'activité = 'libérale'
         alors: 34%
-      - si:
-          une de ces conditions:
-            - entreprise . catégorie d'activité . service ou vente = 'vente'
-            - entreprise . catégorie d'activité . restauration ou hébergement
+      - si: vente ou hébergement
         alors: 71%
       - sinon: 50%
 
@@ -341,10 +359,7 @@ dirigeant . auto-entrepreneur . impôt . versement libératoire . montant:
       assiette: base des cotisations
       taux:
         variations:
-          - si:
-              une de ces conditions:
-                - entreprise . catégorie d'activité . service ou vente = 'vente'
-                - entreprise . catégorie d'activité . restauration ou hébergement
+          - si: vente ou hébergement
             alors: 1%
           - si: entreprise . catégorie d'activité . service ou vente = 'service'
             alors: 1.7%

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -74,15 +74,15 @@ exports[`calculate simulations-artiste-auteur: salarié 2`] = `"[1603]"`;
 
 exports[`calculate simulations-artiste-auteur: salarié 3`] = `"[12410]"`;
 
-exports[`calculate simulations-auto-entrepreneur: ACRE 1`] = `"[21394,116,1667,0,20000]"`;
+exports[`calculate simulations-auto-entrepreneur: ACRE 1`] = `"[20686,57,1667,0,20000]"`;
 
 exports[`calculate simulations-auto-entrepreneur: ACRE 2`] = `"[33228,269,2500,0,30000]"`;
 
 exports[`calculate simulations-auto-entrepreneur: ACRE 3`] = `"[45267,439,3333,0,40000]"`;
 
-exports[`calculate simulations-auto-entrepreneur: aides 1`] = `"[5348,29,417,0,5000]"`;
+exports[`calculate simulations-auto-entrepreneur: aides 1`] = `"[5171,14,417,0,5000]"`;
 
-exports[`calculate simulations-auto-entrepreneur: aides 2`] = `"[53485,290,4167,93,49907]"`;
+exports[`calculate simulations-auto-entrepreneur: aides 2`] = `"[51714,143,4167,11,49989]"`;
 
 exports[`calculate simulations-auto-entrepreneur: impôt sur le revenu 1`] = `"[32092,591,2083,706,24294]"`;
 
@@ -200,9 +200,9 @@ exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): é
 
 exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): échelle de rémunération 8`] = `"[4751,0,0,52684,4,46]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): ACRE 1`] = `"[0,0,779,2046,2,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): ACRE 1`] = `"[0,0,806,2046,2,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): ACRE 2`] = `"[0,0,1558,4093,3,8]"`;
+exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): ACRE 2`] = `"[0,0,1611,4093,3,8]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): ACRE 3`] = `"[0,0,2337,6139,4,12]"`;
 

--- a/publicodes/source/mecanisms/variations.ts
+++ b/publicodes/source/mecanisms/variations.ts
@@ -132,9 +132,10 @@ function evaluate(
 			try {
 				evaluatedConsequence = convertNodeToUnit(unit, evaluatedConsequence)
 			} catch (e) {
-				return typeWarning(
+				typeWarning(
 					cache._meta.contexRule,
-					`L'unité de la branche n° ${i} du mécanisme 'variations' n'est pas compatible avec celle d'une branche précédente`,
+					`L'unité de la branche n° ${i +
+						1} du mécanisme 'variations' n'est pas compatible avec celle d'une branche précédente`,
 					e
 				)
 			}


### PR DESCRIPTION
La réforme a été appliqué à partir du 01/04/2020 et non du 01/01/2020 comme prévu à l'origine.