### PR TITLE
Erreur cotisation maladie pour les indépendants

### DIFF
--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -4976,6 +4976,23 @@ dirigeant . indépendant . PL . cotisations caisse de retraite:
     profession libérale effectuée.
   titre.en: '[automatic] pension fund contributions'
   titre.fr: cotisations caisse de retraite
+dirigeant . indépendant . PL . maladie:
+  note.en: >
+    [automatic] The regulated professions do not contribute the corresponding
+    share to the
+
+    per diems and are therefore not entitled to these allowances in the event of
+
+    illness.
+  note.fr: >
+    Les professions libérales réglementée ne cotisent pour la part
+    correspondante aux
+
+    indemnités journalières et n'ont donc pas le droit à ces indemnités en cas de
+
+    maladie.
+  titre.en: '[automatic] illness (PLR rate)'
+  titre.fr: maladie (taux PLR)
 dirigeant . indépendant . PL . métier:
   question.en: '[automatic] To which category does your profession belong?'
   question.fr: A quelle catégorie appartient votre profession ?
@@ -5208,22 +5225,6 @@ dirigeant . indépendant . PL . régime général:
     d'option](/documentation/dirigeant/indépendant/PL/option-régime-général)
   titre.en: '[automatic] overall regime'
   titre.fr: régime général
-dirigeant . indépendant . PL . régime général . maladie:
-  note.en: >
-    [automatic] The liberal professions do not contribute the corresponding
-    share to the
-
-    per diems and are therefore not entitled to these allowances in the event of
-
-    illness.
-  note.fr: >
-    Les professions libérales ne cotisent pour la part correspondante aux
-
-    indemnités journalières et n'ont donc pas le droit à ces indemnités en cas de
-
-    maladie.
-  titre.en: '[automatic] disease (PLNR rate)'
-  titre.fr: maladie (taux PLNR)
 ? dirigeant . indépendant . PL . régime général . taux spécifique retraite complémentaire
 : description.en: |
     [automatic] The unregulated professions that started their activity at
@@ -5715,35 +5716,19 @@ dirigeant . indépendant . cotisations et contributions . maladie:
   titre.en: '[automatic] disease'
   titre.fr: maladie
 dirigeant . indépendant . cotisations et contributions . maladie . taux:
-  note.en: >
-    [automatic] This contribution is basically very simple: the health
-    contribution is 7.2% up to 5 times the social security ceiling, then 6.5%
-    beyond that. However:
-
-    - for its recovery, this contribution is separated into 2: sickness and sickness 2, the latter at the rate of 0.85%. Thus the amount of 7.2% quoted in the decree is reduced to 6.35% in our calculations.
-
-    - Contribution reductions have been introduced: a simple exemption below 110% of the social security ceiling, then a reinforced exemption below 40%. The above scale takes these reductions into account.
-  note.fr: >
-    Cette cotisation est à la base très simple : la cotisation maladie est de
-    7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà.
-    Cependant :
-
-    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs.
-
-    - des réductions de cotisation ont été introduites : une exonération simple en-dessous de 110% du plafond de la sécurité sociale, puis une exonération renforcée en-dessous de 40%. Le barème ci-dessus prend en compte ces réductions.
   titre.en: '[automatic] rate'
   titre.fr: taux
 dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
-  note.en: >
-    [automatic] For self-employed persons with the RSA, only the simple
-    reduction defined in the decree for calculating the health contribution is
-    taken into account. The reinforced reduction below 40% of the social
-    security ceiling is not, as there is no minimum base.
-  note.fr: >
-    Pour les indépendants au RSA, seule la réduction simple définie dans le
-    décret de calcul de la cotisation maladie est prise en compte. La réduction
-    renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas,
-    car il n'y a pas d'assiette minimale.
+  note.en: |
+    [automatic] For RSA freelancers, only the simple reduction defined in
+    the decree for calculating the health contribution is taken into account.
+    The reinforced reduction below 40% of the security ceiling 
+    social is not, because there is no minimum base.
+  note.fr: |
+    Pour les indépendants au RSA, seule la réduction simple définie dans
+    le décret de calcul de la cotisation maladie est prise en compte.
+    La réduction renforcée en-dessous de 40% du plafond de la sécurité 
+    sociale ne l'est pas, car il n'y a pas d'assiette minimale.
   titre.en: '[automatic] RSA rate'
   titre.fr: taux RSA
 ? dirigeant . indépendant . cotisations et contributions . maladie . taux RSA part variable

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -936,7 +936,9 @@ dirigeant . indépendant . cotisations et contributions . indemnités journaliè
     versé.
   formule:
     produit:
