### PR TITLE
Ajout d'un bot pour les retours utilisateurs

### DIFF
--- a/.github/workflows/zammad-bot.yaml
+++ b/.github/workflows/zammad-bot.yaml
@@ -1,0 +1,23 @@
+# This bot post a comment when issues with a given label are closed.
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  comment-when-issue-close:
+    if: contains(github.event.issue.labels.*.name, '🏓 retour utilisateur')
+    runs-on: ubuntu-latest
+    steps:
+      # Note: we could detect if the comment was already posted in the issue to
+      # avoid posting it multiple times in case the issue was re-opened and
+      # re-closed. https://github.com/peter-evans/create-or-update-comment
+      - uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Ce ticket vient d'être fermé 🎉
+
+            Il est temps de prévenir les utilisateurs qui nous ont fait ce retour : 
+            https://mon-entreprise.zammad.com/#search/tags%3Aissue-${{ github.event.issue.number }}
+
+            Laissez un 👍 quand c'est fait !


### PR DESCRIPTION
L'idée : on ajoute un label "retour utilisateur" sur les issues relatives aux demandes des utilisateurs. Quand le ticket est fermé le robot nous rappelle d'envoyer un message aux utilisateurs.