### PR TITLE
Performances : cache de l'applicabilité

### DIFF
--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -62,6 +62,7 @@ describe('Simulateurs', function() {
 						.invoke('val')
 						.should('be', '500')
 				}
+				cy.contains('€/an').click()
 			})
 
 			it('should allow to navigate to a documentation page', function() {

--- a/mon-entreprise/source/components/TargetSelection.tsx
+++ b/mon-entreprise/source/components/TargetSelection.tsx
@@ -225,7 +225,7 @@ function TargetInputOrValue({
 							color: colors.textColor,
 							borderColor: colors.textColor
 						}}
-						debounce={1000}
+						debounce={750}
 						name={target.dottedName}
 						value={value}
 						className={

--- a/mon-entreprise/source/components/conversation/Input.tsx
+++ b/mon-entreprise/source/components/conversation/Input.tsx
@@ -17,7 +17,7 @@ export default function Input({
 	autoFocus,
 	unit
 }) {
-	const debouncedOnChange = useCallback(debounce(750, onChange), [])
+	const debouncedOnChange = useCallback(debounce(550, onChange), [])
 	const { language } = useTranslation().i18n
 	const { thousandSeparator, decimalSeparator } = currencyFormat(language)
 

--- a/mon-entreprise/source/components/conversation/RuleInput.tsx
+++ b/mon-entreprise/source/components/conversation/RuleInput.tsx
@@ -124,7 +124,7 @@ export default function RuleInput<Name extends string = DottedName>({
 				<CurrencyInput
 					{...commonProps}
 					language={language}
-					debounce={1000}
+					debounce={750}
 					value={value as string}
 					name={dottedName}
 					className="targetInput"

--- a/publicodes/source/evaluateRule.ts
+++ b/publicodes/source/evaluateRule.ts
@@ -5,6 +5,10 @@ import { bonus, mergeAllMissing, mergeMissing } from './evaluation'
 import { convertNodeToUnit } from './nodeUnits'
 
 export const evaluateApplicability: evaluationFunction = function(node: any) {
+	const cacheKey = `${node.dottedName} [applicability]`
+	if (node.dottedName && this.cache[cacheKey]) {
+		return this.cache[cacheKey]
+	}
 	const evaluatedAttributes = pipe(
 			pick(['non applicable si', 'applicable si', 'rendu non applicable']) as (
 				x: any
@@ -49,7 +53,7 @@ export const evaluateApplicability: evaluationFunction = function(node: any) {
 				)
 		  }
 
-	return {
+	const res = {
 		...node,
 		nodeValue,
 		isApplicable: nodeValue,
@@ -57,6 +61,12 @@ export const evaluateApplicability: evaluationFunction = function(node: any) {
 		parentDependencies,
 		...evaluatedAttributes
 	}
+
+	if (node.dottedName) {
+		this.cache[cacheKey] = res
+	}
+
+	return res
 }
 
 export const evaluateFormula: evaluationFunction = function(node) {


### PR DESCRIPTION
En analysant les traces d’exécution, il apparaît qu'un temps conséquent est passé dans la fonction `evaluateApplicability`. L'ajout d'un cache simple semble améliorer significativement les performances (environ -30% dans mes mesures non scientifiques).

cc @johangirod 