### PR TITLE
Corrections pour le calcul de l'IR et utilisation du taux neutre par défaut

### DIFF
--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -5859,6 +5859,16 @@ impôt . foyer fiscal . impôt à payer:
 impôt . foyer fiscal . nombre de parts:
   titre.en: '[automatic] number of shares'
   titre.fr: nombre de parts
+impôt . foyer fiscal . nombre de parts . majoration personne seule avec enfant:
+  description.en: '[automatic] Single, divorced or separated taxpayers who live
+    alone and effectively support one or more children receive an additional
+    half share of the family allowance.'
+  description.fr:
+    Les contribuables célibataires, divorcés ou séparés, qui vivent
+    seuls et supportent effectivement la charge d’un ou plusieurs enfants
+    bénéficient d’une demi-part supplémentaire de quotient familial.
+  titre.en: '[automatic] single person with child surcharge'
+  titre.fr: majoration personne seule avec enfant
 impôt . foyer fiscal . nombre de parts . majoration personne veuve avec enfant:
   description.en: >-
     [automatic] A widow with dependent children receives an additional share for

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -5811,17 +5811,16 @@ impôt . foyer fiscal . enfants à charge:
   titre.en: '[automatic] dependent children'
   titre.fr: enfants à charge
 impôt . foyer fiscal . impôt sur le revenu:
+  titre.en: '[automatic] personal income tax'
+  titre.fr: impôt sur le revenu
+impôt . foyer fiscal . impôt sur le revenu . décote:
   description.en:
     '[automatic] A discount is applied after the income tax scale to
     reduce the tax for low income earners.'
   description.fr: Une décote est appliquée après le barème de l'impôt sur le
     revenu, pour réduire l'impôt des bas revenus.
-  note.en: '[automatic] The calculation used for the discount is for single
-    households only, the calculation is different for couples.'
-  note.fr: Le calcul utilisé pour la décôte concerne uniquement les foyers
-    célibataires, le calcul est différent pour les couples.
-  titre.en: '[automatic] personal income tax'
-  titre.fr: impôt sur le revenu
+  titre.en: '[automatic] discount'
+  titre.fr: décote
 impôt . foyer fiscal . impôt sur le revenu . impôt brut:
   titre.en: '[automatic] gross tax'
   titre.fr: impôt brut
@@ -5862,11 +5861,11 @@ impôt . foyer fiscal . nombre de parts:
 impôt . foyer fiscal . nombre de parts . majoration personne seule avec enfant:
   description.en: '[automatic] Single, divorced or separated taxpayers who live
     alone and effectively support one or more children receive an additional
-    half share of the family allowance.'
+    half of the family allowance.'
   description.fr:
     Les contribuables célibataires, divorcés ou séparés, qui vivent
     seuls et supportent effectivement la charge d’un ou plusieurs enfants
-    bénéficient d’une demi-part supplémentaire de quotient familial.
+    bénéficient d’une demie-part supplémentaire de quotient familial.
   titre.en: '[automatic] single person with child surcharge'
   titre.fr: majoration personne seule avec enfant
 impôt . foyer fiscal . nombre de parts . majoration personne veuve avec enfant:

--- a/mon-entreprise/source/rules/impôt.yaml
+++ b/mon-entreprise/source/rules/impôt.yaml
@@ -32,7 +32,7 @@ impôt . méthode de calcul:
   # applicable si: revenu imposable > 0
   # bizarrement, cette condition ne semble pas marcher, on se résout donc à utiliser une version plus "hacky" et moins proche de la loi. Elle posera problème le jour où l'on aura a calculer l'impot avec plusieurs sources de revenu
   non applicable si: dirigeant . auto-entrepreneur . impôt . versement libératoire
-  par défaut: "'barème standard'"
+  par défaut: "'taux neutre'"
   formule:
     une possibilité:
       choix obligatoire: oui

--- a/mon-entreprise/source/rules/impôt.yaml
+++ b/mon-entreprise/source/rules/impôt.yaml
@@ -311,6 +311,7 @@ impôt . foyer fiscal . nombre de parts:
     somme:
       - principales
       - rattachées
+      - majoration personne seule avec enfant
       - majoration personne veuve avec enfant
 
 impôt . foyer fiscal . nombre de parts . principales:
