### PR TITLE
Améliore les exports de publicode

### DIFF
--- a/modele-social/package.json
+++ b/modele-social/package.json
@@ -25,6 +25,7 @@
 	},
 	"scripts": {
 		"build": "node build.js",
+		"clean": "rimraf dist node_modules",
 		"prepare": "yarn run build",
 		"up": "yarn version --minor && echo \"ℹ N'oubliez pas de poussez le tag git\"",
 		"test": "echo 1"

--- a/publicodes/esm/index.js
+++ b/publicodes/esm/index.js
@@ -2,11 +2,11 @@
 // For a deep explanation see:
 // https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1
 
-import publicodes from '../dist/index.js';
+import publicodes from '../dist/index.js'
 export default publicodes.default
-export const reduceAST = publicodes.reduceAST; 
-export const transformAST = publicodes.transformAST; 
-export const formatValue = publicodes.formatValue; 
-export const utils = publicodes.utils; 
-export const translateRules = publicodes.translateRules; 
-export const evaluateRule = publicodes.evaluateRule;
+export const reduceAST = publicodes.reduceAST
+export const transformAST = publicodes.transformAST
+export const formatValue = publicodes.formatValue
+export const utils = publicodes.utils
+export const translateRules = publicodes.translateRules
+export const evaluateRule = publicodes.evaluateRule

--- a/publicodes/esm/index.js
+++ b/publicodes/esm/index.js
@@ -1,0 +1,12 @@
+// ESM wrapper arrond publicodes CJS Module
+// For a deep explanation see:
+// https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1
+
+import publicodes from '../dist/index.js';
+export default publicodes.default
+export const reduceAST = publicodes.reduceAST; 
+export const transformAST = publicodes.transformAST; 
+export const formatValue = publicodes.formatValue; 
+export const utils = publicodes.utils; 
+export const translateRules = publicodes.translateRules; 
+export const evaluateRule = publicodes.evaluateRule;

--- a/publicodes/esm/package.json
+++ b/publicodes/esm/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+	"engines": {
+		"node": ">=15.0.0"
+  }
+}

--- a/publicodes/package.json
+++ b/publicodes/package.json
@@ -20,6 +20,7 @@
 		"dist/index.js",
 		"dist/types",
 		"dist/images",
+		"dist/publicodes.min.js",
 		"esm"
 	],
 	"private": false,

--- a/publicodes/package.json
+++ b/publicodes/package.json
@@ -4,6 +4,10 @@
 	"description": "A declarative language for encoding public algorithm",
 	"main": "dist/index.js",
 	"types": "dist/types/index.d.ts",
+	"exports": {
+			"require": "./dist/index.js",
+			"import": "./esm/index.js"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/betagouv/mon-entreprise.git",
@@ -15,7 +19,8 @@
 	"files": [
 		"dist/index.js",
 		"dist/types",
-		"dist/images"
+		"dist/images",
+		"esm"
 	],
 	"private": false,
 	"devDependencies": {

--- a/publicodes/webpack.config.js
+++ b/publicodes/webpack.config.js
@@ -12,7 +12,6 @@ const common = {
 	module: {
 		rules: commonLoaders({ file: false }),
 	},
-	
 }
 
 module.exports = [
@@ -26,7 +25,7 @@ module.exports = [
 			globalObject: 'this',
 		},
 		externals:
-		// Every non-relative module is external
+			// Every non-relative module is external
 			/^[a-z\-0-9]+$/,
 	},
 	process.env.NODE_ENV === 'production' && {
@@ -36,5 +35,5 @@ module.exports = [
 			library: 'publicodes',
 			libraryTarget: 'global',
 		},
-	}
+	},
 ].filter(Boolean)

--- a/publicodes/webpack.config.js
+++ b/publicodes/webpack.config.js
@@ -7,17 +7,15 @@ const common = {
 	resolve: {
 		extensions: ['.ts', '.tsx', '.js'],
 	},
-	mode: 'development',
+	mode: process.env.NODE_ENV,
 	entry: path.resolve(__dirname, 'source', 'index.ts'),
 	module: {
 		rules: commonLoaders({ file: false }),
 	},
-	externals:
-		// Every non-relative module is external
-		/^[a-z\-0-9]+$/,
+	
 }
 
-module.exports =
+module.exports = [
 	// Config for UMD export (browser / node)
 	{
 		...common,
@@ -27,4 +25,16 @@ module.exports =
 			libraryTarget: 'umd',
 			globalObject: 'this',
 		},
+		externals:
+		// Every non-relative module is external
+			/^[a-z\-0-9]+$/,
+	},
+	process.env.NODE_ENV === 'production' && {
+		...common,
+		output: {
+			filename: 'publicodes.min.js',
+			library: 'publicodes',
+			libraryTarget: 'global',
+		},
 	}
+].filter(Boolean)


### PR DESCRIPTION
- [x] Ajoute un export ESJ pour être une utilisation native de import dans node >= 14 (fix #1239)
- [x] Ajoute un export qui compile toute les librairie pour être utilisé directement dans le browser (fix #1211)
