### PR TITLE
Covid - réductions de cotisations

### DIFF
--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -96,10 +96,10 @@ describe('Simulateurs', function() {
 				})
 				it('should not have negative value', () => {
 					cy.contains('€/mois').click()
+					cy.wait(100)
 					cy.get(inputSelector)
 						.first()
-						.clear()
-						.type('5000')
+						.type('{selectall}5000')
 					cy.wait(800)
 					cy.get(inputSelector).each($input => {
 						const val = +$input.val().replace(/[\s,.]/g, '')

--- a/mon-entreprise/source/components/MoreInfosOnUs.tsx
+++ b/mon-entreprise/source/components/MoreInfosOnUs.tsx
@@ -24,12 +24,12 @@ export default function MoreInfosOnUs() {
 			<h3 style={{ textAlign: 'center', width: '100%' }}>
 				Plus d'infos sur mon-entreprise.fr
 			</h3>
-			<div className="ui__ full-width box-container">
+			<div className="ui__ full-width center-flex">
 				{!pathname.startsWith(sitePaths.nouveautés) && (
 					<Link className="ui__ interactive card box" to={sitePaths.nouveautés}>
 						<div className="ui__ big box-icon">{emoji('✨')}</div>
 						<h3>Les nouveautés</h3>
-						<p className="ui__ notice" css="flex: 1">
+						<p className="ui__ notice">
 							Qu'avons-nous mis en production ces derniers mois ?
 						</p>
 						<div className="ui__ small simple button">Découvrir</div>
@@ -39,9 +39,7 @@ export default function MoreInfosOnUs() {
 					<Link className="ui__ interactive card box" to={sitePaths.stats}>
 						<div className="ui__ big box-icon">{emoji('📊')}</div>
 						<h3>Les statistiques</h3>
-						<p className="ui__ notice" css="flex: 1">
-							Quel est notre impact ?
-						</p>
+						<p className="ui__ notice">Quel est notre impact ?</p>
 						<div className="ui__ small simple button">Découvrir</div>
 					</Link>
 				)}
@@ -49,7 +47,7 @@ export default function MoreInfosOnUs() {
 					<Link className="ui__ interactive card box" to={sitePaths.budget}>
 						<div className="ui__ big box-icon">{emoji('💶')}</div>
 						<h3>Le budget</h3>
-						<p className="ui__ notice" css="flex: 1">
+						<p className="ui__ notice">
 							Quelles sont nos ressources et comment sont-elles employées ?
 						</p>
 						<div className="ui__ small simple button">Découvrir</div>
@@ -76,7 +74,7 @@ export default function MoreInfosOnUs() {
 						</svg>
 					</div>
 					<h3>Le code source</h3>
-					<p className="ui__ notice" css="flex: 1">
+					<p className="ui__ notice">
 						Nos travaux sont ouverts et libres de droit, ça se passe sur GitHub
 					</p>
 					<div className="ui__ small simple button">Découvrir</div>

--- a/mon-entreprise/source/components/conversation/Aide.tsx
+++ b/mon-entreprise/source/components/conversation/Aide.tsx
@@ -4,6 +4,8 @@ import { Markdown } from 'Components/utils/markdown'
 import { useContext } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
+import { References } from 'publicodes'
+import { Trans } from 'react-i18next'
 import './Aide.css'
 import { EngineContext } from 'Components/utils/EngineContext'
 
@@ -29,6 +31,14 @@ export default function Aide() {
 			>
 				<h2>{rule.title}</h2>
 				<Markdown source={text} />
+				{refs && (
+					<>
+						<h3>
+							<Trans>En savoir plus</Trans>
+						</h3>
+						<References refs={refs} />
+					</>
+				)}
 			</div>
 		</Overlay>
 	)

--- a/mon-entreprise/source/components/conversation/InputSuggestions.tsx
+++ b/mon-entreprise/source/components/conversation/InputSuggestions.tsx
@@ -26,6 +26,7 @@ export default function InputSuggestions({
 			css={`
 				display: flex;
 				align-items: baseline;
+				justify-content: flex-end;
 				margin-bottom: 0.4rem;
 			`}
 		>

--- a/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
@@ -1,0 +1,69 @@
+import Value, { Condition } from 'Components/EngineValue'
+import React from 'react'
+import emoji from 'react-easy-emoji'
+import { DottedName } from 'Rules'
+
+type AidesCovidProps = {
+	rule?: DottedName
+}
+
+export default function AidesCovid({rule}: AidesCovidProps) {
+	rule ??= "dirigeant . indépendant . cotisations et contributions . aides covid 2020"
+	return (
+		<div className="ui__ box-container">
+			<Condition expression={rule}>
+				<div className="ui__ card box">
+					<h4>Réduction de cotisations</h4>
+					<p
+						className="ui__ notice"
+						css={`
+							flex: 1;
+						`}
+					>
+						Vous pouvez bénéficier de réductions de cotisations exceptionnelles.
+					</p>
+					<p className="ui__ lead">
+						<Value
+							displayedUnit="€"
+							expression={rule}
+						/>
+					</p>
+				</div>
+			</Condition>
+			<div className="ui__ card box">
+				<h4>Aides gouvernementales</h4>
+				<p
+					className="ui__ notice"
+					css={`
+						flex: 1;
+					`}
+				>
+					Le ministère de l'Économie propose un portail recensant les mesures de
+					soutien aux entreprises.
+				</p>
+				<a
+					className="ui__ small button"
+					href="https://www.economie.gouv.fr/covid19-soutien-entreprises/les-mesures"
+					target="_blank"
+				>
+					{emoji('▶')} Mesures de soutien
+				</a>
+			</div>
+			<div className="ui__ card box">
+				<h4>Écoute et soutien</h4>
+				<p
+					className="ui__ notice"
+					css={`
+						flex: 1;
+					`}
+				>
+					Une <a>cellule de première écoute et de soutien psychologique</a> a
+					été mise en place pour les chefs d'entreprise fragilisés par la crise.
+				</p>
+				<a className="ui__ small simple button" href="tel:+33805655050">
+					{emoji('📞')} 08 05 65 50 50
+				</a>
+			</div>
+		</div>
+	)
+}

--- a/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
@@ -1,14 +1,12 @@
 import Value, { Condition } from 'Components/EngineValue'
-import React from 'react'
 import emoji from 'react-easy-emoji'
 import { DottedName } from 'Rules'
 
 type AidesCovidProps = {
-	rule?: DottedName
+	rule: DottedName
 }
 
-export default function AidesCovid({rule}: AidesCovidProps) {
-	rule ??= "dirigeant . indépendant . cotisations et contributions . aides covid 2020"
+export default function AidesCovid({ rule }: AidesCovidProps) {
 	return (
 		<div className="ui__ box-container">
 			<Condition expression={rule}>
@@ -23,10 +21,7 @@ export default function AidesCovid({rule}: AidesCovidProps) {
 						Vous pouvez bénéficier de réductions de cotisations exceptionnelles.
 					</p>
 					<p className="ui__ lead">
-						<Value
-							displayedUnit="€"
-							expression={rule}
-						/>
+						<Value displayedUnit="€" expression={rule} />
 					</p>
 				</div>
 			</Condition>
@@ -57,8 +52,15 @@ export default function AidesCovid({rule}: AidesCovidProps) {
 						flex: 1;
 					`}
 				>
-					Une <a>cellule de première écoute et de soutien psychologique</a> a
-					été mise en place pour les chefs d'entreprise fragilisés par la crise.
+					Une{' '}
+					<a
+						href="https://www.economie.gouv.fr/mise-en-place-cellule-ecoute-soutien-psychologique-chefs-entreprise"
+						target="_blank"
+					>
+						cellule de première écoute et de soutien psychologique
+					</a>{' '}
+					a été mise en place pour les chefs d'entreprise fragilisés par la
+					crise.
 				</p>
 				<a className="ui__ small simple button" href="tel:+33805655050">
 					{emoji('📞')} 08 05 65 50 50

--- a/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
@@ -13,7 +13,8 @@ export default function AidesCovid({ rule }: AidesCovidProps) {
 				<div className="ui__ card box lighter-bg">
 					<h4>Réduction de cotisations</h4>
 					<p className="ui__ notice">
-						Vous pouvez bénéficier de réductions de cotisations exceptionnelles.
+						Vous pouvez bénéficier d'une réduction de vos cotisations
+						définitives sur l'année 2020.
 					</p>
 					<p className="ui__ lead">
 						<Value displayedUnit="€" expression={rule} />

--- a/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
@@ -3,22 +3,40 @@ import emoji from 'react-easy-emoji'
 import { DottedName } from 'Rules'
 
 type AidesCovidProps = {
-	rule: DottedName
+	aidesRule?: DottedName
 }
 
-export default function AidesCovid({ rule }: AidesCovidProps) {
+export default function AidesCovid({ aidesRule }: AidesCovidProps) {
 	return (
 		<div className="ui__ box-container">
-			<Condition expression={rule}>
+			{aidesRule && (
+				<Condition expression={aidesRule}>
+					<div className="ui__ card box lighter-bg">
+						<h4>Réduction de cotisations</h4>
+						<p className="ui__ notice">
+							Vous pouvez bénéficier d'une réduction de vos cotisations
+							définitives sur l'année 2020.
+						</p>
+						<p className="ui__ lead">
+							<Value displayedUnit="€" expression={aidesRule} />
+						</p>
+					</div>
+				</Condition>
+			)}
+			<Condition expression={'dirigeant . auto-entrepreneur'}>
 				<div className="ui__ card box lighter-bg">
-					<h4>Réduction de cotisations</h4>
+					<h4>Déduction de chiffre d'affaire</h4>
 					<p className="ui__ notice">
-						Vous pouvez bénéficier d'une réduction de vos cotisations
-						définitives sur l'année 2020.
+						Les conditions et modalités de la réduction "covid" sont présentées
+						sur le site de l'URSSAF.
 					</p>
-					<p className="ui__ lead">
-						<Value displayedUnit="€" expression={rule} />
-					</p>
+					<a
+						className="ui__ small simple button"
+						href="https://www.autoentrepreneur.urssaf.fr/portail/accueil/sinformer-sur-le-statut/toutes-les-actualites/loi-de-finance-rectificative---r.html"
+						target="_blank"
+					>
+						{emoji('▶')} En savoir plus
+					</a>
 				</div>
 			</Condition>
 			<div className="ui__ card box">

--- a/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
@@ -1,5 +1,6 @@
 import Value, { Condition } from 'Components/EngineValue'
 import emoji from 'react-easy-emoji'
+import { Trans } from 'react-i18next'
 import { DottedName } from 'Rules'
 
 type AidesCovidProps = {
@@ -8,68 +9,81 @@ type AidesCovidProps = {
 
 export default function AidesCovid({ aidesRule }: AidesCovidProps) {
 	return (
-		<div className="ui__ box-container">
-			{aidesRule && (
-				<Condition expression={aidesRule}>
+		<>
+			<h2>
+				<Trans>Aides Covid-19</Trans>
+			</h2>
+			<div className="ui__ box-container">
+				{aidesRule && (
+					<Condition expression={aidesRule}>
+						<div className="ui__ card box lighter-bg">
+							<Trans i18nKey="simulateurs.explanation.aides covid.reduction">
+								<h4>Réduction de cotisations</h4>
+								<p className="ui__ notice">
+									Vous pouvez bénéficier d'une réduction de vos cotisations
+									définitives sur l'année 2020.
+								</p>
+								<p className="ui__ lead">
+									<Value displayedUnit="€" expression={aidesRule} />
+								</p>
+							</Trans>
+						</div>
+					</Condition>
+				)}
+				<Condition expression={'dirigeant . auto-entrepreneur'}>
 					<div className="ui__ card box lighter-bg">
-						<h4>Réduction de cotisations</h4>
-						<p className="ui__ notice">
-							Vous pouvez bénéficier d'une réduction de vos cotisations
-							définitives sur l'année 2020.
-						</p>
-						<p className="ui__ lead">
-							<Value displayedUnit="€" expression={aidesRule} />
-						</p>
+						<Trans i18nKey="simulateurs.explanation.aides covid.deduction">
+							<h4>Déduction de chiffre d'affaire</h4>
+							<p className="ui__ notice">
+								Les conditions et modalités de la réduction "covid" sont
+								présentées sur le site de l'URSSAF.
+							</p>
+							<a
+								className="ui__ small simple button"
+								href="https://www.autoentrepreneur.urssaf.fr/portail/accueil/sinformer-sur-le-statut/toutes-les-actualites/loi-de-finance-rectificative---r.html"
+								target="_blank"
+							>
+								<span>{emoji('▶')}</span> En savoir plus
+							</a>
+						</Trans>
 					</div>
 				</Condition>
-			)}
-			<Condition expression={'dirigeant . auto-entrepreneur'}>
-				<div className="ui__ card box lighter-bg">
-					<h4>Déduction de chiffre d'affaire</h4>
-					<p className="ui__ notice">
-						Les conditions et modalités de la réduction "covid" sont présentées
-						sur le site de l'URSSAF.
-					</p>
-					<a
-						className="ui__ small simple button"
-						href="https://www.autoentrepreneur.urssaf.fr/portail/accueil/sinformer-sur-le-statut/toutes-les-actualites/loi-de-finance-rectificative---r.html"
-						target="_blank"
-					>
-						{emoji('▶')} En savoir plus
-					</a>
+				<div className="ui__ card box">
+					<Trans i18nKey="simulateurs.explanation.aides covid.portail">
+						<h4>Aides gouvernementales</h4>
+						<p className="ui__ notice">
+							Le ministère de l'Économie propose un portail recensant les
+							mesures de soutien aux entreprises.
+						</p>
+						<a
+							className="ui__ small simple button"
+							href="https://www.economie.gouv.fr/covid19-soutien-entreprises/les-mesures"
+							target="_blank"
+						>
+							<span>{emoji('▶')}</span> Mesures de soutien
+						</a>
+					</Trans>
 				</div>
-			</Condition>
-			<div className="ui__ card box">
-				<h4>Aides gouvernementales</h4>
-				<p className="ui__ notice">
-					Le ministère de l'Économie propose un portail recensant les mesures de
-					soutien aux entreprises.
-				</p>
-				<a
-					className="ui__ small simple button"
-					href="https://www.economie.gouv.fr/covid19-soutien-entreprises/les-mesures"
-					target="_blank"
-				>
-					{emoji('▶')} Mesures de soutien
-				</a>
+				<div className="ui__ card box">
+					<Trans i18nKey="simulateurs.explanation.aides covid.soutien">
+						<h4>Écoute et soutien</h4>
+						<p className="ui__ notice">
+							Une{' '}
+							<a
+								href="https://www.economie.gouv.fr/mise-en-place-cellule-ecoute-soutien-psychologique-chefs-entreprise"
+								target="_blank"
+							>
+								cellule de première écoute et de soutien psychologique
+							</a>{' '}
+							a été mise en place pour les chefs d'entreprise fragilisés par la
+							crise.
+						</p>
+						<a className="ui__ small simple button" href="tel:+33805655050">
+							<span>{emoji('📞')}</span> 08 05 65 50 50
+						</a>
+					</Trans>
+				</div>
 			</div>
-			<div className="ui__ card box">
-				<h4>Écoute et soutien</h4>
-				<p className="ui__ notice">
-					Une{' '}
-					<a
-						href="https://www.economie.gouv.fr/mise-en-place-cellule-ecoute-soutien-psychologique-chefs-entreprise"
-						target="_blank"
-					>
-						cellule de première écoute et de soutien psychologique
-					</a>{' '}
-					a été mise en place pour les chefs d'entreprise fragilisés par la
-					crise.
-				</p>
-				<a className="ui__ small simple button" href="tel:+33805655050">
-					{emoji('📞')} 08 05 65 50 50
-				</a>
-			</div>
-		</div>
+		</>
 	)
 }

--- a/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AidesCovid.tsx
@@ -10,14 +10,9 @@ export default function AidesCovid({ rule }: AidesCovidProps) {
 	return (
 		<div className="ui__ box-container">
 			<Condition expression={rule}>
-				<div className="ui__ card box">
+				<div className="ui__ card box lighter-bg">
 					<h4>Réduction de cotisations</h4>
-					<p
-						className="ui__ notice"
-						css={`
-							flex: 1;
-						`}
-					>
+					<p className="ui__ notice">
 						Vous pouvez bénéficier de réductions de cotisations exceptionnelles.
 					</p>
 					<p className="ui__ lead">
@@ -27,17 +22,12 @@ export default function AidesCovid({ rule }: AidesCovidProps) {
 			</Condition>
 			<div className="ui__ card box">
 				<h4>Aides gouvernementales</h4>
-				<p
-					className="ui__ notice"
-					css={`
-						flex: 1;
-					`}
-				>
+				<p className="ui__ notice">
 					Le ministère de l'Économie propose un portail recensant les mesures de
 					soutien aux entreprises.
 				</p>
 				<a
-					className="ui__ small button"
+					className="ui__ small simple button"
 					href="https://www.economie.gouv.fr/covid19-soutien-entreprises/les-mesures"
 					target="_blank"
 				>
@@ -46,12 +36,7 @@ export default function AidesCovid({ rule }: AidesCovidProps) {
 			</div>
 			<div className="ui__ card box">
 				<h4>Écoute et soutien</h4>
-				<p
-					className="ui__ notice"
-					css={`
-						flex: 1;
-					`}
-				>
+				<p className="ui__ notice">
 					Une{' '}
 					<a
 						href="https://www.economie.gouv.fr/mise-en-place-cellule-ecoute-soutien-psychologique-chefs-entreprise"

--- a/mon-entreprise/source/components/simulationExplanation/AutoEntrepreneurExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AutoEntrepreneurExplanation.tsx
@@ -16,6 +16,8 @@ export default function AutoEntrepreneurExplanation() {
 
 	return (
 		<section>
+			<AidesCovid />
+			<br />
 			<h2>
 				<Trans>Répartition du chiffre d'affaires</Trans>
 			</h2>
@@ -43,9 +45,6 @@ export default function AutoEntrepreneurExplanation() {
 					}
 				]}
 			/>
-			<br />
-			<h2>Aides Covid-19</h2>
-			<AidesCovid />
 		</section>
 	)
 }

--- a/mon-entreprise/source/components/simulationExplanation/AutoEntrepreneurExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/AutoEntrepreneurExplanation.tsx
@@ -5,6 +5,7 @@ import { default as React, useContext } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { targetUnitSelector } from 'Selectors/simulationSelectors'
+import AidesCovid from './AidesCovid'
 
 export default function AutoEntrepreneurExplanation() {
 	const engine = useContext(EngineContext)
@@ -42,6 +43,9 @@ export default function AutoEntrepreneurExplanation() {
 					}
 				]}
 			/>
+			<br />
+			<h2>Aides Covid-19</h2>
+			<AidesCovid />
 		</section>
 	)
 }

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -31,7 +31,7 @@ export default function IndépendantExplanation() {
 				<PLExplanation />
 			</Condition>
 			<h2>Aides Covid-19</h2>
-			<AidesCovid rule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
+			<AidesCovid aidesRule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
 			<Condition expression="revenu net après impôt > 0 €/an">
 				<section>
 					<h2>Répartition de la rémunération totale</h2>

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -74,12 +74,7 @@ function PLExplanation() {
 							<a target="_blank" href="https://www.urssaf.fr/portail/home.html">
 								<LogoImg src={urssafSrc} title="logo Urssaf" />
 							</a>
-							<p
-								className="ui__ notice"
-								css={`
-									flex: 1;
-								`}
-							>
+							<p className="ui__ notice">
 								Les cotisations recouvrées par l'Urssaf, qui servent au
 								financement de la sécurité sociale (assurance maladie,
 								allocations familiales, dépendance)
@@ -101,12 +96,7 @@ function PLExplanation() {
 								>
 									<LogoImg src={assuranceMaladieSrc} title="Logo CPAM" />
 								</a>
-								<p
-									className="ui__ notice"
-									css={`
-										flex: 1;
-									`}
-								>
+								<p className="ui__ notice">
 									En tant que professionnel de santé conventionné, vous
 									bénéficiez d'une prise en charge d'une partie de vos
 									cotisations par l'Assurance Maladie.
@@ -156,12 +146,7 @@ function CaisseRetraite() {
 							>
 								<LogoImg src={logosSrc[caisse]} title={`logo ${caisse}`} />
 							</a>
-							<p
-								className="ui__ notice"
-								css={`
-									flex: 1;
-								`}
-							>
+							<p className="ui__ notice">
 								{description}{' '}
 								<Trans i18nKey="simulateurs.explanation.CNAPL">
 									Elle recouvre les cotisations liées à votre retraite et au

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -17,6 +17,7 @@ import styled from 'styled-components'
 import BarChartBranch from 'Components/BarChart'
 import 'Components/Distribution.css'
 import RuleLink from 'Components/RuleLink'
+import AidesCovid from './AidesCovid'
 // import Distribution from 'Components/Distribution'
 
 export default function IndépendantExplanation() {
@@ -130,6 +131,8 @@ function PLExplanation() {
 					</Condition>
 				</Animate.fromBottom>
 			</Trans>
+			<h2>Aides Covid-19</h2>
+			<AidesCovid rule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
 		</section>
 	)
 }

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -30,7 +30,6 @@ export default function IndépendantExplanation() {
 			<Condition expression="entreprise . catégorie d'activité . libérale règlementée">
 				<PLExplanation />
 			</Condition>
-			<h2>Aides Covid-19</h2>
 			<AidesCovid aidesRule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
 			<Condition expression="revenu net après impôt > 0 €/an">
 				<section>

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -30,6 +30,8 @@ export default function IndépendantExplanation() {
 			<Condition expression="entreprise . catégorie d'activité . libérale règlementée">
 				<PLExplanation />
 			</Condition>
+			<h2>Aides Covid-19</h2>
+			<AidesCovid rule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
 			<Condition expression="revenu net après impôt > 0 €/an">
 				<section>
 					<h2>Répartition de la rémunération totale</h2>
@@ -121,8 +123,6 @@ function PLExplanation() {
 					</Condition>
 				</Animate.fromBottom>
 			</Trans>
-			<h2>Aides Covid-19</h2>
-			<AidesCovid rule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
 		</section>
 	)
 }

--- a/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -7,7 +7,6 @@ import { useContext, useRef } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { RootState } from 'Reducers/rootReducer'
 import * as Animate from 'Components/ui/animate'
 import { answeredQuestionsSelector } from 'Selectors/simulationSelectors'
 

--- a/mon-entreprise/source/components/ui/Card.css
+++ b/mon-entreprise/source/components/ui/Card.css
@@ -173,3 +173,7 @@
 		justify-content: center;
 	}
 }
+
+.ui__.card .ui__.notice {
+	flex: 1;
+}

--- a/mon-entreprise/source/components/ui/Typography.css
+++ b/mon-entreprise/source/components/ui/Typography.css
@@ -102,7 +102,6 @@ li {
 }
 a {
 	border: none;
-	display: inline-block;
 	font-size: inherit;
 	padding: none;
 	text-decoration: underline;

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -1,6 +1,3 @@
-SMIC:
-  titre.en: '[automatic] SMIC'
-  titre.fr: SMIC
 SMIC horaire:
   titre.en: hourly minimum wage (SMIC)
   titre.fr: SMIC horaire
@@ -247,6 +244,9 @@ artiste-auteur . cotisations . assiette:
 artiste-auteur . cotisations . assiette surcotisation:
   titre.en: over-contribution base
   titre.fr: assiette surcotisation
+artiste-auteur . cotisations . avec réductions:
+  titre.en: '[automatic] with reductions'
+  titre.fr: avec réductions
 artiste-auteur . cotisations . formation professionnelle:
   titre.en: professional training
   titre.fr: formation professionnelle
@@ -308,6 +308,9 @@ artiste-auteur . revenus . traitements et salaires:
   résumé.fr: Le montant brut hors TVA de vos droits d'auteur (recettes précomptées)
   titre.en: Income in wages and salaries
   titre.fr: Revenu en traitements et salaires
+artiste-auteur . réduction de cotisations covid 2020:
+  titre.en: '[automatic] covid 2020 contribution reduction'
+  titre.fr: réduction de cotisations covid 2020
 chômage partiel:
   titre.en: '[automatic] short-time working'
   titre.fr: chômage partiel
@@ -5428,9 +5431,14 @@ dirigeant . indépendant . cotisations et contributions:
     respect of contributions and
 
     mandatory contributions.
+
+
+    This amount includes the "covid" contribution reduction in 2020.
   description.fr: |
     C'est le montant total dû par l'indépendant au titre des cotisations et
     contributions obligatoires.
+
+    Ce montant inclut la réduction de cotisation "covid" en 2020.
   note.en: |
     [automatic] Unlike contributions, contributions are not reintroduced
     for the calculation of the CSG/CRDS. They also do not benefit from the
@@ -5482,6 +5490,20 @@ dirigeant . indépendant . cotisations et contributions . PCV:
     conventionnel.
   titre.en: '[automatic] Supplementary old-age benefits'
   titre.fr: Prestations complémentaires vieillesse
+? dirigeant . indépendant . cotisations et contributions . aide indépendant covid 2020
+: titre.en: '[automatic] independent aid covid 2020'
+  titre.fr: aide indépendant covid 2020
+dirigeant . indépendant . cotisations et contributions . aides covid 2020:
+  description.en: |
+    [automatic] The government and social security agencies have established
+    contribution reduction schemes for self-employed persons affected by the
+    Coronavirus crisis.
+  description.fr: |
+    Le gouvernement et les organismes de sécurité sociale ont mis en place des
+    dispositifs de réduction de cotisation pour les indépendants impactés par la
+    crise du Coronavirus.
+  titre.en: '[automatic] covid 2020 aid'
+  titre.fr: aides covid 2020
 dirigeant . indépendant . cotisations et contributions . allocations familiales:
   titre.en: '[automatic] child benefit'
   titre.fr: allocations familiales
@@ -5795,9 +5817,6 @@ dirigeant . rémunération totale:
   résumé.fr: Dépensé par l'entreprise
   titre.en: Director total income
   titre.fr: rémunération totale
-effectif 20 salarié ou plus:
-  titre.en: '[automatic] 20 or more employees'
-  titre.fr: effectif 20 salarié ou plus
 entreprise:
   description.en: The contract binds a company and an employee
   description.fr: |
@@ -6633,9 +6652,6 @@ plafond sécurité sociale temps plein:
     rémunérations à prendre en compte pour le calcul de certaines cotisations.
   titre.en: full-time social security ceiling
   titre.fr: plafond sécurité sociale temps plein
-primes:
-  titre.en: '[automatic] premiums'
-  titre.fr: primes
 protection sociale:
   description.en: >
     Social protection in France is composed of 5 main branches: sickness,
@@ -7134,48 +7150,6 @@ revenus net de cotisations:
   résumé.fr: Avant impôt
   titre.en: net contribution income
   titre.fr: revenus net de cotisations
-réduction générale:
-  titre.en: '[automatic] overall decrease'
-  titre.fr: réduction générale
-réduction générale . chômage:
-  titre.en: '[automatic] unemployment'
-  titre.fr: chômage
-réduction générale . chômage . coefficient:
-  titre.en: '[automatic] coefficient'
-  titre.fr: coefficient
-réduction générale . chômage . constante:
-  titre.en: '[automatic] constant'
-  titre.fr: constante
-réduction générale . chômage . réduction sans régularisation:
-  titre.en: '[automatic] unregulated reduction'
-  titre.fr: réduction sans régularisation
-réduction générale . début:
-  titre.en: '[automatic] start'
-  titre.fr: début
-réduction générale . urssaf:
-  titre.en: '[automatic] urssaf'
-  titre.fr: urssaf
-réduction générale . urssaf . coefficient:
-  titre.en: '[automatic] coefficient'
-  titre.fr: coefficient
-réduction générale . urssaf . constante:
-  titre.en: '[automatic] constant'
-  titre.fr: constante
-réduction générale . urssaf . réduction sans régularisation:
-  titre.en: '[automatic] unregulated reduction'
-  titre.fr: réduction sans régularisation
-réduction lodeom:
-  titre.en: '[automatic] lodeom reduction'
-  titre.fr: réduction lodeom
-réduction lodeom . constante:
-  titre.en: '[automatic] constant'
-  titre.fr: constante
-réduction sur AC au 1er janvier:
-  titre.en: '[automatic] reduction on AC on January 1st'
-  titre.fr: réduction sur AC au 1er janvier
-rémunération:
-  titre.en: '[automatic] remuneration'
-  titre.fr: rémunération
 situation personnelle:
   titre.en: personal situation
   titre.fr: situation personnelle
@@ -7246,6 +7220,86 @@ situation personnelle . domiciliation fiscale à l'étranger:
 établissement . localisation . outre-mer . Guadeloupe Réunion Martinique:
   titre.en: '[automatic] Guadeloupe Reunion Martinique'
   titre.fr: Guadeloupe Réunion Martinique
+établissement . secteur d'activité covid:
+  description.en: >
+    [automatic] Eligibility conditions for covid aid depend on the sector
+
+    of the establishment's activity. 
+
+
+    Hotels, restaurants, bars, etc. are in
+
+    the so-called "S1" category and are entitled to aid without further conditions.
+
+
+    Sectors whose activity depends on those of "sector 1" may
+
+    also benefit from the aid on condition that they have had a fall in turnover
+
+    of significant business during lockdown.
+
+
+    Finally, the so-called "S2" sectors are those involving the reception of the public, and
+
+    are eligible for aid on condition that they have been closed down
+
+    administrative.
+
+
+    The terms and conditions are specified on the URSSAF website.
+  description.fr: |
+    Les conditions d'éligibilité aux aides "covid" dépendent du secteur
+    d'activité de l'établissement. 
+
+    Les hôtels, restaurants, bars, etc. sont dans
+    la catégorie dite "S1" et ont le droit aux aides sans autre conditions.
+
+    Les secteurs dont l'activité dépendent de celles du "secteur 1" peuvent
+    aussi bénéficier des aides à condition d'avoir eu une baisse de chiffre
+    d'affaire significative pendant le confinement.
+
+    Enfin les secteurs dits "S2" sont ceux impliquant l'accueil du public, et
+    sont éligibles aux aides à condition d'avoir subit une fermeture
+    administrative.
+
+    Les modalités sont précisées sur le site de l'URSSAF.
+  question.en: >
+    [automatic] covid" reduction device: is your main activity in one of the
+    following sectors?
+  question.fr: >
+    Dispositif de réduction "covid" : votre activité principale relève-t'elle
+    d'un des secteurs suivants ?
+  titre.en: '[automatic] covid business line'
+  titre.fr: secteur d'activité covid
+établissement . secteur d'activité covid . S1:
+  titre.en: '[automatic] Sector "1" - tourism, hotels and restaurants'
+  titre.fr: Secteur "1" - tourisme, hôtellerie, restauration
+établissement . secteur d'activité covid . S1-bis:
+  titre.en: '[automatic] Sector "1a" - whose activity depends on that of sector 1'
+  titre.fr: Secteur "1 bis" - dont l'activité dépend de celle des secteurs 1
+établissement . secteur d'activité covid . S2:
+  titre.en: '[automatic] Sector "2" - activity involving the reception of the
+    public that has been interrupted'
+  titre.fr: Secteur "2" - activité impliquant l'accueil du public qui a été interrompue
+établissement . secteur d'activité covid . activité interrompue:
+  question.en: |
+    [automatic] Was your business interrupted because of the Covid-19 outbreak?
+  question.fr: |
+    Votre activité a-t'elle été interrompue à cause de l’épidémie de Covid-19 ?
+  titre.en: '[automatic] interrupted activity'
+  titre.fr: activité interrompue
+? établissement . secteur d'activité covid . baisse significative de chiffre d'affaire
+: question.en: |
+    [automatic] Has your business suffered a drop in turnover of at least 80%?
+    between 15 March and 15 May 2020 compared to the previous year?
+  question.fr: |
+    Votre activité a-t-elle subit une baisse d'au moins 80% de chiffre d'affaire
+    entre le 15 mars et le 15 mai 2020 par rapport à l'année précédentes ?
+  titre.en: '[automatic] significant drop in turnover'
+  titre.fr: baisse significative de chiffre d'affaire
+établissement . secteur d'activité covid . éligible aide:
+  titre.en: '[automatic] eligible aid'
+  titre.fr: éligible aide
 établissement . taux du versement transport:
   titre.en: Rate of transport tax
   titre.fr: taux du versement transport

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -8,6 +8,7 @@ Accueil: Home
 Afficher la description publicode: Display publicode description
 Aide à la déclaration de revenu: Income tax return assistance
 Aide à la déclaration de revenus au titre de l'année 2019: Help with your 2019 income tax return
+Aides Covid-19: Covid-19 Aids
 Alors: Then
 Année d'activité: Years of activity
 Artiste-auteur: Artist-author
@@ -1315,6 +1316,18 @@ simulateurs:
   explanation:
     CNAPL: It recovers contributions related to your retirement and disability/death
       plan.
+    aides covid:
+      deduction: <0>Deduction of turnover</0><1>The terms and conditions of the
+        "covid" discount are presented on the URSSAF
+        website.</1><2><0>{emoji('▶')}</0> More information</2>
+      portail: <0>Government assistance</0><1>The Ministry of the Economy offers a
+        portal listing business support measures.</1><2><0>{emoji('▶')}</0>
+        Support measures</2>
+      reduction: <0>Contribution reduction</0><1>You can benefit from a reduction in
+        your final contributions for the year 2020.</1><2><0></0></2>
+      soutien: <0>Listening and support</0><1>An <2>initial listening and
+        psychological support unit</2> has been set up for company directors
+        weakened by the crisis.</1><2><0>{emoji('📞')}</0> 08 05 65 50 50</2>
     pamc: <0><0>Your partner institutions</0><1><0><0><0></0></0><1>Contributions
       collected by URSSAF, which are used to finance social security (health
       insurance, family allowances, dependency

--- a/mon-entreprise/source/rules/artiste-auteur.yaml
+++ b/mon-entreprise/source/rules/artiste-auteur.yaml
@@ -131,3 +131,28 @@ artiste-auteur . cotisations . formation professionnelle:
     produit:
       assiette: assiette
       taux: 0.35%
+
+artiste-auteur . cotisations . avec réductions:
+  formule:
+    somme:
+      - cotisations
+      - (- réduction de cotisations covid 2020)
+
+artiste-auteur . réduction de cotisations covid 2020:
+  applicable si: 
+    toutes ces conditions:
+      - période . fin d'année = 31/12/2020
+      - cotisations . assiette >= 3000 €/an
+  formule:
+    # TODO: c'est inférieur ou égal ici
+    grille:
+      assiette: cotisations . assiette
+      tranches:
+        - montant: 500 €/an
+          plafond: 800 heures/an * SMIC horaire
+        - montant: 1000 €/an
+          plafond: 2000 heures/an * SMIC horaire
+        - montant: 2000 €/an
+    plafond: cotisations
+  références:
+    Infographie Urssaf: https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/5761-Infographie-Aide-AA-WEB.pdf

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -516,7 +516,19 @@ dirigeant . indépendant . cotisations et contributions . aides covid 2020:
     crise du Coronavirus.
   formule:
     somme:
+      - aide indépendant covid 2020
       - PL . CIPAV . retraite complémentaire . réduction COVID . montant
+
+dirigeant . indépendant . cotisations et contributions . aide indépendant covid 2020:
+  formule:
+    variations:
+      - si: 
+          une de ces conditions:
+            - établissement . secteur d'activité covid = 'S1'
+            - établissement . secteur d'activité covid = 'S1-bis'
+        alors: (- 2400 €/an)
+      - si: établissement . secteur d'activité covid = 'S2'
+        alors: (- 1800 €/an)
 
 dirigeant . indépendant . revenu net de cotisations:
   synonymes:
@@ -751,12 +763,15 @@ dirigeant . indépendant . cotisations et contributions:
     C'est le montant total dû par l'indépendant au titre des cotisations et
     contributions obligatoires.
 
+    Ce montant inclut la réduction de cotisation "covid" en 2020.
+
   formule:
     somme:
       - cotisations
       - CSG et CRDS
       - contributions spéciales
       - formation professionnelle
+      - aide indépendant covid 2020
   note: |
     À la différence des cotisations, les contributions ne sont pas réintroduites
     pour le calcul de la CSG/CRDS. Elles ne bénéficient pas non plus de la

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -509,6 +509,15 @@ dirigeant . indépendant . cotisations et contributions . exonérations . ACRE .
         - taux: 0%
           plafond: 100%
 
+dirigeant . indépendant . cotisations et contributions . aides covid 2020:
+  description: |
+    Le gouvernement et les organismes de sécurité sociale ont mis en place des
+    dispositifs de réduction de cotisation pour les indépendants impactés par la
+    crise du Coronavirus.
+  formule:
+    somme:
+      - PL . CIPAV . retraite complémentaire . réduction COVID . montant
+
 dirigeant . indépendant . revenu net de cotisations:
   synonymes:
     - résultat comptable

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -529,6 +529,8 @@ dirigeant . indépendant . cotisations et contributions . aide indépendant covi
         alors: (- 2400 €/an)
       - si: établissement . secteur d'activité covid = 'S2'
         alors: (- 1800 €/an)
+  références:
+    Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/
 
 dirigeant . indépendant . revenu net de cotisations:
   synonymes:

--- a/mon-entreprise/source/rules/entreprise-établissement.yaml
+++ b/mon-entreprise/source/rules/entreprise-établissement.yaml
@@ -558,3 +558,52 @@ entreprise . auto entreprise impossible:
     durée:
       depuis: entreprise . date de création
       jusqu'à: 31/12/2019
+
+établissement . secteur d'activité covid:
+  question: |
+    Dispositif de réduction "covid" : votre activité principale relève-t'elle d'un des secteurs suivants ?
+  par défaut: non
+  formule:
+    une possibilité:
+      choix obligatoire: non
+      possibilités:
+        - S1
+        - S1-bis
+        - S2
+
+établissement . secteur d'activité covid . S1:
+  titre: Secteur "1" - tourisme, hôtellerie, restauration
+
+établissement . secteur d'activité covid . S1-bis:
+  titre: Secteur "1 bis" - dont l'activité dépend de celle des secteurs 1
+
+établissement . secteur d'activité covid . S2:
+  titre: Secteur "2" - activité impliquant l'accueil du public qui a été interrompue
+
+établissement . secteur d'activité covid . éligible aide:
+  formule:
+    une de ces conditions:
+      - secteur d'activité covid = 'S1'
+      - toutes ces conditions:
+          - secteur d'activité covid = 'S1-bis'
+          - baisse significative de chiffre d'affaire
+      - toutes ces conditions:
+          - secteur d'activité covid = 'S2'
+          - activité interrompue
+  références:
+    Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/
+
+établissement . secteur d'activité covid . baisse significative de chiffre d'affaire:
+  question: |
+    Votre activité a-t-elle subit une baisse d'au moins 80% de chiffre d'affaire
+    entre le 15 mars et le 15 mai 2020 par rapport à l'année précédentes ?
+  par défaut: oui
+  références:
+    Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/
+
+établissement . secteur d'activité covid . activité interrompue:
+  question: |
+    Votre activité a-t'elle été interrompue à cause de l’épidémie de Covid-19 ?
+  par défaut: oui
+  références:
+    Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/

--- a/mon-entreprise/source/rules/entreprise-établissement.yaml
+++ b/mon-entreprise/source/rules/entreprise-établissement.yaml
@@ -562,6 +562,24 @@ entreprise . auto entreprise impossible:
 établissement . secteur d'activité covid:
   question: |
     Dispositif de réduction "covid" : votre activité principale relève-t'elle d'un des secteurs suivants ?
+  description: |
+    Les conditions d'éligibilité aux aides "covid" dépendent du secteur
+    d'activité de l'établissement. 
+    
+    Les hôtels, restaurants, bars, etc. sont dans
+    la catégorie dite "S1" et ont le droit aux aides sans autre conditions.
+
+    Les secteurs dont l'activité dépendent de celles du "secteur 1" peuvent
+    aussi bénéficier des aides à condition d'avoir eu une baisse de chiffre
+    d'affaire significative pendant le confinement.
+
+    Enfin les secteurs dits "S2" sont ceux impliquant l'accueil du public, et
+    sont éligibles aux aides à condition d'avoir subit une fermeture
+    administrative.
+
+    Les modalités sont précisées sur le site de l'URSSAF.
+  références:
+    Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/
   par défaut: non
   formule:
     une possibilité:

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Landing/Landing.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Landing/Landing.tsx
@@ -54,7 +54,7 @@ export default function Landing() {
 						<div className="ui__ big box-icon">{emoji('💡')}</div>
 						<Trans i18nKey="landing.choice.create">
 							<h3>Créer une entreprise</h3>
-							<p className="ui__ notice" css="flex: 1">
+							<p className="ui__ notice">
 								Un accompagnement au choix du statut juridique et la liste
 								complète des démarches de création
 							</p>
@@ -74,7 +74,7 @@ export default function Landing() {
 						<div className="ui__ big box-icon">{emoji('💶')}</div>
 						<Trans i18nKey="landing.choice.manage">
 							<h3>Gérer mon activité</h3>
-							<p className="ui__ notice" css="flex: 1">
+							<p className="ui__ notice">
 								Des outils personnalisés pour anticiper le montant des
 								cotisations sociales à payer et mieux gérer votre trésorerie.
 							</p>
@@ -90,7 +90,7 @@ export default function Landing() {
 						<div className="ui__ big box-icon">{emoji('🧮')}</div>
 						<Trans i18nKey="landing.choice.simulators">
 							<h3>Accéder aux simulateurs</h3>
-							<p className="ui__ notice" css="flex: 1">
+							<p className="ui__ notice">
 								La liste exhaustive de tous les simulateurs disponibles sur le
 								site.
 							</p>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
@@ -105,12 +105,9 @@ function Warning({ dottedName }: WarningProps) {
 	return <li>{warning.description}</li>
 }
 
-const ResultBlock = styled.div`
-	margin-top: 30px;
+const ResultLine = styled.div`
 	padding: 10px;
-	background: #eee;
 	font-size: 1.25em;
-	background: #eee;
 	display: flexbox;
 	flex-direction: column;
 `
@@ -133,16 +130,24 @@ function CotisationsResult() {
 
 	return (
 		<Animate.appear>
-			<ResultBlock className="ui__ card">
-				<ResultLabel>
-					<Trans>Montant des cotisations</Trans>
-				</ResultLabel>
-				<Value
-					displayedUnit="€"
-					precision={0}
-					expression="artiste-auteur . cotisations"
-				/>
-			</ResultBlock>
+			<div
+				className="ui__ card"
+				css={`
+					margin-top: 2rem;
+				`}
+			>
+				<ResultLine>
+					<ResultLabel>
+						<Trans>Montant des cotisations</Trans>
+					</ResultLabel>
+					<Value
+						displayedUnit="€"
+						precision={0}
+						expression="artiste-auteur . cotisations . avec réductions"
+					/>
+				</ResultLine>
+				<AideCovid />
+			</div>
 			<Condition expression="artiste-auteur . cotisations">
 				<RepartitionCotisations />
 			</Condition>
@@ -187,5 +192,20 @@ function RepartitionCotisations() {
 				))}
 			</div>
 		</section>
+	)
+}
+
+function AideCovid() {
+	return (
+		<Condition expression="artiste-auteur . réduction de cotisations covid 2020">
+			<ResultLine>
+				<ResultLabel>Dont réduction de cotisation covid</ResultLabel>
+				<Value
+					displayedUnit="€"
+					precision={0}
+					expression="artiste-auteur . réduction de cotisations covid 2020"
+				/>
+			</ResultLine>
+		</Condition>
 	)
 }

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
@@ -158,7 +158,7 @@ function CotisationsResult() {
 			>
 				<Trans>Aides Covid-19</Trans>
 			</h2>
-			<AidesCovid rule="artiste-auteur . réduction de cotisations covid 2020" />
+			<AidesCovid aidesRule="artiste-auteur . réduction de cotisations covid 2020" />
 			<Condition expression="artiste-auteur . cotisations">
 				<RepartitionCotisations />
 			</Condition>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
@@ -151,13 +151,7 @@ function CotisationsResult() {
 					/>
 				</ResultLine>
 			</div>
-			<h2
-				css={`
-					margin-top: 4rem;
-				`}
-			>
-				<Trans>Aides Covid-19</Trans>
-			</h2>
+			<br />
 			<AidesCovid aidesRule="artiste-auteur . réduction de cotisations covid 2020" />
 			<Condition expression="artiste-auteur . cotisations">
 				<RepartitionCotisations />

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ArtisteAuteur.tsx
@@ -3,6 +3,7 @@ import RuleInput from 'Components/conversation/RuleInput'
 import { DistributionBranch } from 'Components/Distribution'
 import Value, { Condition } from 'Components/EngineValue'
 import SimulateurWarning from 'Components/SimulateurWarning'
+import AidesCovid from 'Components/simulationExplanation/AidesCovid'
 import 'Components/TargetSelection.css'
 import Animate from 'Components/ui/animate'
 import { EngineContext, useEvaluation } from 'Components/utils/EngineContext'
@@ -139,6 +140,9 @@ function CotisationsResult() {
 				<ResultLine>
 					<ResultLabel>
 						<Trans>Montant des cotisations</Trans>
+						<p className="ui__ notice">
+							Incluant les réductions de cotisations liées au Covid-19
+						</p>
 					</ResultLabel>
 					<Value
 						displayedUnit="€"
@@ -146,8 +150,15 @@ function CotisationsResult() {
 						expression="artiste-auteur . cotisations . avec réductions"
 					/>
 				</ResultLine>
-				<AideCovid />
 			</div>
+			<h2
+				css={`
+					margin-top: 4rem;
+				`}
+			>
+				<Trans>Aides Covid-19</Trans>
+			</h2>
+			<AidesCovid rule="artiste-auteur . réduction de cotisations covid 2020" />
 			<Condition expression="artiste-auteur . cotisations">
 				<RepartitionCotisations />
 			</Condition>
@@ -192,20 +203,5 @@ function RepartitionCotisations() {
 				))}
 			</div>
 		</section>
-	)
-}
-
-function AideCovid() {
-	return (
-		<Condition expression="artiste-auteur . réduction de cotisations covid 2020">
-			<ResultLine>
-				<ResultLabel>Dont réduction de cotisation covid</ResultLabel>
-				<Value
-					displayedUnit="€"
-					precision={0}
-					expression="artiste-auteur . réduction de cotisations covid 2020"
-				/>
-			</ResultLine>
-		</Condition>
 	)
 }

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/Home.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/Home.tsx
@@ -140,9 +140,7 @@ export function SimulateurCard({
 			</div>
 			<>{small ? name : <h3>{name}</h3>}</>
 			{!small && meta?.description && (
-				<p className="ui__ notice" css="flex: 1">
-					{meta.description}
-				</p>
+				<p className="ui__ notice">{meta.description}</p>
 			)}
 		</Link>
 	)

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ÉconomieCollaborative/ActivitésSelection.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/ÉconomieCollaborative/ActivitésSelection.tsx
@@ -192,9 +192,7 @@ const ActivitéContent = ({
 			</InfoBulle>
 		</h4>
 
-		<p css="flex: 1" className="ui__ notice">
-			{plateformes.join(', ')}
-		</p>
+		<p className="ui__ notice">{plateformes.join(', ')}</p>
 		{label && <div className="ui__ label"> {label}</div>}
 		<div className="ui__ box-icon">{emoji(icônes)}</div>
 	</>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/integration/Options.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/integration/Options.tsx
@@ -34,13 +34,12 @@ export default function Options() {
 			<section className="ui__ full-width dark-bg center-flex">
 				<Link
 					className="ui__ interactive card box inverted-colors"
-					css="flex: 1"
 					to={sitePaths.integration.iframe}
 				>
 					<div className="ui__ big box-icon">{emoji('📱')}</div>
 					<Trans i18nKey="pages.développeurs.home.choice.iframe">
 						<h3>Intégrer un simulateur</h3>
-						<p className="ui__ notice" css="flex: 1">
+						<p className="ui__ notice">
 							Intégrer l'un de nos simulateurs en un clic dans votre site Web,
 							via un script clé en main.
 						</p>
@@ -51,13 +50,12 @@ export default function Options() {
 				</Link>
 				<Link
 					className="ui__ interactive card box inverted-colors"
-					css="flex: 1"
 					to={sitePaths.integration.library}
 				>
 					<div className="ui__ big box-icon">{emoji('🧰')}</div>
 					<Trans i18nKey="pages.développeurs.choice.library">
 						<h3>Libraire de calcul</h3>
-						<p className="ui__ notice" css="flex: 1">
+						<p className="ui__ notice">
 							L'intégralité du moteur de calcul socio-fiscal développé par
 							l'Urssaf, mis à disposition librement sous forme de bibliothèque
 							NPM.
@@ -69,7 +67,6 @@ export default function Options() {
 				</Link>
 				<a
 					className="ui__ interactive card box inverted-colors"
-					css="flex: 1"
 					target="_blank"
 					href="https://github.com/betagouv/mon-entreprise"
 				>
@@ -89,7 +86,7 @@ export default function Options() {
 					</div>
 					<Trans i18nKey="pages.développeurs.choice.github">
 						<h3>Contribuer sur GitHub</h3>
-						<p className="ui__ notice" css="flex: 1">
+						<p className="ui__ notice">
 							Tous nos outils sont ouverts et développés publiquement sur
 							GitHub.
 						</p>
@@ -100,14 +97,13 @@ export default function Options() {
 				</a>
 				<a
 					className="ui__ interactive card box inverted-colors"
-					css="flex: 1"
 					target="_blank"
 					href="https://publi.codes"
 				>
 					<div className="ui__ big box-icon">{emoji('📚')}</div>
 					<Trans i18nKey="pages.développeurs.choice.publicode">
 						<h3>Publicodes</h3>
-						<p className="ui__ notice" css="flex: 1">
+						<p className="ui__ notice">
 							Nos outils sont propulsés par Publicodes, un nouveau langage pour
 							encoder des algorithmes “explicables”.
 						</p>

--- a/publicodes/source/components/rule/References.tsx
+++ b/publicodes/source/components/rule/References.tsx
@@ -1,11 +1,11 @@
 import { toPairs } from 'ramda'
-import React from 'react'
 import { capitalise0 } from '../../utils'
 import styled from 'styled-components'
 
 const references = {
 	'service-public.fr': require('url-loader!./références/marianne.png').default,
 	'urssaf.fr': require('url-loader!./références/URSSAF.png').default,
+	'secu-independants.fr': require('url-loader!./références/URSSAF.png').default,
 	'gouv.fr': require('url-loader!./références/marianne.png').default,
 	'agirc-arrco.fr': require('url-loader!./références/agirc-arrco.png').default,
 	'pole-emploi.fr': require('url-loader!./références/pole-emploi.png').default,


### PR DESCRIPTION
Avant d'envisager la création d'un simulateur dédié aux aides covid  #1180, dont je ne suis pas encore certain de la pertinence, l'idée est de calculer les réductions de cotisations covid sur tous les simulateurs existants et de le mettre en avant de l'affichage des résultats.

- [x] Artiste-auteurs https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/5761-Infographie-Aide-AA-WEB.pdf
- [x] Indépendant  https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations
- [x] Auto-entrepreneur https://www.autoentrepreneur.urssaf.fr/portail/accueil/sinformer-sur-le-statut/toutes-les-actualites/loi-de-finance-rectificative---r.html (on se contente de référencer la page urssaf pour l'instant, le calcul de l'aide nécessite de connaître le CA mois par mois) #1177
- [x] Caisses PL (CIPAV était déjà fait, j'ai la flemme d'ajouter les autres vu le nombre d'utilisateurs)
- [x] Design du bloc résultat