### PR TITLE
Url with all state

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -384,7 +384,7 @@ dirigeant . auto-entrepreneur . impôt . revenu abattu:
 
 dirigeant . auto-entrepreneur . net après impôt:
   titre: revenu net après impôt
-  identifiant court: auto-entrepreneur-netapresimpot
+  identifiant court: auto-entrepreneur-net-apres-impot
   résumé: Avant déduction des dépenses liées à l'activité
   unité: €/an
   question: Quel est le revenu net après impôt souhaité ?

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -126,6 +126,7 @@ dirigeant . auto-entrepreneur . plafond:
 
 dirigeant . auto-entrepreneur . net de cotisations:
   titre: Revenu net de cotisations
+  identifiant court: auto-entrepreneur-net
   résumé: Avant impôt
   question: Quel revenu avant impôt voulez-vous toucher ?
   description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
@@ -383,6 +384,7 @@ dirigeant . auto-entrepreneur . impôt . revenu abattu:
 
 dirigeant . auto-entrepreneur . net après impôt:
   titre: revenu net après impôt
+  identifiant court: auto-entrepreneur-netapresimpot
   résumé: Avant déduction des dépenses liées à l'activité
   unité: €/an
   question: Quel est le revenu net après impôt souhaité ?
@@ -413,6 +415,7 @@ dirigeant . rémunération totale:
   question: Quel montant pensez-vous dégager pour votre rémunération ?
   résumé: Dépensé par l'entreprise
   unité: €/an
+  identifiant court: dirigeant-total
   description: C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
     Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
 
@@ -547,6 +550,7 @@ dirigeant . indépendant . cotisations et contributions . aide indépendant covi
     Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/
 
 dirigeant . indépendant . revenu net de cotisations:
+  identifiant court: independant-net
   synonymes:
     - résultat comptable
   formule:

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -57,7 +57,7 @@ entreprise . chiffre d'affaires:
   résumé: Montant total des recettes brutes (hors taxe)
   unité: €/an
   formule: dirigeant . rémunération totale + charges
-  identifiant court: entreprise-ca
+  identifiant court: ca
 
 entreprise . chiffre d'affaires minimum:
   identifiant court: entreprise-ca-min
@@ -140,7 +140,7 @@ entreprise . charges:
     - charges d'exploitation
     - charges de fonctionnement
   titre: charges de fonctionnement
-  identifiant court: entreprise-charges
+  identifiant court: charges
   résumé: Toutes les dépenses nécessaires à l'entreprise
   question: Quelles sont les charges de l'entreprise ?
   description: |

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -57,8 +57,10 @@ entreprise . chiffre d'affaires:
   résumé: Montant total des recettes brutes (hors taxe)
   unité: €/an
   formule: dirigeant . rémunération totale + charges
+  identifiant court: entreprise-ca
 
 entreprise . chiffre d'affaires minimum:
+  identifiant court: entreprise-ca-min
   description: Le montant minimum des ventes (H.T) à réaliser pour atteindre le seuil de rentabilité.
   question: Quel est votre chiffre d'affaires minimum envisagé ?
   unité: €/an
@@ -138,6 +140,7 @@ entreprise . charges:
     - charges d'exploitation
     - charges de fonctionnement
   titre: charges de fonctionnement
+  identifiant court: entreprise-charges
   résumé: Toutes les dépenses nécessaires à l'entreprise
   question: Quelles sont les charges de l'entreprise ?
   description: |
@@ -204,10 +207,10 @@ entreprise . ACRE:
   par défaut: ACRE par défaut
   note: Les auto-entreprises crées entre le 1er janvier et le 31 décembre 2019 bénéficient d'un dispositif plus favorable, actif pendant 3 années.
 
-entreprise . ACRE par défaut: 
+entreprise . ACRE par défaut:
   formule:
     variations:
-      - si: 
+      - si:
           toutes ces conditions:
             - dirigeant . auto-entrepreneur
             - une de ces conditions:

--- a/modele-social/règles/impôt.yaml
+++ b/modele-social/règles/impôt.yaml
@@ -274,7 +274,7 @@ revenu net après impôt:
   unité: €/an
   résumé: Disponible sur votre compte en banque
   question: Quel revenu voulez-vous toucher ?
-  identifiant court: netapresimpot
+  identifiant court: net-apres-impot
   description: |
     Il s'agit du revenu net de charges, cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.

--- a/modele-social/règles/impôt.yaml
+++ b/modele-social/règles/impôt.yaml
@@ -274,6 +274,7 @@ revenu net après impôt:
   unité: €/an
   résumé: Disponible sur votre compte en banque
   question: Quel revenu voulez-vous toucher ?
+  identifiant court: netapresimpot
   description: |
     Il s'agit du revenu net de charges, cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1200,7 +1200,7 @@ contrat salarié . cotisations . assiette minimale:
 
 contrat salarié . rémunération . brut de base:
   titre: Salaire brut
-  identifiant court: salarie-brut
+  identifiant court: salaire-brut
   résumé: Brut de référence (sans les primes, indemnités ni majorations)
   type: salaire
   question: Quel est votre salaire brut ?
@@ -1611,8 +1611,8 @@ contrat salarié . plafond sécurité sociale . renonciation proratisation:
     D'un commun accord, l'employeur et l'employé peuvent renoncer à la réduction
     du plafond de la sécurité sociale (applicable pour les salariés à temps
     partiel), notamment afin d'augmenter le montant des cotisations vieillesse.
-  formule: non
-  # TODO : ajouter une question non prioritaire
+  # TODO : Réactiver la règle (peut être ajouter des références et la déplacer dans l'espace de nom temps de travail)
+  valeur: non
   applicable si: temps de travail . quotité de travail < 100%
   remplace:
     - règle: plafond sécurité sociale
@@ -1756,7 +1756,7 @@ contrat salarié . prime d'impatriation:
 
 contrat salarié . rémunération . net:
   titre: Salaire net
-  identifiant court: salarie-net
+  identifiant court: salaire-net
   unité: €/mois
   type: salaire
   question: Quel est votre salaire net ?
@@ -1781,7 +1781,7 @@ contrat salarié . rémunération . net:
 
 contrat salarié . rémunération . net après impôt:
   titre: Salaire net après impôt
-  identifiant court: salarie-netapresimpot
+  identifiant court: salaire-net-apres-impot
   résumé: Versé sur le compte bancaire
   question: Quel est le revenu net du salarié après impôt ?
   type: salaire
@@ -1801,7 +1801,7 @@ contrat salarié . rémunération . net après impôt:
 
 contrat salarié . prix du travail:
   titre: Coût total
-  identifiant court: salarie-coutembauche
+  identifiant court: cout-embauche
   résumé: Dépensé par l'entreprise
   question: Quel est le coût total de cette embauche ?
   description: |
@@ -1819,7 +1819,6 @@ contrat salarié . prix du travail:
 
 contrat salarié . rémunération . total:
   titre: Total chargé
-  identifiant court: salarie-total
   question: Quelle est la rémunération chargée ?
   résumé: Dépensé par l'entreprise
   type: salaire

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1200,6 +1200,7 @@ contrat salarié . cotisations . assiette minimale:
 
 contrat salarié . rémunération . brut de base:
   titre: Salaire brut
+  identifiant court: salarie-brut
   résumé: Brut de référence (sans les primes, indemnités ni majorations)
   type: salaire
   question: Quel est votre salaire brut ?
@@ -1755,6 +1756,7 @@ contrat salarié . prime d'impatriation:
 
 contrat salarié . rémunération . net:
   titre: Salaire net
+  identifiant court: salarie-net
   unité: €/mois
   type: salaire
   question: Quel est votre salaire net ?
@@ -1779,6 +1781,7 @@ contrat salarié . rémunération . net:
 
 contrat salarié . rémunération . net après impôt:
   titre: Salaire net après impôt
+  identifiant court: salarie-netapresimpot
   résumé: Versé sur le compte bancaire
   question: Quel est le revenu net du salarié après impôt ?
   type: salaire
@@ -1798,6 +1801,7 @@ contrat salarié . rémunération . net après impôt:
 
 contrat salarié . prix du travail:
   titre: Coût total
+  identifiant court: salarie-coutembauche
   résumé: Dépensé par l'entreprise
   question: Quel est le coût total de cette embauche ?
   description: |
@@ -1815,6 +1819,7 @@ contrat salarié . prix du travail:
 
 contrat salarié . rémunération . total:
   titre: Total chargé