@@ -326,6 +327,19 @@ impôt . foyer fiscal . nombre de parts . rattachées:
       - si: enfants à charge <= 2 enfants
         alors: 0.5 part/enfant * enfants à charge
       - sinon: (1 part/enfant * enfants à charge) - 1 part
+
+impôt . foyer fiscal . nombre de parts . majoration personne seule avec enfant:
+  description: >-
+    Les contribuables célibataires, divorcés ou séparés, qui vivent seuls et
+    supportent effectivement la charge d’un ou plusieurs enfants bénéficient
+    d’une demi-part supplémentaire de quotient familial.
+  applicable si:
+    toutes ces conditions:
+      - situation de famille = 'célibataire'
+      - enfants à charge > 0 enfants
+  formule: 0.5 part
+  références:
+    Bofip: https://bofip.impots.gouv.fr/bofip/2028-PGP.html/identifiant=BOI-IR-LIQ-10-20-20-10-20140326#Majoration_pour_les_personn_22
 
 impôt . foyer fiscal . nombre de parts . majoration personne veuve avec enfant:
   description: >-
@@ -411,11 +425,21 @@ impôt . foyer fiscal . impôt sur le revenu . quotient familial:
 
 impôt . foyer fiscal . impôt sur le revenu . quotient familial . plafond avantage:
   formule:
-    produit:
-      assiette: nombre de parts . rattachées
-      facteur: 1567 €/part/an
-  référendes:
+    somme:
+      - produit:
+          assiette:
+            variations:
+              - si: nombre de parts . majoration personne seule avec enfant
+                alors: nombre de parts . rattachées - 0.5 part
+              - sinon: nombre de parts . rattachées
+          facteur: 2 * 1567 €/part/an
+      - variations:
+          - si: nombre de parts . majoration personne seule avec enfant
+            alors: 3697 €/an
+          - sinon: 0 €/an
+  références:
     Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000041464047&cidTexte=LEGITEXT000006069577&categorieLien=id&dateTexte=20190608
+    Bofip: https://bofip.impots.gouv.fr/bofip/2494-PGP.html/identifiant=BOI-IR-LIQ-20-20-20-20200515#III._Niveau_du_plafonnement_12
 
 impôt . foyer fiscal . impôt sur le revenu . impôt brut par part:
   description: |

--- a/mon-entreprise/source/rules/impôt.yaml
+++ b/mon-entreprise/source/rules/impôt.yaml
@@ -332,7 +332,7 @@ impôt . foyer fiscal . nombre de parts . majoration personne seule avec enfant:
   description: >-
     Les contribuables célibataires, divorcés ou séparés, qui vivent seuls et
     supportent effectivement la charge d’un ou plusieurs enfants bénéficient
-    d’une demi-part supplémentaire de quotient familial.
+    d’une demie-part supplémentaire de quotient familial.
   applicable si:
     toutes ces conditions:
       - situation de famille = 'célibataire'
@@ -404,20 +404,27 @@ impôt . foyer fiscal . impôt à payer:
       - CEHR
 
 impôt . foyer fiscal . impôt sur le revenu:
-  description: Une décote est appliquée après le barème de l'impôt sur le revenu, pour réduire l'impôt des bas revenus.
   unité: €/an
   formule:
     allègement:
       assiette: impôt brut
-      décote:
-        taux: 45.25%
-        plafond: 1717 €/an
+      abattement: décote
   exemples:
     - nom: Salaire d'un cadre
       situation:
         contrat salarié . rémunération . net imposable: 4000
       valeur attendue: 6977
-  note: Le calcul utilisé pour la décôte concerne uniquement les foyers célibataires, le calcul est différent pour les couples.
+  références:
+    Fiche service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F34328
+
+impôt . foyer fiscal . impôt sur le revenu . décote:
+  description: Une décote est appliquée après le barème de l'impôt sur le revenu, pour réduire l'impôt des bas revenus.
+  formule:
+    variations:
+      - si: foyer fiscal . situation de famille = 'couple'
+        alors: 45.25% * (2842 €/an - impôt brut)
+      - sinon: 45.25% * (1717 €/an - impôt brut)
+    plancher: 0 €/an
 
 impôt . foyer fiscal . impôt sur le revenu . quotient familial:
   unité: €/part/an

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -82,7 +82,7 @@ exports[`calculate simulations-auto-entrepreneur: ACRE 3`] = `"[45267,439,3333,0
 
 exports[`calculate simulations-auto-entrepreneur: aides 1`] = `"[5171,14,417,0,5000]"`;
 
-exports[`calculate simulations-auto-entrepreneur: aides 2`] = `"[51714,143,4167,11,49989]"`;
+exports[`calculate simulations-auto-entrepreneur: aides 2`] = `"[51714,143,4167,0,50000]"`;
 
 exports[`calculate simulations-auto-entrepreneur: impôt sur le revenu 1`] = `"[32092,591,2083,706,24294]"`;
 
@@ -98,19 +98,19 @@ exports[`calculate simulations-auto-entrepreneur: échelle de revenus 5`] = `"[1
 
 exports[`calculate simulations-auto-entrepreneur: échelle de revenus 6`] = `"[22966,247,1667,0,20000]"`;
 
