### PR TITLE
Fix disambiguation ambiguity

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -830,6 +830,7 @@ dirigeant . indépendant . contrats madelin:
   titre: Contrats Madelin
   question: Avez-vous souscrit à des contrats de complémentaire privée dits ("contrats Madelins")
   par défaut: non
+  
 dirigeant . indépendant . contrats madelin . montant:
   titre: Somme des cotisations à contrats Madelin
   formule:

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1595,12 +1595,11 @@ contrat salarié . plafond sécurité sociale . renonciation proratisation:
     du plafond de la sécurité sociale (applicable pour les salariés à temps
     partiel), notamment afin d'augmenter le montant des cotisations vieillesse.
   par défaut: non
-
-contrat salarié . plafond sécurité sociale . renonciation proratisation . plafond sécurité sociale:
   applicable si: temps de travail . quotité de travail < 100%
   remplace:
     - règle: plafond sécurité sociale
       par: plafond sécurité sociale temps plein
+
 
 contrat salarié . SMIC contractuel:
   description: >

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -2739,8 +2739,7 @@ contrat salarié . CSG et CRDS . assiette de base:
 contrat salarié . CSG et CRDS . assiette abattue totale:
   formule:
     barème:
-      assiette:
-        cotisations . assiette
+      assiette: cotisations . assiette
         # - rémunération . revenus de remplacement
       multiplicateur: plafond sécurité sociale
       # c'est en fait un abattement de 1,75% sur la partie en-dessous de 4 fois le plafond
@@ -2767,8 +2766,7 @@ contrat salarié . CSG et CRDS . non déductible:
   titre: CSG non déductible et CRDS
   formule:
     somme:
-      - CSG . base . non déductible
-      - CSG . heures supplémentaires et complémentaires défiscalisées
+      - CSG . non déductible
       - CRDS
       - revenus de remplacement . CSG non déductible
       - revenus de remplacement . CRDS
@@ -2792,10 +2790,24 @@ contrat salarié . CSG et CRDS . CSG:
     Le produit de la CSG est reversé à la Cnam et à la Cnaf, il finance
     également le fonds de solidarité vieillesse
   formule:
-    somme:
-      - base
-      - heures supplémentaires et complémentaires défiscalisées
-
+        multiplication:
+          assiette: assiette de base
+          composantes:
+            - attributs:
+                nom: déductible
+              taux: 
+                nom: taux
+                valeur: 6.8%
+            - attributs:
+                nom: non déductible
+              composantes:
+                - taux: 
+                    nom: taux
+                    valeur: 2.4%
+                - attributs:
+                    nom: heures supplémentaires et complémentaires défiscalisées
+                  assiette: assiette heures supplémentaires et complémentaires défiscalisées
+                  taux: déductible . taux + non déductible . taux
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/la-base-de-calcul/assiette-csg-crds.html
     heures supplémentaires: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
@@ -2812,30 +2824,6 @@ contrat salarié . CSG et CRDS . CSG:
         complémentaire santé . forfait: 40
       valeur attendue: 137.425
 
-contrat salarié . CSG et CRDS . CSG . taux déductible:
-  formule: 6.8%
-contrat salarié . CSG et CRDS . CSG . taux non déductible:
-  formule: 2.4%
-
-contrat salarié . CSG et CRDS . CSG . base:
-  titre: CSG
-  formule:
-    multiplication:
-      assiette: assiette de base
-      composantes:
-        - attributs:
-            nom: déductible
-          taux: taux déductible
-        - attributs:
-            nom: non déductible
-          taux: taux non déductible
-
-contrat salarié . CSG et CRDS . CSG . heures supplémentaires et complémentaires défiscalisées:
-  titre: CSG heures supplémentaires et complémentaires défiscalisées
-  formule:
-    produit:
-      assiette: assiette heures supplémentaires et complémentaires défiscalisées
-      taux: taux déductible + taux non déductible
 
 contrat salarié . CSG et CRDS . CRDS:
   cotisation:
@@ -2848,11 +2836,9 @@ contrat salarié . CSG et CRDS . CRDS:
         somme:
           - assiette de base
           - assiette heures supplémentaires et complémentaires défiscalisées
-      taux: taux
-
-contrat salarié . CSG et CRDS . CRDS . taux:
-  titre: taux CRDS
-  formule: 0.5%
+      taux: 
+        nom: taux
+        valeur: 0.5%
 
 contrat salarié . CSG et CRDS . revenus de remplacement:
   titre: CSG et CRDS revenus de remplacement
@@ -2885,7 +2871,7 @@ contrat salarié . CSG et CRDS . revenus de remplacement . CSG non déductible:
   titre: CSG non déductible revenus de remplacement
   produit:
     assiette: CSG et CRDS . assiette revenu remplacements
