### PR TITLE
Standardise la forme de l'objet retourné par les fonctions d'évaluation

### DIFF
--- a/publicodes/source/mecanisms/applicable.ts
+++ b/publicodes/source/mecanisms/applicable.ts
@@ -20,7 +20,6 @@ const evaluate: EvaluationFunction<'applicable si'> = function (node) {
 		valeur = this.evaluateNode(valeur)
 	}
 	return {
-		...node,
 		nodeValue:
 			condition.nodeValue == null || condition.nodeValue === false
 				? condition.nodeValue
@@ -32,7 +31,7 @@ const evaluate: EvaluationFunction<'applicable si'> = function (node) {
 			'missingVariables' in valeur ? valeur.missingVariables : {},
 			bonus(condition.missingVariables)
 		),
-		...('unit' in valeur && { unit: valeur.unit }),
+		unit: valeur.unit,
 	}
 }
 parseApplicable.nom = 'applicable si' as const

--- a/publicodes/source/mecanisms/arrondi.ts
+++ b/publicodes/source/mecanisms/arrondi.ts
@@ -25,7 +25,6 @@ const evaluate: EvaluationFunction<'arrondi'> = function (node) {
 	}
 
 	return {
-		...node,
 		nodeValue:
 			typeof valeur.nodeValue !== 'number' || !('nodeValue' in arrondi)
 				? valeur.nodeValue

--- a/publicodes/source/mecanisms/barème.ts
+++ b/publicodes/source/mecanisms/barème.ts
@@ -114,7 +114,6 @@ const evaluate: EvaluationFunction<'barème'> = function (node) {
 		temporalTranches
 	)
 	return {
-		...node,
 		nodeValue: temporalAverage(temporalValue),
 		...(temporalValue.length > 1
 			? {
@@ -129,7 +128,7 @@ const evaluate: EvaluationFunction<'barème'> = function (node) {
 				: { tranches: temporalTranches[0].value }),
 		},
 		unit: assiette.unit,
-	} as any
+	}
 }
 
 registerEvaluationFunction('barème', evaluate)

--- a/publicodes/source/mecanisms/condition-allof.ts
+++ b/publicodes/source/mecanisms/condition-allof.ts
@@ -30,7 +30,6 @@ const evaluate: EvaluationFunction<'toutes ces conditions'> = function (node) {
 	)
 
 	return {
-		...node,
 		nodeValue,
 		explanation,
 		missingVariables: mergeAllMissing(explanation),

--- a/publicodes/source/mecanisms/condition-oneof.ts
+++ b/publicodes/source/mecanisms/condition-oneof.ts
@@ -50,10 +50,7 @@ const evaluate: EvaluationFunction<'une de ces conditions'> = function (node) {
 			explanation: [],
 		}
 	)
-	return {
-		...node,
-		...calculations,
-	}
+	return calculations
 }
 
 export const mecanismOneOf = (v, context) => {

--- a/publicodes/source/mecanisms/grille.ts
+++ b/publicodes/source/mecanisms/grille.ts
@@ -94,7 +94,6 @@ const evaluate: EvaluationFunction<'grille'> = function (node) {
 	)
 
 	return {
-		...node,
 		nodeValue: temporalAverage(temporalValue),
 		...(temporalValue.length > 1
 			? {
@@ -110,7 +109,7 @@ const evaluate: EvaluationFunction<'grille'> = function (node) {
 				: { tranches: temporalTranches[0].value }),
 		},
 		unit: activeTranches[0].value[0]?.unit ?? undefined,
-	} as any
+	}
 }
 
 registerEvaluationFunction('grille', evaluate)