+  identifiant court: salarie-total
   question: Quelle est la rémunération chargée ?
   résumé: Dépensé par l'entreprise
   type: salaire

--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -106,8 +106,9 @@ describe('Simulateur salarié mode partagé', () => {
 	const simulatorUrl = '/simulateurs/salaire-brut-net'
 	const searchParams = new URLSearchParams({
 		'contrat salarié': "'CDD'",
-		'salarie-brut': JSON.stringify({ valeur: '1539', unité: '€/mois' }),
+		'salarie-brut': '1539€/mois',
 	})
+
 	const urlWithState = `${simulatorUrl}?${searchParams.toString()}`
 	if (!fr) {
 		return

--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -106,7 +106,7 @@ describe('Simulateur salarié mode partagé', () => {
 	const simulatorUrl = '/simulateurs/salaire-brut-net'
 	const searchParams = new URLSearchParams({
 		'contrat salarié': "'CDD'",
-		'salarie-brut': '1539€/mois',
+		'salaire-brut': '1539€/mois',
 	})
 
 	const urlWithState = `${simulatorUrl}?${searchParams.toString()}`

--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -100,6 +100,40 @@ describe('Simulateur auto-entrepreneur', () => {
 	})
 })
 
+describe('Simulateur salarié mode partagé', () => {
+	const brutInputSelector =
+		'input.currencyInput__input[name="contrat salarié . rémunération . brut de base"]'
+	const simulatorUrl = '/simulateurs/salaire-brut-net'
+	const searchParams = new URLSearchParams({
+		_targetUnit: '€/mois',
+		'contrat salarié': "'CDD'",
+		'salarie-brut': JSON.stringify({ valeur: '1539', unité: '€/mois' }),
+	})
+	const urlWithState = `${simulatorUrl}?${searchParams.toString()}`
+	if (!fr) {
+		return
+	}
+	it('should set input value from URL', function () {
+		cy.visit(urlWithState)
+		cy.wait(800)
+		cy.get(brutInputSelector).first().invoke('val').should('be', '1 539')
+
+		cy.get('button.ui__.small.simple.button').first().click()
+		cy.get('span.answerContent').first().contains('CDD')
+	})
+	it('should set URL from input value', function () {
+		cy.visit(simulatorUrl)
+		cy.get(brutInputSelector).first().type('{selectall}1539')
+		cy.wait(1000)
+		cy.get('.step').find('input[value="\'CDD\'"]').click({ force: true })
+		cy.wait(1000)
+		cy.get('button.shareButton').click()
+		cy.get('.overlayContent textarea')
+			.invoke('val')
+			.should('eq', Cypress.config().baseUrl + urlWithState)
+	})
+})
+
 describe('Simulateur salarié', () => {
 	if (!fr) {
 		return

--- a/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/simulateurs.js
@@ -105,7 +105,6 @@ describe('Simulateur salarié mode partagé', () => {
 		'input.currencyInput__input[name="contrat salarié . rémunération . brut de base"]'
 	const simulatorUrl = '/simulateurs/salaire-brut-net'
 	const searchParams = new URLSearchParams({
-		_targetUnit: '€/mois',
 		'contrat salarié': "'CDD'",
 		'salarie-brut': JSON.stringify({ valeur: '1539', unité: '€/mois' }),
 	})

--- a/mon-entreprise/scripts/i18n/utils.js
+++ b/mon-entreprise/scripts/i18n/utils.js
@@ -16,7 +16,7 @@ let attributesToTranslate = [
 	'question',
 	'résumé',
 	'suggestions',
-	'note',
+	'note'
 ]
 
 function getRulesMissingTranslations() {
@@ -30,7 +30,7 @@ function getRulesMissingTranslations() {
 			dottedName,
 			!rule || !rule.titre // && utils.ruleWithDedicatedDocumentationPage(rule))
 				? { ...rule, titre: dottedName.split(' . ').slice(-1)[0] }
-				: rule,
+				: rule
 		])
 		.map(([dottedName, rule]) => ({
 			[dottedName]: R.mergeAll(
@@ -56,13 +56,13 @@ function getRulesMissingTranslations() {
 									return {
 										...acc,
 										[frTrad]: currentTranslation[frTrad],
-										[enTrad]: currentTranslation[enTrad],
+										[enTrad]: currentTranslation[enTrad]
 									}
 								}
 								missingTranslations.push([dottedName, enTrad, suggestion])
 								return {
 									...acc,
-									[frTrad]: suggestion,
+									[frTrad]: suggestion
 								}
 							}, {})
 						}
@@ -76,15 +76,15 @@ function getRulesMissingTranslations() {
 						)
 							return {
 								[enTrad]: currentTranslation[enTrad],
-								[frTrad]: v,
+								[frTrad]: v
 							}
 
 						missingTranslations.push([dottedName, enTrad, v])
 						return {
-							[frTrad]: v,
+							[frTrad]: v
 						}
 					})
-			),
+			)
 		}))
 	resolved = R.mergeAll(resolved)
 	return [missingTranslations, resolved]
@@ -96,7 +96,7 @@ const getUiMissingTranslations = () => {
 	))
 	const translatedKeys = parse(fs.readFileSync(UiTranslationPath, 'utf-8'))
 
-	const missingTranslations = Object.keys(staticKeys).filter((key) => {
+	const missingTranslations = Object.keys(staticKeys).filter(key => {
 		if (key.match(/^\{.*\}$/)) {
 			return false
 		}
@@ -106,24 +106,29 @@ const getUiMissingTranslations = () => {
 	return R.pick(missingTranslations, staticKeys)
 }
 
-const fetchTranslation = async (text) => {
-	console.log(`Fetch translation for:\n\t${text}`)
+const fetchTranslation = async text => {
 	const response = await fetch(
 		`https://api.deepl.com/v2/translate?${querystring.stringify({
 			text,
 			auth_key: process.env.DEEPL_API_SECRET,
 			tag_handling: 'xml',
 			source_lang: 'FR',
-			target_lang: 'EN',
+			target_lang: 'EN'
 		})}`
 	)
-	const { translations } = await response.json()
-	return translations[0].text
+	try {
+		const { translations } = await response.json()
+		console.log(`✅ Deepl translation succeeded for:\n\t${text}\n`)
+		return translations[0].text
+	} catch (e) {
+		console.warn(`❌ Deepl translation failed for:\n\t${text}\n`)
+		return ''
+	}
 }
 module.exports = {
 	fetchTranslation,
 	getRulesMissingTranslations,
 	getUiMissingTranslations,
 	rulesTranslationPath,
-	UiTranslationPath,
+	UiTranslationPath
 }

--- a/mon-entreprise/scripts/i18n/utils.js
+++ b/mon-entreprise/scripts/i18n/utils.js
@@ -16,7 +16,7 @@ let attributesToTranslate = [
 	'question',
 	'résumé',
 	'suggestions',
-	'note'
+	'note',
 ]
 
 function getRulesMissingTranslations() {
@@ -30,7 +30,7 @@ function getRulesMissingTranslations() {
 			dottedName,
 			!rule || !rule.titre // && utils.ruleWithDedicatedDocumentationPage(rule))
 				? { ...rule, titre: dottedName.split(' . ').slice(-1)[0] }
-				: rule
+				: rule,
 		])
 		.map(([dottedName, rule]) => ({
 			[dottedName]: R.mergeAll(
@@ -56,13 +56,13 @@ function getRulesMissingTranslations() {
 									return {
 										...acc,
 										[frTrad]: currentTranslation[frTrad],
-										[enTrad]: currentTranslation[enTrad]
+										[enTrad]: currentTranslation[enTrad],
 									}
 								}
 								missingTranslations.push([dottedName, enTrad, suggestion])
 								return {
 									...acc,
-									[frTrad]: suggestion
+									[frTrad]: suggestion,
 								}
 							}, {})
 						}
@@ -76,15 +76,15 @@ function getRulesMissingTranslations() {
 						)
 							return {
 								[enTrad]: currentTranslation[enTrad],
-								[frTrad]: v
+								[frTrad]: v,
 							}
 
 						missingTranslations.push([dottedName, enTrad, v])
 						return {
-							[frTrad]: v
+							[frTrad]: v,
 						}
 					})
-			)
+			),
 		}))
 	resolved = R.mergeAll(resolved)
 	return [missingTranslations, resolved]
@@ -96,7 +96,7 @@ const getUiMissingTranslations = () => {
 	))
 	const translatedKeys = parse(fs.readFileSync(UiTranslationPath, 'utf-8'))
 