-exports[`calculate simulations-auto-entrepreneur: échelle de revenus 7`] = `"[57415,618,4167,275,49725]"`;
+exports[`calculate simulations-auto-entrepreneur: échelle de revenus 7`] = `"[57415,618,4167,0,50000]"`;
 
-exports[`calculate simulations-auto-entrepreneur: échelle de revenus 8`] = `"[80381,865,5833,1340,68660]"`;
+exports[`calculate simulations-auto-entrepreneur: échelle de revenus 8`] = `"[80381,865,5833,956,69044]"`;
 
-exports[`calculate simulations-auto-entrepreneur: échelle de revenus 9`] = `"[114830,1236,8333,4008,95992]"`;
+exports[`calculate simulations-auto-entrepreneur: échelle de revenus 9`] = `"[114830,1236,8333,3297,96703]"`;
 
-exports[`calculate simulations-auto-entrepreneur: échelle de revenus 10`] = `"[1148303,12359,83333,131979,868021]"`;
+exports[`calculate simulations-auto-entrepreneur: échelle de revenus 10`] = `"[1148303,12359,83333,126543,873457]"`;
 
-exports[`calculate simulations-indépendant: acre 1`] = `"[73024,23024,50000,51980,8052,41948,0,73024]"`;
+exports[`calculate simulations-indépendant: acre 1`] = `"[73024,23024,50000,51980,8213,41787,0,73024]"`;
 
-exports[`calculate simulations-indépendant: activité 1`] = `"[29120,9120,20000,20788,604,19396,0,29120]"`;
+exports[`calculate simulations-indépendant: activité 1`] = `"[29120,9120,20000,20788,603,19397,0,29120]"`;
 
-exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,604,19396,0,29101]"`;
+exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,603,19397,0,29101]"`;
 
 exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1373,1273,100,134,0,100,0,1373]"`;
 
@@ -124,11 +124,11 @@ exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29085
 
 exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1384,616,667,0,616,0,2000]"`;
 
-exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,3563,30435,0,50000]"`;
+exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,3500,30498,0,50000]"`;
 
 exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
 
-exports[`calculate simulations-indépendant: inversions 4`] = `"[88547,27360,61187,63588,11187,50000,0,88547]"`;
+exports[`calculate simulations-indépendant: inversions 4`] = `"[88863,27436,61427,63837,11427,50000,0,88863]"`;
 
 exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596]"`;
 
@@ -148,9 +148,9 @@ exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7427,2
 
 exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 7`] = `"[139594,39594,100000,103788,24245,75755,0,139594]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 7`] = `"[139594,39594,100000,103788,24909,75091,0,139594]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 8`] = `"[1239955,239955,1000000,1033666,467505,532495,0,1239955]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 8`] = `"[1239955,239955,1000000,1033666,444477,555523,0,1239955]"`;
 
 exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[0,500,0,0,3,0]"`;
 