-    taux: CSG . taux non déductible
+    taux: CSG . non déductible . taux
   plafond [ref]: 
     valeur: CSG déductible . plafond - CSG déductible
 

--- a/mon-entreprise/cypress/integration/mon-entreprise/demande-mobilité.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/demande-mobilité.js
@@ -6,7 +6,7 @@ describe('Formulaire demande mobilité', function () {
 	}
 	before(() => cy.visit('/gérer/demande-mobilité'))
 	it('should not crash', () => {
-		cy.contains('Demande de mobilité en Europe')
+		cy.contains('Demande de mobilité internationale')
 	})
 	it('should allow to complete "coordonnées" section', () => {
 		cy.contains('SIRET').click()

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/DemandeMobilite/index.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/DemandeMobilite/index.tsx
@@ -25,7 +25,7 @@ export default function FormulaireMobilitéIndépendant() {
 	const engine = new Engine(formulaire)
 	return (
 		<EngineProvider value={engine}>
-			<h1>Demande de mobilité en Europe pour travailleur indépendant</h1>
+			<h1>Demande de mobilité internationale pour travailleur indépendant</h1>
 			<h2>
 				<small>
 					Travailleur indépendant exerçant son activité à l’étranger : Régime de
@@ -35,10 +35,11 @@ export default function FormulaireMobilitéIndépendant() {
 			<p>
 				Vous exercez une activité non salariée ou salariée dans un ou plusieurs
 				Etats (pays) membres de l’UE, de l’
-				<abbr title="Espace Économique Européen">EEE</abbr>* ou en Suisse. A ce
-				titre, vous devez <strong>compléter ce formulaire</strong> pour définir
-				votre régime de Sécurité sociale applicable durant cette période et
-				l’envoyer par email à{' '}
+				<abbr title="Espace Économique Européen">EEE</abbr>*, en Suisse ou dans
+				un pays lié à la France par convention bilatérale. A ce titre, vous
+				devez <strong>compléter ce formulaire</strong> pour définir votre régime
+				de Sécurité sociale applicable durant cette période et l’envoyer par
+				email à{' '}
 				<a href="mailto:relations.internationales@urssaf.fr">
 					relations.internationales@urssaf.fr
 				</a>
@@ -46,8 +47,8 @@ export default function FormulaireMobilitéIndépendant() {
 			</p>
 			<p>
 				Après étude de votre demande, si les conditions le permettent, vous
-				recevrez un certificat A1 attestant du maintien à la Sécurité sociale
-				française.
+				recevrez un certificat A1 (ou le formulaire spécifique) attestant du
+				maintien à la Sécurité sociale française.
 			</p>
 
 			<p>
@@ -79,7 +80,7 @@ export default function FormulaireMobilitéIndépendant() {
 				</a>{' '}
 				ou par téléphone au{' '}
 				<strong>
-					<a href="tel:+33320003400">+33 (0)3 2000 3400</a>
+					<a href="tel:+33806804213">+33(0) 806 804 213</a>
 				</strong>{' '}
 				de 9h00 à 12h00 et de 13h00 à 16h00.
 			</p>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/Home.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Gérer/Home.tsx
@@ -192,8 +192,8 @@ export default function SocialSecurity() {
 									<Trans i18nKey="gérer.ressources.embaucher">
 										<p>Exporter son activité en Europe</p>
 										<p className="ui__ notice">
-											Le formulaire pour effectuer une demande de mobilité en
-											Europe (détachement ou pluriactivité)
+											Le formulaire pour effectuer une demande de mobilité
+											internationale (détachement ou pluriactivité)
 										</p>
 									</Trans>
 								</Link>

--- a/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/sites/mon-entreprise.fr/pages/Simulateurs/metadata.tsx
@@ -612,7 +612,7 @@ export function getSimulatorsData({
 			path: sitePaths.gérer.formulaireMobilité,
 			shortName: t(
 				'pages.gérer.demande-mobilité.shortname',
-				'Demande de mobilité en Europe'
+				'Demande de mobilité internationale'
 			),
 			private: true,
 			iframe: 'demande-mobilite',

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -451,7 +451,7 @@ Notifications affichées : contrat salarié . convention collective . contrôle 
 `;
 
 exports[`calculate simulations-salarié: CCN spectacle vivant 1`] = `
-"[3834,0,2500,1938,1856]
+"[3923,0,2500,1938,1856]
 Notifications affichées : contrat salarié . CDD . information, contrat salarié . convention collective . contrôle décharge"
 `;
 

--- a/publicodes/source/components/mecanisms/Rule.tsx
+++ b/publicodes/source/components/mecanisms/Rule.tsx
@@ -3,10 +3,23 @@ import Explanation from '../Explanation'
 
 export default function RuleMecanism({ rawNode, explanation }) {
 	return (
-		<>
-			<code className="ui__ light-bg">{capitalise0(rawNode.nom)}</code>
-			&nbsp;
+		<div
+			css={`
+				display: flex;
+				flex-direction: column;
+			`}
+		>
+			<code
+				className="ui__ light-bg"
+				css={`
+					align-self: flex-start;
+					margin: 0;
+					margin-bottom: 0.2rem;
+				`}
+			>
+				{capitalise0(rawNode.nom)}
+			</code>
 			<Explanation node={explanation.valeur} />
-		</>
+		</div>
 	)
 }

--- a/publicodes/source/components/mecanisms/common.tsx
+++ b/publicodes/source/components/mecanisms/common.tsx
@@ -217,6 +217,7 @@ const StyledMecanism = styled.div<{ name: string }>`
 	padding: 1rem;
 	position: relative;
 	flex: 1;
+	flex-direction: column;
 	border-color: ${({ name }) => mecanismColors(name)};
 
 	.key {
@@ -293,7 +294,7 @@ export function Leaf(
 	return (
 		<div
 			css={`
-				display: flex;
+				display: inline-flex;
 				flex-direction: column;
 			`}
 		>

--- a/publicodes/source/ruleUtils.ts
+++ b/publicodes/source/ruleUtils.ts
@@ -30,11 +30,11 @@ export function disambiguateRuleReference<R extends Record<string, RuleNode>>(
 	contextName = '',
 	partialName: string
 ): keyof R {
-	const possibleDottedName = [
-		contextName,
-		...ruleParents(contextName),
-		'',
-	].map((x) => (x ? x + ' . ' + partialName : partialName))
+	const possibleDottedName = [contextName, ...ruleParents(contextName), '']
+		.map((x) => (x ? x + ' . ' + partialName : partialName))
+		// Rules can reference themselves, but it should be the last thing to check
+		.sort((a, b) => (a === contextName ? 1 : b === contextName ? -1 : 0))
+
 	const dottedName = possibleDottedName.find((name) => name in rules)
 	if (!dottedName) {
 		syntaxError(

--- a/publicodes/test/mécanismes/expressions.yaml
+++ b/publicodes/test/mécanismes/expressions.yaml
@@ -305,13 +305,18 @@ chaine de charactère:
     - situation:
         chaine de charactère: "'je t'y vois'"
       valeur attendue: je t'y vois
-# TODO
-# expression sur plusieurs lignes:
-#   formule: >
-#     salaire de base
-#     + 2000
-#     = 3000
-#   exemples:
-#     - situation:
-#         salaire de base: 1000
-#     - valeur attendue: true
+
+
+a: oui
+b: 5
+a . b: b + 5
+a . c: b + 5
+désambiguation du nom de règle 1:
+  formule: a . b
+  exemples: 
+    - valeur attendue: 10
+
+désambiguation du nom de règle 2:
+  formule: a . c
+  exemples: 
+    - valeur attendue: 15

--- a/publicodes/test/mécanismes/remplace.yaml
+++ b/publicodes/test/mécanismes/remplace.yaml
@@ -204,30 +204,7 @@ convention hôtels cafés restaurants . frais de repas:
   remplace: frais de repas
   formule: 6 €/repas
 
-frais de repas non remplacé:
+remplacement d'un nom de variable identique:
   formule: frais de repas
-  exemples:
-    - valeur attendue: 5
-
-# Note: this would produce an infinite loop
-# frais de repas remplacé:
-#   formule: convention hôtels cafés restaurants . frais de repas
-#   exemples:
-#     - nom: par défaut
-#       valeur attendue: 5
-
-
-frais de repas2:
-  formule: 5 €/repas
-
-convention hôtels cafés restaurants2:
-  formule: oui
-
-convention hôtels cafés restaurants2 . remplaçeur:
-  remplace: frais de repas2
-  formule: 6 €/repas
-
-frais de repas2 remplacé:
-  formule: frais de repas2
   exemples:
     - valeur attendue: 6


### PR DESCRIPTION
Lorsque l'on cherche un nom de règle, on laisse la possibilité à
une règle de se référencer elle même, mais alors cette résolution
est la dernière à être envisagée.

Dans l'exemple :
```yaml
b: 5
a . b: b
```
`a . b` référence bien `b` qui vaut `5`

Et dans celui ci :
```
a: 0
a . b:
  remplace:a
  par: b * 5
  valeur: 2
```
`a . b` remplace `a` en la multipliant par sa propre valeur (ici 2)

fix #1081, fix #1083