-	const missingTranslations = Object.keys(staticKeys).filter(key => {
+	const missingTranslations = Object.keys(staticKeys).filter((key) => {
 		if (key.match(/^\{.*\}$/)) {
 			return false
 		}
@@ -106,14 +106,14 @@ const getUiMissingTranslations = () => {
 	return R.pick(missingTranslations, staticKeys)
 }
 
-const fetchTranslation = async text => {
+const fetchTranslation = async (text) => {
 	const response = await fetch(
 		`https://api.deepl.com/v2/translate?${querystring.stringify({
 			text,
 			auth_key: process.env.DEEPL_API_SECRET,
 			tag_handling: 'xml',
 			source_lang: 'FR',
-			target_lang: 'EN'
+			target_lang: 'EN',
 		})}`
 	)
 	try {
@@ -130,5 +130,5 @@ module.exports = {
 	getRulesMissingTranslations,
 	getUiMissingTranslations,
 	rulesTranslationPath,
-	UiTranslationPath
+	UiTranslationPath,
 }

--- a/mon-entreprise/source/components/Banner.tsx
+++ b/mon-entreprise/source/components/Banner.tsx
@@ -16,7 +16,7 @@ export default function Banner({
 	children,
 	hidden: hiddenProp = false,
 	hideAfterFirstStep = true,
-	icon
+	icon,
 }: BannerProps) {
 	const hiddenState = useSelector(firstStepCompletedSelector)
 

--- a/mon-entreprise/source/components/Banner.tsx
+++ b/mon-entreprise/source/components/Banner.tsx
@@ -8,16 +8,19 @@ import './Banner.css'
 type BannerProps = {
 	children: React.ReactNode
 	hidden?: boolean
+	hideAfterFirstStep?: boolean
 	icon?: string
 }
 
 export default function Banner({
 	children,
 	hidden: hiddenProp = false,
-	icon,
+	hideAfterFirstStep = true,
+	icon
 }: BannerProps) {
 	const hiddenState = useSelector(firstStepCompletedSelector)
-	const hidden = hiddenProp || hiddenState
+
+	const hidden = hiddenProp || (hideAfterFirstStep && hiddenState)
 	return !hidden ? (
 		<Animate.fadeIn>
 			<div className="ui__ banner">

--- a/mon-entreprise/source/components/Overlay.tsx
+++ b/mon-entreprise/source/components/Overlay.tsx
@@ -108,20 +108,37 @@ const StyledOverlayWrapper = styled.div<{ offsetTop: number | null }>`
 		border-left: 0.5rem solid white;
 		bottom: 0;
 		right: 0;
-		color: rgba(0, 0, 0, 0.6);
 		color: var(--lighterTextColor);
 		padding: 0 1rem;
+		text-decoration: none;
 	}
 	.ui__.card[aria-modal='true'] {
 		padding-bottom: 4rem;
 		display: flex;
 		flex-direction: column;
 	}
+	@media (max-width: 600px) {
+		.overlayContent {
+			width: 100%;
+		}
+		.overlayCloseButton {
+			position: fixed;
+			bottom: 0;
+			right: 0;
+			line-height: 1rem;
+			padding: 1.2rem;
+			padding-bottom: 1.5rem;
+			font-size: 3rem;
+			background: var(--lighterColor);
+		}
+	}
 
 	@media (min-width: 600px) {
 		.overlayCloseButton {
+			position: absolute;
 			top: 0;
 			bottom: auto;
+			right: 0;
 			padding: 0 0.5rem;
 			font-size: 2rem;
 		}

--- a/mon-entreprise/source/components/ShareSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ShareSimulationBanner.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import Overlay from './Overlay'
+import Banner from './Banner'
+import { LinkButton } from 'Components/ui/Button'
+
+export default function ShareSimulationBanner({
+	getShareSearchParams,
+}: {
+	getShareSearchParams: () => URLSearchParams
+}) {
+	const [opened, setOpened] = useState(false)
+	const { t } = useTranslation()
+
+	if (typeof window === 'undefined') return null
+
+	const getUrl = () =>
+		[
+			window.location.origin,
+			window.location.pathname,
+			'?',
+			getShareSearchParams().toString(),
+		].join('')
+
+	const handleClose = () => {
+		setOpened(false)
+	}
+	const onClick = () => {
+		if (window.navigator.share) {
+			window.navigator.share({
+				title: document.title,
+				text: t(
+					'shareSimulation.navigatorShare',
+					'Ma simulation Mon Entreprise'
+				),
+				url: getUrl(),
+			})
+		} else {
+			setOpened(true)
+		}
+	}
+
+	return (
+		<Banner hidden={false} hideAfterFirstStep={false} icon="📤">
+			<Trans i18nKey="shareSimulation.banner">
+				Vous pouvez partager votre simulation :{' '}
+				<LinkButton onClick={onClick} className="shareButton">
+					Partager le lien
+				</LinkButton>
+			</Trans>
+			{opened && (
+				<Overlay onClose={handleClose}>
+					<ShareSimulationPopup handleClose={handleClose} getUrl={getUrl} />
+				</Overlay>
+			)}
+		</Banner>
+	)
+}
+
+function ShareSimulationPopup({
+	handleClose,
+	getUrl,
+}: {
+	handleClose: () => void
+	getUrl: () => string
+}) {
+	const textAreaRef: React.RefObject<HTMLTextAreaElement> = React.createRef()
+	const { t } = useTranslation()
+
+	useEffect(() => {
+		const node = textAreaRef.current
+		if (node) {
+			node.select()
+		}
+	})
+
+	return (
+		<>
+			<h2>{t('shareSimulation.modal.title', 'Votre lien de partage')}</h2>
+			<textarea
+				className="ui__ "
+				ref={textAreaRef}
+				style={{
+					whiteSpace: 'nowrap',
+				}}
+			>
+				{getUrl()}
+			</textarea>
+			{navigator.clipboard ? (
+				<button
+					className="ui__ small simple  button "
+					onClick={() => {
+						navigator.clipboard.writeText(getUrl())
+						handleClose()
+					}}
+				>
+					📋 {t('shareSimulation.modal.button', 'Copier le lien')}
+				</button>
+			) : (
+				<p>
+					{t(
+						'shareSimulation.modal.helpText',
+						'Le lien est déjà sélectionné, vous pouvez faire "copier".'
+					)}
+				</p>
+			)}
+		</>
+	)
+}

--- a/mon-entreprise/source/components/Simulation.tsx
+++ b/mon-entreprise/source/components/Simulation.tsx
@@ -14,6 +14,8 @@ import { Trans } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { firstStepCompletedSelector } from 'Selectors/simulationSelectors'
 import LinkToForm from './Feedback/LinkToForm'
+import useSearchParamsSimulationSharing from 'Components/utils/useSearchParamsSimulationSharing'
+import ShareSimulationBanner from 'Components/ShareSimulationBanner'
 
 type SimulationProps = {
 	explanations?: React.ReactNode
@@ -31,6 +33,8 @@ export default function Simulation({
 	showPeriodSwitch,
 }: SimulationProps) {
 	const firstStepCompleted = useSelector(firstStepCompletedSelector)
+	const getShareSearchParams = useSearchParamsSimulationSharing()
+
 	return (
 		<>
 			<TargetSelection showPeriodSwitch={showPeriodSwitch} />
@@ -38,6 +42,7 @@ export default function Simulation({
 			{firstStepCompleted && (
 				<Animate.fromTop>
 					{results}
+					<ShareSimulationBanner getShareSearchParams={getShareSearchParams} />
 					<Questions customEndMessages={customEndMessages} />
 					<br />
 					{showLinkToForm && <LinkToForm />}

--- a/mon-entreprise/source/components/utils/useSearchParams.ts
+++ b/mon-entreprise/source/components/utils/useSearchParams.ts
@@ -1,0 +1,65 @@
+// backported from react-router 6
+// https://github.com/ReactTraining/react-router/blob/a97dbdb7297474ff0114411e363db2c8fb417e55/packages/react-router-dom/index.tsx#L383
+
+import { useCallback, useMemo, useRef } from 'react'
+import { useLocation, useHistory } from 'react-router-dom'
+
+export type ParamKeyValuePair = [string, string]
+export type URLSearchParamsInit =
+	| string
+	| ParamKeyValuePair[]
+	| Record<string, string | string[]>
+	| URLSearchParams
+
+export function useSearchParams(defaultInit?: URLSearchParamsInit) {
+	const defaultSearchParamsRef = useRef(createSearchParams(defaultInit))
+
+	const location = useLocation()
+	const searchParams = useMemo(() => {
+		const searchParams = createSearchParams(location.search)
+
+		for (const key of defaultSearchParamsRef.current.keys()) {
+			if (!searchParams.has(key)) {
+				defaultSearchParamsRef.current.getAll(key).forEach((value) => {
+					searchParams.append(key, value)
+				})
+			}
+		}
+
+		return searchParams
+	}, [location.search])
+
+	const history = useHistory()
+	const setSearchParams = useCallback(
+		(
+			nextInit: URLSearchParamsInit,
+			navigateOptions?: { replace?: boolean }
+		) => {
+			if (navigateOptions?.replace) {
+				history.replace('?' + createSearchParams(nextInit))
+			} else {
+				history.push('?' + createSearchParams(nextInit))
+			}
+		},
+		[history]
+	)
+
+	return [searchParams, setSearchParams] as const
+}
+
+export function createSearchParams(
+	init: URLSearchParamsInit = ''
+): URLSearchParams {
+	return new URLSearchParams(
+		typeof init === 'string' ||
+		Array.isArray(init) ||
+		init instanceof URLSearchParams
+			? init
+			: Object.keys(init).reduce((memo, key) => {
+					const value = init[key]
+					return memo.concat(
+						Array.isArray(value) ? value.map((v) => [key, v]) : [[key, value]]
+					)
+			  }, [] as ParamKeyValuePair[])
+	)
+}

--- a/mon-entreprise/source/components/utils/useSearchParamsSimulationSharing.ts
+++ b/mon-entreprise/source/components/utils/useSearchParamsSimulationSharing.ts
@@ -24,7 +24,7 @@ export default function useSearchParamsSimulationSharing() {
 	const dispatch = useDispatch()
 
 	const dottedNameParamName = useMemo(
-		() => getRulesParamNames(engine.getRules()),
+		() => getRulesParamNames(engine.getParsedRules()),
 		[engine]
 	)
 

--- a/mon-entreprise/source/components/utils/useSearchParamsSimulationSharing.ts
+++ b/mon-entreprise/source/components/utils/useSearchParamsSimulationSharing.ts
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { SimulationConfig, Situation } from 'Reducers/rootReducer'
+import { useSearchParams } from 'Components/utils/useSearchParams'
+import { useEngine } from 'Components/utils/EngineContext'
+import {
+	configSelector,
+	situationSelector,
+	targetUnitSelector,
+} from 'Selectors/simulationSelectors'
+import { ParsedRules } from 'publicodes'
+import { DottedName } from 'modele-social'
+import { updateSituation, updateUnit, setActiveTarget } from 'Actions/actions'
+
+type Objectifs = (string | { objectifs: string[] })[]
+type ShortName = string
+type ParamName = DottedName | ShortName
+
+export default function useSearchParamsSimulationSharing() {
+	const [urlSituationIsExtracted, setUrlSituationIsExtracted] = useState(false)
+	const [searchParams, setSearchParams] = useSearchParams()
+	const config = useSelector(configSelector)
+	const situation = useSelector(situationSelector)
+	const targetUnit = useSelector(targetUnitSelector)
+	const engine = useEngine()
+	const dispatch = useDispatch()
+
+	const dottedNameParamName = useMemo(
+		() => getRulesParamNames(engine.getRules()),
+		[engine]
+	)
+
+	useEffect(() => {
+		const hasConfig = Object.keys(config).length > 0
+		if (!hasConfig) return
+
+		// On load:
+		if (!urlSituationIsExtracted) {
+			const objectifs = objectifsOfConfig(config)
+			const {
+				situation: newSituation,
+				targetUnit: newTargetUnit,
+			} = getSituationFromSearchParams(searchParams, dottedNameParamName)
+
+			if (newTargetUnit) dispatch(updateUnit(newTargetUnit))
+			Object.entries(newSituation).forEach(([dottedName, value]) => {
+				dispatch(updateSituation(dottedName as DottedName, value))
+			})
+			const newActiveTarget = Object.keys(newSituation).filter((dottedName) =>
+				objectifs.includes(dottedName)
+			)[0]
+			if (newActiveTarget) {
+				dispatch(setActiveTarget(newActiveTarget as DottedName))
+			}
+
+			cleanSearchParams(
+				searchParams,
+				setSearchParams,
+				dottedNameParamName,
+				Object.keys(newSituation) as DottedName[]
+			)
+
+			setUrlSituationIsExtracted(true)
+			return
+		}
+	}, [
+		dispatch,
+		dottedNameParamName,
+		config,
+		searchParams,
+		setSearchParams,
+		situation,
+		targetUnit,
+		urlSituationIsExtracted,
+	])
+
+	return () =>
+		getSearchParamsFromSituation(
+			situation,
+			targetUnit || (config['unité par défaut'] as string),
+			dottedNameParamName
+		)
+}
+
+const objectifsOfConfig = (config: Partial<SimulationConfig>) =>
+	(config.objectifs as Objectifs).flatMap((objectifOrSection) => {
+		if (typeof objectifOrSection === 'string') {
+			return [objectifOrSection]
+		}
+		return objectifOrSection.objectifs
+	})
+
+export const cleanSearchParams = (
+	searchParams: ReturnType<typeof useSearchParams>[0],
+	setSearchParams: ReturnType<typeof useSearchParams>[1],
+	dottedNameParamName: [DottedName, ParamName][],
+	dottedNames: DottedName[]
+) => {
+	const dottedNameParamNameMapping = Object.fromEntries(dottedNameParamName)
+	searchParams.delete(TARGET_UNIT_KEY)
+	dottedNames.forEach((dottedName) =>
+		searchParams.delete(dottedNameParamNameMapping[dottedName])
+	)
+	setSearchParams(searchParams.toString())
+}
+
+export const getRulesParamNames = (
+	parsedRules: ParsedRules<DottedName>
+): [DottedName, ParamName][] =>
+	(Object.entries(parsedRules) as [
+		DottedName,
+		{ rawNode: { 'identifiant court'?: ShortName } }
+	][]).map(([dottedName, ruleNode]) => [
+		dottedName,
+		ruleNode.rawNode['identifiant court'] || dottedName,
+	])
+
+// Simple (de)serialization based on value type
+export const serialize = (
+	value: Record<string, unknown> | string | number
+): string => {
+	switch (typeof value) {
+		case 'object':
+			return `${JSON.stringify(value)}`
+		case 'string':
+			return value
+		case 'number':
+			return `_${value}`
+		default:
+			throw new Error('Unexpected type in situation')
+	}
+}
+export const deserialize = (
+	value: string
+): Record<string, unknown> | string | number | undefined => {
+	if (value.startsWith('_')) {
+		try {
+			return parseFloat(value.slice(1))
+		} catch {
+			return
+		}
+	}
+	if (value.startsWith('{')) {
+		try {
+			return JSON.parse(value)
+		} catch {
+			return
+		}
+	}
+	return value
+}
+
+const TARGET_UNIT_KEY = '_targetUnit' as const
+
+// TODO On préfèrerait que le targetUnit soit remonté de manière plus lisible
+// dans l'URL, par ex sous forme de "an" au lieu de "€/an". Ceci dit le format
+// du targetUnit est dépendant de l'engine, duquel il faut être agnostique ici.
+// On pourra revoir cela plus tard quand l'engine exposera une API (notamment un
+// typage) plus clair.
+// XXX ajouter une issue pour ça
+export function getSearchParamsFromSituation(
+	situation: Situation,
+	targetUnit: string,
+	dottedNameParamName: [DottedName, ParamName][]
+): URLSearchParams {
+	const searchParams = new URLSearchParams()
+	const dottedNameParamNameMapping = Object.fromEntries(dottedNameParamName)
+	;(Object.entries(situation) as [DottedName, any][]).forEach(
+		([dottedName, value]) => {
+			const paramName = dottedNameParamNameMapping[dottedName]
+			try {
+				searchParams.set(paramName, serialize(value))
+			} catch {
+				// noop
+			}
+		}
+	)
+	if (targetUnit) searchParams.set(TARGET_UNIT_KEY, targetUnit)
+	searchParams.sort()
+	return searchParams
+}
+
+export function getSituationFromSearchParams(
+	searchParams: URLSearchParams,
+	dottedNameParamName: [DottedName, ParamName][]
+) {
+	const situation = {} as Situation
+	let targetUnit = ''
+
+	const paramNameDottedName = dottedNameParamName.reduce(
+		(dottedNameBySearchParamName, [dottedName, paramName]) => ({
+			...dottedNameBySearchParamName,
+			[paramName]: dottedName,
+		}),
+		{} as Record<ParamName, DottedName>
+	)
+
+	searchParams.forEach((value, paramName) => {
+		if (paramName === TARGET_UNIT_KEY) {
+			targetUnit = value
+		} else if (
+			Object.prototype.hasOwnProperty.call(paramNameDottedName, paramName)
+		) {
+			situation[paramNameDottedName[paramName]] = deserialize(value)
+		}
+	})
+
+	return { situation, targetUnit }
+}

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -2580,6 +2580,8 @@ contrat salarié . prix du travail:
   résumé.fr: Dépensé par l'entreprise
   titre.en: labor cost
   titre.fr: Coût total
+  identifiant court.en: employee-laborcost
+  identifiant court.fr: salarie-coutembauche
 contrat salarié . profession spécifique:
   question.en: '[automatic] Does the employee work in one of the following professions?'
   question.fr: Le salarié exerce t-il l'une des professions suivantes ?
@@ -3044,6 +3046,8 @@ contrat salarié . rémunération . brut de base:
   suggestions.salaire médian.fr: salaire médian
   titre.en: Gross salary
   titre.fr: Salaire brut
+  identifiant court.en: employee-brut
+  identifiant court.fr: salarie-brut
 contrat salarié . rémunération . brut de base . équivalent temps plein:
   question.en: What is the full-time equivalent salary?
   question.fr: Quel est le salaire en équivalent temps plein ?
@@ -3101,6 +3105,8 @@ contrat salarié . rémunération . net:
   résumé.fr: Salaire net avant impôt
   titre.en: Net salary
   titre.fr: Salaire net
+  identifiant court.en: employee-net
+  identifiant court.fr: salarie-net
 contrat salarié . rémunération . net après impôt:
   description.en: >-
     Net salary after deduction of the **neutral** income tax (also called
@@ -3126,6 +3132,8 @@ contrat salarié . rémunération . net après impôt:
   résumé.fr: Versé sur le compte bancaire
   titre.en: Net salary after income tax
   titre.fr: Salaire net après impôt
+  identifiant court.en: employee-netaftertax
+  identifiant court.fr: salarie-netapresimpot
 contrat salarié . rémunération . net avec revenus de remplacement:
   titre.en: '[automatic] net with replacement income'
   titre.fr: net avec revenus de remplacement
@@ -3284,6 +3292,8 @@ contrat salarié . rémunération . total:
   résumé.fr: Dépensé par l'entreprise
   titre.en: Total salary
   titre.fr: Total chargé
+  identifiant court.fr: salarie-total
+  identifiant court.en: employee-total
 contrat salarié . salarié majeur:
   question.en: Is the employee over 18 (age of majority)?
   question.fr: Le salarié est-il majeur ?
@@ -3979,6 +3989,8 @@ dirigeant . auto-entrepreneur . net après impôt:
   résumé.fr: Avant déduction des dépenses liées à l'activité
   titre.en: net income after tax
   titre.fr: revenu net après impôt
+  identifiant court.en: auto-entrepreneur-netaftertax
+  identifiant court.fr: auto-entrepreneur-netapresimpot
 dirigeant . auto-entrepreneur . net de cotisations:
   description.en:
     This is the income net of contributions and expenses, before the
@@ -3991,6 +4003,8 @@ dirigeant . auto-entrepreneur . net de cotisations:
   résumé.fr: Avant impôt
   titre.en: Net contribution income
   titre.fr: Revenu net de cotisations
+  identifiant court.en: auto-entrepreneur-net
+  identifiant court.fr: auto-entrepreneur-net
 dirigeant . auto-entrepreneur . notification calcul ACRE annuel:
   description.en: >
     [automatic] The ACRE rate used is the one corresponding to the current
@@ -5762,6 +5776,8 @@ dirigeant . indépendant . revenu net de cotisations:
   résumé.fr: Avant déduction de l'impôt sur le revenu
   titre.en: net contribution income
   titre.fr: revenu net de cotisations
+  identifiant court.en: independant-net
+  identifiant court.fr: independant-net
 dirigeant . indépendant . revenu professionnel:
   description.en: >
     This is the income net of deductible contributions of the self-employed
@@ -5842,6 +5858,8 @@ dirigeant . rémunération totale:
   résumé.fr: Dépensé par l'entreprise
   titre.en: Director total income
   titre.fr: rémunération totale
+  identifiant court.en: director-total
+  identifiant court.fr: dirigeant-total
 entreprise:
   description.en: The contract binds a company and an employee
   description.fr: |
@@ -6146,6 +6164,8 @@ entreprise . charges:
   résumé.fr: Toutes les dépenses nécessaires à l'entreprise
   titre.en: expenses
   titre.fr: charges de fonctionnement
+  identifiant court.en: company-expenses
+  identifiant court.fr: entreprise-charges
 entreprise . charges dont rémunération dirigeant:
   titre.en: expenses of which executive compensation
   titre.fr: charges dont rémunération dirigeant
@@ -6156,6 +6176,8 @@ entreprise . chiffre d'affaires:
   résumé.fr: Montant total des recettes brutes (hors taxe)
   titre.en: '[automatic] revenues'
   titre.fr: chiffre d'affaires
+  identifiant court.en: company-turnover
+  identifiant court.fr: entreprise-ca
 entreprise . chiffre d'affaires de société:
   titre.en: company turnover
   titre.fr: chiffre d'affaires de société
@@ -6169,6 +6191,8 @@ entreprise . chiffre d'affaires minimum:
   question.fr: Quel est votre chiffre d'affaires minimum envisagé ?
   titre.en: Minimum turnover
   titre.fr: chiffre d'affaires minimum
+  identifiant court.en: company-turnover-min
+  identifiant court.fr: entreprise-ca-min
 entreprise . date de création:
   description.en: >
     [automatic] The activity start date (or creation date) is set at the time of
@@ -7240,6 +7264,8 @@ revenu net après impôt:
   résumé.fr: Disponible sur votre compte en banque
   titre.en: Net income after tax
   titre.fr: revenu net après impôt
+  identifiant court.en: netaftertax
+  identifiant court.fr: netapresimpot
 revenus net de cotisations:
   description.en: |
     l'impôt sur le revenu.

--- a/mon-entreprise/source/locales/translateRules.ts
+++ b/mon-entreprise/source/locales/translateRules.ts
@@ -38,6 +38,7 @@ export const attributesToTranslate = [
 	'résumé',
 	'suggestions',
 	'note',
+	'identifiant court',
 ]
 
 const translateProp = (lang: string, translation: Translation) => (

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -1313,6 +1313,14 @@ selectionRégime:
     titre: Before starting...
     urssaf: The figures are indicative and do not replace the actual accounts of the
       Urssaf, impots.gouv.fr, etc
+shareSimulation:
+  banner: "You can share your simulation: <2 onClick={onClick}>Share
+    link</2>"
+  modal:
+    button: Copy link
+    helpText: The link is already selected, you can just hit "copy".
+    title: Your sharing link
+  navigatorShare: My company simulation
 simulateurs:
   explanation:
     CNAPL: It recovers contributions related to your retirement and disability/death

--- a/mon-entreprise/source/reducers/rootReducer.ts
+++ b/mon-entreprise/source/reducers/rootReducer.ts
@@ -91,13 +91,13 @@ function simulation(
 	existingCompany: Company
 ): Simulation | null {
 	if (action.type === 'SET_SIMULATION') {
+		if (state && state.config === action.config) {
+			return state
+		}
 		const companySituation = action.useCompanyDetails
 			? getCompanySituation(existingCompany)
 			: {}
 		const { config, url } = action
-		if (state && state.config === config) {
-			return state
-		}
 		return {
 			config,
 			url,

--- a/mon-entreprise/source/reducers/rootReducer.ts
+++ b/mon-entreprise/source/reducers/rootReducer.ts
@@ -60,7 +60,7 @@ export type SimulationConfig = {
 	'unité par défaut': string
 }
 
-type Situation = Partial<Record<DottedName, any>>
+export type Situation = Partial<Record<DottedName, any>>
 export type Simulation = {
 	config: SimulationConfig
 	url: string

--- a/mon-entreprise/source/selectors/storageSelectors.ts
+++ b/mon-entreprise/source/selectors/storageSelectors.ts
@@ -4,6 +4,7 @@ import { DottedName } from 'modele-social'
 // Note: it is currently not possible to define SavedSimulation as the return
 // type of the currentSimulationSelector function because the type would then
 // circulary reference itself.
+// TODO: recursive type references should work now: https://github.com/microsoft/TypeScript/pull/33050
 export type SavedSimulation = {
 	situation: Simulation['situation']
 	activeTargetInput: RootState['activeTargetInput']

--- a/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
+++ b/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
@@ -6,8 +6,6 @@ import {
 	getSearchParamsFromSituation,
 	getSituationFromSearchParams,
 	getRulesParamNames,
-	serialize,
-	deserialize,
 	cleanSearchParams,
 } from '../source/components/utils/useSearchParamsSimulationSharing'
 
@@ -35,26 +33,27 @@ rule with:
 rule without:
 	formule: 0
 	`)
-	const dottedNameParamName = getRulesParamNames(
-		new Engine(someRules).getRules()
-	)
+	const engine = new Engine(someRules)
+	const dottedNameParamName = getRulesParamNames(engine.getRules())
 
 	describe('getSearchParamsFromSituation', () => {
 		it('builds search params with and without identifiant court', () => {
 			expect(
 				getSearchParamsFromSituation(
-					{ 'rule with': '2000 €/mois', 'rule without': '1000 €/mois' },
+					engine,
+					{ 'rule with': '2000€/mois', 'rule without': '1000€/mois' },
 					dottedNameParamName
 				).toString()
 			).to.equal(
 				new URLSearchParams(
-					'panta=2000 €/mois&rule without=1000 €/mois'
+					'panta=2000€/mois&rule without=1000€/mois'
 				).toString()
 			)
 		})
-		it('builds search params with object', () => {
+		it.skip('builds search params with object', () => {
 			expect(
 				getSearchParamsFromSituation(
+					engine,
 					{ 'rule without': { 1: 2, 3: { 4: '5' } } },
 					dottedNameParamName
 				).toString()
@@ -64,7 +63,7 @@ rule without:
 		})
 		it('handles empty situation with proper defaults', () => {
 			expect(
-				getSearchParamsFromSituation({}, dottedNameParamName).toString()
+				getSearchParamsFromSituation(engine, {}, dottedNameParamName).toString()
 			).to.equal('')
 		})
 	})
@@ -73,12 +72,12 @@ rule without:
 		it('reads search params with and without identifiant court', () => {
 			expect(
 				getSituationFromSearchParams(
-					new URLSearchParams('panta=2000 €/mois&rule without=1000 €/mois'),
+					new URLSearchParams('panta=2000€/mois&rule without=1000€/mois'),
 					dottedNameParamName
 				)
 			).to.deep.equal({
-				'rule with': '2000 €/mois',
-				'rule without': '1000 €/mois',
+				'rule with': '2000€/mois',
+				'rule without': '1000€/mois',
 			})
 		})
 		it('handles empty search params with proper defaults', () => {
@@ -88,15 +87,6 @@ rule without:
 					dottedNameParamName
 				)
 			).to.deep.equal({})
-		})
-	})
-
-	describe('serialization is somethingpotent', () => {
-		expect(deserialize(serialize(1))).to.equal(1)
-		expect(deserialize(serialize('1'))).to.equal('1')
-		expect(deserialize(serialize({ 1: 2, 3: '4' }))).to.deep.equal({
-			1: 2,
-			3: '4',
 		})
 	})
 })

--- a/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
+++ b/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
@@ -34,7 +34,7 @@ rule without:
 	formule: 0
 	`)
 	const engine = new Engine(someRules)
-	const dottedNameParamName = getRulesParamNames(engine.getRules())
+	const dottedNameParamName = getRulesParamNames(engine.getParsedRules())
 
 	describe('getSearchParamsFromSituation', () => {
 		it('builds search params with and without identifiant court', () => {
@@ -101,7 +101,7 @@ rule without:
 	`)
 
 	const dottedNameParamName = getRulesParamNames(
-		new Engine(someRules).getRules()
+		new Engine(someRules).getParsedRules()
 	)
 	let setSearchParams
 

--- a/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
+++ b/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
@@ -1,0 +1,174 @@
+import { expect } from 'chai'
+var sinon = require('sinon')
+import Engine, { parsePublicodes } from 'publicodes'
+import rules from 'modele-social'
+import {
+	getSearchParamsFromSituation,
+	getSituationFromSearchParams,
+	getRulesParamNames,
+	serialize,
+	deserialize,
+	cleanSearchParams,
+} from '../source/components/utils/useSearchParamsSimulationSharing'
+
+describe('identifiant court', () => {
+	const questions = Object.entries(parsePublicodes(rules))
+		.filter(([, ruleNode]) => ruleNode.rawNode['identifiant court'])
+		.map(([dottedName, ruleNode]) => [
+			dottedName,
+			ruleNode.rawNode['identifiant court'],
+		])
+
+	it('should be unique amongst rules', () => {
+		expect(questions.length).to.greaterThan(0)
+		expect(questions.length).to.eq(
+			new Set(questions.map(([, name]) => name)).size
+		)
+	})
+})
+
+describe('useSearchParamsSimulationSharing', () => {
+	const someRules = parsePublicodes(`
+rule with:
+	identifiant court: panta
+	formule: 0
+rule without:
+	formule: 0
+	`)
+	const dottedNameParamName = getRulesParamNames(
+		new Engine(someRules).getRules()
+	)
+
+	describe('getSearchParamsFromSituation', () => {
+		it('builds search params with and without identifiant court', () => {
+			expect(
+				getSearchParamsFromSituation(
+					{ 'rule with': '2000 €/mois', 'rule without': '1000 €/mois' },
+					'€/mois',
+					dottedNameParamName
+				).toString()
+			).to.equal(
+				new URLSearchParams(
+					'_targetUnit=€/mois&panta=2000 €/mois&rule without=1000 €/mois'
+				).toString()
+			)
+		})
+		it('builds search params with object', () => {
+			expect(
+				getSearchParamsFromSituation(
+					{ 'rule without': { 1: 2, 3: { 4: '5' } } },
+					'€/mois',
+					dottedNameParamName
+				).toString()
+			).to.equal(
+				new URLSearchParams(
+					'_targetUnit=€/mois&rule without={"1":2,"3":{"4":"5"}}'
+				).toString()
+			)
+		})
+		it('handles empty situation with proper defaults', () => {
+			expect(
+				getSearchParamsFromSituation({}, '', dottedNameParamName).toString()
+			).to.equal('')
+		})
+	})
+
+	describe('getSituationFromSearchParams', () => {
+		it('reads search params with and without identifiant court', () => {
+			expect(
+				getSituationFromSearchParams(
+					new URLSearchParams(
+						'_targetUnit=€/an&panta=2000 €/mois&rule without=1000 €/mois'
+					),
+					dottedNameParamName
+				)
+			).to.deep.equal({
+				situation: {
+					'rule with': '2000 €/mois',
+					'rule without': '1000 €/mois',
+				},
+				targetUnit: '€/an',
+			})
+		})
+		it('handles empty search params with proper defaults', () => {
+			expect(
+				getSituationFromSearchParams(
+					new URLSearchParams(''),
+					dottedNameParamName
+				)
+			).to.deep.equal({ situation: {}, targetUnit: '' })
+		})
+	})
+
+	describe('serialization is somethingpotent', () => {
+		expect(deserialize(serialize(1))).to.equal(1)
+		expect(deserialize(serialize('1'))).to.equal('1')
+		expect(deserialize(serialize({ 1: 2, 3: '4' }))).to.deep.equal({
+			1: 2,
+			3: '4',
+		})
+	})
+})
+
+describe('useSearchParamsSimulationSharing hook', () => {
+	const someRules = parsePublicodes(`
+rule with:
+	identifiant court: panta
+	formule: 0
+rule without:
+	formule: 0
+	`)
+
+	const dottedNameParamName = getRulesParamNames(
+		new Engine(someRules).getRules()
+	)
+	let setSearchParams
+
+	beforeEach(() => {
+		setSearchParams = sinon.spy(() => {})
+	})
+	it('removes searchParams that are in situation', () => {
+		const searchParams = new URLSearchParams('panta=123&rule without=333')
+		const { situation: newSituation } = getSituationFromSearchParams(
+			searchParams,
+			dottedNameParamName
+		)
+		cleanSearchParams(
+			searchParams,
+			setSearchParams,
+			dottedNameParamName,
+			Object.keys(newSituation)
+		)
+		expect(setSearchParams.calledWith('')).to.be.true
+	})
+	it('removes targetUnit', () => {
+		const searchParams = new URLSearchParams('_targetUnit=1&rule without=123')
+		const { situation: newSituation } = getSituationFromSearchParams(
+			searchParams,
+			dottedNameParamName
+		)
+		cleanSearchParams(
+			searchParams,
+			setSearchParams,
+			dottedNameParamName,
+			Object.keys(newSituation)
+		)
+		expect(setSearchParams.calledWith('')).to.be.true
+	})
+	it("doesn't remove other search params", () => {
+		const searchParams = new URLSearchParams(
+			'rule without=123&utm_campaign=marketing'
+		)
+		const { situation: newSituation } = getSituationFromSearchParams(
+			searchParams,
+			dottedNameParamName
+		)
+		cleanSearchParams(
+			searchParams,
+			setSearchParams,
+			dottedNameParamName,
+			Object.keys(newSituation)
+		)
+		expect(setSearchParams.calledWith('utm_campaign=marketing')).to.be.true
+	})
+})

--- a/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
+++ b/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
@@ -44,12 +44,11 @@ rule without:
 			expect(
 				getSearchParamsFromSituation(
 					{ 'rule with': '2000 €/mois', 'rule without': '1000 €/mois' },
-					'€/mois',
 					dottedNameParamName
 				).toString()
 			).to.equal(
 				new URLSearchParams(
-					'_targetUnit=€/mois&panta=2000 €/mois&rule without=1000 €/mois'
+					'panta=2000 €/mois&rule without=1000 €/mois'
 				).toString()
 			)
 		})
@@ -57,18 +56,15 @@ rule without:
 			expect(
 				getSearchParamsFromSituation(
 					{ 'rule without': { 1: 2, 3: { 4: '5' } } },
-					'€/mois',
 					dottedNameParamName
 				).toString()
 			).to.equal(
-				new URLSearchParams(
-					'_targetUnit=€/mois&rule without={"1":2,"3":{"4":"5"}}'
-				).toString()
+				new URLSearchParams('rule without={"1":2,"3":{"4":"5"}}').toString()
 			)
 		})
 		it('handles empty situation with proper defaults', () => {
 			expect(
-				getSearchParamsFromSituation({}, '', dottedNameParamName).toString()
+				getSearchParamsFromSituation({}, dottedNameParamName).toString()
 			).to.equal('')
 		})
 	})
