### PR TITLE
Vérifie le nom des règles dans les tests de regressions

### DIFF
--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -362,7 +362,7 @@ exports[`calculate simulations-salarié: cdd 1`] = `"[2509,0,2000,1561,1524]"`;
 
 exports[`calculate simulations-salarié: cdd 2`] = `"[2591,0,2000,1599,1557]"`;
 
-exports[`calculate simulations-salarié: cdd 3`] = `"[3394,0,2400,1967,1883]"`;
+exports[`calculate simulations-salarié: cdd 3`] = `"[3417,0,2400,1987,1902]"`;
 
 exports[`calculate simulations-salarié: cdd 4`] = `"[3745,0,2400,1878,1794]"`;
 

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -62,8 +62,8 @@ cdd:
     contrat salarié . rémunération . brut de base: 2400 €/mois
     contrat salarié . CDD . durée contrat: 10
     contrat salarié . temps de travail . heures supplémentaires: 5
-    contrat salarié . indemnité kilométrique vélo: oui
-    contrat salarié . avantages en nature . montant: 200
+    contrat salarié . frais professionnels . indemnité kilométrique vélo: oui
+    contrat salarié . rémunération . avantages en nature . montant: 200
   - contrat salarié: "'CDD'"
     contrat salarié . rémunération . brut de base: 2400 €/mois
     contrat salarié . convention collective: "'BTP'"
@@ -95,18 +95,18 @@ aides:
     contrat salarié . aides employeur . emploi franc . éligible: oui
 
 aides embauche covid:
-  - ancienneté . date d'embauche: 01/08/2020
+  - contrat salarié . ancienneté . date d'embauche: 01/08/2020
     contrat salarié . jeune de moins de 26 ans: oui
     contrat salarié . rémunération . brut de base: 1500 €/mois
-  - ancienneté . date d'embauche: 01/08/2020
+  - contrat salarié . ancienneté . date d'embauche: 01/08/2020
     contrat salarié . jeune de moins de 26 ans: oui
     contrat salarié . rémunération . brut de base: 5000 €/mois
-  - ancienneté . date d'embauche: 01/08/2020
+  - contrat salarié . ancienneté . date d'embauche: 01/08/2020
     contrat salarié: "'CDD'"
     contrat salarié . CDD . durée contrat: 3 mois
     contrat salarié . jeune de moins de 26 ans: oui
     contrat salarié . rémunération . brut de base: 1500 €/mois
-  - ancienneté . date d'embauche: 01/08/2020
+  - contrat salarié . ancienneté . date d'embauche: 01/08/2020
     contrat salarié: "'apprentissage'"
     contrat salarié . rémunération . brut de base: 1500 €/mois
 

--- a/mon-entreprise/test/regressions/simulations.jest.js
+++ b/mon-entreprise/test/regressions/simulations.jest.js
@@ -26,6 +26,14 @@ const engine = new Engine(rules)
 const runSimulations = (situations, targets, baseSituation = {}) =>
 	Object.entries(situations).map(([name, situations]) =>
 		situations.forEach(situation => {
+			Object.keys(situation).forEach(situationRuleName => {
+				// TODO: This check may be moved in the `engine.setSituation` method
+				if (!Object.keys(engine.getParsedRules()).includes(situationRuleName)) {
+					throw new Error(
+						`La règle ${situationRuleName} n'existe pas dans la base de règles.`
+					)
+				}
+			})
 			engine.setSituation({ ...baseSituation, ...situation })
 			const res = targets.map(target => engine.evaluate(target).nodeValue)
 			// Stringify is not required, but allows the result to be displayed in a single


### PR DESCRIPTION
Pour éviter des situations comme https://github.com/betagouv/mon-entreprise/pull/1104#discussion_r481170617.
Plusieurs noms de règles erronés étaient présents.