### PR TITLE
Améliorations des simulateurs PAM suite aux retours URSSAF

### DIFF
--- a/mon-entreprise/source/components/Notifications.tsx
+++ b/mon-entreprise/source/components/Notifications.tsx
@@ -39,10 +39,10 @@ export default function Notifications() {
 		? [
 				{
 					dottedName: 'inversion fail',
-					description: t([
+					description: t(
 						'simulateurs.inversionFail',
-						'Le montant saisi ne permet pas de calculer un résultat, nous vous invitons à essayer une autre valeur.'
-					]),
+						'Le montant saisi abouti à un résultat impossible. Cela est dû à un effet de seuil dans le calcul des cotisations.\n\nNous vous invitons à réessayer en modifiant légèrement le montant renseignée (quelques euros de plus par exemple).'
+					),
 					type: 'notification',
 					sévérité: 'avertissement'
 				}

--- a/mon-entreprise/source/components/TargetSelection.css
+++ b/mon-entreprise/source/components/TargetSelection.css
@@ -64,7 +64,11 @@
 	font-weight: bold;
 	text-decoration: none;
 }
+#targetSelection .small-target .targetInputOrValue a {
+	text-decoration: none;
+}
 #targetSelection .optionTitle a:hover,
+#targetSelection .small-target .targetInputOrValue a:hover,
 #targetSelection .aidesGlimpse a:hover {
 	text-decoration: underline;
 }
@@ -76,7 +80,8 @@
 }
 
 @media (hover: none) {
-	#targetSelection .optionTitle a {
+	#targetSelection .optionTitle a,
+	#targetSelection .small-target .targetInputOrValue a {
 		text-decoration: underline;
 	}
 }

--- a/mon-entreprise/source/components/TargetSelection.tsx
+++ b/mon-entreprise/source/components/TargetSelection.tsx
@@ -126,6 +126,7 @@ const Target = ({ dottedName }: TargetProps) => {
 								}}
 							/>
 						)}
+
 						<TargetInputOrValue
 							{...{
 								target,
@@ -248,9 +249,13 @@ function TargetInputOrValue({
 				</>
 			) : (
 				<span>
-					{value && Number.isNaN(value)
-						? '—'
-						: formatValue(value, { displayedUnit: '€', language })}
+					{value && Number.isNaN(value) ? (
+						'—'
+					) : (
+						<RuleLink dottedName={target.dottedName}>
+							{formatValue(value, { displayedUnit: '€', language })}
+						</RuleLink>
+					)}
 				</span>
 			)}
 			{target.dottedName.includes('prix du travail') && <AidesGlimpse />}

--- a/mon-entreprise/source/components/simulationConfigs/indépendant.yaml
+++ b/mon-entreprise/source/components/simulationConfigs/indépendant.yaml
@@ -26,14 +26,13 @@ questions:
   liste:
     - entreprise
     - établissement
-    - dirigeant . indépendant . PL
     - dirigeant . indépendant
     - situation personnelle
     - impôt
   non prioritaires:
-    - entreprise . ZFU
-    - dirigeant . indépendant . cotisations et contributions . exonérations
     - dirigeant . indépendant . IJSS
+    - dirigeant . indépendant . cotisations et contributions . exonérations
+    - entreprise . ZFU
     - entreprise . catégorie d'activité . débit de tabac
 unité par défaut: €/an
 situation:

--- a/mon-entreprise/source/components/simulationConfigs/profession-libérale.yaml
+++ b/mon-entreprise/source/components/simulationConfigs/profession-libérale.yaml
@@ -24,5 +24,5 @@ questions:
     - entreprise . ZFU
 unité par défaut: €/an
 situation:
-  entreprise . catégorie d'activité: "'libérale'"
   dirigeant: "'indépendant'"
+  entreprise . catégorie d'activité: "'libérale'"

--- a/mon-entreprise/source/components/simulationConfigs/profession-libérale.yaml
+++ b/mon-entreprise/source/components/simulationConfigs/profession-libérale.yaml
@@ -1,5 +1,5 @@
 objectifs:
-  - dirigeant . indépendant . PL . PAM . honoraires
+  - entreprise . chiffre d'affaires
   - entreprise . charges
   - dirigeant . indépendant . cotisations et contributions
   - dirigeant . indépendant . revenu net de cotisations
@@ -9,17 +9,19 @@ objectifs:
 questions:
   liste noire:
     - entreprise . charges
+  liste:
+    - entreprise . catégorie d'activité
+    - dirigeant . indépendant . PL
+    - dirigeant . indépendant
+    - établissement
+    - situation personnelle
+    - impôt
   non prioritaires:
-    - entreprise . date de création
-    - dirigeant . indépendant . contrats madelin . mutuelle . montant
-    - dirigeant . indépendant . contrats madelin . retraite . montant
+    - dirigeant . indépendant . contrats madelin
     - dirigeant . indépendant . IJSS
-    - entreprise . ZFU
-    - dirigeant . indépendant . cotisations et contributions . exonérations . âge
-    - dirigeant . indépendant . cotisations et contributions . exonérations . invalidité
-    - situation personnelle . RSA
-    - situation personnelle . domiciliation fiscale à l'étranger
+    - dirigeant . indépendant . cotisations et contributions . exonérations
     - dirigeant . indépendant . revenus étrangers
+    - entreprise . ZFU
 unité par défaut: €/an
 situation:
   entreprise . catégorie d'activité: "'libérale'"

--- a/mon-entreprise/source/components/ui/AnimatedTargetValue.tsx
+++ b/mon-entreprise/source/components/ui/AnimatedTargetValue.tsx
@@ -37,6 +37,7 @@ export default function AnimatedTargetValue({
 		previousUnit.current === currentUnit &&
 		Math.abs(difference) > 1 &&
 		previousValue.current != null &&
+		previousValue.current != 0 &&
 		value != null
 
 	previousValue.current = value

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -3898,6 +3898,245 @@ dirigeant . indépendant . IJSS . total:
 dirigeant . indépendant . PL:
   titre.en: '[automatic] Liberal profession'
   titre.fr: Profession libérale
+dirigeant . indépendant . PL . CARCDSF:
+  description.en: >
+    [automatic] CARCDSF is the autonomous pension fund for dental surgeons and
+    midwives.
+  description.fr: >
+    La CARCDSF est la caisse de retraite autonome des chirurgiens dentiste et
+    des sages femmes.
+  titre.en: '[automatic] CARCDSF'
+  titre.fr: CARCDSF
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste:
+  titre.en: '[automatic] dental surgeon'
+  titre.fr: chirurgien-dentiste
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . PCV:
+  note.en: >-
+    [automatic] An exemption can be granted when the 2019 professional income is
+    less than or equal to C 500 (value on 1 January of the year in question),
+    i.e. € 11,500.
+
+    The application must be accompanied by a photocopy of the tax return n° 2042 C or 2035 or 2065 and their annexes (2033 B and D or 2053 and 2058 A) for the year 2019.
+
+    This exemption results in the cancellation of the fees for the year and the unassessed points are not redeemable.
+  note.fr: >-
+    Une dispense peut être accordée lorsque les revenus professionnels 2019 sont
+    inférieurs ou égaux à 500 C (valeur au 1er janvier de l’année considérée),
+    soit 11 500 €.
+
+    La demande doit être accompagnée d’une photocopie de la déclaration d’impôt n° 2042 C ou 2035 ou 2065 et de leurs annexes (2033 B et D ou 2053 et 2058 A) de l’année 2019.
+
+    Cette dispense entraîne l’annulation des droits pour l’année et les points non cotisés ne sont pas rachetables.
+  titre.en: '[automatic] Supplementary old-age benefit (CARCDSF dental surgeon)'
+  titre.fr: Prestation complémentaire vieillesse (CARCDSF chirurgien-dentiste)
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . RID:
+  titre.en: '[automatic] disability and death (CARCDSF Dental Surgeon)'
+  titre.fr: invalidité et décès (CARCDSF chirurgien-dentiste)
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . exonération PCV:
+  description.en: "[automatic] You have the option of taking a full contribution
+    waiver for supplementary old-age benefits (AVC) if you apply for it. [More
+    information](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cot\
+    isations)"
+  description.fr:
+    Vous avez la possibilité de bénéficier d'une exonération totale
+    de cotisation pour la prestation complémentaire de vieillesse (PCV) si vous
+    en faites la demande. [En savoir
+    plus](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations)
+? dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . exonération PCV . prix d'une consultation
+: titre.en: '[automatic] consulting fee'
+  titre.fr: prix d'une consultation
+dirigeant . indépendant . PL . CARCDSF . retraite complémentaire:
+  titre.en: '[automatic] supplementary pension (CARCDSF)'
+  titre.fr: retraite complémentaire (CARCDSF)
+dirigeant . indépendant . PL . CARCDSF . sage-femme:
+  titre.en: '[automatic] midwife'
+  titre.fr: sage-femme
+dirigeant . indépendant . PL . CARCDSF . sage-femme . PCV:
+  description.en: >
+    [automatic] For 2020, the amount is set at €780, a third of which, i.e. €260
+    to your
+
+    and 520 € to be paid by the Primary Health Insurance Funds.
+
+    (CPAM).
+  description.fr: |
+    Pour 2020, le montant est fixé à 780 € dont un tiers, soit 260 € à votre
+    charge et 520 € à la charge des Caisses Primaires d’Assurance Maladie
+    (CPAM).
+  note.en: >
+    [automatic] An exemption may be granted where the professional income is
+
+    less than or equal to 3120 €.
+
+
+    The application must be accompanied by a photocopy of the tax return.
+
+    No 2042 C or 2035 or 2065 and their annexes (2033 B and D or 2053 and 2058
+
+    A).
+
+
+    This waiver will result in the cancellation of the fees for the year and the points for the year.
+
+    are not redeemable.
+  note.fr: |
+    Une dispense peut être accordée lorsque les revenus professionnels sont
+    inférieurs ou égaux à 3120 €.
+
+    La demande doit être accompagnée d’une photocopie de la déclaration d’impôt
+    n° 2042 C ou 2035 ou 2065 et de leurs annexes (2033 B et D ou 2053 et 2058
+    A).
+
+    Cette dispense entraîne l’annulation des droits pour l’année et les points
+    non cotisés ne sont pas rachetables.
+  titre.en: '[automatic] PCV'
+  titre.fr: PCV
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID:
+  description.en: >
+    [automatic] There are contribution classes to choose from, corresponding to
+    contributions
+
+    and different levels of compensation.
+
+
+    The change of option to a higher class must be requested before the
+
+    1 July of the current year, to take effect on 1 January of
+
+    the following year.
+
+
+    No change of class is permitted after July 1 of the 56th birthday.
+  description.fr: >
+    Il existe classes de cotisations aux choix, correspondant à des cotisations
+
+    et des degrés d'indemnisations différents.
+
+
+    Le changement d'option pour une classe supérieure doit être demandé avant le
+
+    1er juillet de l'année en cours, pour prendre effet au 1er janvier de
+
+    l'année suivante.
+
+
+    Aucun changement de classe n'est autorisé après le 1er juillet du 56e anniversaire.
+  titre.en: '[automatic] disability and death (CARCDSF midwife)'
+  titre.fr: invalidité et décès (CARCDSF sage-femme)
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe:
+  description.en: >
+    [automatic] There are contribution classes to choose from, corresponding to
+    contributions
+
+    and different levels of compensation.
+  description.fr: |
+    Il existe classes de cotisations aux choix, correspondant à des cotisations
+    et des degrés d'indemnisations différents.
+  question.en: '[automatic] In which class do you contribute to the DCFDC
+    Disability Death Plan?'
+  question.fr:
+    Dans quelle classe cotisez-vous pour le régime invalidité-décès de
+    la CARCDSF ?
+  titre.en: '[automatic] Contribution class'
+  titre.fr: Classe de cotisation
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe . A:
+  titre.en: '[automatic] class A'
+  titre.fr: classe A
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe . B:
+  titre.en: '[automatic] class B'
+  titre.fr: classe B
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe . C:
+  titre.en: '[automatic] class C'
+  titre.fr: classe C
+dirigeant . indépendant . PL . CARCDSF . sage-femme . exonération PCV:
+  description.en: "[automatic] You have the option of taking a full contribution
+    waiver for supplementary old-age benefits (AVC) if you apply for it. [More
+    information](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cot\
+    isations)"
+  description.fr:
+    Vous avez la possibilité de bénéficier d'une exonération totale
+    de cotisation pour la prestation complémentaire de vieillesse (PCV) si vous
+    en faites la demande. [En savoir
+    plus](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations)
+dirigeant . indépendant . PL . CARMF:
+  description.en: >
+    [automatic] The CARMF is the autonomous pension fund for doctors in France.
+
+
+    Affiliation is compulsory for doctors holding the diploma of
+
+    doctor of medicine, registered with the Council of the Order and exercising an activity
+
+    (installation, replacements, expertise for companies, etc.).
+
+    insurance companies or private laboratories, private sector to hospital, in
+
+    or any other remunerated activity in the form of a private practice or any other
+
+    of fees, even if it is not a question of medical care) in France
+
+    metropolitan France and in the overseas departments or Monaco.
+  description.fr: |
+    La CARMF est la caisse de retraite autonome des médecins de France.
+
+    L’affiliation est obligatoire pour les médecins titulaires du diplôme de
+    docteur en médecine, inscrits au conseil de l’Ordre et exerçant une activité
+    libérale (installation, remplacements, expertises pour les compagnies
+    d’assurance ou les laboratoires privés, secteur privé à l’hôpital, en
+    société d’exercice libéral ou toute autre activité rémunérée sous forme
+    d’honoraires, même s’il ne s’agit pas de la médecine de soins) en France
+    métropolitaine et dans les départements d’Outre-Mer ou à Monaco.
+  titre.en: '[automatic] CARMF'
+  titre.fr: CARMF
+dirigeant . indépendant . PL . CARMF . ASV:
+  titre.en: '[automatic] Advantage social vieillesse (CARMF)'
+  titre.fr: Avantage social vieillesse (CARMF)
+dirigeant . indépendant . PL . CARMF . ASV . taux participation CPAM:
+  titre.en: '[automatic] CPAM participation rate'
+  titre.fr: taux participation CPAM
+dirigeant . indépendant . PL . CARMF . invalidité décès:
+  description.en: >-
+    [automatic] The CARMF manages a provident scheme paying a pension in the
+    event of permanent disability and a death benefit as well as a pension for
+    surviving spouses and children in the event of the death of the insured. 
+
+    The contribution is divided into three flat-rate classes, the amount of which is determined according to your net income from self-employment in the penultimate year.
+
+    Without communication of the self-employed earnings and the tax notice of the penultimate year, the compensation rate cannot be determined. Pending receipt of this document, compensation will be based on the rate for class A.
+  description.fr: >-
+    La CARMF gère un régime de prévoyance versant une pension en cas
+    d'invalidité permanente et un capital décès ainsi qu’une rente pour les
+    conjoints et enfants survivants en cas de décès de l'assuré. 
+
+    La cotisation comporte trois classes forfaitaires dont le montant est déterminé en fonction de vos revenus nets d'activité indépendante de l’avant-dernière année.
+
+    Sans communication des revenus professionnels non salariés et de l’avis d’imposition de l’avant dernière année, le taux d’indemnisation ne peut être fixé. Dans l’attente de la réception de ce document l’indemnisation sera basée sur le taux prévu pour la classe A.
+  titre.en: '[automatic] disability and death (CARMF)'
+  titre.fr: invalidité et décès (CARMF)
+dirigeant . indépendant . PL . CARMF . retraite complémentaire:
+  titre.en: '[automatic] supplementary pension (CARMF)'
+  titre.fr: retraite complémentaire (CARMF)
+dirigeant . indépendant . PL . CARPIMKO:
+  titre.en: '[automatic] CARPIMKO'
+  titre.fr: CARPIMKO
+dirigeant . indépendant . PL . CARPIMKO . ASV:
+  titre.en: '[automatic] Old-age benefit (CARPIMKO)'
+  titre.fr: Avantage social vieillesse (CARPIMKO)
+dirigeant . indépendant . PL . CARPIMKO . ASV . forfaitaire:
+  titre.en: '[automatic] lump sum'
+  titre.fr: forfaitaire
+dirigeant . indépendant . PL . CARPIMKO . ASV . participation CPAM:
+  titre.en: '[automatic] CPAM participation'
+  titre.fr: participation CPAM
+dirigeant . indépendant . PL . CARPIMKO . ASV . proportionnelle:
+  titre.en: '[automatic] proportional'
+  titre.fr: proportionnelle
+dirigeant . indépendant . PL . CARPIMKO . invalidité et décès:
+  titre.en: '[automatic] disability and death (CARPIMKO)'
+  titre.fr: invalidité et décès (CARPIMKO)
+dirigeant . indépendant . PL . CARPIMKO . retraite complémentaire:
+  titre.en: '[automatic] supplementary pension (CARPIMKO)'
+  titre.fr: retraite complémentaire (CARPIMKO)
 dirigeant . indépendant . PL . CIPAV:
   titre.en: '[automatic] CIPAV'
   titre.fr: CIPAV
@@ -3969,363 +4208,10 @@ dirigeant . indépendant . PL . CIPAV . retraite complémentaire:
 ? dirigeant . indépendant . PL . CIPAV . retraite complémentaire . réduction COVID . montant
 : titre.en: '[automatic] VIDOC reduction'
   titre.fr: réduction COVID
-dirigeant . indépendant . PL . PAM:
-  titre.en: '[automatic] WFP'
-  titre.fr: PAM
-dirigeant . indépendant . PL . PAM . CARCDSF:
-  description.en: >
-    [automatic] CARCDSF is the autonomous pension fund for dental surgeons and
-    midwives.
-  description.fr: >
-    La CARCDSF est la caisse de retraite autonome des chirurgiens dentiste et
-    des sages femmes.
-  titre.en: '[automatic] CARCDSF'
-  titre.fr: CARCDSF
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste:
-  titre.en: '[automatic] dental surgeon'
-  titre.fr: chirurgien-dentiste
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . PCV:
-  note.en: >-
-    [automatic] An exemption can be granted when the 2019 professional income is
-    less than or equal to C 500 (value on 1 January of the year in question),
-    i.e. € 11,500.
-
-    The application must be accompanied by a photocopy of the tax return n° 2042 C or 2035 or 2065 and their annexes (2033 B and D or 2053 and 2058 A) for the year 2019.
-
-    This exemption results in the cancellation of the fees for the year and the unassessed points are not redeemable.
-  note.fr: >-
-    Une dispense peut être accordée lorsque les revenus professionnels 2019 sont
-    inférieurs ou égaux à 500 C (valeur au 1er janvier de l’année considérée),
-    soit 11 500 €.
-
-    La demande doit être accompagnée d’une photocopie de la déclaration d’impôt n° 2042 C ou 2035 ou 2065 et de leurs annexes (2033 B et D ou 2053 et 2058 A) de l’année 2019.
-
-    Cette dispense entraîne l’annulation des droits pour l’année et les points non cotisés ne sont pas rachetables.
-  titre.en: '[automatic] PCV'
-  titre.fr: PCV
-? dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . PCV . info exonération
-: description.en: "[automatic] You have the option of taking a full contribution
-    waiver for supplementary old-age benefits (AVC) if you apply for it. [More
-    information](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cot\
-    isations)"
-  description.fr:
-    Vous avez la possibilité de bénéficier d'une exonération totale
-    de cotisation pour la prestation complémentaire de vieillesse (PCV) si vous
-    en faites la demande. [En savoir
-    plus](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations)
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . RID:
-  titre.en: '[automatic] disability and death (CARCDSF Dental Surgeon)'
-  titre.fr: invalidité et décès (CARCDSF chirurgien-dentiste)
-? dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . assiette participation CPAM
-: titre.en: '[automatic] CPAM contribution base'
-  titre.fr: assiette participation CPAM
-? dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . prix d'une consultation
-: titre.en: '[automatic] consulting fee'
-  titre.fr: prix d'une consultation
-? dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . taux Urssaf
-: description.en: >
-    [automatic] The "Urssaf rate" (UR rate) is used to calculate the share of
-    your
-
-    health and maternity insurance contribution paid by the CPAM. 
-
-
-    This rate is pre-filled on your professional income tax return and
-
-    is derived from your Individual Activity Report data and from
-
-    requirements (RIAP).
-
-
-    The lower the rate, the greater the CPAM participation, and therefore the greater the CPAM participation and therefore the greater the CPAM participation.
-
-    the share to be borne by the practitioner is low.
-
-
-    ## Rate calculation
-
-
-    The formula for calculating the rate of overshoot is as follows: 
-
-    &gt; Urssaf rate = (overruns - amounts reimbursed CMU lump sums) / (amounts reimbursed acts + amounts reimbursed CMU lump sums)
-  description.fr: >
-    Le « taux Urssaf » (taux UR) permet de calculer la part de votre
-
-    cotisation d’assurance maladie-maternité prise en charge par la CPAM. 
-
-
-    Ce taux est pré-rempli sur votre déclaration de revenus professionnels et
-
-    est issu des données de votre Relevé individuel d’activité et de
-
-    prescriptions (RIAP).
-
-
-    Plus le taux est faible, plus la participation CPAM est importante et donc
-
-    la part à la charge du praticien est faible.
-
-
-    ## Calcul du taux
-
-
-    La formule de calcul du taux de dépassement est la suivante : 
-
-    > Taux Urssaf = (dépassements - montants remboursés forfaits CMU) / (montants remboursables actes + montants remboursés forfaits CMU)
-  question.en: '[automatic] What is your "Urssaf rate"?'
-  question.fr: Quel est votre "taux Urssaf" ?
-  titre.en: '[automatic] URSSAF rate'
-  titre.fr: taux Urssaf
-dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire:
-  titre.en: '[automatic] supplementary pension (CARCDSF)'
-  titre.fr: retraite complémentaire (CARCDSF)
-? dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire
-: description.en: >
-    [automatic] Affiliates whose net professional income for the year N-1 is
-    less than 85%.
-
-    % of the PASS in force on 1 January of the year in question (€34,966 in 2020)
-
-    may, on request, obtain a reduction in the lump-sum contribution.
-
-
-    The reduction coefficient applied shall be equal to the ratio of income
-
-    non-salaried professionals on the above-mentioned threshold.
-
-
-    The request must be addressed to the CARDSF and be accompanied by a
-
-    photocopy of the tax return no. 2042 C or 2035 or 2065 and their
-
-    annexes (2033 B and D or 2053 and 2058 A) for the year 2019.
-  description.fr: >
-    Les affiliés dont les revenus professionnels nets sur l'année N-1 sont
-    inférieurs à 85
-
-    % du PASS en vigueur au 1er janvier de l’année considérée (34 966 € en 2020)
-
-    peuvent, sur demande, obtenir une réduction de la cotisation forfaitaire.
-
-
-    Le coefficient de réduction appliqué est égal au rapport des revenus
-
-    professionnels non-salariés sur le seuil mentionné ci-dessus.
-
-
-    La demande doit être adressée à la CARCDSF et être accompagnée d’une
-
-    photocopie de la déclaration d’impôt n° 2042 C ou 2035 ou 2065 et de leurs
-
-    annexes (2033 B et D ou 2053 et 2058 A) de l’année 2019.
-  titre.en: '[automatic] reduced flat-rate contribution'
-  titre.fr: réduction de la cotisation forfaitaire
-? dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction
-: description.en: "[automatic] You have the possibility to benefit from a
-    contribution reduction for the supplementary pension if you apply for it.
-    Find out
-    more](/documentation/documentation/manager/self-employed/PL/PAM/CARCDSF/com\
-    plementary pension/deduction)"
-  description.fr: Vous avez la possibilité de bénéficier d'une réduction de
-    cotisation pour la retraite complémentaire si vous en faites la demande. [En
-    savoir
-    plus](/documentation/dirigeant/indépendant/PL/PAM/CARCDSF/retraite-complémentaire/forfaitaire/réduction)
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme:
-  titre.en: '[automatic] midwife'
-  titre.fr: sage-femme
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV:
-  description.en: >
-    [automatic] For 2020, the amount is set at €780, a third of which, i.e. €260
-    to your
-
-    and 520 € to be paid by the Primary Health Insurance Funds.
-
-    (CPAM).
-
-
-    ### Possibilities of reduction or dispensation
-
-
-    An exemption may be granted where the professional income is
-
-    less than or equal to 3120 €.
-
-
-    The application must be accompanied by a photocopy of the tax return.
-
-    No 2042 C or 2035 or 2065 and their annexes (2033 B and D or 2053 and 2058
-
-    A).
-
-
-    This waiver will result in the cancellation of the fees for the year and the points for the year.
-
-    are not redeemable.
-  description.fr: |
-    Pour 2020, le montant est fixé à 780 € dont un tiers, soit 260 € à votre
-    charge et 520 € à la charge des Caisses Primaires d’Assurance Maladie
-    (CPAM).
-
-    ### Possibilités de réduction ou dispense
-
-    Une dispense peut être accordée lorsque les revenus professionnels sont
-    inférieurs ou égaux à 3120 €.
-
-    La demande doit être accompagnée d’une photocopie de la déclaration d’impôt
-    n° 2042 C ou 2035 ou 2065 et de leurs annexes (2033 B et D ou 2053 et 2058
-    A).
-
-    Cette dispense entraîne l’annulation des droits pour l’année et les points
-    non cotisés ne sont pas rachetables.
-  titre.en: '[automatic] PCV'
-  titre.fr: PCV
-? dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV . info exonération
-: description.en: "[automatic] You have the option of taking a full contribution
-    waiver for supplementary old-age benefits (AVC) if you apply for it. [More
-    information](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cot\
-    isations)"
-  description.fr:
-    Vous avez la possibilité de bénéficier d'une exonération totale
-    de cotisation pour la prestation complémentaire de vieillesse (PCV) si vous
-    en faites la demande. [En savoir
-    plus](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations)
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID:
-  description.en: >
-    [automatic] There are contribution classes to choose from, corresponding to
-    contributions
-
-    and different levels of compensation.
-
-
-    The change of option to a higher class must be requested before the
-
-    1 July of the current year, to take effect on 1 January of
-
-    the following year.
-
-
-    No change of class is permitted after July 1 of the 56th birthday.
-  description.fr: >
-    Il existe classes de cotisations aux choix, correspondant à des cotisations
-
-    et des degrés d'indemnisations différents.
-
-
-    Le changement d'option pour une classe supérieure doit être demandé avant le
-
-    1er juillet de l'année en cours, pour prendre effet au 1er janvier de
-
-    l'année suivante.
-
-
-    Aucun changement de classe n'est autorisé après le 1er juillet du 56e anniversaire.
-  titre.en: '[automatic] disability and death (CARCDSF midwife)'
-  titre.fr: invalidité et décès (CARCDSF sage-femme)
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe:
-  description.en: >
-    [automatic] There are contribution classes to choose from, corresponding to
-    contributions
-
-    and different levels of compensation.
-  description.fr: |
-    Il existe classes de cotisations aux choix, correspondant à des cotisations
-    et des degrés d'indemnisations différents.
-  question.en: '[automatic] In which class do you contribute to the DCFDC
-    Disability Death Plan?'
-  question.fr:
-    Dans quelle classe cotisez-vous pour le régime invalidité-décès de
-    la CARCDSF ?
-  titre.en: '[automatic] Contribution class'
-  titre.fr: Classe de cotisation
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe . A:
-  titre.en: '[automatic] class A'
-  titre.fr: classe A
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe . B:
-  titre.en: '[automatic] class B'
-  titre.fr: classe B
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe . C:
-  titre.en: '[automatic] class C'
-  titre.fr: classe C
-dirigeant . indépendant . PL . PAM . CARMF:
-  description.en: >
-    [automatic] The CARMF is the autonomous pension fund for doctors in France.
-
-
-    Affiliation is compulsory for doctors holding the diploma of
-
-    doctor of medicine, registered with the Council of the Order and exercising an activity
-
-    (installation, replacements, expertise for companies, etc.).
-
-    insurance companies or private laboratories, private sector to hospital, in
-
-    or any other remunerated activity in the form of a private practice or any other
-
-    of fees, even if it is not a question of medical care) in France
-
-    metropolitan France and in the overseas departments or Monaco.
-  description.fr: |
-    La CARMF est la caisse de retraite autonome des médecins de France.
-
-    L’affiliation est obligatoire pour les médecins titulaires du diplôme de
-    docteur en médecine, inscrits au conseil de l’Ordre et exerçant une activité
-    libérale (installation, remplacements, expertises pour les compagnies
-    d’assurance ou les laboratoires privés, secteur privé à l’hôpital, en
-    société d’exercice libéral ou toute autre activité rémunérée sous forme
-    d’honoraires, même s’il ne s’agit pas de la médecine de soins) en France
-    métropolitaine et dans les départements d’Outre-Mer ou à Monaco.
-  titre.en: '[automatic] CARMF'
-  titre.fr: CARMF
-dirigeant . indépendant . PL . PAM . CARMF . ASV:
-  titre.en: '[automatic] Advantage social vieillesse (CARMF)'
-  titre.fr: Avantage social vieillesse (CARMF)
-dirigeant . indépendant . PL . PAM . CARMF . ASV . taux participation CPAM:
-  titre.en: '[automatic] CPAM participation rate'
-  titre.fr: taux participation CPAM
-dirigeant . indépendant . PL . PAM . CARMF . invalidité décès:
-  description.en: >-
-    [automatic] The CARMF manages a provident scheme paying a pension in the
-    event of permanent disability and a death benefit as well as a pension for
-    surviving spouses and children in the event of the death of the insured. 
-
-    The contribution is divided into three flat-rate classes, the amount of which is determined according to your net income from self-employment in the penultimate year.
-
-    Without communication of the self-employed earnings and the tax notice of the penultimate year, the compensation rate cannot be determined. Pending receipt of this document, compensation will be based on the rate for class A.
-  description.fr: >-
-    La CARMF gère un régime de prévoyance versant une pension en cas
-    d'invalidité permanente et un capital décès ainsi qu’une rente pour les
-    conjoints et enfants survivants en cas de décès de l'assuré. 
-
-    La cotisation comporte trois classes forfaitaires dont le montant est déterminé en fonction de vos revenus nets d'activité indépendante de l’avant-dernière année.
-
-    Sans communication des revenus professionnels non salariés et de l’avis d’imposition de l’avant dernière année, le taux d’indemnisation ne peut être fixé. Dans l’attente de la réception de ce document l’indemnisation sera basée sur le taux prévu pour la classe A.
-  titre.en: '[automatic] disability and death (CARMF)'
-  titre.fr: invalidité et décès (CARMF)
-dirigeant . indépendant . PL . PAM . CARMF . retraite complémentaire:
-  titre.en: '[automatic] supplementary pension (CARMF)'
-  titre.fr: retraite complémentaire (CARMF)
-dirigeant . indépendant . PL . PAM . CARPIMKO:
-  titre.en: '[automatic] CARPIMKO'
-  titre.fr: CARPIMKO
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV:
-  titre.en: '[automatic] Old-age benefit (CARPIMKO)'
-  titre.fr: Avantage social vieillesse (CARPIMKO)
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . forfaitaire:
-  titre.en: '[automatic] lump sum'
-  titre.fr: forfaitaire
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . participation CPAM:
-  titre.en: '[automatic] CPAM participation'
-  titre.fr: participation CPAM
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . proportionnelle:
-  titre.en: '[automatic] proportional'
-  titre.fr: proportionnelle
-dirigeant . indépendant . PL . PAM . CARPIMKO . invalidité et décès:
-  titre.en: '[automatic] disability and death (CARPIMKO)'
-  titre.fr: invalidité et décès (CARPIMKO)
-dirigeant . indépendant . PL . PAM . CARPIMKO . retraite complémentaire:
-  titre.en: '[automatic] supplementary pension (CARPIMKO)'
-  titre.fr: retraite complémentaire (CARPIMKO)
-dirigeant . indépendant . PL . PAM . CURPS:
+dirigeant . indépendant . PL . PAMC:
+  titre.en: '[automatic] PAMC'
+  titre.fr: PAMC
+dirigeant . indépendant . PL . PAMC . CURPS:
   description.en: >
     [automatic] The health professions are represented by the following unions
 
@@ -4363,174 +4249,230 @@ dirigeant . indépendant . PL . PAM . CURPS:
     régularisé. Un nouvel échéancier de cotisations sera ensuite adressé.
   titre.en: '[automatic] Contribution to regional unions of health professionals'
   titre.fr: Contribution aux unions régionales des professionnels de santé
-dirigeant . indépendant . PL . PAM . PCV:
-  description.en: >
-    [automatic] Certain professional categories benefit from
-
-    supplementary old-age benefits (PCV), previously known as "benefits".
-
-    social old age" (ASV). This concerns general practitioners, the
-
-    dental surgeons, midwives, paramedics and medical assistants, and
-
-    laboratory directors. This scheme results from
-
-    partial by the Health Insurance of their insurance contributions
-
-    old age, provided that they have exercised their activity within the framework of the
-
-    conventional.
-  description.fr: |
-    Certaines catégories professionnelles bénéficient de
-    prestations complémentaires vieillesse (PCV), auparavant nommées « avantage
-    social vieillesse » (ASV). Cela concerne les médecins généralistes, les
-    chirurgiens-dentistes, les sages-femmes, les auxiliaires médicaux et les
-    directeurs de laboratoires. Ce régime résulte de la prise en charge
-    partielle par l’Assurance maladie de leurs cotisations d’assurance
-    vieillesse sous réserve qu’ils aient exercé leur activité dans le cadre
-    conventionnel.
-  titre.en: '[automatic] Supplementary old-age benefits'
-  titre.fr: Prestations complémentaires vieillesse
-dirigeant . indépendant . PL . PAM . allocations familiales:
+dirigeant . indépendant . PL . PAMC . allocations familiales:
   titre.en: '[automatic] family allowances (after CPAM participation)'
   titre.fr: allocations familiales (après participation CPAM)
-? dirigeant . indépendant . PL . PAM . allocations familiales . participation CPAM
-: titre.en: '[automatic] CPAM participation'
-  titre.fr: participation CPAM
-dirigeant . indépendant . PL . PAM . assiette participation CPAM:
+dirigeant . indépendant . PL . PAMC . assiette participation CPAM:
   description.en:
     '[automatic] Also known as conventional income, this is the net
     overrun fee income.'
   description.fr: Aussi appelé revenu conventionnel, il s'agit du revenu des
     honoraires nets de dépassement.
+  note.en: >
+    [automatic] The formula referenced in the Urssaf texts is as follows: 
+
+    &gt; (income from the agreed activity) x (total fees - total fee overruns) / total amount of fees. 
+
+
+    This formula can be simplified into: 
+
+    &gt; (income from the activity covered by the agreement) / (100% + average fee overrun)
+
+
+    ### Proof
+
+    If we take the following variables, 
+
+    &gt; `h+`: total fees (with overruns)
+      `h` : fees without exceeding
+      d%': percentage by which the average fee is exceeded
+
+    We've got: 
+
+    &gt;  
+      `h+ = h + h * d%`
+      `h+ = h * (100% + d%)`
+
+    If we replace in the formula the CPAM participation base, we have :
+
+    &gt; 1. `(income from the activity covered by the agreement) * h / h+`
+
+    &gt; 2. `(income from the activity covered by the agreement) * h / (h * (100% + d%)) 
+
+    &gt; 3. `(income from the agreement activity) / (100% + d%)`.
+  note.fr: >
+    La formule référencée dans les textes Urssaf est la suivante : 
+
+    > (revenu de l’activité conventionnée) x (total des honoraires - total des dépassements d’honoraires) / montant total des honoraires. 
+
+
+    On peut simplififer cette formule en : 
+
+    > (revenu de l’activité conventionnée) / (100% + dépassement d'honoraire moyen)
+
+
+    ### Preuve
+
+    Si on prends les variables suivantes, 
+
+    > `h+` : total des honoraires (avec dépassement)
+      `h` : honoraires sans dépassement
+      `d%`: pourcentage de dépassement d'honoraire moyen
+
+    On a : 
+
+    >  
+      `h+ = h + h * d%`
+      `h+ = h * (100% + d%)`
+
+    Si on remplace dans la formule de l'assiette participation CPAM, on a :
+
+    > 1. `(revenu de l’activité conventionnée) * h / h+`
+
+    > 2. `(revenu de l’activité conventionnée) * h / (h * (100% + d%)) 
+
+    > 3. `(revenu de l’activité conventionnée) / (100% + d%)`
   titre.en: '[automatic] CPAM contribution base'
   titre.fr: assiette participation CPAM
-dirigeant . indépendant . PL . PAM . cotisations additionnelles PAM:
-  titre.en: '[automatic] WFP additional contributions'
-  titre.fr: cotisations additionnelles PAM
-dirigeant . indépendant . PL . PAM . dépassement d'honoraire moyen:
+? dirigeant . indépendant . PL . PAMC . assiette participation chirurgien-dentiste
+: titre.en: '[automatic] CPAM participation plate (dental surgeon)'
+  titre.fr: assiette participation CPAM (chirurgien dentiste)
+? dirigeant . indépendant . PL . PAMC . assiette participation chirurgien-dentiste . taux Urssaf
+: description.en: >
+    [automatic] The "Urssaf rate" (UR rate) is used to calculate the share of
+    your
+
+    health and maternity insurance contribution paid by the CPAM. 
+
+
+    This rate is pre-filled on your professional income tax return and
+
+    is derived from your Individual Activity Report data and from
+
+    requirements (RIAP).
+
+
+    The lower the rate, the greater the CPAM participation, and therefore the greater the CPAM participation and therefore the greater the CPAM participation.
+
+    the share to be borne by the practitioner is small.
+
+
+    ## Rate calculation
+
+
+    The formula for calculating the rate of overshoot is as follows: 
+
+    &gt; Urssaf rate = (overruns - amounts reimbursed CMU lump sums) / (amounts reimbursed acts + amounts reimbursed CMU lump sums)
+  description.fr: >
+    Le « taux Urssaf » (taux UR) permet de calculer la part de votre
+
+    cotisation d’assurance maladie-maternité prise en charge par la CPAM. 
+
+
+    Ce taux est pré-rempli sur votre déclaration de revenus professionnels et
+
+    est issu des données de votre Relevé individuel d’activité et de
+
+    prescriptions (RIAP).
+
+
+    Plus le taux est faible, plus la participation CPAM est importante et donc
+
+    la part à la charge du praticien est faible.
+
+
+    ## Calcul du taux
+
+
+    La formule de calcul du taux de dépassement est la suivante : 
+
+    > Taux Urssaf = (dépassements - montants remboursés forfaits CMU) / (montants remboursables actes + montants remboursés forfaits CMU)
+  question.en: '[automatic] What is your "Urssaf rate"?'
+  question.fr: Quel est votre "taux Urssaf" ?
+  titre.en: '[automatic] URSSAF rate'
+  titre.fr: taux Urssaf
+dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen:
   question.en: '[automatic] What is your average fee overrun (estimate)?'
   question.fr: Quels est votre dépassement honoraires moyen (estimation) ?
   titre.en: '[automatic] average overpayment'
   titre.fr: dépassement d'honoraire moyen
-dirigeant . indépendant . PL . PAM . honoraires:
-  question.en: '[automatic] What is the total amount of your fees?'
-  question.fr: Quel est le montant total de vos honoraires ?
-  résumé.en: '[automatic] Including overruns'
-  résumé.fr: En incluant les dépassements
-  titre.en: '[automatic] Total fees'
-  titre.fr: Total des honoraires
-dirigeant . indépendant . PL . PAM . maladie:
+dirigeant . indépendant . PL . PAMC . maladie:
   titre.en: '[automatic] disease (after CPAM participation)'
   titre.fr: maladie (après participation CPAM)
-dirigeant . indépendant . PL . PAM . maladie . contribution additionnelle:
+dirigeant . indépendant . PL . PAMC . maladie . contribution additionnelle:
   titre.en: '[automatic] supplementary contribution'
   titre.fr: contribution additionnelle
-dirigeant . indépendant . PL . PAM . maladie . participation CPAM:
+dirigeant . indépendant . PL . PAMC . maladie . participation CPAM:
   titre.en: '[automatic] CPAM participation'
   titre.fr: participation CPAM
-dirigeant . indépendant . PL . PAM . secteur:
-  description.en: |
-    [automatic] The rates of contributions and CPAM refunds are not the same in
-    depending on the pricing regime chosen by the practitioner.
+? dirigeant . indépendant . PL . PAMC . proportion recette activité non conventionnée
+: description.en: >
+    [automatic] Non-agreement revenues are all those which do not fall within
+    the scope of
+
+    the following categories: 
+        
+    - Reimbursable deed fees (including the
+
+    fee overruns and travel expenses shown on the statement
+
+    SNIR)
+
+
+    - Fees resulting from retrocessions concerning reimbursable deeds
+
+    received as a substitute
+
+
+    - All lump sums paid by health insurance
+
+    (teletransmission assistance, compensation, compensation for training, etc.).
+
+    continuous, installation bonus, ...)
   description.fr: |
