### PR TITLE
Corrige la disparition du widget covid quand on quitte la page

### DIFF
--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ChômagePartiel.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ChômagePartiel.tsx
@@ -16,8 +16,11 @@ declare global {
 		StonlyWidget?: {
 			open: () => void
 			close: () => void
+			toggle: () => void
 			launcherShow: () => void
 			launcherHide: () => void
+			startURLWatcher: () => void
+			stopURLWatcher: () => void
 		}
 	}
 }
@@ -28,15 +31,18 @@ export default function ChômagePartiel() {
 		if (inIframe) {
 			return
 		}
-		const script = document.createElement('script')
-		window.STONLY_WID = '0128ae02-6780-11ea-ac13-0a4250848ba4'
-		script.src = 'https://stonly.com/js/widget/stonly-widget.js'
-		script.async = true
-		document.body.appendChild(script)
-		window.StonlyWidget?.launcherShow()
+		if (!window.StonlyWidget) {
+			const script = document.createElement('script')
+			window.STONLY_WID = '0128ae02-6780-11ea-ac13-0a4250848ba4'
+			script.src = 'https://stonly.com/js/widget/stonly-widget.js'
+			script.async = true
+			document.body.appendChild(script)
+		} else {
+			window.StonlyWidget?.launcherShow()
+		}
 		return () => {
+			window.StonlyWidget?.stopURLWatcher()
 			window.StonlyWidget?.launcherHide()
-			document.body.removeChild(script)
 		}
 	}, [inIframe])
 	return (


### PR DESCRIPTION
Corrige l'implémentation de #1162 

J'ai impression que le seul moyen de tester est de mettre la branche en production 
https://github.com/betagouv/mon-entreprise/wiki/Stat%C3%A9gie-de-d%C3%A9ploiement-des-refontes
car le widget ne s'affiche pas si le domaine n'est pas le bon ? (ou alors modifier mon `/etc/hosts` ? mais sur windows ?)