@@ -338,43 +338,43 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 8`] = `"[0,69895,0,36431,4,56]"`;
 
-exports[`calculate simulations-salarié: JEI 1`] = `"[3440,0,3000,2353,2187]"`;
+exports[`calculate simulations-salarié: JEI 1`] = `"[3440,0,3000,2353,2168]"`;
 
-exports[`calculate simulations-salarié: JEI 2`] = `"[26635,0,20000,15969,10681]"`;
+exports[`calculate simulations-salarié: JEI 2`] = `"[26635,0,20000,15969,10503]"`;
 
-exports[`calculate simulations-salarié: JEI 3`] = `"[4517,0,4000,3141,2741]"`;
+exports[`calculate simulations-salarié: JEI 3`] = `"[4517,0,4000,3141,2745]"`;
 
 exports[`calculate simulations-salarié: activité partielle 1`] = `"[27,0,1560,1197,1197]"`;
 
-exports[`calculate simulations-salarié: activité partielle 2`] = `"[427,0,4000,2594,2365]"`;
+exports[`calculate simulations-salarié: activité partielle 2`] = `"[427,0,4000,2594,2392]"`;
 
-exports[`calculate simulations-salarié: activité partielle 3`] = `"[1470,0,8000,5209,4253]"`;
+exports[`calculate simulations-salarié: activité partielle 3`] = `"[1470,0,8000,5209,4245]"`;
 
-exports[`calculate simulations-salarié: activité partielle 4`] = `"[1172,0,4000,2704,2444]"`;
+exports[`calculate simulations-salarié: activité partielle 4`] = `"[1172,0,4000,2704,2426]"`;
 
-exports[`calculate simulations-salarié: activité partielle 5`] = `"[2683,0,4000,2870,2562]"`;
+exports[`calculate simulations-salarié: activité partielle 5`] = `"[2683,0,4000,2870,2574]"`;
 
-exports[`calculate simulations-salarié: activité partielle 6`] = `"[327,3750,3000,1940,1848]"`;
+exports[`calculate simulations-salarié: activité partielle 6`] = `"[327,3750,3000,1940,1833]"`;
 
-exports[`calculate simulations-salarié: activité partielle 7`] = `"[427,0,4000,2594,2497]"`;
+exports[`calculate simulations-salarié: activité partielle 7`] = `"[427,0,4000,2594,2485]"`;
 
-exports[`calculate simulations-salarié: activité partielle 8`] = `"[409,0,2000,1578,1547]"`;
+exports[`calculate simulations-salarié: activité partielle 8`] = `"[409,0,2000,1578,1544]"`;
 
-exports[`calculate simulations-salarié: activité partielle 9`] = `"[1247,0,2000,1540,1510]"`;
+exports[`calculate simulations-salarié: activité partielle 9`] = `"[1247,0,2000,1540,1506]"`;
 
-exports[`calculate simulations-salarié: activité partielle 10`] = `"[927,0,6000,4182,3511]"`;
+exports[`calculate simulations-salarié: activité partielle 10`] = `"[927,0,6000,4182,3498]"`;
 
-exports[`calculate simulations-salarié: aides 1`] = `"[2302,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: aides 1`] = `"[2302,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: aides 2`] = `"[12823,0,10000,8911,7667]"`;
+exports[`calculate simulations-salarié: aides 2`] = `"[12823,0,10000,8911,7620]"`;
 
-exports[`calculate simulations-salarié: aides 3`] = `"[2062,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: aides 3`] = `"[2062,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: aides 4`] = `"[2292,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: aides 4`] = `"[2292,0,2000,1561,1527]"`;
 
 exports[`calculate simulations-salarié: aides embauche covid 1`] = `"[1237,0,1500,1165,1165]"`;
 
-exports[`calculate simulations-salarié: aides embauche covid 2`] = `"[7085,0,5000,3948,3336]"`;
+exports[`calculate simulations-salarié: aides embauche covid 2`] = `"[7085,0,5000,3948,3298]"`;
 
 exports[`calculate simulations-salarié: aides embauche covid 3`] = `"[1256,0,1500,1165,1165]"`;
 
@@ -384,79 +384,79 @@ exports[`calculate simulations-salarié: apprentissage 1`] = `"[1552,0,1500,1448
 
 exports[`calculate simulations-salarié: apprentissage 2`] = `"[1385,0,1500,1448,1448]"`;
 
-exports[`calculate simulations-salarié: assimilé salarié 1`] = `"[7015,0,5000,3943,3318]"`;
+exports[`calculate simulations-salarié: assimilé salarié 1`] = `"[7015,0,5000,3943,3286]"`;
 
 exports[`calculate simulations-salarié: assimilé salarié 2`] = `"[1583,0,1500,1163,1163]"`;
 
-exports[`calculate simulations-salarié: assimilé salarié 3`] = `"[3685,0,3000,2348,2172]"`;
+exports[`calculate simulations-salarié: assimilé salarié 3`] = `"[3685,0,3000,2348,2161]"`;
 
-exports[`calculate simulations-salarié: atmp 1`] = `"[2534,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: atmp 1`] = `"[2534,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: avantages 1`] = `"[2667,0,2000,1540,1492]"`;
+exports[`calculate simulations-salarié: avantages 1`] = `"[2667,0,2000,1540,1491]"`;
 
-exports[`calculate simulations-salarié: avantages 2`] = `"[2677,0,2000,1539,1490]"`;
+exports[`calculate simulations-salarié: avantages 2`] = `"[2677,0,2000,1539,1489]"`;
 
-exports[`calculate simulations-salarié: avantages 3`] = `"[2587,0,2000,1549,1506]"`;
+exports[`calculate simulations-salarié: avantages 3`] = `"[2587,0,2000,1549,1500]"`;
 
-exports[`calculate simulations-salarié: cadre 1`] = `"[4122,0,3000,2348,2171]"`;
+exports[`calculate simulations-salarié: cadre 1`] = `"[4122,0,3000,2348,2160]"`;
 
-exports[`calculate simulations-salarié: cdd 1`] = `"[2509,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: cdd 1`] = `"[2509,0,2000,1561,1528]"`;
 
-exports[`calculate simulations-salarié: cdd 2`] = `"[2591,0,2000,1599,1557]"`;
+exports[`calculate simulations-salarié: cdd 2`] = `"[2591,0,2000,1599,1551]"`;
 
-exports[`calculate simulations-salarié: cdd 3`] = `"[3417,0,2400,1987,1902]"`;
+exports[`calculate simulations-salarié: cdd 3`] = `"[3417,0,2400,1987,1906]"`;
 
-exports[`calculate simulations-salarié: cdd 4`] = `"[3745,0,2400,1878,1794]"`;
+exports[`calculate simulations-salarié: cdd 4`] = `"[3745,0,2400,1878,1799]"`;
 
-exports[`calculate simulations-salarié: effectif 1`] = `"[2479,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: effectif 1`] = `"[2479,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: effectif 2`] = `"[2525,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: effectif 2`] = `"[2525,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: effectif 3`] = `"[2539,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: effectif 3`] = `"[2539,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: effectif 4`] = `"[2539,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: effectif 4`] = `"[2539,0,2000,1561,1527]"`;
 
 exports[`calculate simulations-salarié: frais pro - DFS 1`] = `"[2242,0,2000,1630,1630]"`;
 