-    Les taux de cotisations et remboursement de la CPAM ne sont pas les même en
-    fonction du régime de tarification choisie par le praticien.
-  question.en: '[automatic] What sector are you contracted to?'
-  question.fr: Sur quel secteur êtes-vous conventionné ?
-  titre.en: '[automatic] sector'
-  titre.fr: secteur
-dirigeant . indépendant . PL . PAM . secteur . 1:
-  titre.en: '[automatic] Sector 1'
-  titre.fr: Secteur 1
-dirigeant . indépendant . PL . PAM . secteur . 2:
-  titre.en: '[automatic] Sector 2'
-  titre.fr: Secteur 2
+    Les recettes non conventionnées sont toutes celles qui ne rentrent pas dans
+    les catégories suivantes : 
+        
+    - Honoraires tirés des actes remboursables (y compris les
+    dépassements d’honoraires et les frais de déplacement figurant sur le relevé
+    SNIR)
+
+    - Honoraires issus de rétrocessions concernant les actes remboursables
+    perçues en qualité de remplaçant
+
+    - Toutes les rémunérations forfaitaires versées par l’assurance maladie
+    (aide à la télétransmission, indemnisation, indemnisation de la formation
+    continue, prime à l’installation, ...)
+  question.en: |
+    [automatic] How much of your turnover is related to a non-trading activity?
+    conventionnée (estimate) ?
+  question.fr: |
+    Quel est la part de votre chiffre d'affaires liée à une activité non
+    conventionnée (estimation) ?
+  titre.en: '[automatic] proportion of revenue from non-agreement activities'
+  titre.fr: proportion recette activité non conventionnée
+dirigeant . indépendant . PL . PAMC . revenus activité conventionnée:
+  description.en: >
+    [automatic] The revenues covered by the agreement are those corresponding to
+    revenues from
+
+    fees and flat-rate remuneration paid by CPAM.
+  description.fr: |
+    Les revenus conventionnés sont ceux correspondant aux recettes tirées des
+    honoraires et des rémunérations forfaitaires versées par la CPAM.
+  note.en: >
+    [automatic] To avoid having to distribute loads between those from
+
+    the activities covered by the agreements and those that are not (which would result in
+
+    two separate accounts), it can be calculated from income
+
+    which is adjusted according to the share of the turnover
+
+    from the acts covered by the agreements.
+  note.fr: |
+    Pour éviter d'avoir à ventiler les charges entre celles issues de
+    l'activités conventionnées et celles qui ne le sont pas (ce qui aboutirait à
+    deux comptabilités distinct), on peut le calculer à partir du revenu
+    professionnel que l'on ajuste en fonction de la part du chiffre d'affaires
+    provenant des actes conventionnés.
+  titre.en: '[automatic] income from agreement activity'
+  titre.fr: revenus activité conventionnée
 dirigeant . indépendant . PL . métier:
   question.en: '[automatic] To which category does your profession belong?'
   question.fr: A quelle catégorie appartient votre profession ?
   titre.en: '[automatic] profession'
   titre.fr: métier