-      assiette: maladie . assiette
+      assiette: 
+        valeur: assiette des cotisations
+        plancher [ref]: 40% * plafond sécurité sociale temps plein
       taux [ref]: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
     arrondi: oui
@@ -944,9 +946,7 @@ dirigeant . indépendant . cotisations et contributions . indemnités journaliè
 dirigeant . indépendant . cotisations et contributions . maladie:
   formule:
     barème:
-      assiette [ref]:
-        valeur: assiette des cotisations
-        plancher [ref]: 40% * plafond sécurité sociale temps plein
+      assiette: assiette des cotisations
       multiplicateur: plafond sécurité sociale temps plein
       tranches:
         - taux: taux variable
@@ -1051,7 +1051,7 @@ dirigeant . indépendant . cotisations et contributions . exonération de cotisa
   applicable si: situation personnelle . RSA
   remplace:
     - invalidité et décès . assiette . plancher
-    - maladie . assiette . plancher
+    - indemnités journalières maladie . plancher
     - retraite de base . assiette . plancher
   formule: non
   références:
@@ -1231,7 +1231,7 @@ dirigeant . indépendant . cotisations et contributions . maladie domiciliation 
   remplace: maladie
   formule:
     produit:
-      assiette: maladie . assiette
+      assiette: assiette des cotisations
       taux: 14.5%
   arrondi: oui
 

--- a/mon-entreprise/source/rules/dirigeant.yaml
+++ b/mon-entreprise/source/rules/dirigeant.yaml
@@ -942,6 +942,9 @@ dirigeant . indépendant . cotisations et contributions . indemnités journaliè
       taux [ref]: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
     arrondi: oui
+  références:
+    Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
+    Taux de cotisations: https://www.secu-independants.fr/cotisations/calcul-cotisations/taux-de-cotisations/
 
 dirigeant . indépendant . cotisations et contributions . maladie:
   formule:
@@ -955,7 +958,7 @@ dirigeant . indépendant . cotisations et contributions . maladie:
     arrondi: oui
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
-    Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
+
   note: |
     On retrouve dans le décret ci-dessous la phrase suivante :
 
@@ -975,7 +978,10 @@ dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
     valeur: taux RSA part variable + 1.35%
     plafond: 6.35%
   note: |
-    Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
+    Pour les indépendants au RSA, seule la réduction simple définie dans
+    le décret de calcul de la cotisation maladie est prise en compte.
+    La réduction renforcée en-dessous de 40% du plafond de la sécurité 
+    sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
 dirigeant . indépendant . cotisations et contributions . maladie . taux RSA part variable:
   unité: '%'
@@ -993,16 +999,13 @@ dirigeant . indépendant . cotisations et contributions . maladie . taux:
         - plafond: 0%
           taux: 0%
         - plafond: 40%
-          taux: 3.168%
+          taux: 3.16%
         - plafond: 110%
           taux: 6.35%
-  note: |
-    Cette cotisation est à la base très simple : la cotisation maladie est de 7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà. Cependant :
-    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs.
-    - des réductions de cotisation ont été introduites : une exonération simple en-dessous de 110% du plafond de la sécurité sociale, puis une exonération renforcée en-dessous de 40%. Le barème ci-dessus prend en compte ces réductions.
-
   références:
+    Taux de cotisations: https://www.secu-independants.fr/cotisations/calcul-cotisations/taux-de-cotisations/
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
+    
 
 dirigeant . indépendant . cotisations et contributions . retraite de base:
   formule:

--- a/mon-entreprise/source/rules/profession-libérale.yaml
+++ b/mon-entreprise/source/rules/profession-libérale.yaml
@@ -168,8 +168,12 @@ dirigeant . indépendant . PL . régime général . taux spécifique retraite co
           plafond: 4
     arrondi: oui
 
-dirigeant . indépendant . PL . régime général . maladie:
-  titre: maladie (taux PLNR)
+dirigeant . indépendant . PL . maladie:
+  titre: maladie (taux PLR)
+  non applicable si: 
+    une de ces conditions: 
+      - régime général
+      - PAMC
   remplace: cotisations et contributions . maladie
   formule:
     produit:
@@ -188,7 +192,7 @@ dirigeant . indépendant . PL . régime général . maladie:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/taux-de-cotisations
     guide urssaf (pdf): https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Guide-Professions-liberales.pdf
   note: |
-    Les professions libérales ne cotisent pour la part correspondante aux
+    Les professions libérales réglementée ne cotisent pour la part correspondante aux
     indemnités journalières et n'ont donc pas le droit à ces indemnités en cas de
     maladie.
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calculate aide-déclaration-indépendant: ACRE 1`] = `"[50000,3177,11384,101,14662,35338]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 1`] = `"[50000,3177,11383,101,14661,35339]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[15000,949,3172,101,4222,10778]"`;
 
@@ -12,7 +12,7 @@ Notifications affichées : dirigeant . indépendant . avertissement base forfait
 `;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `
-"[10000,630,-1330,101,-599,10599]
+"[10000,630,-1329,101,-598,10598]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
@@ -22,36 +22,36 @@ exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[500,25,82,101,20
 
 exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[5000,312,1021,101,1434,3566]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[50000,3175,17728,138,21041,28959]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[50000,3175,17727,138,21040,28960]"`;
 
 exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[50000,3175,16580,138,19893,30107]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[50000,3175,14664,138,17977,32023]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[50000,3175,14663,138,17976,32024]"`;
 
 exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[50000,3176,17732,118,21026,28974]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[50000,3175,16186,138,19499,30501]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[50000,3175,16185,138,19498,30502]"`;
 
 exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[50000,3177,5672,101,8950,41050]"`;
 
 exports[`calculate aide-déclaration-indépendant: international 1`] = `"[50000,0,14612,101,14713,35287]"`;
 
-exports[`calculate aide-déclaration-indépendant: international 2`] = `"[50000,1267,11893,101,13261,36739]"`;
+exports[`calculate aide-déclaration-indépendant: international 2`] = `"[50000,1267,11892,101,13260,36740]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[50000,3176,11379,118,14673,35327]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1278,118,1707,3293]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[50000,3177,11384,101,14662,35338]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[50000,3177,11383,101,14661,35339]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[5000,312,1279,101,1692,3308]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `"[50000,3177,11423,101,14701,35299]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `"[50000,3177,11383,101,14661,35339]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[5000,312,1316,101,1729,3271]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[5000,312,1279,101,1692,3308]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 7`] = `
-"[50000,3177,9515,101,12793,37207]
+"[50000,3177,9472,101,12750,37250]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
@@ -132,33 +132,33 @@ Notifications affichées : dirigeant . auto-entrepreneur . contrôle seuil de CA
 
 exports[`calculate simulations-indépendant: acre 1`] = `"[73025,23025,50000,51980,8213,41787,0,73025]"`;
 
-exports[`calculate simulations-indépendant: activité 1`] = `"[26805,6805,20000,20725,601,19399,0,26805]"`;
+exports[`calculate simulations-indépendant: activité 1`] = `"[26840,6840,20000,20726,601,19399,0,26840]"`;
 
-exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,603,19397,0,29101]"`;
+exports[`calculate simulations-indépendant: activité 2`] = `"[29100,9100,20000,20787,603,19397,0,29100]"`;
 
 exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1368,1268,100,134,0,100,0,1368]"`;
 
 exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[244,144,100,104,0,100,0,244]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29085,9085,20000,20787,603,19397,0,29085]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29084,9084,20000,20787,603,19397,0,29084]"`;
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73025,23025,50000,51980,8213,41787,0,73025]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29085,9085,20000,20787,2079,17921,0,29085]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29084,9084,20000,20787,2079,17921,0,29084]"`;
 
 exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1365,635,687,0,635,0,2000]"`;
 
-exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,3500,30497,0,50000]"`;
+exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16002,33998,35353,3500,30498,0,50000]"`;
 
-exports[`calculate simulations-indépendant: inversions 3`] = `"[14461,4461,10000,10390,0,10000,0,14461]"`;
+exports[`calculate simulations-indépendant: inversions 3`] = `"[14460,4460,10000,10390,0,10000,0,14460]"`;
 
 exports[`calculate simulations-indépendant: inversions 4`] = `"[69940,22078,47862,49758,7862,40000,0,69940]"`;
 
-exports[`calculate simulations-indépendant: inversions 5`] = `"[14461,4461,10000,10390,0,10000,1000,15461]"`;
+exports[`calculate simulations-indépendant: inversions 5`] = `"[14460,4460,10000,10390,0,10000,1000,15460]"`;
 
-exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5871,13129,13642,0,13129,1000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5870,13130,13643,0,13130,1000,20000]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5558,12442,12928,0,12442,2000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5557,12443,12929,0,12443,2000,20000]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1841,1341,500,547,0,500,0,1841]"`;
 
@@ -170,27 +170,27 @@ exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3618,1
 
 exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7303,2303,5000,5195,0,5000,0,7303]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14461,4461,10000,10390,0,10000,0,14461]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14460,4460,10000,10390,0,10000,0,14460]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `"[139595,39595,100000,103788,24909,75091,0,139595]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 8`] = `"[1239955,239955,1000000,1033666,444476,555524,0,1239955]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[2750,0,2250,500,0,500]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[2759,0,2259,500,0,500]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[3301,0,2301,1000,0,1000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[3319,0,2319,1000,0,1000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[3855,0,2355,1500,0,1500]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[3879,0,2379,1500,0,1500]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[4409,0,2409,2000,0,2000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[4440,0,2440,2000,0,2000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[7810,0,2810,5000,0,5000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[7872,0,2872,5000,0,5000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14054,0,4054,10000,0,10000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14129,0,4129,10000,0,10000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 7`] = `"[144691,0,44691,100000,24942,75058]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 7`] = `"[144865,0,44865,100000,24943,75057]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 8`] = `"[1236171,0,236171,1000000,444432,555568]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 8`] = `"[1236512,0,236512,1000000,444436,555564]"`;
 
 exports[`calculate simulations-professions-libérales: auxiliaire médical 1`] = `"[30000,0,7751,22249,945,21304]"`;
 
@@ -198,13 +198,13 @@ exports[`calculate simulations-professions-libérales: auxiliaire médical 2`] =
 
 exports[`calculate simulations-professions-libérales: auxiliaire médical 3`] = `"[300000,0,61784,238216,81297,156919]"`;
 
-exports[`calculate simulations-professions-libérales: avocat 1`] = `"[50000,0,11410,38589,4753,33836]"`;
+exports[`calculate simulations-professions-libérales: avocat 1`] = `"[50000,0,11461,38540,4747,33793]"`;
 
-exports[`calculate simulations-professions-libérales: avocat 2`] = `"[50000,0,11770,38230,4711,33519]"`;
+exports[`calculate simulations-professions-libérales: avocat 2`] = `"[50000,0,11821,38180,4705,33475]"`;
 
-exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5018,14982,0,14982]"`;
+exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5049,14951,0,14951]"`;
 
-exports[`calculate simulations-professions-libérales: expert-comptable 2`] = `"[50000,0,14831,35169,3616,31553]"`;
+exports[`calculate simulations-professions-libérales: expert-comptable 2`] = `"[50000,0,14877,35123,3611,31512]"`;
 
 exports[`calculate simulations-professions-libérales: médecin 1`] = `"[50000,0,14273,35727,3671,32056]"`;
 