-exports[`calculate simulations-salarié: frais pro - DFS 2`] = `"[2335,0,2000,1584,1544]"`;
+exports[`calculate simulations-salarié: frais pro - DFS 2`] = `"[2335,0,2000,1584,1549]"`;
 
-exports[`calculate simulations-salarié: frais pro - DFS 3`] = `"[2265,0,2000,1606,1563]"`;
+exports[`calculate simulations-salarié: frais pro - DFS 3`] = `"[2265,0,2000,1606,1558]"`;
 
-exports[`calculate simulations-salarié: frais pro - DFS 4`] = `"[2243,0,2000,1613,1569]"`;
+exports[`calculate simulations-salarié: frais pro - DFS 4`] = `"[2243,0,2000,1613,1564]"`;
 
 exports[`calculate simulations-salarié: frais pro - DFS 5`] = `"[2437,0,2000,1590,1590]"`;
 
 exports[`calculate simulations-salarié: frais pro - DFS 6`] = `"[1767,0,1700,1364,1364]"`;
 
-exports[`calculate simulations-salarié: frais pro - DFS 7`] = `"[3287,0,2600,2125,2097]"`;
+exports[`calculate simulations-salarié: frais pro - DFS 7`] = `"[3287,0,2600,2125,2092]"`;
 
-exports[`calculate simulations-salarié: frais pro - IKV 1`] = `"[4367,0,3200,2530,2320]"`;
+exports[`calculate simulations-salarié: frais pro - IKV 1`] = `"[4367,0,3200,2530,2334]"`;
 
-exports[`calculate simulations-salarié: frais pro - IKV 2`] = `"[4346,0,3200,2511,2302]"`;
+exports[`calculate simulations-salarié: frais pro - IKV 2`] = `"[4346,0,3200,2511,2314]"`;
 
-exports[`calculate simulations-salarié: frais pro - IKV 3`] = `"[2774,0,2157,1685,1630]"`;
+exports[`calculate simulations-salarié: frais pro - IKV 3`] = `"[2764,0,2151,1681,1630]"`;
 