-dirigeant . indépendant . PL . métier . PAM:
-  description.en: >
-    [automatic] If you are a licensed medical practitioner or paramedic, you are
-    under the jurisdiction of the
-
-    health insurance scheme for medical practitioners and medical auxiliaries
-
-    (PAMC). The point on the conditions to be met to benefit from
-
-    of this health insurance plan and the terms and conditions of your coverage
-
-    social.
-
-
-    &gt; *Exceptions* : Osteopath, psychologist, psychotherapist, occupational therapist,
-
-    dietician and chiropractor do not depend on the PAMC diet but on the
-
-    CIPAV for their retirement and disability.
-  description.fr: >
-    Si vous êtes praticien ou auxiliaire médical conventionné, vous relevez du
-
-    régime d'assurance maladie des praticiens et auxiliaires médicaux
-
-    conventionnés (PAMC). Le point sur les conditions à remplir pour bénéficier
-
-    de ce régime d'assurance maladie et sur les modalités de votre protection
-
-    sociale.
-
-
-    > *Exceptions* : Les ostéopathe, psychologue, psychothérapeute, ergothérapeute,
-
-    diététicien et chiropracteur ne dépendent pas du régime PAMC mais de la
-
-    CIPAV pour leur retraite et invalidité.
-  question.en: '[automatic] What do you do as a healthcare professional?'
-  question.fr: Quel métier exercez-vous en tant que professionnel de santé ?
-  titre.en: '[automatic] Medical practitioner or paramedic'
-  titre.fr: Practicien ou auxiliaire médical
-dirigeant . indépendant . PL . métier . PAM . auxiliaire médical:
-  description.en: >
-    [automatic] You work in one of the following professions: nurse,
-    masseur-physiotherapist, speech therapist, orthoptist or podiatrist.
-  description.fr: >
-    Vous exercez un des métiers suivants : infirmier, masseur-kinésithérapeute,
-    orthophoniste, orthoptiste ou pédicure-podologue.
-  titre.en: '[automatic] medical auxiliary'
-  titre.fr: auxiliaire médical
-dirigeant . indépendant . PL . métier . PAM . chirurgien-dentiste:
-  titre.en: '[automatic] dental surgeon'
-  titre.fr: chirurgien-dentiste
-dirigeant . indépendant . PL . métier . PAM . médecin:
-  titre.en: '[automatic] doctor'
-  titre.fr: médecin
-dirigeant . indépendant . PL . métier . PAM . médecin remplaçant:
-  description.en: >
-    [automatic] Replacement general practitioner or specialist (student,
-    salaried employee or
-
-    pensioner) are the retroceded fees do not exceed €19,000 per year
-
-    civil society organisations can benefit from a special scheme for the payment of
-
-    their social security contributions.
-
-
-    This consists of a single contribution rate of 13.30%.
-  description.fr: |
-    Les médecin remplaçant généraliste ou spécialiste (étudiant, salarié ou
-    retraité) sont les honoraires rétrocédés ne dépassent pas 19 000 € par année
-    civile peuvent bénéficier d'un dispositif particulier pour le paiement de
-    leur cotisation de sécurité sociale.
-
-    Cela consiste en un taux unique de cotisations à 13,30%
-  titre.en: '[automatic] substitute physician'
-  titre.fr: médecin remplaçant
-dirigeant . indépendant . PL . métier . PAM . sage-femme:
-  titre.en: '[automatic] midwife'
-  titre.fr: sage-femme
 dirigeant . indépendant . PL . métier . rattaché CIPAV:
   description.en: >
     [automatic] You work in a regulated profession attached to the CIPAV. The
@@ -4582,6 +4524,84 @@ dirigeant . indépendant . PL . métier . rattaché CIPAV:
     - Guide-conférencier
   titre.en: '[automatic] Other CIPAV-related professions'
   titre.fr: Autre métier rattaché à la CIPAV
+dirigeant . indépendant . PL . métier . santé:
+  description.en: >
+    [automatic] If you are a licensed medical practitioner or paramedic, you are
+    under the jurisdiction of the
+
+    health insurance scheme for medical practitioners and medical auxiliaries
+
+    (PAMC). The point on the conditions to be met to benefit from
+
+    of this health insurance plan and the terms and conditions of your coverage
+
+    social.
+
+
+    &gt; *Exceptions* : Osteopath, psychologist, psychotherapist, occupational therapist,
+
+    dietician and chiropractor do not depend on the PAMC diet but on the
+
+    CIPAV for their retirement and disability.
+  description.fr: >
+    Si vous êtes praticien ou auxiliaire médical conventionné, vous relevez du
+
+    régime d'assurance maladie des praticiens et auxiliaires médicaux
+
+    conventionnés (PAMC). Le point sur les conditions à remplir pour bénéficier
+
+    de ce régime d'assurance maladie et sur les modalités de votre protection
+
+    sociale.
+
+
+    > *Exceptions* : Les ostéopathe, psychologue, psychothérapeute, ergothérapeute,
+
+    diététicien et chiropracteur ne dépendent pas du régime PAMC mais de la
+
+    CIPAV pour leur retraite et invalidité.
+  question.en: '[automatic] What do you do as a healthcare professional?'
+  question.fr: Quel métier exercez-vous en tant que professionnel de santé ?
+  titre.en: '[automatic] Medical practitioner or paramedic'
+  titre.fr: Practicien ou auxiliaire médical
+dirigeant . indépendant . PL . métier . santé . auxiliaire médical:
+  description.en: >
+    [automatic] You work in one of the following professions: nurse,
+    masseur-physiotherapist, speech therapist, orthoptist or podiatrist.
+  description.fr: >
+    Vous exercez un des métiers suivants : infirmier, masseur-kinésithérapeute,
+    orthophoniste, orthoptiste ou pédicure-podologue.
+  titre.en: '[automatic] medical auxiliary'
+  titre.fr: auxiliaire médical
+dirigeant . indépendant . PL . métier . santé . chirurgien-dentiste:
+  titre.en: '[automatic] dental surgeon'
+  titre.fr: chirurgien-dentiste
+dirigeant . indépendant . PL . métier . santé . médecin:
+  titre.en: '[automatic] doctor'
+  titre.fr: médecin
+dirigeant . indépendant . PL . métier . santé . sage-femme:
+  titre.en: '[automatic] midwife'
+  titre.fr: sage-femme
+dirigeant . indépendant . PL . métier . secteur médecin:
+  description.en: |
+    [automatic] The rates of contributions and CPAM refunds are not the same in
+    depending on the pricing regime chosen by the practitioner.
+  description.fr: |
+    Les taux de cotisations et remboursement de la CPAM ne sont pas les même en
+    fonction du régime de tarification choisie par le praticien.
+  question.en: '[automatic] What sector are you contracted to?'
+  question.fr: Sur quel secteur êtes-vous conventionné ?
+  titre.en: '[automatic] medical sector'
+  titre.fr: secteur médecin
+dirigeant . indépendant . PL . métier . secteur médecin . 1:
+  titre.en: '[automatic] Sector 1'
+  titre.fr: Secteur 1
+dirigeant . indépendant . PL . métier . secteur médecin . 2:
+  titre.en: '[automatic] Sector 2'
+  titre.fr: Secteur 2
+dirigeant . indépendant . PL . métier . secteur médecin . non conventionné:
+  titre.en: '[automatic] non-treaty'
+  titre.fr: non conventionné
 dirigeant . indépendant . PL . option régime général:
   description.en: >
     [automatic] Persons already practising an unregulated professional practice
@@ -4906,6 +4926,22 @@ dirigeant . indépendant . contrôle base forfaitaire:
 
     Ce simulateur calcul les cotisations au régime de croisière (après régularisation). Il vous permet donc de connaître le montant à provisionner pour la régularisation.
 dirigeant . indépendant . cotisations et contributions:
+  description.en: >
+    [automatic] This is the total amount owed by the self-employed person in
+    respect of contributions and
+
+    mandatory contributions.
+  description.fr: |
+    C'est le montant total dû par l'indépendant au titre des cotisations et
+    contributions obligatoire.
+  note.en: |
+    [automatic] Unlike contributions, contributions are not reintroduced
+    for the calculation of the CSG/CRDS. They also do not benefit from the
+    ACRE reduction.
+  note.fr: |
+    À la différence des cotisations, les contributions ne sont pas réintroduites
+    pour le calcul de la CSG/CRDS. Elles ne bénéficient pas non plus de la
+    réduction ACRE.
   titre.en: all contributions
   titre.fr: cotisations et contributions
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
@@ -4921,28 +4957,58 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
     fiscal fourni
   titre.en: basis
   titre.fr: assiette
-dirigeant . indépendant . cotisations et contributions . PLR:
-  description.en: '[automatic] Specific contributions for regulated liberal
-    professions (doctors, lawyers, etc.)'
-  description.fr: Cotisations spécifique aux professions libérales réglementées
-    (medecins, avocats, etc.)
-  titre.en: '[automatic] regulated professional fees'
-  titre.fr: cotisations professions libérales réglementées
+dirigeant . indépendant . cotisations et contributions . PCV:
+  description.en: >
+    [automatic] Certain professional categories benefit from
+
+    supplementary old-age benefits (PCV), previously known as "benefits".
+
+    social old age" (ASV). This concerns general practitioners, the
+
+    dental surgeons, midwives, paramedics and medical assistants, and
+
+    laboratory directors. This scheme results from
+
+    partial by the Health Insurance of their insurance contributions
+
+    old age, provided that they have exercised their activity within the framework of the
+
+    conventional.
+  description.fr: |
+    Certaines catégories professionnelles bénéficient de
+    prestations complémentaires vieillesse (PCV), auparavant nommées « avantage
+    social vieillesse » (ASV). Cela concerne les médecins généralistes, les
+    chirurgiens-dentistes, les sages-femmes, les auxiliaires médicaux et les
+    directeurs de laboratoires. Ce régime résulte de la prise en charge
+    partielle par l’Assurance maladie de leurs cotisations d’assurance
+    vieillesse sous réserve qu’ils aient exercé leur activité dans le cadre
+    conventionnel.
+  titre.en: '[automatic] Supplementary old-age benefits'
+  titre.fr: Prestations complémentaires vieillesse
+dirigeant . indépendant . cotisations et contributions . allocations familiales:
+  titre.en: '[automatic] child benefit'
+  titre.fr: allocations familiales
+? dirigeant . indépendant . cotisations et contributions . contributions spéciales
+: description.en: |
+    [automatic] Some special plans may add additional contributions
+    (e.g. CURPS for the CPAMs)
+  description.fr: |
+    Certains régimes spéciaux peuvent ajouter des contributions additionnelles
+    (par exemple, la CURPS pour les CPAM)
+  titre.en: '[automatic] special contributions'
+  titre.fr: contributions spéciales
 dirigeant . indépendant . cotisations et contributions . cotisations:
   titre.en: social contributions
   titre.fr: cotisations
-? dirigeant . indépendant . cotisations et contributions . cotisations . allocations familiales
-: titre.en: family allowances
-  titre.fr: allocations familiales
-? dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac
-: description.en: >
-    activité commerciale, vous avez la possibilité d’opter pour le calcul de
-    votre cotisation d’assurance vieillesse sur le seul revenu tiré de votre
-    activité commerciale (en effet, les remises pour débit de tabac sont
-    soumises par ailleurs à un prélèvement vieillesse particulier). Nous
-    attirons cependant votre attention sur le fait qu’en cotisant sur une base
-    moins importante, excluant les revenus de débit de tabac, vos droits à
-    retraite pour l’assurance vieillesse des commerçants en seront diminués.
+dirigeant . indépendant . cotisations et contributions . déduction tabac:
+  description.en: >
+    [automatic] If you are also engaged in a commercial activity as a
+    tobacconist, you can opt to have your pension insurance contribution
+    calculated solely on the income from your commercial activity (since tobacco
+    discounts are also subject to a special pension levy). However, we would
+    like to draw your attention to the fact that by contributing on a lower
+    basis, excluding tobacco debit income, your pension rights for the
+    merchant's pension insurance will be reduced.
   description.fr: >
     Si vous exercez une activité de débit de tabac simultanément à une activité
     commerciale, vous avez la possibilité d’opter pour le calcul de votre
@@ -4952,116 +5018,19 @@ dirigeant . indépendant . cotisations et contributions . cotisations:
     votre attention sur le fait qu’en cotisant sur une base moins importante,
     excluant les revenus de débit de tabac, vos droits à retraite pour
     l’assurance vieillesse des commerçants en seront diminués.
-  question.en: souhaitez exonérer de cotisation vieillesse ?
+  question.en: '[automatic] How much income from the sale of tobacco do you wish
+    to exempt from paying pension contributions?'
   question.fr:
     Quel est le montant des revenus issus de la vente de tabac que vous
     souhaitez exonérer de cotisation vieillesse ?
-  titre.en: tobacco deduction
+  titre.en: '[automatic] tobacco deduction'
   titre.fr: déduction tabac
-? dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac . revenus déduits
+? dirigeant . indépendant . cotisations et contributions . déduction tabac . revenus déduits
 : titre.en: '[automatic] contribution base (with tobacco deduction)'
   titre.fr: assiette des cotisations (avec déduction tabac)
-? dirigeant . indépendant . cotisations et contributions . cotisations . exonération de cotisations minimales
+? dirigeant . indépendant . cotisations et contributions . exonération de cotisations minimales
 : titre.en: '[automatic] minimum contribution holiday'
   titre.fr: exonération de cotisations minimales
-? dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
-: description.en: >
-    [automatic] Contributions for daily allowances for self-employed persons. If
-    the
-
-    health of craftsmen, traders, industrialists and collaborating spouses
-
-    requires a work stoppage, a portion of their former income will be returned to them.
-
-    paid up.
-  description.fr: |
-    Cotisations pour les indemnités journalières des indépendants. Si l'état de
-    santé des artisans, commerçants, industriels et conjoints collaborateurs
-    nécessite un arrêt de travail, une part de leur ancien revenu leur sera
-    versé.
-  titre.en: '[automatic] sick pay'
-  titre.fr: indemnités journalières maladie
-? dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès
-: titre.en: disability and death
-  titre.fr: invalidité et décès
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
-  note.en: >
-    [automatic] The decree below contains the following sentence:
-
-
-    &gt; I.- By way of derogation from the first paragraph, the rate of the contribution shall be fixed at 6.5% where earned income is greater than five times the annual value of the social security ceiling determined in accordance with Article D. 613-2.
-
-
-    The word "when" implies that if the 5xPSS threshold is exceeded, all income is subject to 6.5%. It would seem that an opposite interpretation is to be preferred: only the share above this threshold is subject to this rate, and it is this implementation that we have chosen.
-  note.fr: >
-    On retrouve dans le décret ci-dessous la phrase suivante :
-
-
-    > I.-Par dérogation au premier alinéa, le taux de la cotisation est fixé à 6,5 % lorsque le revenu d'activité est supérieur à cinq fois la valeur annuelle du plafond de la sécurité sociale déterminée conformément à l'article D. 613-2.
-
-
-    Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
-  titre.en: health insurance
-  titre.fr: maladie
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux
-: note.en: >
-    [automatic] This contribution is basically very simple: the health
-    contribution is 7.2% up to 5 times the social security ceiling, then 6.5%
-    above. However:
-
-    - for its collection, this contribution is separated into 2: sickness and sickness 2, the latter at the rate of 0.85%. Thus the amount of 7.2% quoted in the decree is reduced to 6.35% in our calculations.
-
-    - Contribution reductions have been introduced: a simple exemption below 110% of the social security ceiling, then a reinforced exemption below 40%. The above scale takes these reductions into account.
-  note.fr: >
-    Cette cotisation est à la base très simple : la cotisation maladie est de
-    7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà.
-    Cependant :
-
-    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs.
-
-    - des réductions de cotisation ont été introduites : une exonération simple en-dessous de 110% du plafond de la sécurité sociale, puis une exonération renforcée en-dessous de 40%. Le barème ci-dessus prend en compte ces réductions.
-  titre.en: rates
-  titre.fr: taux
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA
-: note.en: >
-    [automatic] For self-employed persons with an RSA, only the simple reduction
-    defined in the decree for calculating the health contribution is taken into
-    account. The reinforced reduction below 40% of the social security ceiling
-    is not, as there is no minimum base.
-  note.fr: >
-    Pour les indépendants au RSA, seule la réduction simple définie dans le
-    décret de calcul de la cotisation maladie est prise en compte. La réduction
-    renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas,
-    car il n'y a pas d'assiette minimale.
-  titre.en: RSA rate
-  titre.fr: taux RSA
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA part variable
-: titre.en: rate RSA variable portion
-  titre.fr: taux RSA part variable
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux variable
-: titre.en: variable rate
-  titre.fr: taux variable
-? dirigeant . indépendant . cotisations et contributions . cotisations . maladie domiciliation fiscale étranger
-: description.en:
-    '[automatic] In return for the CSG exemption, contributors have
-    a higher sickness rate. Unlike other insured tradesmen/artisans, they do not
-    benefit from the reduction of the health contribution rate according to
-    their declared income.'
-  description.fr: En contrepartie de l'exonération de CSG, les cotisants ont un
-    taux maladie plus elevé. Contrairement aux autres assurés
-    commerçants/artisans ils ne bénéficient pas de la réduction du taux de la
-    cotisation maladie en fonction du revenu déclaré.
-  titre.en: Illness (tax domicile abroad)
-  titre.fr: Maladie (domiciliation fiscale à l'étranger)
-? dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire
-: titre.en: supplementary pension
-  titre.fr: retraite complémentaire
-? dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire . plafond
-: titre.en: '[automatic] supplementary pension ceiling for self-employed persons'
-  titre.fr: plafond retraite complémentaire des indépendants
-? dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base
-: titre.en: pension
-  titre.fr: retraite de base
 dirigeant . indépendant . cotisations et contributions . exonérations:
   titre.en: exemptions
   titre.fr: exonérations
@@ -5139,6 +5108,104 @@ dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   note.fr: Le taux n'est pas majoré pour les artisans avec conjoint collaborateur
   titre.en: professional training
   titre.fr: formation professionnelle
+? dirigeant . indépendant . cotisations et contributions . indemnités journalières maladie
+: description.en: >
+    [automatic] Contributions for daily allowances for self-employed persons. If
+    the
+
+    health of craftsmen, traders, industrialists and collaborating spouses
+
+    requires a work stoppage, a portion of their former income will be returned to them.
+
+    paid up.
+  description.fr: |
+    Cotisations pour les indemnités journalières des indépendants. Si l'état de
+    santé des artisans, commerçants, industriels et conjoints collaborateurs
+    nécessite un arrêt de travail, une part de leur ancien revenu leur sera
+    versé.
+  titre.en: '[automatic] sick pay'
+  titre.fr: indemnités journalières maladie
+dirigeant . indépendant . cotisations et contributions . invalidité et décès:
+  titre.en: '[automatic] disability and death'
+  titre.fr: invalidité et décès
+dirigeant . indépendant . cotisations et contributions . maladie:
+  note.en: >
+    [automatic] The decree below contains the following sentence:
+
+
+    &gt; I.- By derogation from the first paragraph, the contribution rate shall be set at 6.5% where earned income exceeds five times the annual value of the social security ceiling determined in accordance with Article D. 613-2.
+
+
+    The word "when" implies that if the 5xPSS threshold is exceeded, all income is subject to 6.5%. It would seem that an opposite interpretation is to be preferred: only the portion above this threshold is subject to this rate, and it is this implementation that we have chosen.
+  note.fr: >
+    On retrouve dans le décret ci-dessous la phrase suivante :
+
+
+    > I.-Par dérogation au premier alinéa, le taux de la cotisation est fixé à 6,5 % lorsque le revenu d'activité est supérieur à cinq fois la valeur annuelle du plafond de la sécurité sociale déterminée conformément à l'article D. 613-2.
+
+
+    Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
+  titre.en: '[automatic] disease'
+  titre.fr: maladie
+dirigeant . indépendant . cotisations et contributions . maladie . taux:
+  note.en: >
+    [automatic] This contribution is basically very simple: the health
+    contribution is 7.2% up to 5 times the social security ceiling, then 6.5%
+    beyond that. However:
+
+    - for its recovery, this contribution is separated into 2: sickness and sickness 2, the latter at the rate of 0.85%. Thus the amount of 7.2% quoted in the decree is reduced to 6.35% in our calculations.
+
+    - Contribution reductions have been introduced: a simple exemption below 110% of the social security ceiling, then a reinforced exemption below 40%. The above scale takes these reductions into account.
+  note.fr: >
+    Cette cotisation est à la base très simple : la cotisation maladie est de
+    7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà.
+    Cependant :
+
+    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs.
+
+    - des réductions de cotisation ont été introduites : une exonération simple en-dessous de 110% du plafond de la sécurité sociale, puis une exonération renforcée en-dessous de 40%. Le barème ci-dessus prend en compte ces réductions.
+  titre.en: '[automatic] rate'
+  titre.fr: taux
+dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
+  note.en: >
+    [automatic] For self-employed persons with the RSA, only the simple
+    reduction defined in the decree for calculating the health contribution is
+    taken into account. The reinforced reduction below 40% of the social
+    security ceiling is not, as there is no minimum base.
+  note.fr: >
+    Pour les indépendants au RSA, seule la réduction simple définie dans le
+    décret de calcul de la cotisation maladie est prise en compte. La réduction
+    renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas,
+    car il n'y a pas d'assiette minimale.
+  titre.en: '[automatic] RSA rate'
+  titre.fr: taux RSA
+? dirigeant . indépendant . cotisations et contributions . maladie . taux RSA part variable
+: titre.en: '[automatic] rate RSA variable part'
+  titre.fr: taux RSA part variable
+? dirigeant . indépendant . cotisations et contributions . maladie . taux variable
+: titre.en: '[automatic] floating rate'
+  titre.fr: taux variable
+? dirigeant . indépendant . cotisations et contributions . maladie domiciliation fiscale étranger
+: description.en:
+    '[automatic] In return for the CSG exemption, contributors have
+    a higher sickness rate. In contrast to other insured tradesmen/artisans,
+    they do not benefit from the reduction of the health contribution rate
+    according to their declared income.'
+  description.fr: En contrepartie de l'exonération de CSG, les cotisants ont un
+    taux maladie plus elevé. Contrairement aux autres assurés
+    commerçants/artisans ils ne bénéficient pas de la réduction du taux de la
+    cotisation maladie en fonction du revenu déclaré.
+  titre.en: '[automatic] Illness (tax domicile abroad)'
+  titre.fr: Maladie (domiciliation fiscale à l'étranger)
+? dirigeant . indépendant . cotisations et contributions . retraite complémentaire
+: titre.en: '[automatic] retirement supplement'
+  titre.fr: retraite complémentaire
+? dirigeant . indépendant . cotisations et contributions . retraite complémentaire . plafond
+: titre.en: '[automatic] supplementary pension ceiling for self-employed persons'
+  titre.fr: plafond retraite complémentaire des indépendants
+dirigeant . indépendant . cotisations et contributions . retraite de base:
+  titre.en: '[automatic] basic retirement'
+  titre.fr: retraite de base
 dirigeant . indépendant . revenu net de cotisations:
   description.en:
     This is the income net of contributions and expenses, before the
@@ -5551,10 +5618,10 @@ entreprise . charges dont rémunération dirigeant:
 entreprise . chiffre d'affaires:
   question.en: What is your expected turnover ?
   question.fr: Quel est votre chiffre d'affaires envisagé ?
-  résumé.en: The amount of sales
-  résumé.fr: Le montant des ventes réalisées
-  titre.en: Turnover
-  titre.fr: chiffre d'affaires (H.T.)
+  résumé.en: '[automatic] Total amount of transactions (excluding tax)'
+  résumé.fr: Le montant total des transactions (hors taxe)
+  titre.en: '[automatic] revenues'
+  titre.fr: chiffre d'affaires
 entreprise . chiffre d'affaires de société:
   titre.en: company turnover
   titre.fr: chiffre d'affaires de société

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -3948,6 +3948,58 @@ dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . exonération PCV
 dirigeant . indépendant . PL . CARCDSF . retraite complémentaire:
   titre.en: '[automatic] supplementary pension (CARCDSF)'
   titre.fr: retraite complémentaire (CARCDSF)
+? dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire
+: description.en: >
+    [automatic] You have the possibility of benefiting from a contribution
+    reduction
+
+    for the supplementary pension if you apply for it. More information
+
+    more](/documentation/lead/independent/WFP/WFP/CARCDSF/additional withdrawal/removal)
+  description.fr: >
+    Vous avez la possibilité de bénéficier d'une réduction de cotisation
+
+    pour la retraite complémentaire si vous en faites la demande. [En savoir
+
+    plus](/documentation/dirigeant/indépendant/PL/PAM/CARCDSF/retraite-complémentaire/forfaitaire/réduction)
+  note.en: >
+    [automatic] Affiliates whose net professional income for the year N-1 is
+    less than 85%.
+
+    % of the PASS in force on 1 January of the year in question (€34,966 in 2020)
+
+    may, on request, obtain a reduction in the lump-sum contribution.
+
+
+    The reduction coefficient applied shall be equal to the ratio of income
+
+    non-salaried professionals on the above-mentioned threshold.
+
+
+    The request must be addressed to the CARDSF and be accompanied by a
+
+    photocopy of the tax return no. 2042 C or 2035 or 2065 and their
+
+    annexes (2033 B and D or 2053 and 2058 A) for the year 2019.
+  note.fr: >
+    Les affiliés dont les revenus professionnels nets sur l'année N-1 sont
+    inférieurs à 85
+
+    % du PASS en vigueur au 1er janvier de l’année considérée (34 966 € en 2020)
+
+    peuvent, sur demande, obtenir une réduction de la cotisation forfaitaire.
+
+
+    Le coefficient de réduction appliqué est égal au rapport des revenus
+
+    professionnels non-salariés sur le seuil mentionné ci-dessus.
+
+
+    La demande doit être adressée à la CARCDSF et être accompagnée d’une
+
+    photocopie de la déclaration d’impôt n° 2042 C ou 2035 ou 2065 et de leurs
+
+    annexes (2033 B et D ou 2053 et 2058 A) de l’année 2019.
 dirigeant . indépendant . PL . CARCDSF . sage-femme:
   titre.en: '[automatic] midwife'
   titre.fr: sage-femme
@@ -4724,6 +4776,27 @@ dirigeant . indépendant . assiette des cotisations:
   description.fr: Il s'agit de l'assiette des cotisations sociales, nombre forcément positif
   titre.en: '[automatic] contribution base'
   titre.fr: assiette des cotisations
+dirigeant . indépendant . avertissement base forfaitaire:
+  description.en: >-
+    [automatic] When you start your activity, as your professional income is not
+    known, the contributions and fees for the first two years are calculated on
+    a flat-rate basis.
+
+    This base is 19% of the annual Social Security ceiling for the first and second year of activity.
+
+    There is an adjustment in the second year based on the actual income declared for the previous year.
+
+    This simulator calculates the cruise contributions (after adjustment). It therefore allows you to know the amount to be accrued for the regularization.
+  description.fr: >-
+    Lorsque vous commencez votre activité, vos revenus professionnels n’étant
+    pas connus, les cotisations et contributions des deux premières années sont
+    calculées sur une base forfaitaire.
+
+    Cette base s’élève à 19 % du plafond annuel de la Sécurité sociale au titre de la première et de la deuxième année d’activité.
+
+    Il y a un ajustement au cours de la deuxième année en fonction des revenus réels déclarés pour l'année précédente.
+
+    Ce simulateur calcul les cotisations au régime de croisière (après régularisation). Il vous permet donc de connaître le montant à provisionner pour la régularisation.
 dirigeant . indépendant . conjoint collaborateur:
   description.en: >
     [automatic] Allows the executive's spouse to be covered by social protection
@@ -4904,27 +4977,6 @@ dirigeant . indépendant . contrats madelin . retraite . montant:
 dirigeant . indépendant . contrats madelin . retraite . plafond:
   titre.en: ceiling
   titre.fr: plafond
-dirigeant . indépendant . contrôle base forfaitaire:
-  description.en: >-
-    [automatic] When you start your activity, as your professional income is not
-    known, the contributions and fees for the first two years are calculated on
-    a flat-rate basis.
-
-    This base is 19% of the annual Social Security ceiling for the first and second year of activity.
-
-    There is an adjustment in the third year based on the actual income declared in the two previous years.
-
-    This simulator calculates the contributions to the cruise scheme (after regularisation). It therefore allows you to know the amount to be accrued for the regularization.
-  description.fr: >-
-    Lorsque vous commencez votre activité, vos revenus professionnels n’étant
-    pas connus, les cotisations et contributions des deux premières années sont
-    calculées sur une base forfaitaire.
-
-    Cette base s’élève à 19 % du plafond annuel de la Sécurité sociale au titre de la première et de la deuxième année d’activité.
-
-    Il y a un ajustement la troisième année en fonction des revenus réels déclarées lors des deux années précédentes.
-
-    Ce simulateur calcul les cotisations au régime de croisière (après régularisation). Il vous permet donc de connaître le montant à provisionner pour la régularisation.
 dirigeant . indépendant . cotisations et contributions:
   description.en: >
     [automatic] This is the total amount owed by the self-employed person in

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -4985,7 +4985,7 @@ dirigeant . indépendant . cotisations et contributions:
     mandatory contributions.
   description.fr: |
     C'est le montant total dû par l'indépendant au titre des cotisations et
-    contributions obligatoire.
+    contributions obligatoires.
   note.en: |
     [automatic] Unlike contributions, contributions are not reintroduced
     for the calculation of the CSG/CRDS. They also do not benefit from the

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -5558,17 +5558,6 @@ entreprise . catégorie d'activité . libérale règlementée:
   question.fr: Est-ce une activité libérale règlementée ?
   titre.en: regulated liberal
   titre.fr: libérale règlementée
-entreprise . catégorie d'activité . libérale règlementée . avertissement:
-  description.en: >-
-    [automatic] Attention, the simulator is not yet complete for regulated
-    professions:
-
-    - for supplementary retirement, only the interprofessional scale, that of the CIPAV, has been integrated for the moment. - Make sure that the auto-entrepreneur status is compatible with your regulated profession - for medical practitioners and medical auxiliaries (PAM), [the specificities of contribution calculation](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) and the [CURPS](https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) are not yet integrated.
-  description.fr: >-
-    Attention, le simulateur n'est pas encore complet pour les professions
-    libérales règlementées :
-
-    - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant. - assurez-vous que le statut auto-entrepreneur est bien compatible avec votre profession règlementée - pour les praticiens et auxiliaires médicaux (PAM), [les spécificités de calcul des cotisations](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) et la [CURPS](https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) ne sont pas encore intégrées.
 ? entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
 : titre.en: type of regulated liberal activity
   titre.fr: type d'activité libérale règlementée

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -1,7 +1,7 @@
-"404":
+'404':
   action: Return to safe place
   message: This page does not exist or no longer exists
-"<0>Covid-19 et chômage partiel </0>: <3>Calculez votre indemnité</3>": "<0>Covid-19 and Short-Time </0>Work: <3>Calculate Your Benefit</3>"
+'<0>Covid-19 et chômage partiel </0>: <3>Calculez votre indemnité</3>': '<0>Covid-19 and Short-Time </0>Work: <3>Calculate Your Benefit</3>'
 <0>Oui</0>: <0>Yes</0>
 A quoi servent mes cotisations ?: What's included in my contributions?
 Accueil: Home
@@ -28,16 +28,16 @@ Choisir plus tard: Choose later
 Chômage partiel: Partial unemployment
 Code d'intégration: Integration Code
 Commencer: Get started
-"Commerçant, artisan, ou libéral ?": Trader, craftsman, or liberal?
+'Commerçant, artisan, ou libéral ?': Trader, craftsman, or liberal?
 Comparaison statuts: Status comparison
 Continuer: Continue
 Coronavirus: Coronavirus
 Cotisations: Contributions
 Cotisations sociales: Social contributions
 Covid 19: Covid 19
-"Covid-19 : Calculer l'impact du chômage partiel": "Covid-19: Calculating the impact of short-time work"
-"Covid-19 : Découvrez les mesures de soutien aux entreprises": "Covid-19: Find out about business support measures"
-"Covid-19 : Découvrir les mesures de soutien aux entreprises": "Covid-19: Discovering Business Support Measures"
+"Covid-19 : Calculer l'impact du chômage partiel": 'Covid-19: Calculating the impact of short-time work'
+'Covid-19 : Découvrez les mesures de soutien aux entreprises': 'Covid-19: Find out about business support measures'
+'Covid-19 : Découvrir les mesures de soutien aux entreprises': 'Covid-19: Discovering Business Support Measures'
 Coût pour l'entreprise: Cost to the company
 Crée le: Created on
 Créer une: Create a
@@ -71,7 +71,7 @@ Gérant minoritaire: Managing director
 Habituellement: Usually
 Imprimer: Print
 Impôts: Taxes
-"Indemnité chômage partiel prise en charge par l'état :": "State-paid short-time working allowance :"
+"Indemnité chômage partiel prise en charge par l'état :": 'State-paid short-time working allowance :'
 Indépendant: Indépendant
 International: International
 Intégrer l'interface de simulation: Integrate the simulation interface
@@ -102,7 +102,7 @@ Pas en auto-entrepreneur: Not in auto-entrepreneur
 Pas implémenté: Not implemented
 Passer: Skip
 Personnalisez l'integration: Customize the integration
-"Perte de revenu net :": "Loss of net income :"
+'Perte de revenu net :': 'Loss of net income :'
 Plafonds des tranches: Wafer ceilings
 Plein écran: Fullscreen
 Plus d'informations: More information (fr)
@@ -130,7 +130,7 @@ Retour à mon activité: Back to my business
 Revenir à la documentation: Go back to documentation
 Revenu (incluant les dépenses liées à l'activité): Revenue (including expenses related to the activity)
 Revenu disponible: Disposable income
-"Revenu net avec chômage partiel :": "Net income with short-time work :"
+'Revenu net avec chômage partiel :': 'Net income with short-time work :'
 Revenu net mensuel: Monthly net income
 Réductions: Discounts
 Rémunération du dirigeant: Director's remuneration
@@ -154,7 +154,7 @@ Taux: Rate
 Taux calculé: Calculated rate
 Taux moyen: Average rate
 Total des retenues: Total withheld
-"Total payé par l'entreprise :": "Total paid by the company :"
+"Total payé par l'entreprise :": 'Total paid by the company :'
 Tout effacer: Delete all
 Tranche de l'assiette: Scale bracket
 Un seul associé: Only one partner
@@ -214,11 +214,11 @@ après:
     registered, you'll have access to the following
   kbis:
     description:
-      "1": It is the official document attesting to <2>the legal existence of a
+      '1': It is the official document attesting to <2>the legal existence of a
         commercial enterprise</2>. In most cases, to be opposable and authentic
         for administrative procedures, the extract must be less than 3 months
         old.
-      "2": This document is generally requested when applying for a public tender,
+      '2': This document is generally requested when applying for a public tender,
         opening a professional bank account, purchasing professional equipment
         from distributors, etc.
     titre: The Kbis
@@ -272,7 +272,7 @@ autoentrepreneur:
   titre: Auto-entrepeneur
 back: Resume simulation
 barème: scale
-calcul-avec: "Calculation from <1></1>with :"
+calcul-avec: 'Calculation from <1></1>with :'
 cancelExample: Back to your situation
 car dépend de: because it depends on
 cible: target
@@ -384,8 +384,8 @@ comparaisonRégimes:
     AS: SAS, SASU or SARL with minority director
     auto: Auto-entreprise
     indep:
-      "1": EI, EIRL, EURL or SARL with majority director
-      "2": EI or EIRL
+      '1': EI, EIRL, EURL or SARL with majority director
+      '2': EI or EIRL
     legend: Possible legal status
   sécuritéSociale: |
     <0> Social security</0>
@@ -399,13 +399,13 @@ comparaisonRégimes:
   trimestreValidés: <0>Number of quarters validated <1>(for retirement)</1></0>
 composantes: components
 coronavirus:
-  description: "<0>Coronavirus and short-time working: what impact on my
+  description: '<0>Coronavirus and short-time working: what impact on my
     income?</0><1>The government is putting in place measures to support
     employees affected by the Coronavirus crisis. One of the key measures is the
-    assumption of the entire short-time working compensation by the State.</1>"
+    assumption of the entire short-time working compensation by the State.</1>'
   page:
     description: Estimate net income with short-time working benefits
-    titre: "Coronavirus and short-time working: what impact on your income?"
+    titre: 'Coronavirus and short-time working: what impact on your income?'
 cotisation: contribution
 créer:
   cta:
@@ -424,7 +424,7 @@ créer:
       <0>List of legal statuses</0>
       <1>EURL, SARL, SASU, etc: a shortcut if you already know your status </1>
   titre: Create a company
-  warningPL: "Note: the case of regulated liberal professions is not covered"
+  warningPL: 'Note: the case of regulated liberal professions is not covered'
 d'aides: of aid
 domiciliation inconnue: unknown address
 domiciliée à: domiciled in
@@ -540,9 +540,9 @@ entreprise:
       creation process. It is automatically saved in your browser.
     banque:
       description:
-        "1": The purpose of a <1>professional bank account</1> is to separate your
+        '1': The purpose of a <1>professional bank account</1> is to separate your
           company's assets from your personal assets.
-        "2": "The professional bank account allows you to:"
+        '2': 'The professional bank account allows you to:'
         EI: If its opening is not obligatory for an EI, it is strongly recommended.
         liste: >
           <0>Differentiate your private and professional operations and simplify
@@ -745,13 +745,13 @@ indicationTempsPlein: in full-time gross salary equivalent
 inférieurs à: lower than
 jour: day
 landing:
-  aboutUs: "<0>Who are we ?</0><1>We are a small<2>, autonomous and
+  aboutUs: '<0>Who are we ?</0><1>We are a small<2>, autonomous and
     multidisciplinary team</2> within<4> URSSAF</4>. We have at heart to be
     close to your needs in order to constantly improve this site in accordance
     with the <7>beta.gouv.fr</7> approach.</1><2>We have developed this site to
     <2>support entrepreneurs</2> in the development of their business.</2><3>Our
     goal is to <2>remove all uncertainties with regard to the administration</2>
-    so that you can concentrate on what matters: your business.</3>"
+    so that you can concentrate on what matters: your business.</3>'
   choice:
     create: <0>Create a company</0><1>Assistance in choosing the status and the
       complete list of creation steps</1>
@@ -760,7 +760,7 @@ landing:
       flow.</1>
     simulators: <0>Access the simulators</0><1>The exhaustive list of all the
       simulators available on the site.</1>
-  covid19: "Covid-19: Calculating the impact of short-time work"
+  covid19: 'Covid-19: Calculating the impact of short-time work'
   seeSimulators: See the simulators list
   subtitle: All the resources you need to develop your business, from legal status
     to hiring.
@@ -819,13 +819,13 @@ pages:
         authorities concerning auto-entrepreneurs and the micro-enterprise
         scheme (in french).</1></0>
   dévelopeurs:
-    bibliothèque: "<0>Integrate our calculation library</0><1>If you think that your
+    bibliothèque: '<0>Integrate our calculation library</0><1>If you think that your
       site or service would benefit from displaying salary calculations, for
       example switching from gross salary to net salary, good news: all the
       contribution and tax calculations behind my-company.fr are free and <2>can
       be integrated in the form of an <2>NPM library</2></2>.</1><2>Put simply,
-      your team's developers are able to integrate the calculation into your
-      interface in 5 minutes{emoji('⌚')}, without having to deal with the
+      your team''s developers are able to integrate the calculation into your
+      interface in 5 minutes{emoji(''⌚'')}, without having to deal with the
       complexity of payroll and the regular updating of calculation
       rules.</2><3>This library is a common digital library developed by the
       State and ACOSS. It is based on a new programming language,
@@ -836,36 +836,36 @@ pages:
       recipe for a calculation is simple: input variables (gross wage), one or
       more output variables (net wage).</9><10>All these variables are listed
       and explained in our <2>online documentation</2>.</10><11>Use the search
-      engine to find the right variable, then click on \"View source code\" to
-      get all the documentation: default value, possible values when it's an
-      enumeration of choice, unit when it's a number, description, associated
-      user question, etc.</11><12>Let's run a calculation closer to a payslip:
+      engine to find the right variable, then click on "View source code" to
+      get all the documentation: default value, possible values when it''s an
+      enumeration of choice, unit when it''s a number, description, associated
+      user question, etc.</11><12>Let''s run a calculation closer to a payslip:
       Here is a description of the input situation with links to the
       corresponding pages of the documentation :</12><13> An <3>executive</3>
       earning <7>€3,400 gross</7>, who benefits from the<10> bicycle mileage
       allowance</10> and works in a company with <14>12
       employees</14>.</13><14>The calculation for this more complete example is
-      as follows:</14><15><0></0></15><16>{emoji('ℹ️ ')} Note that in the
+      as follows:</14><15><0></0></15><16>{emoji(''ℹ️ '')} Note that in the
       previous example we have to specify the transport payment rate
       ourselves.</16><17>Whereas in the <2>employee</2> simulator, it is
       sufficient to fill in the municipality and the corresponding rate is
-      automatically determined. It's intentional: to keep the library (and the
+      automatically determined. It''s intentional: to keep the library (and the
       site) light, we use two online APIs. The<4> Geo API - communes</4> to
       switch from the commune name to the common code. Then the<7> transport
       payout API</7>, developed and maintained by us, which is not documented
       but its use is very simple and understandable <10>in this React component
       that calls it</10>, a component that also uses the common
-      API.</17><18>Making economic charts{emoji(' 📈')}</18><19>It is also
+      API.</17><18>Making economic charts{emoji('' 📈'')}</18><19>It is also
       possible to use the library for economic or political analysis
       calculations. Here, the price of labour and the net wage is plotted
       against the gross wage.</19><20>We can see the progressiveness of the
       total wage, which is in percent lower for a minimum wage than for a high
       income. In other words, high-wage earners pay part of the social security
-      contributions of low-wage earners.</20><21>{emoji('⚠️ ')}Beware, this
+      contributions of low-wage earners.</20><21>{emoji(''⚠️ '')}Beware, this
       example does a lot of calculations in one go, which can block your browser
       for a few seconds. To overcome this problem, you would have to call the
       library in a Web Worker, but this is not possible for the <3>moment</3> in
-      these demos.</21><22><0></0></22>"
+      these demos.</21><22><0></0></22>'
   développeurs:
     choice:
       github: <0>Contribute to GitHub</0><1>All our tools are open and publicly
@@ -876,10 +876,10 @@ pages:
       publicode: <0>Publicodes</0><1>Our tools are powered by Publicodes, a new
         language for encoding "explainable" algorithms.</1>
     code:
-      description: "Here is the code to copy and paste on your site:"
+      description: 'Here is the code to copy and paste on your site:'
       titre: Integration Code
-    code à copier: "Here is the code to copy and paste on your site:"
-    couleur: "What color? "
+    code à copier: 'Here is the code to copy and paste on your site:'
+    couleur: 'What color? '
     home:
       choice:
         iframe: <0>Integrating a simulator</0><1>Integrate one of our simulators in one
@@ -903,18 +903,18 @@ pages:
       meta:
         description: Calculation of your income based on turnover, after deduction of
           contributions and income tax.
-        ogDescription: "Thanks to the auto-entrepreneur income simulator developed by
+        ogDescription: 'Thanks to the auto-entrepreneur income simulator developed by
           URSSAF, you can estimate the amount of your income based on your
           monthly or annual turnover to better manage your cash flow. Or in the
           opposite direction: to know what amount to invoice to achieve a
-          certain income."
-        ogTitle: "Auto-entrepreneur: quickly calculate your net income from sales and
-          vice versa"
-        titre: "Auto-entrepreneurs: income simulator"
-      seo explanation: "<0>How do you calculate the net income for an
+          certain income.'
+        ogTitle: 'Auto-entrepreneur: quickly calculate your net income from sales and
+          vice versa'
+        titre: 'Auto-entrepreneurs: income simulator'
+      seo explanation: '<0>How do you calculate the net income for an
         auto-entrepreneur?</0><1>An auto-entrepreneur has to pay social
         security         contributions to the administration (also known as
-        \"social charge\"). These social contributions are used to finance
+        "social charge"). These social contributions are used to finance
         social security, and give rights for retirement or health insurance.
         They are also used to finance vocational training.</1><2><0></0> <2>See
         details of how the contributions are calculated</2></2><3>But this is
@@ -922,7 +922,7 @@ pages:
         account all expenses incurred in the course of the professional activity
         (assets, raw materials, premises, transport). Although they are not
         useful for the calculation of contributions and taxes, they must be
-        taken into account to estimate the viability of one''s
+        taken into account to estimate the viability of one''''s
         activity.</3><4>The complete calculation formula is therefore:<1><0>Net
         income = Turnover - Social contributions - Professional
         expenses</0></1></4><5>How to calculate income tax for an
@@ -936,7 +936,7 @@ pages:
         carried out. It is said to be lump-sum because it does not take into
         account the actual expenses incurred in the activity.</8><9><0></0>
         <2>See details of the calculation of the income allowance for an
-        auto-entrepreneur</2></9><10>Useful resources</10><11><0></0></11>'"
+        auto-entrepreneur</2></9><10>Useful resources</10><11><0></0></11>'''
       titre: Auto-entrepreneur income simulator
     chômage-partiel:
       explications seo: >-
@@ -979,11 +979,11 @@ pages:
           then be able to personalize your situation (part-time, agreement,
           etc). Take into account all contributions, including those specific to
           the allowance (CSG and CRDS).
-        ogTitle: "Short-time working simulator: find out the impact on the net salaried
-          income and the total employer cost."
+        ogTitle: 'Short-time working simulator: find out the impact on the net salaried
+          income and the total employer cost.'
         titre: Calculation of the short-time working allowance in France
     dirigean sasu:
-      explication seo: "<0>How to calculate the salary of a SASU executive? </0><1>As
+      explication seo: '<0>How to calculate the salary of a SASU executive? </0><1>As
         for a conventional employee, the SASU <1>manager</1> pays social
         security contributions on the salary he or she pays. The contributions
         are calculated in the same way as for the employee: they are broken down
@@ -992,15 +992,15 @@ pages:
         manager-employee does not pay <2>unemployment contributions</2>.
         Moreover, they do not benefit from the <5>general reduction</5> in
         contributions or from the schemes governed by the Labour Code, such as
-        <9>overtime</9> or bonuses.</2><3>A SASU executive's salary can be
-        calculated by entering the total amount of the salary in the \"total
-        expense\" box, but he or she can claim the <2>ACRE reduction</2> at the
+        <9>overtime</9> or bonuses.</2><3>A SASU executive''s salary can be
+        calculated by entering the total amount of the salary in the "total
+        expense" box, but he or she can claim the <2>ACRE reduction</2> at the
         beginning of the activity, under certain conditions.</3><4>You can use
         our simulator to calculate the <2>net remuneration</2> from a
-        super-gross amount allocated to the executive's remuneration. To do
+        super-gross amount allocated to the executive''s remuneration. To do
         this, simply enter the announced compensation in the total loaded box.
         The simulation can then be refined by answering the various
-        questions.</4>"
+        questions.</4>'
     salarié:
       explication seo: <0>Calculate your net salary</0><1>During the job interview,
         the employer usually offers a "gross" remuneration. The announced amount
@@ -1036,24 +1036,24 @@ pages:
           (executive status, internship, apprenticeship, overtime, restaurant
           vouchers, mutual insurance, part-time work, collective agreement,
           etc.).
-        ogTitle: "Gross, net, net after-tax salary, total cost: the ultimate simulator
-          for employees and employers"
-        titre: "Gross / net salary: the Urssaf converter"
+        ogTitle: 'Gross, net, net after-tax salary, total cost: the ultimate simulator
+          for employees and employers'
+        titre: 'Gross / net salary: the Urssaf converter'
       titre: Income simulator for employees
     sasu:
       meta:
         description: Calculation of net salary from turnover + expenses and vice versa.
         ogDescription: As an officer in a similar position, immediately calculate your
           net income after tax from the total allocated to your compensation.
-        ogTitle: "SASU executive compensation: a simulator to find out your net salary"
-        titre: "Head of SASU: Urssaf revenue simulator"
+        ogTitle: 'SASU executive compensation: a simulator to find out your net salary'
+        titre: 'Head of SASU: Urssaf revenue simulator'
       titre: Revenue simulator for SAS(U) executive
 par: per
 payslip:
   disclaimer: It takes into account national law but not union negotiated rules.
     Lots of financial aids for your enterprise exist, explore them on
     <1>aides-entreprises.fr (French)</1>.
-  heures: "Hours worked per month: "
+  heures: 'Hours worked per month: '
   notice: This simulation helps you understand your French payslip, but it should
     not be used as one. For further details, check <1>service-public.fr
     (French)</1>.
@@ -1165,8 +1165,11 @@ simulateurs:
         and income tax are taken into account. Official URSSAF simulator
       titre: Official income simulator for self-employed person
     titre: Self-employed income simulator
-  inversionFail: The amount entered does not enable us to calculate a result, we
-    invite you to try another value.
+  inversionFail: |
+    The amount entered results in an impossible result. This is due to a
+    threshold effect in the calculation of contributions.
+
+    We invite you to try again by slightly modifying the amount entered (a few euros more for example).
   profession-libérale:
     page:
       description: simulators.profession-liberal.page.description
@@ -1174,7 +1177,7 @@ simulateurs:
     titre: Income simulator for {professionName}.
   précision:
     bonne: Good accuracy
-    défaut: "Refine the simulation by answering the following questions:"
+    défaut: 'Refine the simulation by answering the following questions:'
     faible: Low accuracy
     moyenne: Medium accuracy
   résumé:
@@ -1223,7 +1226,7 @@ simulation-end:
   text: You have reached the most accurate estimate.
   title: No more questions left!
 site:
-  titleTemplate: "%s"
+  titleTemplate: '%s'
 statut du dirigeant:
   description: <0>This choice is important because it determines the social
     security regime and the social coverage of the manager. The amount and terms
@@ -1274,8 +1277,8 @@ une de ces conditions: one of these applies
       onwards, these revenues will be automatically reported by the platforms to
       the tax authorities and Urssaf.</2>
     question: What types of activity did you undertake?
-    réassurance: "PS: this tool is only there to inform you, no data will be
-      transmitted to the administrations"
+    réassurance: 'PS: this tool is only there to inform you, no data will be
+      transmitted to the administrations'
     titre: How to declare income from digital platforms?
   activité:
     choix: What are more precisely the activities carried out?

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -465,7 +465,13 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ACRE:
   applicable si: entreprise . ACRE
   formule:
     produit:
-      assiette: cotisations - cotisations . retraite complémentaire
+      assiette:
+        somme:
+          - maladie
+          - retraite de base
+          - indemnités journalières maladie
+          - invalidité et décès
+          - allocations familiales
       taux: taux
       facteur: prorata sur l'année
 
@@ -598,9 +604,9 @@ dirigeant . indépendant . conjoint collaborateur . assiette . revenu avec parta
     règle: assiette des cotisations
     par: assiette des cotisations - cotisations . assiette
     dans:
-      - cotisations et contributions . cotisations . retraite de base
-      - cotisations et contributions . cotisations . retraite complémentaire
-      - cotisations et contributions . cotisations . invalidité et décès
+      - cotisations et contributions . retraite de base
+      - cotisations et contributions . retraite complémentaire
+      - cotisations et contributions . invalidité et décès
 dirigeant . indépendant . conjoint collaborateur . assiette . revenu sans partage:
   description: Le conjoint collaborateur paiera des cotisations sociales calculées sur une base d'un pourcentage du assiette des cotisations du gérant de l'entreprise (un tiers ou la moitié).
   formule: assiette = 'revenu sans partage'
@@ -672,9 +678,10 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite compl
       assiette: retraite complémentaire . assiette
       tranches:
         - taux: 7%
-          plafond: cotisations et contributions . cotisations . retraite complémentaire . plafond
+          plafond: cotisations et contributions . retraite complémentaire . plafond
         - taux: 8%
           plafond: 4 * plafond sécurité sociale temps plein
+    arrondi: oui
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire . assiette:
   titre: assiette retraite complémentaire
@@ -719,30 +726,53 @@ dirigeant . indépendant . cotisations et contributions . cotisations:
       - indemnités journalières maladie
       - invalidité et décès
       - allocations familiales
+      - conjoint collaborateur . cotisations
+      - PCV
+      - (- exonérations)
 
 dirigeant . indépendant . cotisations et contributions:
+  description: |
+    C'est le montant total dû par l'indépendant au titre des cotisations et
+    contributions obligatoire.
+
   formule:
     somme:
       - cotisations
       - CSG et CRDS
+      - contributions spéciales
       - formation professionnelle
-      - conjoint collaborateur . cotisations
-      - PLR
-      - (- exonérations)
-
-dirigeant . indépendant . cotisations et contributions . PLR:
-  titre: cotisations professions libérales réglementées
-  description: Cotisations spécifique aux professions libérales réglementées (medecins, avocats, etc.)
+  note: |
+    À la différence des cotisations, les contributions ne sont pas réintroduites
+    pour le calcul de la CSG/CRDS. Elles ne bénéficient pas non plus de la
+    réduction ACRE.
+dirigeant . indépendant . cotisations et contributions . contributions spéciales:
+  description: |
+    Certains régimes spéciaux peuvent ajouter des contributions additionnelles
+    (par exemple, la CURPS pour les CPAM)
   formule: non
 
-dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac:
+dirigeant . indépendant . cotisations et contributions . PCV:
+  titre: Prestations complémentaires vieillesse
+  acronyme: PCV
+  formule: non
+  description: |
+    Certaines catégories professionnelles bénéficient de
+    prestations complémentaires vieillesse (PCV), auparavant nommées « avantage
+    social vieillesse » (ASV). Cela concerne les médecins généralistes, les
+    chirurgiens-dentistes, les sages-femmes, les auxiliaires médicaux et les
+    directeurs de laboratoires. Ce régime résulte de la prise en charge
+    partielle par l’Assurance maladie de leurs cotisations d’assurance
+    vieillesse sous réserve qu’ils aient exercé leur activité dans le cadre
+    conventionnel.
+
+dirigeant . indépendant . cotisations et contributions . déduction tabac:
   applicable si: entreprise . catégorie d'activité . débit de tabac
   question: Quel est le montant des revenus issus de la vente de tabac que vous souhaitez exonérer de cotisation vieillesse ?
   description: |
     Si vous exercez une activité de débit de tabac simultanément à une activité commerciale, vous avez la possibilité d’opter pour le calcul de votre cotisation d’assurance vieillesse sur le seul revenu tiré de votre activité commerciale (en effet, les remises pour débit de tabac sont soumises par ailleurs à un prélèvement vieillesse particulier). Nous attirons cependant votre attention sur le fait qu’en cotisant sur une base moins importante, excluant les revenus de débit de tabac, vos droits à retraite pour l’assurance vieillesse des commerçants en seront diminués.
   par défaut: 0 €/an
 
-dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac . revenus déduits:
+dirigeant . indépendant . cotisations et contributions . déduction tabac . revenus déduits:
   titre: assiette des cotisations (avec déduction tabac)
   applicable si: déduction tabac
   remplace:
@@ -857,7 +887,7 @@ dirigeant . indépendant . contrats madelin . retraite . plafond:
     Bofip: https://bofip.impots.gouv.fr/bofip/1124-PGP.html
     LegiFiscal: https://www.legifiscal.fr/impots-personnels/impot-revenu/deduction-des-contrats-madelin-retraite.html
 
-dirigeant . indépendant . cotisations et contributions . cotisations . indemnités journalières maladie:
+dirigeant . indépendant . cotisations et contributions . indemnités journalières maladie:
   description: |
     Cotisations pour les indemnités journalières des indépendants. Si l'état de
     santé des artisans, commerçants, industriels et conjoints collaborateurs
@@ -869,7 +899,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . indemnit
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
+dirigeant . indépendant . cotisations et contributions . maladie:
   formule:
     barème:
       assiette [ref]:
@@ -891,14 +921,14 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie:
 
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux variable:
+dirigeant . indépendant . cotisations et contributions . maladie . taux variable:
   formule:
     variations:
       - si: situation personnelle . RSA
         alors: taux RSA
       - sinon: taux
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA:
+dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
   formule:
     encadrement:
       valeur: taux RSA part variable + 1.35%
@@ -906,14 +936,14 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
   note: |
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux RSA part variable:
+dirigeant . indépendant . cotisations et contributions . maladie . taux RSA part variable:
   unité: '%'
   formule:
     produit:
       assiette: 5%
       taux: assiette des cotisations / (110% * plafond sécurité sociale temps plein)
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie . taux:
+dirigeant . indépendant . cotisations et contributions . maladie . taux:
   formule:
     taux progressif:
       assiette: assiette des cotisations
@@ -933,7 +963,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . maladie 
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
-dirigeant . indépendant . cotisations et contributions . cotisations . retraite de base:
+dirigeant . indépendant . cotisations et contributions . retraite de base:
   formule:
     barème:
       assiette [ref]:
@@ -948,7 +978,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
   références:
     Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire:
+dirigeant . indépendant . cotisations et contributions . retraite complémentaire:
   formule:
     barème:
       assiette: assiette des cotisations
@@ -958,12 +988,12 @@ dirigeant . indépendant . cotisations et contributions . cotisations . retraite
         - taux: 8%
           plafond: 4 * plafond sécurité sociale temps plein
 
-dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire . plafond:
+dirigeant . indépendant . cotisations et contributions . retraite complémentaire . plafond:
   acronyme: PRCI
   titre: plafond retraite complémentaire des indépendants
   formule: 38340 €/an
 
-dirigeant . indépendant . cotisations et contributions . cotisations . invalidité et décès:
+dirigeant . indépendant . cotisations et contributions . invalidité et décès:
   formule:
     produit:
       assiette [ref]:
@@ -975,7 +1005,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations . invalidi
   références:
     Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-dirigeant . indépendant . cotisations et contributions . cotisations . exonération de cotisations minimales:
+dirigeant . indépendant . cotisations et contributions . exonération de cotisations minimales:
   applicable si: situation personnelle . RSA
   remplace:
     - invalidité et décès . assiette . plancher
@@ -1029,14 +1059,14 @@ dirigeant . indépendant . revenus étrangers . montant:
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette:
   note: >-
     Seule la partie imposable des IJSS est retranchée de l'assiette de la CSG,
-    puisque la partie non imposable a déjà été retranchée du revenu net fiscal fourni
+    puisque la partie non imposable a déjà été retranchée du revenu net fiscal
+    fourni
   formule:
     allègement:
       assiette:
         somme:
           - revenu professionnel
           - cotisations
-          - conjoint collaborateur . cotisations
       abattement:
         somme:
           - revenus étrangers . montant
@@ -1045,7 +1075,7 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS . assiette
 dirigeant . indépendant . cotisations et contributions . formation professionnelle:
   formule:
     produit:
-      assiette: plafond sécurité sociale temps plein
+      assiette: plafond sécurité sociale temps plein [€/an]
       taux:
         variations:
           - si: entreprise . catégorie d'activité = 'artisanale'
@@ -1060,7 +1090,7 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
     fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-indépendant/transfert-du-recouvrement-de-la.html
 
-dirigeant . indépendant . cotisations et contributions . cotisations . allocations familiales:
+dirigeant . indépendant . cotisations et contributions . allocations familiales:
   formule:
     produit:
       assiette: assiette des cotisations
@@ -1084,7 +1114,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
   applicable si: établissement . ZFU
   formule:
     produit:
-      assiette: cotisations . maladie
+      assiette: maladie
       taux: taux
       # TODO : Le plafond est proratisé en début / fin d'exonération
       plafond:
@@ -1097,7 +1127,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   description: Ce dispositif a été arrêté en 2015, mais est toujours actif pour les personnes qui en bénéficiait avant son abbrogation.
   par défaut: non
   applicable si: entreprise . date de création < 01/2016
-  rend non applicable: cotisations . invalidité et décès
+  rend non applicable: invalidité et décès
 
 dirigeant . indépendant . cotisations et contributions . exonérations . invalidité:
   question: Êtes-vous titulaire d’une pension d’invalidité à titre de travailleur indépendant ?
@@ -1105,9 +1135,9 @@ dirigeant . indépendant . cotisations et contributions . exonérations . invali
   par défaut: non
   rend non applicable:
     - exonérations . ZFU
-    - cotisations . maladie
-    - cotisations . indemnités journalières maladie
-    - cotisations . retraite complémentaire
+    - maladie
+    - indemnités journalières maladie
+    - retraite complémentaire
 
 dirigeant . indépendant . cotisations et contributions . exonérations . ZFU . taux:
   titre: taux exonération ZFU
@@ -1148,7 +1178,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ZFU . 
               - plafond: 9 ans
                 taux: 0%
 
-dirigeant . indépendant . cotisations et contributions . cotisations . maladie domiciliation fiscale étranger:
+dirigeant . indépendant . cotisations et contributions . maladie domiciliation fiscale étranger:
   applicable si: situation personnelle . domiciliation fiscale à l'étranger
   titre: Maladie (domiciliation fiscale à l'étranger)
   description: En contrepartie de l'exonération de CSG, les cotisants ont un taux maladie plus elevé. Contrairement aux autres assurés commerçants/artisans ils ne bénéficient pas de la réduction du taux de la cotisation maladie en fonction du revenu déclaré.

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -474,6 +474,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ACRE:
           - allocations familiales
       taux: taux
       facteur: prorata sur l'année
+    arrondi: oui
 
 dirigeant . indépendant . cotisations et contributions . exonérations . ACRE . PSS proratisé:
   formule:
@@ -511,7 +512,8 @@ dirigeant . indépendant . revenu net de cotisations:
     - résultat comptable
   formule:
     somme:
-      - revenu professionnel
+      - valeur: revenu professionnel
+        arrondi: oui
       - (- cotisations et contributions . CSG et CRDS .non déductible)
       - (- contrats madelin . part non-déductible fiscalement)
   résumé: Avant déduction de l'impôt sur le revenu
@@ -553,8 +555,8 @@ dirigeant . indépendant . revenu professionnel:
         - revenu net après impôt
         - entreprise . chiffre d'affaires
         - entreprise . chiffre d'affaires minimum
-
       valeurs négatives possibles: oui
+    arrondi: oui
 
 dirigeant . indépendant . assiette des cotisations:
   description: Il s'agit de l'assiette des cotisations sociales, nombre forcément positif
@@ -659,6 +661,7 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . assiette retra
       - cotisations . assiette
       - 5.25% * plafond sécurité sociale temps plein
       - 200 heures/an * SMIC horaire
+    arrondi: oui
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite de base:
   unité: €/an
@@ -670,6 +673,7 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite de ba
         - taux: 17.75%
           plafond: 1
         - taux: 0.6%
+    arrondi: oui
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire:
   unité: €/an
@@ -706,6 +710,7 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et
       assiette: assiette
       taux: 1.3%
       plafond: plafond sécurité sociale temps plein
+    arrondi: oui
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . indemnités journalières maladie:
   unité: €/an
@@ -714,6 +719,7 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . indemnités jo
       assiette: plafond sécurité sociale temps plein
       facteur: 40%
       taux: 0.85%
+    arrondi: oui
 
 dirigeant . indépendant . cotisations et contributions . cotisations:
   références:
@@ -898,6 +904,7 @@ dirigeant . indépendant . cotisations et contributions . indemnités journaliè
       assiette: maladie . assiette
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
+    arrondi: oui
 
 dirigeant . indépendant . cotisations et contributions . maladie:
   formule:
@@ -911,6 +918,7 @@ dirigeant . indépendant . cotisations et contributions . maladie:
         - taux: taux variable
           plafond: 5
         - taux: 6.5%
+    arrondi: oui
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
     Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
@@ -975,6 +983,7 @@ dirigeant . indépendant . cotisations et contributions . retraite de base:
         - taux: 17.75%
           plafond: 1
         - taux: 0.6%
+    arrondi: oui
   références:
     Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
@@ -987,6 +996,7 @@ dirigeant . indépendant . cotisations et contributions . retraite complémentai
           plafond: plafond
         - taux: 8%
           plafond: 4 * plafond sécurité sociale temps plein
+    arrondi: oui
 
 dirigeant . indépendant . cotisations et contributions . retraite complémentaire . plafond:
   acronyme: PRCI
@@ -1002,6 +1012,7 @@ dirigeant . indépendant . cotisations et contributions . invalidité et décès
           plancher [ref]: 11.5% * plafond sécurité sociale temps plein
       taux: 1.3%
       plafond: plafond sécurité sociale temps plein
+    arrondi: oui
   références:
     Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
@@ -1036,6 +1047,7 @@ dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
             impôt sur le revenu: déductible
           assiette: dirigeant . indépendant . IJSS . total
           taux: 3.8%
+    arrondi: oui
 
   références:
     fiche URSSAF: https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/les-contributions-csg-crds/taux-de-la-csg-crds.html
@@ -1083,6 +1095,7 @@ dirigeant . indépendant . cotisations et contributions . formation professionne
           - si: conjoint collaborateur
             alors: 0.34%
           - sinon: 0.25%
+    arrondi: oui
   note: Le taux n'est pas majoré pour les artisans avec conjoint collaborateur
 
   références:
@@ -1103,6 +1116,7 @@ dirigeant . indépendant . cotisations et contributions . allocations familiales
               taux: 0%
             - plafond: 140%
               taux: 3.1%
+    arrondi: oui
 
 dirigeant . indépendant . cotisations et contributions . exonérations:
   formule:
@@ -1121,6 +1135,7 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ZFU:
         recalcul:
           avec:
             dirigeant . indépendant . revenu professionnel: 3042 heures/an * SMIC horaire
+    arrondi: oui
 
 dirigeant . indépendant . cotisations et contributions . exonérations . âge:
   question: Bénéficiez-vous du dispositif d'exonération "âge"
@@ -1187,6 +1202,7 @@ dirigeant . indépendant . cotisations et contributions . maladie domiciliation 
     produit:
       assiette: maladie . assiette
       taux: 14.5%
+  arrondi: oui
 
 dirigeant . indépendant . IJSS:
   titre: indemnités journalières de sécurité sociale

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -440,7 +440,7 @@ dirigeant . indépendant:
   rend non applicable: contrat salarié
   formule: dirigeant = 'indépendant'
 
-dirigeant . indépendant . contrôle base forfaitaire:
+dirigeant . indépendant . avertissement base forfaitaire:
   type: notification
   applicable si:
     toutes ces conditions:
@@ -454,8 +454,8 @@ dirigeant . indépendant . contrôle base forfaitaire:
     Cette base s’élève à 19 % du plafond annuel de la Sécurité sociale au titre de
     la première et de la deuxième année d’activité.
 
-    Il y a un ajustement la troisième année en fonction des revenus réels
-    déclarées lors des deux années précédentes.
+    Il y a un ajustement au cours de la deuxième année en fonction des
+    revenus réels déclarés pour l'année précédente.
 
     Ce simulateur calcul les cotisations au régime de croisière (après
     régularisation). Il vous permet donc de connaître le montant à

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -545,7 +545,6 @@ dirigeant . indépendant . revenu professionnel:
         - résultat fiscal
         - rémunération totale
         - revenu net après impôt
-        - PL . PAM . honoraires
         - entreprise . chiffre d'affaires
         - entreprise . chiffre d'affaires minimum
 

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -739,7 +739,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations:
 dirigeant . indépendant . cotisations et contributions:
   description: |
     C'est le montant total dû par l'indépendant au titre des cotisations et
-    contributions obligatoire.
+    contributions obligatoires.
 
   formule:
     somme:

--- a/mon-entreprise/source/rules/entreprise-établissement.yaml
+++ b/mon-entreprise/source/rules/entreprise-établissement.yaml
@@ -384,16 +384,6 @@ entreprise . catégorie d'activité . libérale règlementée:
   références:
     Liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales
 
-entreprise . catégorie d'activité . libérale règlementée . avertissement:
-  type: notification
-  sévérité: avertissement
-  description: >-
-    Attention, le simulateur n'est pas encore complet pour les professions libérales règlementées :
-
-    - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant.
-    - assurez-vous que le statut auto-entrepreneur est bien compatible avec votre profession règlementée
-    - pour les praticiens et auxiliaires médicaux (PAM), [les spécificités de calcul des cotisations](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) et la [CURPS](https://www.urssaf.fr/portail/home/indépendant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) ne sont pas encore intégrées.
-
 entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée:
   formule:
     une possibilité:

--- a/mon-entreprise/source/rules/entreprise-établissement.yaml
+++ b/mon-entreprise/source/rules/entreprise-établissement.yaml
@@ -52,9 +52,8 @@ entreprise . durée d'activité . en début d'année:
       jusqu'à: période . début d'année
 
 entreprise . chiffre d'affaires:
-  titre: chiffre d'affaires (H.T.)
   question: Quel est votre chiffre d'affaires envisagé ?
-  résumé: Le montant des ventes réalisées
+  résumé: Le montant total des transactions (hors taxe)
   unité: €/an
   formule: dirigeant . rémunération totale + charges
 

--- a/mon-entreprise/source/rules/impôt.yaml
+++ b/mon-entreprise/source/rules/impôt.yaml
@@ -6,9 +6,10 @@ impôt:
   formule:
     somme:
       - produit:
-          assiette: revenu imposable
+          assiette: revenu imposable [€/an]
           taux: taux d'imposition
-      - dirigeant . auto-entrepreneur . impôt . versement libératoire . montant
+      - dirigeant . auto-entrepreneur . impôt . versement libératoire . montant [€/an]
+    arrondi: oui
 
 impôt . taux d'imposition:
   formule:

--- a/mon-entreprise/source/rules/profession-libérale.yaml
+++ b/mon-entreprise/source/rules/profession-libérale.yaml
@@ -154,6 +154,7 @@ dirigeant . indépendant . PL . régime général . taux spécifique retraite co
           plafond: 1
         - taux: 14%
           plafond: 4
+    arrondi: oui
 
 dirigeant . indépendant . PL . régime général . maladie:
   titre: maladie (taux PLNR)
@@ -170,6 +171,7 @@ dirigeant . indépendant . PL . régime général . maladie:
               taux: 1.5%
             - plafond: 110%
               taux: 6.5%
+    arrondi: oui
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/taux-de-cotisations
     guide urssaf (pdf): https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Guide-Professions-liberales.pdf
@@ -296,6 +298,7 @@ dirigeant . indépendant . PL . retraite CNAVPL:
         - nom: tranche 2
           taux: 1.87%
           plafond: 5 * plafond sécurité sociale temps plein
+    arrondi: oui
   références:
     cnavpl.fr: https://www.cnavpl.fr/
     liste des caisses: https://www.cnavpl.fr/regimes-complementaires-et-prevoyance/
@@ -368,6 +371,7 @@ dirigeant . indépendant . PL . PAMC . CURPS:
             alors: 0.3%
           - sinon: 0.1%
     plafond: 0.50% * plafond sécurité sociale temps plein
+    arrondi: oui
   références:
     Fiche Urssaf.fr: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/la-base-de-calcul-et-le-taux-de.html
 
@@ -379,6 +383,7 @@ dirigeant . indépendant . PL . PAMC . maladie:
       - produit:
           assiette: assiette des cotisations
           taux: 6.50%
+        arrondi: oui
       - contribution additionnelle
       - (- participation CPAM)
 
@@ -438,12 +443,14 @@ dirigeant . indépendant . PL . PAMC . maladie . participation CPAM:
     produit:
       assiette: assiette participation CPAM
       taux: 6.40%
+    arrondi: oui
 
 dirigeant . indépendant . PL . PAMC . maladie . contribution additionnelle:
   formule:
     produit:
       assiette: (assiette des cotisations - assiette participation CPAM)
       taux: 3.25%
+    arrondi: oui
 
 dirigeant . indépendant . PL . PAMC . allocations familiales:
   applicable si: métier . secteur médecin = '1'
@@ -462,6 +469,7 @@ dirigeant . indépendant . PL . PAMC . allocations familiales:
             - montant: 75%
               plafond: 250%
             - montant: 60%
+    arrondi: oui
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/taux-et-baremes/taux-de-cotisations/les-praticiens-et-auxiliaires-me/taux-de-cotisations-medecin-sect.html
 
@@ -516,6 +524,7 @@ dirigeant . indépendant . PL . CARPIMKO . retraite complémentaire:
               plafond: 25246 €/an
             - taux: 3%
               plafond: 176413 €/an
+        arrondi: oui
   références:
     Site CARPIMKO: https://www.carpimko.com/cotisations/cotisations_cas_general
 
@@ -534,6 +543,7 @@ dirigeant . indépendant . PL . CARPIMKO . ASV:
       - forfaitaire
       - proportionnelle
       - (- participation CPAM)
+    arrondi: oui
   références:
     Taux 2020: http://www.carpimko.com/cotisations/cotisations_cas_general
 
@@ -554,6 +564,7 @@ dirigeant . indépendant . PL . CARPIMKO . ASV . participation CPAM:
           taux: 2 / 3
         arrondi: oui
       - 60% * proportionnelle
+
   références:
     Prise en charge CPAM: http://www.carpimko.com/cotisations/cotisations_cas_general
 
@@ -581,6 +592,7 @@ dirigeant . indépendant . PL . CARMF . retraite complémentaire:
       assiette: assiette des cotisations
       plafond: 3.5 * plafond sécurité sociale temps plein
       taux: 9.80%
+    arrondi: oui
   références:
     Site CARMF: http://www.carmf.fr/page.php?page=cdrom/coti/coti-chiffre.htm
 
@@ -610,6 +622,7 @@ dirigeant . indépendant . PL . CARMF . invalidité décès:
         - montant: 738 €/an
           plafond: 300%
         - montant: 863 €/an
+    arrondi: oui
   références:
     Montant des cotisations: http://www.carmf.fr/page.php?page=cdrom/coti/coti-cours.htm#base
     Détails des couvertures: http://www.carmf.fr/page.php?page=cdrom/prev/prev-chiffre.htm
@@ -628,6 +641,7 @@ dirigeant . indépendant . PL . CARMF . ASV:
               plafond: 5 * plafond sécurité sociale temps plein
               taux: 3.80%
       abattement: taux participation CPAM
+    arrondi: oui
 
   références:
     Taux 2020: http://www.carmf.fr/page.php?page=chiffrescles/stats/2020/taux2020.htm
@@ -657,6 +671,7 @@ dirigeant . indépendant . PL . CARCDSF . retraite complémentaire:
       - produit:
           assiette: 2960.40 €/an
           taux: réduction de la cotisation forfaitaire
+        arrondi: oui
       - barème:
           assiette: assiette des cotisations
           multiplicateur: plafond sécurité sociale temps plein
@@ -665,6 +680,7 @@ dirigeant . indépendant . PL . CARCDSF . retraite complémentaire:
               plafond: 0.85
             - taux: 10.65%
               plafond: 5
+    arrondi: oui
   références:
     Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
 
@@ -722,6 +738,7 @@ dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . PCV:
           assiette: assiette des cotisations
           plafond: 5 * plafond sécurité sociale temps plein
           taux: 0.725 %
+    arrondi: oui
   références:
     Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
 
@@ -796,6 +813,7 @@ dirigeant . indépendant . PL . CARCDSF . sage-femme . PCV:
     produit:
       assiette: 780 €/an
       taux: 1 / 3
+    arrondi: oui
   références:
     Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
   note: |

--- a/mon-entreprise/source/rules/profession-libérale.yaml
+++ b/mon-entreprise/source/rules/profession-libérale.yaml
@@ -12,7 +12,7 @@ dirigeant . indépendant . PL . métier:
     une possibilité:
       choix obligatoire: oui
       possibilités:
-        - PAM
+        - santé
         - rattaché CIPAV
 
 dirigeant . indépendant . PL . métier . rattaché CIPAV:
@@ -31,7 +31,7 @@ dirigeant . indépendant . PL . métier . rattaché CIPAV:
     - Ingénieur conseil
     - Guide-conférencier
 
-dirigeant . indépendant . PL . métier . PAM:
+dirigeant . indépendant . PL . métier . santé:
   titre: Practicien ou auxiliaire médical
   question: Quel métier exercez-vous en tant que professionnel de santé ?
   description: |
@@ -44,7 +44,6 @@ dirigeant . indépendant . PL . métier . PAM:
     > *Exceptions* : Les ostéopathe, psychologue, psychothérapeute, ergothérapeute,
     diététicien et chiropracteur ne dépendent pas du régime PAMC mais de la
     CIPAV pour leur retraite et invalidité.
-  par défaut: "'médecin'"
   formule:
     une possibilité:
       choix obligatoire: oui
@@ -54,21 +53,42 @@ dirigeant . indépendant . PL . métier . PAM:
         - sage-femme
         - auxiliaire médical
 
-dirigeant . indépendant . PL . métier . PAM . auxiliaire médical:
+dirigeant . indépendant . PL . métier . santé . auxiliaire médical:
   description: |
     Vous exercez un des métiers suivants : infirmier, masseur-kinésithérapeute, orthophoniste, orthoptiste ou pédicure-podologue.
-dirigeant . indépendant . PL . métier . PAM . médecin:
-dirigeant . indépendant . PL . métier . PAM . chirurgien-dentiste:
-dirigeant . indépendant . PL . métier . PAM . sage-femme:
-dirigeant . indépendant . PL . métier . PAM . médecin remplaçant:
-  description: |
-    Les médecin remplaçant généraliste ou spécialiste (étudiant, salarié ou
-    retraité) sont les honoraires rétrocédés ne dépassent pas 19 000 € par année
-    civile peuvent bénéficier d'un dispositif particulier pour le paiement de
-    leur cotisation de sécurité sociale.
 
-    Cela consiste en un taux unique de cotisations à 13,30%
-  références: https://www.calcul.urssaf.fr/medecin_remplacant.html
+dirigeant . indépendant . PL . métier . santé . chirurgien-dentiste:
+dirigeant . indépendant . PL . métier . santé . sage-femme:
+# dirigeant . indépendant . PL . métier . santé . médecin remplaçant:
+#   description: |
+#     Les médecin remplaçant généraliste ou spécialiste (étudiant, salarié ou
+#     retraité) sont les honoraires rétrocédés ne dépassent pas 19 000 € par année
+#     civile peuvent bénéficier d'un dispositif particulier pour le paiement de
+#     leur cotisation de sécurité sociale.
+
+#     Cela consiste en un taux unique de cotisations à 13,30%
+#   références: https://www.calcul.urssaf.fr/medecin_remplacant.html
+dirigeant . indépendant . PL . métier . santé . médecin:
+dirigeant . indépendant . PL . métier . secteur médecin:
+  applicable si: métier = 'santé . médecin'
+  question: Sur quel secteur êtes-vous conventionné ?
+  description: |
+    Les taux de cotisations et remboursement de la CPAM ne sont pas les même en
+    fonction du régime de tarification choisie par le praticien.
+  par défaut: "'1'"
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - '1'
+        - '2'
+        - 'non conventionné'
+
+dirigeant . indépendant . PL . métier . secteur médecin . 1:
+  titre: Secteur 1
+dirigeant . indépendant . PL . métier . secteur médecin . 2:
+  titre: Secteur 2
+dirigeant . indépendant . PL . métier . secteur médecin . non conventionné:
 
 dirigeant . indépendant . PL . option régime général:
   applicable si:
@@ -124,7 +144,7 @@ dirigeant . indépendant . PL . régime général . taux spécifique retraite co
 
 dirigeant . indépendant . PL . régime général . taux spécifique retraite complémentaire . montant:
   titre: retraite complémentaire (taux PLNR)
-  remplace: cotisations et contributions . cotisations . retraite complémentaire
+  remplace: cotisations et contributions . retraite complémentaire
   formule:
     barème:
       assiette: assiette des cotisations
@@ -137,7 +157,7 @@ dirigeant . indépendant . PL . régime général . taux spécifique retraite co
 
 dirigeant . indépendant . PL . régime général . maladie:
   titre: maladie (taux PLNR)
-  remplace: cotisations et contributions . cotisations . maladie
+  remplace: cotisations et contributions . maladie
   formule:
     produit:
       assiette: indépendant . assiette des cotisations
@@ -160,7 +180,7 @@ dirigeant . indépendant . PL . régime général . maladie:
 
 dirigeant . indépendant . PL . CIPAV:
   rend non applicable:
-    - cotisations et contributions . cotisations . indemnités journalières maladie
+    - cotisations et contributions . indemnités journalières maladie
     - conjoint collaborateur
   références:
     article de loi (chercher "travailleurs indépendants créant leur activité"): https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/texte#JORFARTI000036339157
@@ -173,7 +193,7 @@ dirigeant . indépendant . PL . CIPAV:
           - entreprise . catégorie d'activité . libérale règlementée = non
 
 dirigeant . indépendant . PL . CIPAV . retraite complémentaire:
-  remplace: cotisations et contributions . cotisations . retraite complémentaire
+  remplace: cotisations et contributions . retraite complémentaire
   titre: retraite complémentaire (CIPAV)
   formule:
     somme:
@@ -218,7 +238,7 @@ dirigeant . indépendant . PL . CIPAV . retraite complémentaire . réduction CO
   formule: 1392 €/an
 
 dirigeant . indépendant . PL . CIPAV . invalidité et décès:
-  remplace: cotisations et contributions . cotisations . invalidité et décès
+  remplace: cotisations et contributions . invalidité et décès
   titre: invalidité et décès (CIPAV)
   formule:
     variations:
@@ -265,10 +285,10 @@ dirigeant . indépendant . PL . retraite CNAVPL:
     libérales est l'organisme qui fédère les différentes caisses 
     existantes (CIPAV, CARPIMKO, CARCDSF, CAVEC etc..)
 
-  remplace: cotisations et contributions . cotisations . retraite de base
+  remplace: cotisations et contributions . retraite de base
   formule:
     produit:
-      assiette: cotisations et contributions . cotisations . retraite de base . assiette
+      assiette: cotisations et contributions . retraite de base . assiette
       composantes:
         - nom: tranche 1
           taux: 8.23%
@@ -280,83 +300,48 @@ dirigeant . indépendant . PL . retraite CNAVPL:
     cnavpl.fr: https://www.cnavpl.fr/
     liste des caisses: https://www.cnavpl.fr/regimes-complementaires-et-prevoyance/
 
-dirigeant . indépendant . PL . PAM:
+dirigeant . indépendant . PL . PAMC:
   applicable si:
     une de ces conditions:
-      - métier = 'PAM . médecin'
-      - métier = 'PAM . sage-femme'
-      - métier = 'PAM . chirugien-dentiste'
-      - métier = 'PAM . auxiliaire médical'
+      - toutes ces conditions:
+          - métier = 'santé . médecin'
+          - métier . secteur médecin != 'non conventionné'
+      - métier = 'santé . sage-femme'
+      - métier = 'santé . chirurgien-dentiste'
+      - métier = 'santé . auxiliaire médical'
   rend non applicable:
-    - cotisations et contributions . cotisations . indemnités journalières maladie
+    - cotisations et contributions . indemnités journalières maladie
     - conjoint collaborateur
     - entreprise . franchise de TVA
     - dirigeant . indépendant . revenus étrangers
   formule: oui
 
-# TODO : medecins remplacant comme micro-BNC avec taux cotisation unique (comme les auto-entrepreneurs)
-# dirigeant . indépendant . PL . PAM . remplaçant:
-#   applicable si: métier = 'PAM . médecin'
-#   rend non applicable:
-#     - entreprise . chiffre d'affaires
-#     - entreprise . charges
-#     - revenu professionnel
-#     - cotisations et contributions
-#   remplace:
-#     - règle: revenu net de cotisations
-#       par: rémunération totale - cotisations
-#     - règle: résultat fiscal
-#       par: revenu net de cotisations
-#   question: Bénéficiez-vous du dispositif de taux unique pour les médecins remplaçant ?
-#   par défaut: non
-#   description: |
-#     Les médecin remplaçant généraliste ou spécialiste (étudiant, salarié ou
-#     retraité) peuvent bénéficier d'un dispositif de taux unique de cotisations
-#     pour le paiement de leur cotisation de sécurité sociale.
+dirigeant . indépendant . PL . PAMC . proportion recette activité non conventionnée:
+  question: |
+    Quel est la part de votre chiffre d'affaires liée à une activité non
+    conventionnée (estimation) ?
+  par défaut: 0%
+  suggestion:
+    10%: 10%
+    30%: 30%
+  description: |
+    Les recettes non conventionnées sont toutes celles qui ne rentrent pas dans
+    les catégories suivantes : 
+        
+    - Honoraires tirés des actes remboursables (y compris les
+    dépassements d’honoraires et les frais de déplacement figurant sur le relevé
+    SNIR)
 
-#     Pour cela trois critères doivent être respecté:
+    - Honoraires issus de rétrocessions concernant les actes remboursables
+    perçues en qualité de remplaçant
 
-#     - Vous effectuez exclusivement des remplacements
+    - Toutes les rémunérations forfaitaires versées par l’assurance maladie
+    (aide à la télétransmission, indemnisation, indemnisation de la formation
+    continue, prime à l’installation, ...)
 
-#     - Vos honoraires rétrocédés ne dépassent pas 19 000 € par année civile
-
-#     - Vous n'exercez pas d'autre activité en tant que travailleur indépendant
-#   références:
-#     Portail médecins remplaçants: https://www.medecins-remplacants.urssaf.fr/accueil
-#   contrôles:
-#     - si:
-#         toutes ces conditions:
-#           - remplaçant
-#           - rémunération totale > 19000 €/an
-#       message: |
-#         Pour pouvoir bénéficier de ce dispositif, les revenus de remplacement ne
-#         doivent pas dépasser 19000€ pendant plus de deux années consécutives,
-#         ou 38000€ au cours d'une seule année.
-#       niveau: avertissement
-
-# dirigeant . indépendant . PL . PAM . remplaçant . cotisations:
-#   remplace:
-#     - règle: rémunération totale
-#       par:
-#         inversion numérique:
-#           avec:
-#             - revenu net de cotisations
-#             - revenu net après impôt
-#   formule:
-#     somme:
-#       - produit:
-#           assiette: rémunération totale
-#           taux: 13.30 %
-#       - 158 €/an
-
-dirigeant . indépendant . PL . PAM . cotisations additionnelles PAM:
-  remplace: cotisations et contributions . PLR
-  formule:
-    somme:
-      - CURPS
-      - PCV
-dirigeant . indépendant . PL . PAM . CURPS:
+dirigeant . indépendant . PL . PAMC . CURPS:
   titre: Contribution aux unions régionales des professionnels de santé
+  remplace: cotisations et contributions . contributions spéciales
   description: |
     Les professions libérales de santé sont représentées par des unions
     régionales des professionnels de santé qui contribuent à l’organisation et à
@@ -377,17 +362,17 @@ dirigeant . indépendant . PL . PAM . CURPS:
       assiette: assiette des cotisations
       taux:
         variations:
-          - si: métier = 'PAM . médecin'
+          - si: métier = 'santé . médecin'
             alors: 0.5%
-          - si: métier = 'PAM . chirurgien-dentiste'
+          - si: métier = 'santé . chirurgien-dentiste'
             alors: 0.3%
           - sinon: 0.1%
     plafond: 0.50% * plafond sécurité sociale temps plein
   références:
     Fiche Urssaf.fr: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/la-base-de-calcul-et-le-taux-de.html
 
-dirigeant . indépendant . PL . PAM . maladie:
-  remplace: cotisations et contributions . cotisations . maladie
+dirigeant . indépendant . PL . PAMC . maladie:
+  remplace: cotisations et contributions . maladie
   titre: maladie (après participation CPAM)
   formule:
     somme:
@@ -397,64 +382,77 @@ dirigeant . indépendant . PL . PAM . maladie:
       - contribution additionnelle
       - (- participation CPAM)
 
-dirigeant . indépendant . PL . PAM . dépassement d'honoraire moyen:
+dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen:
+  non applicable si: métier . secteur médecin = '1'
   question: Quels est votre dépassement honoraires moyen (estimation) ?
   par défaut: 0%
 
-dirigeant . indépendant . PL . PAM . assiette participation CPAM:
+dirigeant . indépendant . PL . PAMC . revenus activité conventionnée:
+  description: |
+    Les revenus conventionnés sont ceux correspondant aux recettes tirées des
+    honoraires et des rémunérations forfaitaires versées par la CPAM.
+  note: |
+    Pour éviter d'avoir à ventiler les charges entre celles issues de
+    l'activités conventionnées et celles qui ne le sont pas (ce qui aboutirait à
+    deux comptabilités distinct), on peut le calculer à partir du revenu
+    professionnel que l'on ajuste en fonction de la part du chiffre d'affaires
+    provenant des actes conventionnés.
+  formule:
+    produit:
+      assiette: assiette des cotisations
+      facteur: 100% - proportion recette activité non conventionnée
+
+dirigeant . indépendant . PL . PAMC . assiette participation CPAM:
   description: Aussi appelé revenu conventionnel, il s'agit du revenu des honoraires nets
     de dépassement.
-  formule: assiette des cotisations / (100% + dépassement d'honoraire moyen)
+  formule: revenus activité conventionnée  / (100% + dépassement d'honoraire moyen)
+  note: |
+    La formule référencée dans les textes Urssaf est la suivante : 
+    > (revenu de l’activité conventionnée) x (total des honoraires - total des dépassements d’honoraires) / montant total des honoraires. 
+
+    On peut simplififer cette formule en : 
+    > (revenu de l’activité conventionnée) / (100% + dépassement d'honoraire moyen)
+
+    ### Preuve
+    Si on prends les variables suivantes, 
+    > `h+` : total des honoraires (avec dépassement)
+      `h` : honoraires sans dépassement
+      `d%`: pourcentage de dépassement d'honoraire moyen
+
+    On a : 
+    >  
+      `h+ = h + h * d%`
+      `h+ = h * (100% + d%)`
+
+    Si on remplace dans la formule de l'assiette participation CPAM, on a :
+    > 1. `(revenu de l’activité conventionnée) * h / h+`
+    > 2. `(revenu de l’activité conventionnée) * h / (h * (100% + d%)) 
+    > 3. `(revenu de l’activité conventionnée) / (100% + d%)`
+
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me/je-suis-medecin-du-secteur-1/assiette-de-participation-de-la.html
 
-dirigeant . indépendant . PL . PAM . secteur:
-  applicable si: métier = 'PAM . médecin'
-  question: Sur quel secteur êtes-vous conventionné ?
-  description: |
-    Les taux de cotisations et remboursement de la CPAM ne sont pas les même en
-    fonction du régime de tarification choisie par le praticien.
-  par défaut: "'1'"
-  formule:
-    une possibilité:
-      choix obligatoire: oui
-      possibilités:
-        - '1'
-        - '2'
-
-dirigeant . indépendant . PL . PAM . secteur . 1:
-  titre: Secteur 1
-dirigeant . indépendant . PL . PAM . secteur . 2:
-  titre: Secteur 2
-
-dirigeant . indépendant . PL . PAM . maladie . participation CPAM:
-  non applicable si: secteur = '2'
+dirigeant . indépendant . PL . PAMC . maladie . participation CPAM:
+  non applicable si: métier . secteur médecin = '2'
   formule:
     produit:
       assiette: assiette participation CPAM
       taux: 6.40%
 
-dirigeant . indépendant . PL . PAM . maladie . contribution additionnelle:
+dirigeant . indépendant . PL . PAMC . maladie . contribution additionnelle:
   formule:
     produit:
       assiette: (assiette des cotisations - assiette participation CPAM)
       taux: 3.25%
 
-dirigeant . indépendant . PL . PAM . allocations familiales:
-  applicable si: secteur = '1'
+dirigeant . indépendant . PL . PAMC . allocations familiales:
+  applicable si: métier . secteur médecin = '1'
   titre: allocations familiales (après participation CPAM)
-  remplace: cotisations et contributions . cotisations . allocations familiales
+  remplace: cotisations et contributions . allocations familiales
   formule:
     allègement:
-      assiette: cotisations et contributions . cotisations . allocations familiales
-      abattement: participation CPAM
-
-dirigeant . indépendant . PL . PAM . allocations familiales . participation CPAM:
-  formule:
-    produit:
-      assiette: assiette participation CPAM
-      taux: cotisations et contributions . cotisations . allocations familiales . taux
-      facteur:
+      assiette: cotisations et contributions . allocations familiales
+      abattement:
         grille:
           assiette: assiette participation CPAM
           multiplicateur: plafond sécurité sociale temps plein
@@ -467,14 +465,46 @@ dirigeant . indépendant . PL . PAM . allocations familiales . participation CPA
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/taux-et-baremes/taux-de-cotisations/les-praticiens-et-auxiliaires-me/taux-de-cotisations-medecin-sect.html
 
-dirigeant . indépendant . PL . PAM . CARPIMKO:
+dirigeant . indépendant . PL . PAMC . assiette participation chirurgien-dentiste:
+  applicable si: métier = 'santé . chirurgien-dentiste'
+  titre: assiette participation CPAM (chirurgien dentiste)
+  remplace: assiette participation CPAM
+  formule:
+    produit:
+      assiette: revenus activité conventionnée
+      taux: 1 - taux Urssaf / (1 + taux Urssaf)
+  référence:
+    Fiche Urssaf: https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me/je-suis-chirurgien-dentiste/assiette-de-participation-de-la.html
+    Texte de loi: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000020429271&categorieLien=id
+
+dirigeant . indépendant . PL . PAMC . assiette participation chirurgien-dentiste . taux Urssaf:
+  description: |
+    Le « taux Urssaf » (taux UR) permet de calculer la part de votre
+    cotisation d’assurance maladie-maternité prise en charge par la CPAM. 
+
+    Ce taux est pré-rempli sur votre déclaration de revenus professionnels et
+    est issu des données de votre Relevé individuel d’activité et de
+    prescriptions (RIAP).
+
+    Plus le taux est faible, plus la participation CPAM est importante et donc
+    la part à la charge du praticien est faible.
+
+    ## Calcul du taux
+
+    La formule de calcul du taux de dépassement est la suivante : 
+    > Taux Urssaf = (dépassements - montants remboursés forfaits CMU) / (montants remboursables actes + montants remboursés forfaits CMU)
+  question: Quel est votre "taux Urssaf" ?
+  unité: ''
+  par défaut: 1
+
+dirigeant . indépendant . PL . CARPIMKO:
   formule: oui
-  applicable si: métier = 'PAM . auxiliaire médical'
+  applicable si: métier = 'santé . auxiliaire médical'
   références:
     Site CARPIMKO: https://www.carpimko.com
 
-dirigeant . indépendant . PL . PAM . CARPIMKO . retraite complémentaire:
-  remplace: cotisations et contributions . cotisations . retraite complémentaire
+dirigeant . indépendant . PL . CARPIMKO . retraite complémentaire:
+  remplace: cotisations et contributions . retraite complémentaire
   titre: retraite complémentaire (CARPIMKO)
   formule:
     somme:
@@ -489,16 +519,16 @@ dirigeant . indépendant . PL . PAM . CARPIMKO . retraite complémentaire:
   références:
     Site CARPIMKO: https://www.carpimko.com/cotisations/cotisations_cas_general
 
-dirigeant . indépendant . PL . PAM . CARPIMKO . invalidité et décès:
+dirigeant . indépendant . PL . CARPIMKO . invalidité et décès:
   titre: invalidité et décès (CARPIMKO)
-  remplace: cotisations et contributions . cotisations . invalidité et décès
+  remplace: cotisations et contributions . invalidité et décès
   formule: 678 €/an
   références:
     Site CARPIMKO: https://www.carpimko.com/cotisations/cotisations_cas_general
 
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV:
+dirigeant . indépendant . PL . CARPIMKO . ASV:
   titre: Avantage social vieillesse (CARPIMKO)
-  remplace: PCV
+  remplace: cotisations et contributions . PCV
   formule:
     somme:
       - forfaitaire
@@ -507,15 +537,16 @@ dirigeant . indépendant . PL . PAM . CARPIMKO . ASV:
   références:
     Taux 2020: http://www.carpimko.com/cotisations/cotisations_cas_general
 
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . forfaitaire:
+dirigeant . indépendant . PL . CARPIMKO . ASV . forfaitaire:
   formule: 590 €/an
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . proportionnelle:
+dirigeant . indépendant . PL . CARPIMKO . ASV . proportionnelle:
   formule:
     produit:
-      assiette: assiette participation CPAM
+      assiette: PAMC . assiette participation CPAM
       taux: 0.40%
 
-dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . participation CPAM:
+dirigeant . indépendant . PL . CARPIMKO . ASV . participation CPAM:
+  applicable si: PAMC
   formule:
     somme:
       - produit:
@@ -526,7 +557,7 @@ dirigeant . indépendant . PL . PAM . CARPIMKO . ASV . participation CPAM:
   références:
     Prise en charge CPAM: http://www.carpimko.com/cotisations/cotisations_cas_general
 
-dirigeant . indépendant . PL . PAM . CARMF:
+dirigeant . indépendant . PL . CARMF:
   formule: oui
   description: |
     La CARMF est la caisse de retraite autonome des médecins de France.
@@ -538,12 +569,12 @@ dirigeant . indépendant . PL . PAM . CARMF:
     société d’exercice libéral ou toute autre activité rémunérée sous forme
     d’honoraires, même s’il ne s’agit pas de la médecine de soins) en France
     métropolitaine et dans les départements d’Outre-Mer ou à Monaco.
-  applicable si: métier = 'PAM . médecin'
+  applicable si: métier = 'santé . médecin'
   références:
     Site CARMF: https://www.carmf.fr
 
-dirigeant . indépendant . PL . PAM . CARMF . retraite complémentaire:
-  remplace: cotisations et contributions . cotisations . retraite complémentaire
+dirigeant . indépendant . PL . CARMF . retraite complémentaire:
+  remplace: cotisations et contributions . retraite complémentaire
   titre: retraite complémentaire (CARMF)
   formule:
     produit:
@@ -553,9 +584,9 @@ dirigeant . indépendant . PL . PAM . CARMF . retraite complémentaire:
   références:
     Site CARMF: http://www.carmf.fr/page.php?page=cdrom/coti/coti-chiffre.htm
 
-dirigeant . indépendant . PL . PAM . CARMF . invalidité décès:
+dirigeant . indépendant . PL . CARMF . invalidité décès:
   titre: invalidité et décès (CARMF)
-  remplace: cotisations et contributions . cotisations . invalidité et décès
+  remplace: cotisations et contributions . invalidité et décès
   description: >-
     La CARMF gère un régime de prévoyance versant une pension en cas
     d'invalidité permanente et un capital décès ainsi qu’une rente pour les
@@ -583,16 +614,17 @@ dirigeant . indépendant . PL . PAM . CARMF . invalidité décès:
     Montant des cotisations: http://www.carmf.fr/page.php?page=cdrom/coti/coti-cours.htm#base
     Détails des couvertures: http://www.carmf.fr/page.php?page=cdrom/prev/prev-chiffre.htm
 
-dirigeant . indépendant . PL . PAM . CARMF . ASV:
+dirigeant . indépendant . PL . CARMF . ASV:
+  # TODO
   titre: Avantage social vieillesse (CARMF)
-  remplace: PCV
+  remplace: cotisations et contributions . PCV
   formule:
     allègement:
       assiette:
         somme:
           - 5253 €/an
           - produit:
-              assiette: assiette participation CPAM
+              assiette: PAMC . revenus activité conventionnée
               plafond: 5 * plafond sécurité sociale temps plein
               taux: 3.80%
       abattement: taux participation CPAM
@@ -600,26 +632,26 @@ dirigeant . indépendant . PL . PAM . CARMF . ASV:
   références:
     Taux 2020: http://www.carmf.fr/page.php?page=chiffrescles/stats/2020/taux2020.htm
 
-dirigeant . indépendant . PL . PAM . CARMF . ASV . taux participation CPAM:
-  applicable si: secteur = '1'
+dirigeant . indépendant . PL . CARMF . ASV . taux participation CPAM:
+  applicable si: métier . secteur médecin = '1'
   unité: '%'
   formule: 2 / 3
 
-dirigeant . indépendant . PL . PAM . CARCDSF:
+dirigeant . indépendant . PL . CARCDSF:
   formule: oui
   description: |
     La CARCDSF est la caisse de retraite autonome des chirurgiens dentiste et des sages femmes.
 
   applicable si:
     une de ces conditions:
-      - métier = 'PAM . chirurgien-dentiste'
-      - métier = 'PAM . sage-femme'
+      - métier = 'santé . chirurgien-dentiste'
+      - métier = 'santé . sage-femme'
   références:
     Site CARMF: https://www.carcdsf.fr
 
-dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire:
+dirigeant . indépendant . PL . CARCDSF . retraite complémentaire:
   titre: retraite complémentaire (CARCDSF)
-  remplace: cotisations et contributions . cotisations . retraite complémentaire
+  remplace: cotisations et contributions . retraite complémentaire
   formule:
     somme:
       - produit:
@@ -636,9 +668,14 @@ dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire:
   références:
     Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
 
-dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire:
+dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire:
   applicable si: assiette des cotisations < 85% * plafond sécurité sociale temps plein
   description: |
+    Vous avez la possibilité de bénéficier d'une réduction de cotisation
+    pour la retraite complémentaire si vous en faites la demande. [En savoir
+    plus](/documentation/dirigeant/indépendant/PL/PAM/CARCDSF/retraite-complémentaire/forfaitaire/réduction)
+  type: notification
+  note: |
     Les affiliés dont les revenus professionnels nets sur l'année N-1 sont inférieurs à 85
     % du PASS en vigueur au 1er janvier de l’année considérée (34 966 € en 2020)
     peuvent, sur demande, obtenir une réduction de la cotisation forfaitaire.
@@ -651,32 +688,23 @@ dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . rédu
     annexes (2033 B et D ou 2053 et 2058 A) de l’année 2019.
   unité: '%'
   formule: assiette des cotisations / (85% * plafond sécurité sociale temps plein)
+
   références:
     Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
 
-dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction:
-  type: notification
-  applicable si: assiette des cotisations < 85% * plafond sécurité sociale temps plein
-  description: >-
-    Vous avez la possibilité de bénéficier d'une réduction de cotisation
-    pour la retraite complémentaire si vous en faites la demande. [En savoir
-    plus](/documentation/dirigeant/indépendant/PL/PAM/CARCDSF/retraite-complémentaire/forfaitaire/réduction)
-
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste:
-  applicable si: métier = 'PAM . chirurgien-dentiste'
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste:
+  applicable si: métier = 'santé . chirurgien-dentiste'
   formule: oui
 
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . RID:
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . RID:
   titre: invalidité et décès (CARCDSF chirurgien-dentiste)
-  remplace: cotisations et contributions . cotisations . invalidité et décès
+  remplace: cotisations et contributions . invalidité et décès
   formule: 1078 €/an
 
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . prix d'une consultation:
-  formule: 23 €/consultation
-
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . PCV:
-  remplace: PAM . PCV
-  non applicable si: (assiette des cotisations / prix d'une consultation) <=  500 consultation/an
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . PCV:
+  titre: Prestation complémentaire vieillesse (CARCDSF chirurgien-dentiste)
+  remplace: cotisations et contributions . PCV
+  non applicable si: exonération PCV
   note: Une dispense peut être accordée lorsque les revenus professionnels 2019 sont
     inférieurs ou égaux à 500 C (valeur au 1er janvier de l’année considérée),
     soit 11 500 €.
@@ -697,7 +725,7 @@ dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . PCV:
   références:
     Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
 
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . PCV . info exonération:
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . exonération PCV:
   type: notification
   applicable si: (assiette des cotisations / prix d'une consultation) <=  500 consultation/an
   description: >-
@@ -706,41 +734,13 @@ dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . PCV . info
     faites la demande. [En savoir
     plus](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations)
 
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . taux Urssaf:
-  description: |
-    Le « taux Urssaf » (taux UR) permet de calculer la part de votre
-    cotisation d’assurance maladie-maternité prise en charge par la CPAM. 
+dirigeant . indépendant . PL . CARCDSF . chirurgien-dentiste . exonération PCV . prix d'une consultation:
+  formule: 23 €/consultation
 
-    Ce taux est pré-rempli sur votre déclaration de revenus professionnels et
-    est issu des données de votre Relevé individuel d’activité et de
-    prescriptions (RIAP).
-
-    Plus le taux est faible, plus la participation CPAM est importante et donc
-    la part à la charge du praticien est faible.
-
-    ## Calcul du taux
-
-    La formule de calcul du taux de dépassement est la suivante : 
-    > Taux Urssaf = (dépassements - montants remboursés forfaits CMU) / (montants remboursables actes + montants remboursés forfaits CMU)
-  question: Quel est votre "taux Urssaf" ?
-  unité: ''
-  par défaut: 1
-
-dirigeant . indépendant . PL . PAM . CARCDSF . chirurgien-dentiste . assiette participation CPAM:
-  remplace: PAM . assiette participation CPAM
-  formule:
-    produit:
-      assiette: assiette des cotisations
-      taux: 1 - taux Urssaf / (1 + taux Urssaf)
-  référence:
-    Fiche Urssaf: https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me/je-suis-chirurgien-dentiste/assiette-de-participation-de-la.html
-    Texte de loi: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000020429271&categorieLien=id
-
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme:
+dirigeant . indépendant . PL . CARCDSF . sage-femme:
   applicable si: métier = 'PAM . sage-femme'
-  formule: oui
 
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID:
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID:
   titre: invalidité et décès (CARCDSF sage-femme)
   description: |
     Il existe classes de cotisations aux choix, correspondant à des cotisations
@@ -751,7 +751,7 @@ dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID:
     l'année suivante.
 
     Aucun changement de classe n'est autorisé après le 1er juillet du 56e anniversaire.
-  remplace: cotisations et contributions . cotisations . invalidité et décès
+  remplace: cotisations et contributions . invalidité et décès
   formule:
     variations:
       - si: classe = 'A'
@@ -763,7 +763,7 @@ dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID:
   références:
     Montant des cotisations: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
 
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe:
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe:
   titre: Classe de cotisation
   question: Dans quelle classe cotisez-vous pour le régime invalidité-décès de la CARCDSF ?
   description: |
@@ -777,23 +777,28 @@ dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe:
         - A
         - B
         - C
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe . A:
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe . A:
   titre: classe A
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe . B:
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe . B:
   titre: classe B
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe . C:
+dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe . C:
   titre: classe C
 
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV:
-  remplace: PAM . PCV
-  non applicable si: assiette des cotisations <= 3120 €/an
+dirigeant . indépendant . PL . CARCDSF . sage-femme . PCV:
+  remplace: cotisations et contributions . PCV
+  non applicable si: exonération PCV
   description: |
     Pour 2020, le montant est fixé à 780 € dont un tiers, soit 260 € à votre
     charge et 520 € à la charge des Caisses Primaires d’Assurance Maladie
     (CPAM).
 
-    ### Possibilités de réduction ou dispense
-
+  formule:
+    produit:
+      assiette: 780 €/an
+      taux: 1 / 3
+  références:
+    Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
+  note: |
     Une dispense peut être accordée lorsque les revenus professionnels sont
     inférieurs ou égaux à 3120 €.
 
@@ -804,14 +809,7 @@ dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV:
     Cette dispense entraîne l’annulation des droits pour l’année et les points
     non cotisés ne sont pas rachetables.
 
-  formule:
-    produit:
-      assiette: 780 €/an
-      taux: 1 / 3
-  références:
-    Site CARCDSF: www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations
-
-dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV . info exonération:
+dirigeant . indépendant . PL . CARCDSF . sage-femme . exonération PCV:
   type: notification
   applicable si: assiette des cotisations <= 3120 €/an
   description: >-
@@ -819,17 +817,3 @@ dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV . info exonéra
     cotisation pour la prestation complémentaire de vieillesse (PCV) si vous en
     faites la demande. [En savoir
     plus](http://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations)
-
-dirigeant . indépendant . PL . PAM . PCV:
-  titre: Prestations complémentaires vieillesse
-  acronyme: PCV
-  formule: non
-  description: |
-    Certaines catégories professionnelles bénéficient de
-    prestations complémentaires vieillesse (PCV), auparavant nommées « avantage
-    social vieillesse » (ASV). Cela concerne les médecins généralistes, les
-    chirurgiens-dentistes, les sages-femmes, les auxiliaires médicaux et les
-    directeurs de laboratoires. Ce régime résulte de la prise en charge
-    partielle par l’Assurance maladie de leurs cotisations d’assurance
-    vieillesse sous réserve qu’ils aient exercé leur activité dans le cadre
-    conventionnel.

--- a/mon-entreprise/source/rules/profession-libérale.yaml
+++ b/mon-entreprise/source/rules/profession-libérale.yaml
@@ -294,13 +294,6 @@ dirigeant . indépendant . PL . PAM:
     - dirigeant . indépendant . revenus étrangers
   formule: oui
 
-dirigeant . indépendant . PL . PAM . honoraires:
-  titre: Total des honoraires
-  question: Quel est le montant total de vos honoraires ?
-  résumé: En incluant les dépassements
-  unité: €/an
-  formule: entreprise . chiffre d'affaires
-
 # TODO : medecins remplacant comme micro-BNC avec taux cotisation unique (comme les auto-entrepreneurs)
 # dirigeant . indépendant . PL . PAM . remplaçant:
 #   applicable si: métier = 'PAM . médecin'

--- a/mon-entreprise/source/rules/protection-sociale.yaml
+++ b/mon-entreprise/source/rules/protection-sociale.yaml
@@ -234,7 +234,7 @@ protection sociale . retraite . complémentaire sécurité des indépendants . p
     produit:
       assiette:
         somme:
-          - dirigeant . indépendant . cotisations et contributions . cotisations . retraite complémentaire
+          - dirigeant . indépendant . cotisations et contributions . retraite complémentaire
           - dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
       facteur: 1 / prix d'achat du point
 

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendant/index.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/AideDéclarationIndépendant/index.tsx
@@ -140,7 +140,7 @@ export default function() {
 							<SubSection dottedName="aide déclaration revenu indépendant 2019 . nature de l'activité" />
 							{/* PLNR */}
 							<SimpleField dottedName="entreprise . catégorie d'activité . débit de tabac" />
-							<SimpleField dottedName="dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac" />
+							<SimpleField dottedName="dirigeant . indépendant . cotisations et contributions . déduction tabac" />
 							<SimpleField dottedName="dirigeant . indépendant . PL . régime général . taux spécifique retraite complémentaire" />
 
 							<h2>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ProfessionLibérale.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ProfessionLibérale.tsx
@@ -64,11 +64,11 @@ export default function ProfessionLibérale() {
 	const { t } = useTranslation()
 	const inIframe = useContext(IsEmbeddedContext)
 	const sitePaths = useContext(SitePathsContext)
-	const professionName =
-		useSubSimulators(
-			'dirigeant . indépendant . PL . métier . PAM',
-			sitePaths.simulateurs['profession-libérale']
-		) ?? 'professionnel de santé'
+	const professionName = 'profession libérale'
+	// useSubSimulators(
+	// 	'dirigeant . indépendant . PL . métier . santé',
+	// 	sitePaths.simulateurs['profession-libérale']
+	// ) ?? 'profession libérale'
 
 	return (
 		<>

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -7,40 +7,40 @@ exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[15000,949,3261,
 exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[5000,312,1354,101,1767,3233]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `
-"[10000,630,560,101,1292,8708]
-Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
+"[10000,630,560,101,1291,8709]
+Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `
-"[10000,630,-1456,101,-724,10724]
-Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
+"[10000,630,-1457,101,-726,10726]
+Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
 exports[`calculate aide-déclaration-indépendant: IJSS (indemnité sécurité sociale) 1`] = `"[50000,3024,11424,101,14549,35451]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[500,25,82,101,209,291]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[500,25,82,101,208,292]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[5000,312,1021,101,1435,3565]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[5000,312,1021,101,1434,3566]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[50000,3175,17727,138,21039,28961]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[50000,3175,17728,138,21041,28959]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[50000,3175,16595,138,19907,30093]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[50000,3175,16580,138,19893,30107]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[50000,3175,14662,138,17974,32026]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[50000,3175,14664,138,17977,32023]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[50000,3176,17732,118,21025,28975]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[50000,0,0,118,0,0]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[50000,3175,16206,138,19518,30482]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[50000,3175,16186,138,19499,30501]"`;
 
 exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[50000,3177,5672,101,8950,41050]"`;
 
-exports[`calculate aide-déclaration-indépendant: international 1`] = `"[50000,0,14610,101,14711,35289]"`;
+exports[`calculate aide-déclaration-indépendant: international 1`] = `"[50000,0,0,101,0,0]"`;
 
 exports[`calculate aide-déclaration-indépendant: international 2`] = `"[50000,1267,11893,101,13261,36739]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[50000,3176,11380,118,14673,35327]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[50000,3176,11379,118,14673,35327]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1353,118,1781,3219]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1353,118,1782,3218]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[50000,3177,11384,101,14662,35338]"`;
 
@@ -52,7 +52,7 @@ exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 7`] = `
 "[50000,3177,9515,101,12793,37207]
-Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
+Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `"[500,25,1026,101,1152,0]"`;
@@ -61,13 +61,13 @@ exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `"[
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1500,89,1052,101,1242,258]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[2000,121,1095,101,1317,683]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[2000,121,1096,101,1318,682]"`;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[5000,312,1354,101,1767,3233]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[10000,630,2202,101,2934,7066]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[10000,630,2203,101,2934,7066]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `"[100000,6361,20834,101,27296,72704]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `"[100000,6361,20835,101,27297,72703]"`;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 8`] = `"[1000000,63664,106148,101,169913,830087]"`;
 
@@ -121,37 +121,37 @@ exports[`calculate simulations-auto-entrepreneur: échelle de revenus 10`] = `
 Notifications affichées : dirigeant . auto-entrepreneur . contrôle seuil de CA dépassé, dirigeant . auto-entrepreneur . contrôle seuil de TVA dépassé"
 `;
 
-exports[`calculate simulations-indépendant: acre 1`] = `"[73024,23024,50000,51980,8213,41787,0,73024]"`;
+exports[`calculate simulations-indépendant: acre 1`] = `"[73025,23025,50000,51980,8213,41787,0,73025]"`;
 
-exports[`calculate simulations-indépendant: activité 1`] = `"[29120,9120,20000,20788,603,19397,0,29120]"`;
+exports[`calculate simulations-indépendant: activité 1`] = `"[29119,9119,20000,20788,603,19397,0,29119]"`;
 
 exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,603,19397,0,29101]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1373,1273,100,134,0,100,0,1373]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1372,1272,100,134,0,100,0,1372]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[245,145,100,104,0,100,0,245]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[244,144,100,104,0,100,0,244]"`;
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29085,9085,20000,20787,603,19397,0,29085]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73024,23024,50000,51980,8213,41787,0,73024]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73025,23025,50000,51980,8213,41787,0,73025]"`;
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29085,9085,20000,20787,2079,17921,0,29085]"`;
 
-exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1384,616,667,0,616,0,2000]"`;
+exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1384,616,668,0,616,0,2000]"`;
 
-exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,3500,30498,0,50000]"`;
+exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,3500,30497,0,50000]"`;
 
 exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
 
-exports[`calculate simulations-indépendant: inversions 4`] = `"[88863,27436,61427,63837,11427,50000,0,88863]"`;
+exports[`calculate simulations-indépendant: inversions 4`] = `"[0,0,0,0,0,50000,0,0]"`;
 
 exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596]"`;
 
 exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5928,13072,13585,0,13072,1000,20000]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5626,12374,12860,0,12374,2000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5625,12375,12861,0,12375,2000,20000]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1859,1359,500,548,0,500,0,1859]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1858,1358,500,548,0,500,0,1858]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2467,1467,1000,1064,0,1000,0,2467]"`;
 
@@ -159,122 +159,71 @@ exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3075,1
 
 exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3682,1682,2000,2097,0,2000,0,3682]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7427,2427,5000,5199,0,5000,0,7427]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7428,2428,5000,5199,0,5000,0,7428]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14595,4595,10000,10393,0,10000,0,14595]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 7`] = `"[139594,39594,100000,103788,24909,75091,0,139594]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 7`] = `"[139595,39595,100000,103788,24909,75091,0,139595]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 8`] = `"[1239955,239955,1000000,1033666,444477,555523,0,1239955]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 8`] = `"[1239955,239955,1000000,1033666,444476,555524,0,1239955]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 1`] = `