@@ -214,7 +214,7 @@ exports[`calculate simulations-professions-libérales: médecin 3`] = `"[300000,
 
 exports[`calculate simulations-professions-libérales: médecin 4`] = `"[400000,0,106201,293799,115768,178031]"`;
 
-exports[`calculate simulations-professions-libérales: médecin 5`] = `"[120000,0,34595,85405,17732,67673]"`;
+exports[`calculate simulations-professions-libérales: médecin 5`] = `"[120000,0,34704,85296,17710,67586]"`;
 
 exports[`calculate simulations-professions-libérales: sage-femme 1`] = `"[50000,0,12383,37617,4638,32979]"`;
 
@@ -374,38 +374,38 @@ Notifications affichées : dirigeant . indépendant . avertissement base forfait
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `
-"[0,21650,0,15827,4,31]
+"[0,21651,0,15828,4,31]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,20620,0,15102,4,29]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,20621,0,15102,4,29]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,20264,0,15647,4,30]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,20265,0,15647,4,30]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,20620,0,15102,4,29]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,20621,0,15102,4,29]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13813,0,10115,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13814,0,10116,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `"[0,226877,0,57936,4,56]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `
-"[0,13813,0,10115,4,21]
+"[0,13814,0,10116,4,21]
 Notifications affichées : dirigeant . indépendant . contrats madelin . contrôle montant charges"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,14678,0,0,4,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,14644,0,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14678,0,0,4,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14644,0,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13803,0,10107,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13804,0,10108,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13813,0,10115,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13814,0,10116,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13813,0,10115,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13814,0,10116,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6894,0,5046,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13813,0,10115,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13814,0,10116,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 1`] = `"[0,-1044,0,0,3,21]"`;
 
@@ -417,9 +417,9 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6894,0,5046,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13813,0,10115,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13814,0,10116,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33997,0,24913,4,48]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33998,0,24913,4,48]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 8`] = `"[0,69895,0,36431,4,56]"`;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -2,17 +2,17 @@
 
 exports[`calculate aide-déclaration-indépendant: ACRE 1`] = `"[50000,3177,11384,101,14662,35338]"`;
 
-exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[15000,949,3261,101,4311,10689]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[15000,949,3172,101,4222,10778]"`;
 
-exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[5000,312,1354,101,1767,3233]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[5000,312,1279,101,1692,3308]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `
-"[10000,630,560,101,1291,8709]
+"[10000,630,564,101,1295,8705]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `
-"[10000,630,-1457,101,-726,10726]
+"[10000,630,-1330,101,-599,10599]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
@@ -40,11 +40,11 @@ exports[`calculate aide-déclaration-indépendant: international 2`] = `"[50000,
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[50000,3176,11379,118,14673,35327]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1353,118,1782,3218]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[5000,311,1278,118,1707,3293]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[50000,3177,11384,101,14662,35338]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[5000,312,1354,101,1767,3233]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[5000,312,1279,101,1692,3308]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `"[50000,3177,11423,101,14701,35299]"`;
 
@@ -59,13 +59,13 @@ exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `"[
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `"[1000,57,1026,101,1184,0]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1500,89,1052,101,1242,258]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1500,89,1045,101,1235,265]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[2000,121,1096,101,1318,682]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[2000,121,1076,101,1298,702]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[5000,312,1354,101,1767,3233]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[5000,312,1279,101,1692,3308]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[10000,630,2203,101,2934,7066]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[10000,630,2105,101,2836,7164]"`;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `"[100000,6361,20835,101,27297,72703]"`;
 
@@ -136,7 +136,7 @@ exports[`calculate simulations-indépendant: activité 1`] = `"[26805,6805,20000
 
 exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,603,19397,0,29101]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1372,1272,100,134,0,100,0,1372]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1368,1268,100,134,0,100,0,1368]"`;
 
 exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[244,144,100,104,0,100,0,244]"`;
 
@@ -146,47 +146,47 @@ exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73025
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29085,9085,20000,20787,2079,17921,0,29085]"`;
 
-exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1384,616,668,0,616,0,2000]"`;
+exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1365,635,687,0,635,0,2000]"`;
 
 exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,3500,30497,0,50000]"`;
 
-exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
+exports[`calculate simulations-indépendant: inversions 3`] = `"[14461,4461,10000,10390,0,10000,0,14461]"`;
 
 exports[`calculate simulations-indépendant: inversions 4`] = `"[69940,22078,47862,49758,7862,40000,0,69940]"`;
 
-exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596]"`;
+exports[`calculate simulations-indépendant: inversions 5`] = `"[14461,4461,10000,10390,0,10000,1000,15461]"`;
 
-exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5928,13072,13585,0,13072,1000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5871,13129,13642,0,13129,1000,20000]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5625,12375,12861,0,12375,2000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5558,12442,12928,0,12442,2000,20000]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1859,1359,500,548,0,500,0,1859]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1841,1341,500,547,0,500,0,1841]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2467,1467,1000,1064,0,1000,0,2467]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2431,1431,1000,1063,0,1000,0,2431]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3075,1575,1500,1581,0,1500,0,3075]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3025,1525,1500,1579,0,1500,0,3025]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3682,1682,2000,2097,0,2000,0,3682]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3618,1618,2000,2095,0,2000,0,3618]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7428,2428,5000,5199,0,5000,0,7428]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7303,2303,5000,5195,0,5000,0,7303]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14461,4461,10000,10390,0,10000,0,14461]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `"[139595,39595,100000,103788,24909,75091,0,139595]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 8`] = `"[1239955,239955,1000000,1033666,444476,555524,0,1239955]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[2769,0,2269,500,0,500]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[2750,0,2250,500,0,500]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[3337,0,2337,1000,0,1000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[3301,0,2301,1000,0,1000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[3905,0,2405,1500,0,1500]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[3855,0,2355,1500,0,1500]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[4473,0,2473,2000,0,2000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[4409,0,2409,2000,0,2000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[7934,0,2934,5000,0,5000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[7810,0,2810,5000,0,5000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14188,0,4188,10000,0,10000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14054,0,4054,10000,0,10000]"`;
 
 exports[`calculate simulations-professions-libérales: CIPAV 7`] = `"[144691,0,44691,100000,24942,75058]"`;
 
@@ -202,7 +202,7 @@ exports[`calculate simulations-professions-libérales: avocat 1`] = `"[50000,0,1
 
 exports[`calculate simulations-professions-libérales: avocat 2`] = `"[50000,0,11770,38230,4711,33519]"`;
 
-exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5042,14958,0,14958]"`;
+exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5018,14982,0,14982]"`;
 
 exports[`calculate simulations-professions-libérales: expert-comptable 2`] = `"[50000,0,14831,35169,3616,31553]"`;
 
@@ -384,40 +384,40 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,20620,0,15102,4,29]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13769,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13813,0,10115,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `"[0,226877,0,57936,4,56]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `
-"[0,13769,0,10084,4,21]
+"[0,13813,0,10115,4,21]
 Notifications affichées : dirigeant . indépendant . contrats madelin . contrôle montant charges"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,14646,0,0,4,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,14678,0,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14646,0,0,4,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14678,0,0,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13757,0,10075,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13803,0,10107,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13769,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13813,0,10115,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13769,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13813,0,10115,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6794,0,4976,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6894,0,5046,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13769,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13813,0,10115,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 1`] = `"[0,-1044,0,0,3,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 2`] = `"[0,-225,0,0,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,616,0,471,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,635,0,484,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3084,0,2266,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3160,0,2319,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6794,0,4976,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6894,0,5046,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13769,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13813,0,10115,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33997,0,24913,4,48]"`;
 


### PR DESCRIPTION
Suite à un retour utilisateur, en comparant les montants des cotisations minimale indep du [livret Urssaf](https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Guide-Professions-liberales.pdf), j'ai repéré deux erreurs importantes : 

- Il ne faut pas de cotisation minimale pour la maladie
- Le taux progressif de la maladie n'est pas bon

C'est maintenant corrigé