-exports[`calculate simulations-salarié: frais pro - titres restaurant 1`] = `"[2519,0,2000,1521,1484]"`;
+exports[`calculate simulations-salarié: frais pro - titres restaurant 1`] = `"[2519,0,2000,1521,1487]"`;
 
-exports[`calculate simulations-salarié: frais pro - titres restaurant 2`] = `"[4307,0,3000,2134,1949]"`;
+exports[`calculate simulations-salarié: frais pro - titres restaurant 2`] = `"[4307,0,3000,2134,1944]"`;
 
-exports[`calculate simulations-salarié: frais pro - titres restaurant 3`] = `"[2562,0,2000,1493,1456]"`;
+exports[`calculate simulations-salarié: frais pro - titres restaurant 3`] = `"[2562,0,2000,1493,1458]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 1`] = `"[2583,0,2000,1636,1599]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 1`] = `"[2583,0,2000,1636,1601]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 2`] = `"[3105,0,2000,2009,1965]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 2`] = `"[3105,0,2000,2009,1960]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 3`] = `"[2654,0,2000,1636,1599]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 3`] = `"[2654,0,2000,1636,1601]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 4`] = `"[2565,0,2000,1627,1590]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 4`] = `"[2565,0,2000,1627,1592]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 5`] = `"[3025,0,2000,1970,1932]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 5`] = `"[3025,0,2000,1970,1936]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 6`] = `"[3041,0,2000,1978,1939]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 6`] = `"[3041,0,2000,1978,1943]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 7`] = `"[3336,2446,2000,1919,1889]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 7`] = `"[3336,2446,2000,1919,1886]"`;
 
-exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 8`] = `"[3286,2286,2000,1889,1859]"`;
+exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 8`] = `"[3286,2286,2000,1889,1856]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 1`] = `"[4076,0,3000,2353,2332]"`;
 
