### PR TITLE
Corrige les sous-simulateurs PAM

### DIFF
--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -144,3 +144,14 @@ describe('Simulateur salarié', () => {
 		cy.contains('Steenvoorde (59114)')
 	})
 })
+
+describe('Simulateurs professions-libérales', () => {
+	if (!fr) {
+		return
+	}
+	before(() => cy.visit('/simulateurs/profession-libérale/médecin'))
+
+	it('should put the profession name in page title', () => {
+		cy.get('h1').contains('médecin')
+	})
+})


### PR DESCRIPTION
Exemple : https://deploy-preview-1120--syso.netlify.app/simulateurs/profession-lib%C3%A9rale/sage%E2%80%91femme

Cela ne fonctionnait plus suite à l'utilisation de catégories pour la questions des professions (et au regroupements des professions médicales). L'UI rend bien, mais je me demande s'il ne serait pas opportun de revoir la représentation publicode de ce système de catégorie, en particulier parce qu'il rend la lecture et l'écrite de la situation plus compliqué qu'à l’accoutumé (le fix de cette PR est partiel, il ne fonctionne que dans le sens URL → situation, mais pas dans le sens situation → URL) 