-"[0,500,0,0,3,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[0,500,0,0,3,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 2`] = `
-"[0,1000,0,0,3,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[0,1000,0,0,3,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 3`] = `
-"[0,1500,0,0,3,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[0,1500,0,0,3,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 4`] = `
-"[0,2000,0,0,3,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[0,2000,0,0,3,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 5`] = `
-"[0,5000,0,0,3,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[0,5000,0,0,3,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 6`] = `
-"[0,10000,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[0,10000,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 7`] = `
-"[0,100000,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 7`] = `"[0,100000,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 8`] = `
-"[0,1000000,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: CIPAV 8`] = `"[0,1000000,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: auxiliaire médical 1`] = `
-"[0,22249,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: auxiliaire médical 1`] = `"[0,22249,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: auxiliaire médical 2`] = `
-"[0,21923,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: auxiliaire médical 2`] = `"[0,21923,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: auxiliaire médical 3`] = `
-"[0,238216,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: auxiliaire médical 3`] = `"[0,238215,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: médecin 1`] = `
-"[0,35072,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: médecin 1`] = `"[0,35073,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: médecin 2`] = `
-"[0,29772,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: médecin 2`] = `"[0,29771,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: médecin 3`] = `
-"[0,213519,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: médecin 3`] = `"[0,213518,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: médecin 4`] = `
-"[0,293799,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: médecin 4`] = `"[0,293798,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: médecin 5`] = `
-"[0,81099,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: médecin 5`] = `"[0,81098,0,0,4,0]"`;
 
-exports[`calculate simulations-professions-libérales: sage-femme 1`] = `
-"[0,40085,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-professions-libérales: sage-femme 1`] = `"[0,40086,0,0,4,0]"`;
 
 exports[`calculate simulations-professions-libérales: sage-femme 2`] = `
 "[0,14852,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 3`] = `
-"[0,2729,0,0,3,0]
-Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, dirigeant . indépendant . PL . CARCDSF . sage-femme . exonération PCV, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+"[0,2728,0,0,3,0]
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, dirigeant . indépendant . PL . CARCDSF . sage-femme . exonération PCV"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 4`] = `
 "[0,14852,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 5`] = `
 "[0,14775,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 6`] = `
-"[0,14699,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+"[0,14698,0,0,4,0]
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): ACRE 1`] = `"[605,0,0,7184,4,13]"`;
@@ -297,10 +246,7 @@ exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): Co
 
 exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): activités 1`] = `"[915,0,0,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): activités 2`] = `
-"[915,0,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): activités 2`] = `"[915,0,0,0,4,0]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): activités 3`] = `"[915,0,0,10742,4,19]"`;
 
@@ -351,10 +297,7 @@ exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): Con
 
 exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): activités 1`] = `"[0,0,1298,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): activités 2`] = `
-"[0,0,1297,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): activités 2`] = `"[0,0,1297,0,4,0]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): activités 3`] = `"[0,0,1445,4093,3,8]"`;
 
