### PR TITLE
Refacto fonction evaluate

### DIFF
--- a/publicodes/source/cyclesLib/ASTTypes.ts
+++ b/publicodes/source/cyclesLib/ASTTypes.ts
@@ -127,20 +127,12 @@ export function isPossibilities2(node: ASTNode): node is Possibilities2 {
 
 export type Reference<Names extends string> = ASTNode & {
 	category: 'reference'
-	name: Names
-	partialReference: Names
-	dottedName: Names
 }
 export function isReference<Names extends string>(
 	node: ASTNode
 ): node is Reference<Names> {
 	const reference = node as Reference<Names>
-	return (
-		reference.category === 'reference' &&
-		isWannabeDottedName(reference.name) &&
-		isWannabeDottedName(reference.partialReference) &&
-		isWannabeDottedName(reference.dottedName)
-	)
+	return reference.category === 'reference'
 }
 
 export type AbstractMechanism = ASTNode & {


### PR DESCRIPTION
Cette PR poursuit la simplication de l'API de l'évaluation, en particulier pour ne pas redefinir une nouvelle fonction `evaluate` pour chaque nœud parsé.

Voir aussi l'explication dans https://github.com/betagouv/mon-entreprise/pull/1117#discussion_r492802931.

* **1ère étape :**
  Ne plus définir les fonctions `evaluate` dans les fonctions `parse`. Modification déjà effectuée pour les mécanismes dans #1032, reste à l'appliquer pour `parseReference` et `parseRule`.
  Note: il est possible que cette modification ait un impact positif sur les performances ?
* **2ème étape :**
  Ajouter un attribut `kind` sur chaque nœud et l'utiliser dans une fonction `evaluate` globale et polymorphique
  ```js
  function evaluate(node) {
    return evaluationFunctions[node.kind].call(this, node)
  }
  ```
* **3ème étape:**
  Modifier l'API de la fonction `evaluate` et transmettre le contexte avec `this`. Si l'argument `parsedRules` est toujours transmis sans modification, les arguments `cache` et `situation` sont parfois réinitialisés et une simple substitution par `this.cache` et `this.situation` dans le code est insuffisante, il faut réimplémenter une logique de pile de cache. Cela permettra ensuite d'enchaîner sur une implémentation plus efficiente du cache, cf. #986.

L'objet `this` (qui contient `this.parsedRules`, `this.situation`, `this.evaluate`, etc.) est un interpréteur Publicode, mais nous n'avons pas besoin de créer une nouvelle abstraction car cet objet présente exactement la même interface que l'objet public exposé dans `publicode/index.ts` et c'est donc l'interface publique qui sera utilisée dans les appels internes.