--- a/publicodes/source/mecanisms/inversion.ts
+++ b/publicodes/source/mecanisms/inversion.ts
@@ -145,7 +145,6 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 	this.cache = originalCache
 	this.parsedSituation = originalSituation
 	return {
-		...node,
 		unit,
 		nodeValue,
 		explanation: {

--- a/publicodes/source/mecanisms/nonApplicable.ts
+++ b/publicodes/source/mecanisms/nonApplicable.ts
@@ -19,7 +19,6 @@ const evaluate: EvaluationFunction<'non applicable si'> = function (node) {
 		valeur = this.evaluateNode(valeur)
 	}
 	return {
-		...node,
 		nodeValue:
 			condition.nodeValue === null
 				? null
@@ -33,7 +32,7 @@ const evaluate: EvaluationFunction<'non applicable si'> = function (node) {
 			'missingVariables' in valeur ? valeur.missingVariables : {},
 			bonus(condition.missingVariables)
 		),
-		...('unit' in valeur && { unit: valeur.unit }),
+		unit: valeur.unit,
 	}
 }
 

--- a/publicodes/source/mecanisms/parDéfaut.ts
+++ b/publicodes/source/mecanisms/parDéfaut.ts
@@ -26,7 +26,6 @@ const evaluate: EvaluationFunction<'par défaut'> = function (node) {
 	}
 
 	return {
-		...node,
 		nodeValue: valeur.nodeValue,
 		explanation,
 		missingVariables: mergeMissing(

--- a/publicodes/source/mecanisms/plafond.ts
+++ b/publicodes/source/mecanisms/plafond.ts
@@ -44,9 +44,8 @@ const evaluate: EvaluationFunction<'plafond'> = function (node) {
 		;(plafond as any).isActive = true
 	}
 	return {
-		...node,
 		nodeValue,
-		...('unit' in valeur && { unit: valeur.unit }),
+		unit: valeur.unit,
 		explanation: { valeur, plafond },
 		missingVariables: mergeAllMissing([valeur, plafond]),
 	}

--- a/publicodes/source/mecanisms/plancher.ts
+++ b/publicodes/source/mecanisms/plancher.ts
@@ -42,9 +42,8 @@ const evaluate: EvaluationFunction<'plancher'> = function (node) {
 		;(plancher as any).isActive = true
 	}
 	return {
-		...node,
 		nodeValue,
-		...('unit' in valeur && { unit: valeur.unit }),
+		unit: valeur.unit,
 		explanation: { valeur, plancher },
 		missingVariables: mergeAllMissing([valeur, plancher]),
 	}

--- a/publicodes/source/mecanisms/recalcul.ts
+++ b/publicodes/source/mecanisms/recalcul.ts
@@ -62,14 +62,13 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 		this.situationVersion++
 	}
 	return {
-		...node,
 		nodeValue: evaluatedNode.nodeValue,
 		explanation: {
 			recalcul: evaluatedNode,
 			amendedSituation,
 		},
 		missingVariables: evaluatedNode.missingVariables,
-		...('unit' in evaluatedNode && { unit: evaluatedNode.unit }),
+		unit: evaluatedNode.unit,
 		...(evaluatedNode.temporalValue && {
 			temporalValue: evaluatedNode.temporalValue,
 		}),


### PR DESCRIPTION
Plutôt que de retourner directement leur résultat, les fonctions `evaluate` retournent le nœud qu'on leur a fourni et y ajoutent les attributs calculés :

```js
return {
  ...node,
  nodeValue,
  unit,
  missingVariables,
  explanations,
  temporalValues
}
```

Le spread réalisé des milliers de fois à chaque situation consomme inutilement du temps de calcul. Par ailleurs les moteurs JavaScript peuvent optimiser les fonctions appelées souvent et dont le résultat a toujours la même forme, mais ici la fonction `evaluateNode` retoure un objet un peu différent en fonction de chaque mécanisme.

La transformation `{...node, ...evaluateNode(node)}` n'est utile qu'au niveau du point d'entrée `engine.evaluateRule` ou `engine.evaluateExpression`.

Je pense qu'on peut aussi simplifier la forme de l'objet retourné en `{nodeValue, missingVariables}` :
- les `temporalValues` ne sont pas utilisées, et lorsqu'elles seront ré-introduites, l'idée est de ne pas les gérer explicitement au niveau de chaque mécanisme, mais seulement des mécanismes de base.
- `unit` peut être calculé lors du `parse` ou d'une étape `load` d'analyse statique, et n'a pas besoin d'être recalculé à chaque évaluation (gain de performance estimé ~20%) #1142
- C'est moins clair pour `explanations`, mais je pense que cet attribut n'est utile que pour documenter le calcul et qu'il n'a pas spécialement besoin d'être retourné par la fonction `evaluateNode` mais à voir

Il me semble même que les `missingVariables` pourraient être inférées automatiquement à partir des appels à `this.evaluateNode` et du graphe des dépendances, ce qui permettrait de simplifier la signature de la fonction `evaluate` en `(node: ASTNode) => nodeValue`, mais pareil à voir sur ce dernier point.