@@ -386,49 +329,46 @@ Notifications affichées : dirigeant . auto-entrepreneur . contrôle seuil de TV
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 1`] = `
-"[0,8392,0,6103,4,21]
-Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
+"[0,8392,0,6102,4,21]
+Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 2`] = `
 "[0,16871,0,12270,4,24]
-Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
+Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `
-"[0,21650,0,15828,4,31]
-Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
+"[0,21650,0,15827,4,31]
+Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,20567,0,15183,4,30]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,0,0,0,0,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,20264,0,15648,4,30]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,20264,0,15647,4,30]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,20620,0,15102,4,29]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13769,0,10084,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `"[0,226878,0,57937,4,56]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `"[0,226877,0,57936,4,56]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `
 "[0,13769,0,10084,4,21]
 Notifications affichées : dirigeant . indépendant . contrats madelin . contrôle montant charges"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13779,0,10090,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13779,0,10089,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `
-"[0,14670,0,0,4,0]
-Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
-`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14669,0,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13758,0,10075,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13757,0,10075,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13769,0,10084,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13769,0,10084,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6795,0,4977,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6794,0,4976,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13769,0,10084,4,21]"`;
 
@@ -436,15 +376,15 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 2`] = `"[0,-225,0,0,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,616,0,470,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,616,0,471,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3084,0,2267,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3084,0,2266,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6795,0,4977,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6794,0,4976,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13769,0,10084,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33997,0,24912,4,48]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33997,0,24913,4,48]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 8`] = `"[0,69895,0,36431,4,56]"`;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -1,75 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calculate aide-déclaration-indépendant: ACRE 1`] = `"[50000,3177,11384,8,14662,35338]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 1`] = `"[50000,3177,11384,101,14662,35338]"`;
 
-exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[15000,949,3261,8,4311,10689]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[15000,949,3261,101,4311,10689]"`;
 
-exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[5000,312,1354,8,1767,3233]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[5000,312,1354,101,1767,3233]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `
-"[10000,689,1477,8,2267,7733]
+"[10000,630,560,101,1292,8708]
 Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
 `;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `
-"[10000,760,598,8,1459,8541]
+"[10000,630,-1456,101,-724,10724]
 Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
 `;
 
-exports[`calculate aide-déclaration-indépendant: IJSS (indemnité sécurité sociale) 1`] = `"[50000,3024,11424,8,14549,35451]"`;
+exports[`calculate aide-déclaration-indépendant: IJSS (indemnité sécurité sociale) 1`] = `"[50000,3024,11424,101,14549,35451]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[500,25,82,8,209,291]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[500,25,82,101,209,291]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[5000,312,1021,8,1435,3565]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[5000,312,1021,101,1435,3565]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[50000,3175,14066,11,17378,32622]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[50000,3175,17727,138,21039,28961]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[50000,3175,13590,11,16903,33097]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[50000,3175,16595,138,19907,30093]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[50000,3175,11476,11,14788,35212]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[50000,3175,14662,138,17974,32026]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[50000,3176,14071,10,17364,32636]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[50000,3176,17732,118,21025,28975]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[50000,3175,11476,11,14788,35212]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[50000,3175,16206,138,19518,30482]"`;
 
-exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[50000,3177,5672,8,8950,41050]"`;
+exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[50000,3177,5672,101,8950,41050]"`;
 
-exports[`calculate aide-déclaration-indépendant: international 1`] = `"[50000,0,14610,8,14711,35289]"`;
+exports[`calculate aide-déclaration-indépendant: international 1`] = `"[50000,0,14610,101,14711,35289]"`;
 
-exports[`calculate aide-déclaration-indépendant: international 2`] = `"[50000,1267,11893,8,13261,36739]"`;
+exports[`calculate aide-déclaration-indépendant: international 2`] = `"[50000,1267,11893,101,13261,36739]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[50000,3176,11380,10,14673,35327]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[50000,3176,11380,118,14673,35327]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1353,10,1781,3219]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1353,118,1781,3219]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[50000,3177,11384,8,14662,35338]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[50000,3177,11384,101,14662,35338]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[5000,312,1354,8,1767,3233]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[5000,312,1354,101,1767,3233]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `"[50000,3177,11423,8,14701,35299]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `"[50000,3177,11423,101,14701,35299]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[5000,312,1316,8,1729,3271]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[5000,312,1316,101,1729,3271]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 7`] = `
-"[50000,3177,9515,8,12793,37207]
+"[50000,3177,9515,101,12793,37207]
 Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
 `;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `"[500,25,1026,8,1152,0]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `"[500,25,1026,101,1152,0]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `"[1000,57,1026,8,1184,0]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `"[1000,57,1026,101,1184,0]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1500,89,1052,8,1242,258]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1500,89,1052,101,1242,258]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[2000,121,1095,8,1317,683]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[2000,121,1095,101,1317,683]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[5000,312,1354,8,1767,3233]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[5000,312,1354,101,1767,3233]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[10000,630,2202,8,2934,7066]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[10000,630,2202,101,2934,7066]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `"[100000,6361,20834,8,27296,72704]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `"[100000,6361,20834,101,27296,72704]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 8`] = `"[1000000,63664,106148,8,169913,830087]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 8`] = `"[1000000,63664,106148,101,169913,830087]"`;
 
 exports[`calculate simulations-artiste-auteur: bnc 1`] = `"[1230]"`;
 
@@ -208,68 +208,73 @@ Notifications affichées : entreprise . catégorie d'activité . libérale règl
 `;
 
 exports[`calculate simulations-professions-libérales: auxiliaire médical 1`] = `
-"[0,22269,0,0,4,0]
+"[0,22249,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: auxiliaire médical 2`] = `
-"[0,21942,0,0,4,0]
+"[0,21923,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: auxiliaire médical 3`] = `
-"[0,238250,0,0,4,0]
+"[0,238216,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: médecin 1`] = `
-"[0,35248,0,0,4,0]
+"[0,35072,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: médecin 2`] = `
-"[0,34827,0,0,4,0]
+"[0,29772,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: médecin 3`] = `
-"[0,30391,0,0,4,0]
+"[0,213519,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: médecin 4`] = `
-"[0,216374,0,0,4,0]
+"[0,293799,0,0,4,0]
+Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
+`;
+
+exports[`calculate simulations-professions-libérales: médecin 5`] = `
+"[0,81099,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 1`] = `
-"[0,40107,0,0,4,0]
+"[0,40085,0,0,4,0]
 Notifications affichées : entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 2`] = `
-"[0,14873,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+"[0,14852,0,0,4,0]
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 3`] = `
 "[0,2729,0,0,3,0]
-Notifications affichées : dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction, dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . PCV . info exonération, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, dirigeant . indépendant . PL . CARCDSF . sage-femme . exonération PCV, entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 4`] = `
-"[0,14873,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+"[0,14852,0,0,4,0]
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 5`] = `
-"[0,14796,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+"[0,14775,0,0,4,0]
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-professions-libérales: sage-femme 6`] = `
-"[0,14720,0,0,4,0]
-Notifications affichées : dirigeant . indépendant . PL . PAM . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire . info réduction, entreprise . catégorie d'activité . libérale règlementée . avertissement"
+"[0,14699,0,0,4,0]
+Notifications affichées : dirigeant . indépendant . PL . CARCDSF . retraite complémentaire . réduction de la cotisation forfaitaire, entreprise . catégorie d'activité . libérale règlementée . avertissement"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (assimilé salarié): ACRE 1`] = `"[605,0,0,7184,4,13]"`;
@@ -381,17 +386,17 @@ Notifications affichées : dirigeant . auto-entrepreneur . contrôle seuil de TV
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 1`] = `
-"[0,8215,0,6018,4,21]
+"[0,8392,0,6103,4,21]
 Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 2`] = `
-"[0,16527,0,12103,4,24]
+"[0,16871,0,12270,4,24]
 Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `
-"[0,21570,0,15799,4,31]
+"[0,21650,0,15828,4,31]
 Notifications affichées : dirigeant . indépendant . contrôle base forfaitaire"
 `;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -143,7 +143,7 @@ exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,339
 
 exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
 
-exports[`calculate simulations-indépendant: inversions 4`] = `"[0,0,0,0,0,50000,0,0]"`;
+exports[`calculate simulations-indépendant: inversions 4`] = `"[69940,22078,47862,49758,7862,40000,0,69940]"`;
 
 exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596]"`;
 
@@ -343,7 +343,7 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,0,0,0,0,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,20620,0,15102,4,29]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,20264,0,15647,4,30]"`;
 
@@ -466,7 +466,7 @@ exports[`calculate simulations-salarié: assimilé salarié 3`] = `"[3685,0,3000
 
 exports[`calculate simulations-salarié: atmp 1`] = `"[2534,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: avantages 1`] = `"[2667,0,2000,1540,1491]"`;
+exports[`calculate simulations-salarié: avantages 1`] = `"[2667,0,2000,1540,1490]"`;
 
 exports[`calculate simulations-salarié: avantages 2`] = `"[2677,0,2000,1539,1489]"`;
 
@@ -520,7 +520,7 @@ exports[`calculate simulations-salarié: frais pro - IKV 1`] = `"[4367,0,3200,25
 
 exports[`calculate simulations-salarié: frais pro - IKV 2`] = `"[4346,0,3200,2511,2314]"`;
 
-exports[`calculate simulations-salarié: frais pro - IKV 3`] = `"[2764,0,2151,1681,1630]"`;
+exports[`calculate simulations-salarié: frais pro - IKV 3`] = `"[2764,0,2152,1681,1630]"`;
 
 exports[`calculate simulations-salarié: frais pro - titres restaurant 1`] = `"[2519,0,2000,1521,1487]"`;
 
@@ -611,7 +611,7 @@ exports[`calculate simulations-salarié: inversions 1`] = `"[2000,0,1746,1360,13
 
 exports[`calculate simulations-salarié: inversions 2`] = `"[3474,0,2554,2000,1889]"`;
 
-exports[`calculate simulations-salarié: inversions 3`] = `"[3674,0,2703,2117,2000]"`;
+exports[`calculate simulations-salarié: inversions 3`] = `"[3675,0,2703,2117,2000]"`;
 
 exports[`calculate simulations-salarié: lodeom 1`] = `
 "[1592,0,1521,1182,1182]

--- a/mon-entreprise/test/regressions/aide-déclaration-indépendants.yaml
+++ b/mon-entreprise/test/regressions/aide-déclaration-indépendants.yaml
@@ -30,7 +30,7 @@ débit de tabac:
   - aide déclaration revenu indépendant 2019 . nature de l'activité: "'commerciale ou industrielle'"
     dirigeant . rémunération totale: 50000 €/an
     entreprise . catégorie d'activité . débit de tabac: oui
-    dirigeant . indépendant . cotisations et contributions . cotisations . déduction tabac: 30000 €/an
+    dirigeant . indépendant . cotisations et contributions . déduction tabac: 30000 €/an
 
 RSA:
   - situation personnelle . RSA: oui

--- a/mon-entreprise/test/regressions/simulations-indépendant.yaml
+++ b/mon-entreprise/test/regressions/simulations-indépendant.yaml
@@ -12,7 +12,7 @@ inversions:
   - dirigeant . rémunération totale: 2000 €/an
   - dirigeant . rémunération totale: 50000 €/an
   - revenu net après impôt: 10000 €/an
-  - revenu net après impôt: 50000 €/an
+  - revenu net après impôt: 40000 €/an
   - revenu net après impôt: 10000 €/an
     entreprise . charges: 1000 €/an
   - entreprise . chiffre d'affaires minimum: 20000 €/an

--- a/mon-entreprise/test/regressions/simulations-professions-libérales.yaml
+++ b/mon-entreprise/test/regressions/simulations-professions-libérales.yaml
@@ -1,53 +1,60 @@
 médecin:
-  - dirigeant . indépendant . PL . métier: "'PAM . médecin'"
+  - dirigeant . indépendant . PL . métier: "'santé . médecin'"
     dirigeant . rémunération totale: 50000 €/an
-  - # Dépassement honoraire
-    dirigeant . indépendant . PL . métier: "'PAM . médecin'"
+  - # Secteur 2 dépassement honoraire
+    dirigeant . indépendant . PL . métier: "'santé . médecin'"
     dirigeant . rémunération totale: 50000 €/an
-    dirigeant . indépendant . PL . PAM . dépassement d'honoraire moyen: 20%
-  - # Secteur 2
-    dirigeant . indépendant . PL . métier: "'PAM . médecin'"
-    dirigeant . rémunération totale: 50000 €/an
-    dirigeant . indépendant . PL . PAM . secteur: "'2'"
-  - # Secteur 2 avec dépassement honoraire et gros se rémunération
-    dirigeant . indépendant . PL . métier: "'PAM . médecin'"
+    dirigeant . indépendant . PL . métier . secteur médecin: "'2'"
+    dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 20%
+  - # Secteur 2 avec dépassement honoraire et grosse rémunération
+    dirigeant . indépendant . PL . métier: "'santé . médecin'"
     dirigeant . rémunération totale: 300000 €/an
-    dirigeant . indépendant . PL . PAM . secteur: "'2'"
-    dirigeant . indépendant . PL . PAM . dépassement d'honoraire moyen: 50%
+    dirigeant . indépendant . PL . métier . secteur médecin: "'2'"
+    dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 50%
+  - # Secteur 2 avec grosse rémunération et activité non conventionnée
+    dirigeant . indépendant . PL . métier: "'santé . médecin'"
+    dirigeant . rémunération totale: 400000 €/an
+    dirigeant . indépendant . PL . métier . secteur médecin: "'2'"
+    dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 50%
+    dirigeant . indépendant . PL . PAMC . proportion recette activité non conventionnée: 40%
+  - # Non conventionné
+    dirigeant . indépendant . PL . métier: "'santé . médecin'"
+    dirigeant . rémunération totale: 120000 €/an
+    dirigeant . indépendant . PL . métier . secteur médecin: "'non conventionné'"
 
 sage-femme:
-  - dirigeant . indépendant . PL . métier: "'PAM . sage-femme'"
+  - dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
     dirigeant . rémunération totale: 50000 €/an
   - # Réduction retraite complémentaire
-    dirigeant . indépendant . PL . métier: "'PAM . sage-femme'"
+    dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
     dirigeant . rémunération totale: 20000 €/an
   - # Exonération RID
-    dirigeant . indépendant . PL . métier: "'PAM . sage-femme'"
+    dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
     dirigeant . rémunération totale: 4000 €/an
   - # Classe A
-    dirigeant . indépendant . PL . métier: "'PAM . sage-femme'"
+    dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
     dirigeant . rémunération totale: 20000 €/an
-    dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe: "'A'"
+    dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe: "'A'"
   - # Classe B
-    dirigeant . indépendant . PL . métier: "'PAM . sage-femme'"
+    dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
     dirigeant . rémunération totale: 20000 €/an
-    dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe: "'B'"
+    dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe: "'B'"
   - # Classe C
-    dirigeant . indépendant . PL . métier: "'PAM . sage-femme'"
+    dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
     dirigeant . rémunération totale: 20000 €/an
-    dirigeant . indépendant . PL . PAM . CARCDSF . sage-femme . RID . classe: "'C'"
+    dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe: "'C'"
 
 auxiliaire médical:
-  - dirigeant . indépendant . PL . métier: "'PAM . auxiliaire médical'"
+  - dirigeant . indépendant . PL . métier: "'santé . auxiliaire médical'"
     dirigeant . rémunération totale: 30000 €/an
   - # Dépassement honoraire
-    dirigeant . indépendant . PL . métier: "'PAM . auxiliaire médical'"
+    dirigeant . indépendant . PL . métier: "'santé . auxiliaire médical'"
     dirigeant . rémunération totale: 30000 €/an
-    dirigeant . indépendant . PL . PAM . dépassement d'honoraire moyen: 20%
+    dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 20%
   - # Grosse rémunération
-    dirigeant . indépendant . PL . métier: "'PAM . auxiliaire médical'"
+    dirigeant . indépendant . PL . métier: "'santé . auxiliaire médical'"
     dirigeant . rémunération totale: 300000 €/an
-    dirigeant . indépendant . PL . PAM . dépassement d'honoraire moyen: 100%
+    dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 100%
 
 CIPAV:
   - dirigeant . indépendant . revenu net de cotisations: 500 €/an

--- a/mon-entreprise/test/regressions/simulations-rémunération-dirigeant.yaml
+++ b/mon-entreprise/test/regressions/simulations-rémunération-dirigeant.yaml
@@ -47,7 +47,7 @@ Contrats Madelin:
   # cotisations ne change pas:
   - dirigeant . rémunération totale: 30000 €/an
     entreprise . charges: 10000
-    dirigeant . indépendant . contrats madelin . mutuelle . montant: 4000 # plafond: 10% PSS donc environ 4100
+    dirigeant . indépendant . contrats madelin . mutuelle . montant: 3800 # plafond: 10% PSS donc environ 4100
   # Cas retraite: la cotisation Madelin est supérieure au plafond => le revenu net de
   # cotisations est affecté car l'assiette des cotisations est plus élevée
   - dirigeant . rémunération totale: 30000 €/an

--- a/publicodes/source/parseRule.tsx
+++ b/publicodes/source/parseRule.tsx
@@ -119,7 +119,7 @@ export default function<Names extends string>(
 			}),
 		remplace: evolveReplacement(rules, rule, parsedRules),
 		defaultValue: value =>
-			typeof value === 'string'
+			typeof value === 'string' || typeof value === 'number'
 				? parse(rules, rule, parsedRules)(value)
 				: // TODO : An "object" default value is only used in the
 				// "synchronisation" mecanism. This should be refactored to not use the


### PR DESCRIPTION
- Enlève la notion d'honoraire aux simulateurs 
- Change l'organisation des cotisations indépendant (toutes les cotisations sont au même niveau)
- Change l'assiette de calcul de la CSG, qui est basée sur toutes les cotisations sociales obligatoire (à vérifier)
- Change le mode de calcul de l'assiette de remboursement CPAM, qui est basée sur les revenus conventionnés (ajoute une question sur le pourcentage conventionné / non conventionné)
- Change l'organisation des PL en PL . PAMC (régime URSSAF) et PL . CAR*** (caisse de retraite) pour mieux prendre en compte le médecin non conventionné
- Désactive le subSimulateur en attendant d'améliorer sa logique
- Corrige l'avertissement sur la régularisation
- Arrondi toutes les cotisations des indépendants
- Rends les montants intermédiaires cliquables dans les simulateurs (#733)
- Arrondi l'impôt annuel à l'unité 
- Améliore le message en cas d'échec de l'inversion