@@ -496,39 +496,39 @@ exports[`calculate simulations-salarié: impôt sur le revenu 8`] = `"[4076,0,30
 
 exports[`calculate simulations-salarié: inversions 1`] = `"[2000,0,1746,1360,1353]"`;
 
-exports[`calculate simulations-salarié: inversions 2`] = `"[3474,0,2554,2000,1898]"`;
+exports[`calculate simulations-salarié: inversions 2`] = `"[3474,0,2554,2000,1889]"`;
 
-exports[`calculate simulations-salarié: inversions 3`] = `"[3679,0,2706,2120,2000]"`;
+exports[`calculate simulations-salarié: inversions 3`] = `"[3674,0,2703,2117,2000]"`;
 
 exports[`calculate simulations-salarié: lodeom 1`] = `"[1592,0,1521,1182,1182]"`;
 
-exports[`calculate simulations-salarié: lodeom 2`] = `"[2085,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: lodeom 2`] = `"[2085,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: lodeom 3`] = `"[3896,0,3000,2353,2187]"`;
+exports[`calculate simulations-salarié: lodeom 3`] = `"[3896,0,3000,2353,2168]"`;
 
-exports[`calculate simulations-salarié: lodeom 4`] = `"[5674,0,4000,3146,2759]"`;
+exports[`calculate simulations-salarié: lodeom 4`] = `"[5674,0,4000,3146,2755]"`;
 
-exports[`calculate simulations-salarié: lodeom 5`] = `"[7889,0,5500,4349,3625]"`;
+exports[`calculate simulations-salarié: lodeom 5`] = `"[7889,0,5500,4349,3634]"`;
 
 exports[`calculate simulations-salarié: lodeom compétitivité renforcée 1`] = `"[1592,0,1521,1182,1182]"`;
 
-exports[`calculate simulations-salarié: lodeom compétitivité renforcée 2`] = `"[2085,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: lodeom compétitivité renforcée 2`] = `"[2085,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: lodeom compétitivité renforcée 3`] = `"[3444,0,3000,2353,2187]"`;
+exports[`calculate simulations-salarié: lodeom compétitivité renforcée 3`] = `"[3444,0,3000,2353,2168]"`;
 
-exports[`calculate simulations-salarié: lodeom compétitivité renforcée 4`] = `"[5588,0,4000,3146,2759]"`;
+exports[`calculate simulations-salarié: lodeom compétitivité renforcée 4`] = `"[5588,0,4000,3146,2755]"`;
 
-exports[`calculate simulations-salarié: lodeom compétitivité renforcée 5`] = `"[7889,0,5500,4349,3625]"`;
+exports[`calculate simulations-salarié: lodeom compétitivité renforcée 5`] = `"[7889,0,5500,4349,3634]"`;
 
 exports[`calculate simulations-salarié: lodeom innovation et croissance 1`] = `"[1592,0,1521,1182,1182]"`;
 
-exports[`calculate simulations-salarié: lodeom innovation et croissance 2`] = `"[2085,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: lodeom innovation et croissance 2`] = `"[2085,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: lodeom innovation et croissance 3`] = `"[3235,0,3000,2353,2187]"`;
+exports[`calculate simulations-salarié: lodeom innovation et croissance 3`] = `"[3235,0,3000,2353,2168]"`;
 
-exports[`calculate simulations-salarié: lodeom innovation et croissance 4`] = `"[4915,0,4000,3146,2759]"`;
+exports[`calculate simulations-salarié: lodeom innovation et croissance 4`] = `"[4915,0,4000,3146,2755]"`;
 
-exports[`calculate simulations-salarié: lodeom innovation et croissance 5`] = `"[7889,0,5500,4349,3625]"`;
+exports[`calculate simulations-salarié: lodeom innovation et croissance 5`] = `"[7889,0,5500,4349,3634]"`;
 
 exports[`calculate simulations-salarié: stage 1`] = `"[507,0,500,500,500]"`;
 
@@ -536,23 +536,23 @@ exports[`calculate simulations-salarié: stage 2`] = `"[2490,0,2000,1750,1750]"`
 
 exports[`calculate simulations-salarié: taux spécifiques retraite complémentaire 1`] = `"[1606,0,1521,1195,1195]"`;
 
-exports[`calculate simulations-salarié: taux spécifiques retraite complémentaire 2`] = `"[3423,0,2500,1979,1880]"`;
+exports[`calculate simulations-salarié: taux spécifiques retraite complémentaire 2`] = `"[3423,0,2500,1979,1869]"`;
 
 exports[`calculate simulations-salarié: taux spécifiques retraite complémentaire 3`] = `"[1592,0,1521,1170,1170]"`;
 
-exports[`calculate simulations-salarié: taux spécifiques retraite complémentaire 4`] = `"[3382,0,2500,1938,1844]"`;
+exports[`calculate simulations-salarié: taux spécifiques retraite complémentaire 4`] = `"[3382,0,2500,1938,1830]"`;
 
-exports[`calculate simulations-salarié: temps partiel 1`] = `"[2592,2188,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: temps partiel 1`] = `"[2592,2188,2000,1561,1527]"`;
 
 exports[`calculate simulations-salarié: temps partiel 2`] = `"[2533,2500,1857,1448,1428]"`;
 
 exports[`calculate simulations-salarié: temps partiel 3`] = `"[1159,1750,1000,770,770]"`;
 
-exports[`calculate simulations-salarié: treizième mois 1`] = `"[3390,0,2300,1950,1856]"`;
+exports[`calculate simulations-salarié: treizième mois 1`] = `"[3390,0,2300,1950,1842]"`;
 
-exports[`calculate simulations-salarié: treizième mois 2`] = `"[3800,2965,2300,2186,2073]"`;
+exports[`calculate simulations-salarié: treizième mois 2`] = `"[3800,2965,2300,2186,2071]"`;
 
-exports[`calculate simulations-salarié: treizième mois 3`] = `"[3044,0,2300,1799,1726]"`;
+exports[`calculate simulations-salarié: treizième mois 3`] = `"[3044,0,2300,1799,1721]"`;
 
 exports[`calculate simulations-salarié: échelle de salaires 1`] = `"[130,0,100,57,57]"`;
 
@@ -568,20 +568,20 @@ exports[`calculate simulations-salarié: échelle de salaires 6`] = `"[1313,0,12
 
 exports[`calculate simulations-salarié: échelle de salaires 7`] = `"[1571,0,1500,1165,1165]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 8`] = `"[2479,0,2000,1561,1524]"`;
+exports[`calculate simulations-salarié: échelle de salaires 8`] = `"[2479,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 9`] = `"[3401,0,2500,1957,1861]"`;
+exports[`calculate simulations-salarié: échelle de salaires 9`] = `"[3401,0,2500,1957,1848]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 10`] = `"[4076,0,3000,2353,2187]"`;
+exports[`calculate simulations-salarié: échelle de salaires 10`] = `"[4076,0,3000,2353,2168]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 11`] = `"[5674,0,4000,3146,2759]"`;
+exports[`calculate simulations-salarié: échelle de salaires 11`] = `"[5674,0,4000,3146,2755]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 12`] = `"[7085,0,5000,3948,3336]"`;
+exports[`calculate simulations-salarié: échelle de salaires 12`] = `"[7085,0,5000,3948,3298]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 13`] = `"[14319,0,10000,7958,6080]"`;
+exports[`calculate simulations-salarié: échelle de salaires 13`] = `"[14319,0,10000,7958,5975]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 14`] = `"[28345,0,20000,15969,10681]"`;
+exports[`calculate simulations-salarié: échelle de salaires 14`] = `"[28345,0,20000,15969,10503]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 15`] = `"[128575,0,100000,87157,46271]"`;
+exports[`calculate simulations-salarié: échelle de salaires 15`] = `"[128575,0,100000,87157,48426]"`;
 