@@ -77,17 +73,12 @@ rule without:
 		it('reads search params with and without identifiant court', () => {
 			expect(
 				getSituationFromSearchParams(
-					new URLSearchParams(
-						'_targetUnit=€/an&panta=2000 €/mois&rule without=1000 €/mois'
-					),
+					new URLSearchParams('panta=2000 €/mois&rule without=1000 €/mois'),
 					dottedNameParamName
 				)
 			).to.deep.equal({
-				situation: {
-					'rule with': '2000 €/mois',
-					'rule without': '1000 €/mois',
-				},
-				targetUnit: '€/an',
+				'rule with': '2000 €/mois',
+				'rule without': '1000 €/mois',
 			})
 		})
 		it('handles empty search params with proper defaults', () => {
@@ -96,7 +87,7 @@ rule without:
 					new URLSearchParams(''),
 					dottedNameParamName
 				)
-			).to.deep.equal({ situation: {}, targetUnit: '' })
+			).to.deep.equal({})
 		})
 	})
 
@@ -129,21 +120,7 @@ rule without:
 	})
 	it('removes searchParams that are in situation', () => {
 		const searchParams = new URLSearchParams('panta=123&rule without=333')
-		const { situation: newSituation } = getSituationFromSearchParams(
-			searchParams,
-			dottedNameParamName
-		)
-		cleanSearchParams(
-			searchParams,
-			setSearchParams,
-			dottedNameParamName,
-			Object.keys(newSituation)
-		)
-		expect(setSearchParams.calledWith('')).to.be.true
-	})
-	it('removes targetUnit', () => {
-		const searchParams = new URLSearchParams('_targetUnit=1&rule without=123')
-		const { situation: newSituation } = getSituationFromSearchParams(
+		const newSituation = getSituationFromSearchParams(
 			searchParams,
 			dottedNameParamName
 		)
@@ -159,7 +136,7 @@ rule without:
 		const searchParams = new URLSearchParams(
 			'rule without=123&utm_campaign=marketing'
 		)
-		const { situation: newSituation } = getSituationFromSearchParams(
+		const newSituation = getSituationFromSearchParams(
 			searchParams,
 			dottedNameParamName
 		)

--- a/publicodes/core/source/grammar.ne
+++ b/publicodes/core/source/grammar.ne
@@ -8,7 +8,7 @@
 @{%
 const {
   string, date, variable, temporalNumericValue, binaryOperation, 
-  unaryOperation, boolean, number, numberWithUnit
+  unaryOperation, boolean, number, numberWithUnit, JSONObject
 } = require('./grammarFunctions')
 
 const moo = require("moo");
@@ -23,6 +23,7 @@ const periodWord = `\\| ${word}(?:[\\s]${word})*`
 
 const numberRegExp = '-?(?:[1-9][0-9]+|[0-9])(?:\\.[0-9]+)?';
 const lexer = moo.compile({
+
   '(': '(',
   ')': ')',
   '[': '[',
@@ -35,6 +36,7 @@ const lexer = moo.compile({
   words: new RegExp(words),
   number: new RegExp(numberRegExp),
   string: /'.*'/,
+  JSONObject: /{.*}/,
   additionSubstraction: /[\+-]/,
   multiplicationDivision: ['*','/'],
   dot: ' . ',
@@ -54,6 +56,7 @@ main ->
   | NumericValue {% id %}
   | Date {% id %}
   | NonNumericTerminal {% id %}
+  | JSONObject {% id %}
 
 NumericValue ->
     AdditionSubstraction {% id %}
@@ -116,3 +119,5 @@ number ->
   | %number (%space):? Unit {% numberWithUnit %}
 
 string -> %string {% string %}
+
+JSONObject -> %JSONObject {% JSONObject %}

--- a/publicodes/core/source/grammarFunctions.js
+++ b/publicodes/core/source/grammarFunctions.js
@@ -34,6 +34,10 @@ export let variable = ([firstFragment, nextFragment], _, reject) => {
 	}
 }
 
+export const JSONObject = ([{ value }]) => {
+	console.log(value)
+	// TODO
+}
 export let number = ([{ value }]) => ({
 	constant: {
 		type: 'number',

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -47,6 +47,7 @@ export { simplifyNodeUnit } from './nodeUnits'
 export { serializeUnit } from './units'
 export { parsePublicodes, utils }
 export { Rule, RuleNode, ASTNode, EvaluatedNode }
+export { default as serializeEvaluation } from './serializeEvaluation'
 
 type PublicodesExpression = string | Record<string, unknown> | number
 

--- a/publicodes/core/source/rule.ts
+++ b/publicodes/core/source/rule.ts
@@ -34,6 +34,7 @@ export type Rule = {
 	suggestions?: Record<string, string | number | Record<string, unknown>>
 	références?: { [source: string]: string }
 	API?: string
+	'identifiant court'?: string
 }
 
 type Remplace =
@@ -58,6 +59,7 @@ export type RuleNode = {
 		valeur: ASTNode
 	}
 	suggestions: Record<string, ASTNode>
+	'identifiant court'?: string
 }
 
 export default function parseRule(

--- a/publicodes/core/source/serializeEvaluation.ts
+++ b/publicodes/core/source/serializeEvaluation.ts
@@ -1,0 +1,18 @@
+import { EvaluatedNode } from './index'
+import { serializeUnit } from './units'
+export default function serializeEvaluation(
+	node: EvaluatedNode
+): string | undefined {
+	if (typeof node.nodeValue === 'number') {
+		const serializedUnit = serializeUnit(node.unit)
+		return (
+			'' +
+			node.nodeValue +
+			(serializedUnit ? serializedUnit.replace(/\s/g, '') : '')
+		)
+	} else if (typeof node.nodeValue === 'boolean') {
+		return node.nodeValue ? 'oui' : 'non'
+	} else if (typeof node.nodeValue === 'string') {
+		return `'${node.nodeValue}'`
+	}
+}

--- a/publicodes/core/source/units.ts
+++ b/publicodes/core/source/units.ts
@@ -33,7 +33,7 @@ export const serializeUnit = (
 	rawUnit: Unit | undefined | string,
 	count: number = plural,
 	formatUnit: formatUnit = (x) => x
-) => {
+): string | undefined => {
 	if (rawUnit === null || typeof rawUnit !== 'object') {
 		return typeof rawUnit === 'string' ? formatUnit(rawUnit, count) : rawUnit
 	}

--- a/publicodes/test/serializeEvaluation.test.js
+++ b/publicodes/test/serializeEvaluation.test.js
@@ -1,0 +1,45 @@
+import Engine from '../source/index'
+import serializeEvaluation from '../source/serializeEvaluation'
+import { expect } from 'chai'
+
+describe('serializeEvaluation', () => {
+	it('should serialize a number', () => {
+		const engine = new Engine()
+		const expression = '2300'
+		const evaluation = engine.evaluate(expression)
+
+		expect(serializeEvaluation(evaluation)).to.eq(expression)
+	})
+
+	it('should serialize a boolean', () => {
+		const engine = new Engine()
+		const expression = 'oui'
+		const evaluation = engine.evaluate(expression)
+
+		expect(serializeEvaluation(evaluation)).to.eq(expression)
+	})
+
+	it('should serialize a number with unit', () => {
+		const engine = new Engine()
+		const expression = '457€/mois'
+		const evaluation = engine.evaluate(expression)
+
+		expect(serializeEvaluation(evaluation)).to.eq(expression)
+	})
+
+	it('should serialize a string', () => {
+		const engine = new Engine()
+		const expression = "'CDI'"
+		const evaluation = engine.evaluate(expression)
+
+		expect(serializeEvaluation(evaluation)).to.eq(expression)
+	})
+
+	it.skip('should serialize an object', () => {
+		const engine = new Engine()
+		const expression = '{ a: 45, b: {a: 15}}'
+		const evaluation = engine.evaluate(expression)
+
+		expect(serializeEvaluation(evaluation)).to.eq(expression)
+	})
+})

--- a/publicodes/ui-react/source/Overlay.tsx
+++ b/publicodes/ui-react/source/Overlay.tsx
@@ -109,20 +109,37 @@ const StyledOverlayWrapper = styled.div<{ offsetTop: number | null }>`
 		border-left: 0.5rem solid white;
 		bottom: 0;
 		right: 0;
-		color: rgba(0, 0, 0, 0.6);
 		color: var(--lighterTextColor);
 		padding: 0 1rem;
+		text-decoration: none;
 	}
 	.ui__.card[aria-modal='true'] {
 		padding-bottom: 4rem;
 		display: flex;
 		flex-direction: column;
 	}
+	@media (max-width: 600px) {
+		.overlayContent {
+			width: 100%;
+		}
+		.overlayCloseButton {
+			position: fixed;
+			bottom: 0;
+			right: 0;
+			line-height: 1rem;
+			padding: 1.2rem;
+			padding-bottom: 1.5rem;
+			font-size: 3rem;
+			background: var(--lighterColor);
+		}
+	}
 
 	@media (min-width: 600px) {
 		.overlayCloseButton {
+			position: absolute;
 			top: 0;
 			bottom: auto;
+			right: 0;
 			padding: 0 0.5rem;
 			font-size: 2rem;
 		}


### PR DESCRIPTION
Issue https://github.com/betagouv/mon-entreprise/issues/552

# Code

⚠️ J'ai laissé plein de commentaires XXX à ne pas relire.

L'approche:

- sauvegarder toute la situation
- garder les identifiants courts pour les objectifs
- pour le reste sauvegarder bêtement dans l'URL avec le dottedName complet
- pour les data, utiliser une sérialisation simplissime.

Les principes que j'ai suivis:

- ne pas supposer une quelconque connaissance interne de l'engine au sein de ce module
- ne pas faire de cas particuliers à la mano àla `RuleInput` à moins justement de les mutualiser proprement.

Je pense en réalité qu'on va vouloir faire mieux et donc regarder les rule.type pour mieux serialiser, mais ça va demander du boulot dans une autre PR. Pour l'instant je n'ai aucune idée de à quoi doivent ressembler les valeurs de redux `state.simulation.situation` qui n'est pas clairement typé. De ce que je comprends il s'agit de creuser directement dans l'engine qui est celui qui gère cette info.  
Donc il faut améliorer l'API avec l'engine niveau informations sur les types (par ex: créer un `Engine.getTypeInfo(DottedName)` pour pouvoir créer des sérialiseurs explicites et aussi peut-être retravailler `RuleInput` sur les mêmes principes).

il reste à

- [ ] corriger les tests e2e et vérifier que ça marche bien
- [x] virer le `throw` que j'ai laissé qquepart
- [ ] virer les commentaires qui trainent

# Feature

A l'heure actuelle ça génère des URLs du genre:

```
http://localhost:8080/mon-entreprise/simulateurs/salaire-brut-net?_=%E2%82%AC%2Fmois&contrat+salari%C3%A9=%27CDI%27&contrat+salari%C3%A9+.+ATMP+.+taux+collectif+ATMP=_5.3&contrat+salari%C3%A9+.+ATMP+.+taux+r%C3%A9duit=non&contrat+salari%C3%A9+.+activit%C3%A9+partielle=oui&contrat+salari%C3%A9+.+activit%C3%A9+partielle+.+convention+syntec=non&contrat+salari%C3%A9+.+activit%C3%A9+partielle+.+heures+travaill%C3%A9es=86.6666+heures%2Fmois&contrat+salari%C3%A9+.+activit%C3%A9+partielle+.+secteur+d%27activit%C3%A9+restreint=non&contrat+salari%C3%A9+.+aides+employeur+.+emploi+franc+.+%C3%A9ligible=non&contrat+salari%C3%A9+.+convention+collective=%27SVP%27&contrat+salari%C3%A9+.+jeune+de+moins+de+26+ans=non&contrat+salari%C3%A9+.+profession+sp%C3%A9cifique=%27ouvrier+du+b%C3%A2timent%27&contrat+salari%C3%A9+.+r%C3%A9mun%C3%A9ration+.+primes+.+activit%C3%A9+.+base=_231&contrat+salari%C3%A9+.+r%C3%A9mun%C3%A9ration+.+primes+.+fin+d%27ann%C3%A9e+.+treizi%C3%A8me+mois=non&contrat+salari%C3%A9+.+statut+cadre=non&contrat+salari%C3%A9+.+temps+de+travail+.+heures+suppl%C3%A9mentaires=30.33+heures%2Fmois&contrat+salari%C3%A9+.+temps+de+travail+.+temps+partiel=non&salarie-coutembauche=1231232+%E2%82%AC%2Fmois&%C3%A9tablissement+.+localisation=%7B%22nom%22%3A%22Boulogne-Billancourt%22%2C%22code%22%3A%2292012%22%2C%22departement%22%3A%7B%22code%22%3A%2292%22%2C%22nom%22%3A%22Hauts-de-Seine%22%7D%2C%22region%22%3A%7B%22code%22%3A%2211%22%2C%22nom%22%3A%22%C3%8Ele-de-France%22%7D%2C%22codePostal%22%3A%2292100%22%2C%22taux+du+versement+transport%22%3A%220.0295%22%7D
```

erf :/

Si ça ne convient pas comme ça, il y a qques arbitrages:

- virer certaines valeurs (donc ne pas suivre le principe "sauvegarder toute la situation"), donc revenir vers qqch qui ressemble plus à la PR précédente
- améliorer la sérialisation (cf. rq ci-dessus), ce qui demande un peu de boulot
- chercher une solution alternative pour simplifier.

D'autre part, si on regarde juste les objectifs, j'ai dû faire une marche arrière sur la lisibilité de l'URL:

```
http://localhost:8080/mon-entreprise/simulateurs/salaire-brut-net?_=%E2%82%AC%2Fmois&salarie-coutembauche=1321+%E2%82%AC%2Fmois
```

En effet, je n'ai rien supposé du tout sur la structure de Redux situation que je ne connais pas tant que j'ai pas mis au clair comment extraire l'info depuis l'engine. Ca revient à ma remarque plus haut.

En revanche on pourrait réfléchir à un truc simple pour essayer d'avoir un URL encoding plus lisible, mais sincèrement ça ne changera pas du tout au tout.

Discutons-en. De mon côté, comme déjà discuté dans l'issue, je suppose que ce n'est pas trop un soucis de shipper comme ça et de demander le feedback des utilisateurs avant de s'impliquer plus là-dedans.