### PR TITLE
WIP - Explicit redux state/actions/reducers types

### DIFF
--- a/modele-social/index.d.ts
+++ b/modele-social/index.d.ts
@@ -4,6 +4,6 @@
 import { Rule } from 'publicodes'
 import { Names } from './dist/names'
 
-export type DottedName = Names
+export type DottedName = string // XXX
 declare let rules: Record<Names, Rule>
 export default rules

--- a/mon-entreprise/source/Provider.tsx
+++ b/mon-entreprise/source/Provider.tsx
@@ -7,7 +7,7 @@ import React, { createContext, useEffect, useMemo } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { Provider as ReduxProvider } from 'react-redux'
 import { Router } from 'react-router-dom'
-import { PreloadedState } from 'redux'
+import { DeepPartial, PreloadedState } from 'redux'
 import reducers, { RootState } from 'Reducers/rootReducer'
 import { applyMiddleware, compose, createStore, Middleware, Store } from 'redux'
 import thunk from 'redux-thunk'
@@ -50,7 +50,7 @@ export type ProviderProps = {
 	children: React.ReactNode
 	tracker?: Tracker
 	sitePaths?: SitePaths
-	initialStore?: PreloadedState<RootState>
+	preloadedState?: DeepPartial<RootState>
 	onStoreCreated?: (store: Store) => void
 	reduxMiddlewares?: Array<Middleware>
 }
