### PR TITLE
Pas d'activité partielle pour un stagiaire

### DIFF
--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1073,6 +1073,7 @@ contrat salarié . stage:
   rend non applicable:
     - statut cadre
     - statut JEI
+    - activité partielle
     - réduction générale
     - allocations familiales . taux réduit
     - maladie . taux employeur . taux réduit


### PR DESCRIPTION
Note : les exclusions sont quasiment les mêmes pour les assimilés salariés et pour les stagiaires car dans les deux cas il ne s'agit pas de "contrat salarié", il faudrait rendre ce point explicite dans l'organisation des règles pour éviter le type d'oublis corrigé dans ce commit (par exemple `applicable si: contrat salarié` qui ne s'applique pas pour les stagiaires et AS).

Edit: oups ce n'est pas la bonne modification, l'activité partielle était déjà non applicable mais la question apparaît quand même dans le simulateur stagiaire.