-exports[`calculate simulations-salarié: échelle de salaires 16`] = `"[1243819,0,1000000,896257,446123]"`;
+exports[`calculate simulations-salarié: échelle de salaires 16`] = `"[1243819,0,1000000,896257,498390]"`;

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -458,21 +458,21 @@ exports[`calculate simulations-salarié: heures supplémentaires et complémenta
 
 exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 8`] = `"[3286,2286,2000,1889,1859]"`;
 
-exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 1`] = `"[4076,0,3000,2353,2265]"`;
+exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 1`] = `"[4076,0,3000,2353,2332]"`;
 
-exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 2`] = `"[4076,0,3000,2353,2332]"`;
+exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 2`] = `"[4076,0,3000,2353,2353]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 3`] = `"[4076,0,3000,2353,2353]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 4`] = `"[4076,0,3000,2353,1587]"`;
 
-exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 5`] = `"[4076,0,3000,2353,1718]"`;
+exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 5`] = `"[4076,0,3000,2353,2120]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 6`] = `"[12890,0,9000,7156,6146]"`;
 
-exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 7`] = `"[12890,0,9000,7156,6277]"`;
+exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 7`] = `"[12890,0,9000,7156,6407]"`;
 
-exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 8`] = `"[12890,0,9000,7156,6538]"`;
+exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 8`] = `"[12890,0,9000,7156,6882]"`;
 
 exports[`calculate simulations-salarié: impôt sur le revenu - quotient familial 9`] = `"[4076,0,3000,2353,2187]"`;
 

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -158,28 +158,38 @@ impôt sur le revenu:
     impôt . taux personnalisé: 10
 
 impôt sur le revenu - quotient familial:
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . enfants à charge: 1
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . enfants à charge: 2
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . enfants à charge: 3
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . revenu imposable . autres revenus imposables: 2000 €/mois
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . revenu imposable . autres revenus imposables: 2000 €/mois
     impôt . foyer fiscal . enfants à charge: 2
-  - contrat salarié . rémunération . brut de base: 9000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 9000 €/mois
     impôt . foyer fiscal . situation de famille: "'couple'"
-  - contrat salarié . rémunération . brut de base: 9000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 9000 €/mois
     impôt . foyer fiscal . situation de famille: "'couple'"
     impôt . foyer fiscal . enfants à charge: 2
-  - contrat salarié . rémunération . brut de base: 9000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 9000 €/mois
     impôt . foyer fiscal . situation de famille: "'couple'"
     impôt . foyer fiscal . enfants à charge: 4
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . situation de famille: "'veuf'"
-  - contrat salarié . rémunération . brut de base: 3000 €/mois
+  - impôt . méthode de calcul: "'barème standard'"
+    contrat salarié . rémunération . brut de base: 3000 €/mois
     impôt . foyer fiscal . situation de famille: "'veuf'"
     impôt . foyer fiscal . enfants à charge: 2
 


### PR DESCRIPTION
Intégration des corrections suivantes :

- Demie part supplémentaire pour les personnes vivant seules avec un enfant à charge
- Plafonnement spécifique pour cette part
- Décote d'IR pour les couples

Par ailleurs, retour à l'utilisation du taux neutre comme méthode de calcul par défaut pour des raisons de performance.