@@ -59,7 +59,7 @@ export default function Provider({
 	tracker = new Tracker(),
 	basename,
 	reduxMiddlewares,
-	initialStore,
+	preloadedState,
 	onStoreCreated,
 	children,
 	sitePaths = {} as SitePaths,
@@ -91,7 +91,7 @@ export default function Provider({
 
 	// Hack: useMemo is used to persist the store across hot reloads.
 	const store = useMemo(() => {
-		return createStore(reducers, initialStore, storeEnhancer)
+		return createStore(reducers, preloadedState as PreloadedState<RootState>, storeEnhancer)
 	}, [])
 	onStoreCreated?.(store)
 

--- a/mon-entreprise/source/actions/index.ts
+++ b/mon-entreprise/source/actions/index.ts
@@ -1,0 +1,12 @@
+import { Action as BaseAction } from './actions'
+import { Action as CompanyCreationChecklistAction } from './companyCreationChecklistActions'
+import { CompanyStatusAction } from './companyStatusActions'
+import { ActionExistingCompany } from './existingCompanyActions'
+import { Action as HiringChecklistAction } from './hiringChecklistAction'
+
+export type EveryAction =
+	| BaseAction
+	| CompanyStatusAction
+	| CompanyCreationChecklistAction
+	| ActionExistingCompany
+	| HiringChecklistAction

--- a/mon-entreprise/source/reducers/inFranceAppReducer.ts
+++ b/mon-entreprise/source/reducers/inFranceAppReducer.ts
@@ -1,24 +1,16 @@
-import { Action as CreationChecklistAction } from 'Actions/companyCreationChecklistActions'
-import { ActionExistingCompany } from 'Actions/existingCompanyActions'
-import { Action as HiringChecklist } from 'Actions/hiringChecklistAction'
 import { ApiCommuneJson } from 'Components/conversation/select/SelectCommune'
 import { omit } from 'ramda'
 import { combineReducers } from 'redux'
 import { LegalStatus } from 'Selectors/companyStatusSelectors'
 import {
-	Action as CompanyStatusAction,
 	LegalStatusRequirements,
 } from 'Types/companyTypes'
+import { EveryAction} from 'actions'
 
-type Action =
-	| CompanyStatusAction
-	| CreationChecklistAction
-	| HiringChecklist
-	| ActionExistingCompany
 
 function companyLegalStatus(
 	state: LegalStatusRequirements = {},
-	action: Action
+	action: EveryAction
 ): LegalStatusRequirements {
 	switch (action.type) {
 		case 'COMPANY_IS_SOLE_PROPRIETORSHIP':
@@ -40,7 +32,7 @@ function companyLegalStatus(
 
 function hiringChecklist(
 	state: { [key: string]: boolean } = {},
-	action: Action
+	action: EveryAction
 ) {
 	switch (action.type) {
 		case 'CHECK_HIRING_ITEM':
@@ -62,7 +54,7 @@ function hiringChecklist(
 
 function companyCreationChecklist(
 	state: { [key: string]: boolean } = {},
-	action: Action
+	action: EveryAction
 ) {
 	switch (action.type) {
 		case 'CHECK_COMPANY_CREATION_ITEM':
@@ -84,7 +76,7 @@ function companyCreationChecklist(
 	}
 }
 
-function companyStatusChoice(state: LegalStatus | null = null, action: Action) {
+function companyStatusChoice(state: LegalStatus | null = null, action: EveryAction) {
 	if (action.type === 'RESET_COMPANY_STATUS_CHOICE') {
 		return null
 	}
@@ -138,7 +130,7 @@ export type Company = {
 
 function existingCompany(
 	state: Company | null = null,
-	action: Action
+	action: EveryAction
 ): Company | null {
 	if (!action.type.startsWith('EXISTING_COMPANY::')) {
 		return state

--- a/mon-entreprise/source/reducers/inFranceAppReducer.ts
+++ b/mon-entreprise/source/reducers/inFranceAppReducer.ts
@@ -184,4 +184,10 @@ const inFranceAppReducer = combineReducers({
 })
 export default inFranceAppReducer
 
-export type InFranceAppState = ReturnType<typeof inFranceAppReducer>
+export type InFranceAppState = {
+	companyLegalStatus: LegalStatusRequirements
+	companyStatusChoice: LegalStatus | null
+	companyCreationChecklist: Record<string, boolean>
+	existingCompany: Company | null
+	hiringChecklist: Record<string, boolean>
+}

--- a/mon-entreprise/source/reducers/previousSimulationRootReducer.ts
+++ b/mon-entreprise/source/reducers/previousSimulationRootReducer.ts
@@ -1,7 +1,7 @@
 import { Simulation } from 'Reducers/rootReducer'
-import { Action } from 'Actions/actions'
 import { RootState } from './rootReducer'
 import { retrievePersistedSimulation } from '../storage/persistSimulation'
+import { EveryAction} from 'actions'
 
 export const createStateFromPreviousSimulation = (
 	state: RootState
@@ -18,7 +18,7 @@ export const createStateFromPreviousSimulation = (
 		  }
 		: {}
 
-export default (state: RootState, action: Action): RootState => {
+export default (state: RootState, action: EveryAction): RootState => {
 	switch (action.type) {
 		case 'SET_SIMULATION':
 			return {

--- a/mon-entreprise/source/reducers/rootReducer.ts
+++ b/mon-entreprise/source/reducers/rootReducer.ts
@@ -5,7 +5,10 @@ import { combineReducers, Reducer } from 'redux'
 import { PreviousSimulation } from 'Selectors/previousSimulationSelectors'
 import { DottedName } from 'modele-social'
 import { objectifsSelector } from '../selectors/simulationSelectors'
-import inFranceAppReducer, { Company } from './inFranceAppReducer'
+import inFranceAppReducer, {
+	Company,
+	InFranceAppState,
+} from './inFranceAppReducer'
 import previousSimulationRootReducer from './previousSimulationRootReducer'
 
 function explainedVariable(
@@ -202,4 +205,10 @@ export default reduceReducers<RootState>(
 	previousSimulationRootReducer as any
 ) as Reducer<RootState>
 
-export type RootState = ReturnType<typeof mainReducer>
+export type RootState = {
+	explainedVariable: DottedName | null
+	simulation: Simulation | null
+	previousSimulation: PreviousSimulation | null
+	activeTargetInput: DottedName | null
+	inFranceApp: InFranceAppState
+}

--- a/mon-entreprise/source/site/App.tsx
+++ b/mon-entreprise/source/site/App.tsx
@@ -99,7 +99,7 @@ export default function Root({ basename, rules }: RootProps) {
 				setupInFranceAppPersistence(store)
 				setupSimulationPersistence(store)
 			}}
-			initialStore={{
+			preloadedState={{
 				inFranceApp: retrievePersistedInFranceApp(),
 			}}
 		>


### PR DESCRIPTION
Je suis parti dans l'idée d'essayer de retirer les `any` qui se trimballent dans `rootReducer.ts`, et explorer rapidement à quoi pourrait ressembler un fix.

J'ai créé une branche `explicit-redux-state-types` qui essaie de:

- mettre des types top-down au state (donc, ne pas utiliser `ReturnType<>`). C'est un effet de bord de cette approche que je trouve sain: il me semble bien de définir dans un premier temps les types de nos data structures et ensuite de les utiliser. De plus, le ReturnType a tendance à complexifier le typage du state.
- fixer le problème soulevé par la présence de type `Action` (de `actions/actions.ts`, qui ne
  représente qu'une partie des actions): création du type `EveryAction` (en fait ça devrait peut-être être `Action` dans `actions/actions.ts`, à voir).

Ceci dit, il semble inadéquat pour les développeurs de devoir se
trimballer le `EveryAction` dans chaque sous-reducer combiné avec `combineReducers`, et ainsi de ne pas pouvoir profiter d'un typage précis.  
A creuser donc: comment faire pour correctement typer les actions des reducers combinés? Pour l'instant je n'ai pas trouvé d'exemple de codebase qui gère ça de manière satisfaisante, mais je n'ai pas trop cherché.

Notons qu'on n'a pas le même pb avec le state car celui-ci est plus naturellement défini comme
top-down, avec un bon mix de Record et d'unions.

Le pb qu'il me restait à lever pour faire marcher mon code, apparemment, c'est les
ThunkActions (`ThunkResult`) qui sont dépendants de `Action` et non pas de `EveryAction`.

Que pensez-vous de l'approche et des solutions aux problèmes soulevés? @mquandalle @johangirod 