### PR TITLE
 Supprime Ramda du moteur

### DIFF
--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1194,7 +1194,7 @@ contrat salarié . rémunération . brut de base:
   unité: €/mois
   suggestions:
     salaire médian: 2300 €/mois
-    SMIC: contrat salarié . SMIC contractuel
+    SMIC: SMIC contractuel
   formule:
     inversion numérique:
       question: Quel est le salaire ?

--- a/publicodes/core/package.json
+++ b/publicodes/core/package.json
@@ -31,7 +31,6 @@
 	"dependencies": {
 		"moo": "^0.5.1",
 		"nearley": "^2.19.2",
-		"ramda": "^0.27.0",
 		"yaml": "^1.9.2"
 	},
 	"scripts": {

--- a/publicodes/core/source/AST/graph.ts
+++ b/publicodes/core/source/AST/graph.ts
@@ -1,5 +1,4 @@
 import graphlib from '@dagrejs/graphlib'
-import * as R from 'ramda'
 import parsePublicodes from '../parsePublicodes'
 import { RuleNode } from '../rule'
 import { reduceAST } from './index'
@@ -10,9 +9,10 @@ type GraphCyclesWithDependencies = Array<RulesDependencies>
 function buildRulesDependencies(
 	parsedRules: Record<string, RuleNode>
 ): RulesDependencies {
+	const uniq = <T>(arr: Array<T>): Array<T> => [...new Set(arr)]
 	return Object.entries(parsedRules).map(([name, node]) => [
 		name,
-		R.uniq(buildRuleDependancies(node)),
+		uniq(buildRuleDependancies(node)),
 	])
 }
 
@@ -79,7 +79,7 @@ export function cyclicDependencies(
 	const rulesDependencies = buildRulesDependencies(parsedRules)
 	const dependenciesGraph = buildDependenciesGraph(rulesDependencies)
 	const cycles = (graphlib as any).alg.findCycles(dependenciesGraph)
-	const rulesDependenciesObject = R.fromPairs(rulesDependencies)
+	const rulesDependenciesObject = Object.fromEntries(rulesDependencies)
 
 	return cycles.map((cycle) => {
 		const c = cycle.reverse()

--- a/publicodes/core/source/AST/index.ts
+++ b/publicodes/core/source/AST/index.ts
@@ -1,4 +1,3 @@
-import { mapObjIndexed } from 'ramda'
 import { InternalError } from '../error'
 import { TrancheNodes } from '../mecanisms/trancheUtils'
 import { ReplacementRule } from '../replacement'
@@ -151,7 +150,9 @@ const traverseASTNode: TraverseFunction<NodeKind> = (fn, node) => {
 const traverseRuleNode: TraverseFunction<'rule'> = (fn, node) => ({
 	...node,
 	replacements: node.replacements.map(fn) as Array<ReplacementRule>,
-	suggestions: mapObjIndexed(fn, node.suggestions),
+	suggestions: Object.fromEntries(
+		Object.entries(node.suggestions).map(([key, value]) => [key, fn(value)])
+	),
 	explanation: {
 		parent: node.explanation.parent && fn(node.explanation.parent),
 		valeur: fn(node.explanation.valeur),

--- a/publicodes/core/source/format.ts
+++ b/publicodes/core/source/format.ts
@@ -1,11 +1,5 @@
-import { memoizeWith } from 'ramda'
 import { Evaluation, Unit } from './AST/types'
 import { formatUnit, serializeUnit } from './units'
-
-const NumberFormat = memoizeWith(
-	(...args) => JSON.stringify(args),
-	Intl.NumberFormat
-)
 
 export const numberFormatter = ({
 	style,
@@ -27,7 +21,7 @@ export const numberFormatter = ({
 		!Number.isInteger(value)
 			? 2
 			: minimumFractionDigits
-	return NumberFormat(language, {
+	return Intl.NumberFormat(language, {
 		style,
 		currency: 'EUR',
 		maximumFractionDigits,

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { compose, mapObjIndexed } from 'ramda'
 import { ASTNode, EvaluatedNode, NodeKind } from './AST/types'
 import { evaluationFunctions } from './evaluationFunctions'
 import { simplifyNodeUnit } from './nodeUnits'
@@ -104,22 +103,26 @@ export default class Engine<Name extends string = string> {
 		situation: Partial<Record<Name, string | number | object | ASTNode>> = {}
 	) {
 		this.resetCache()
-		this.parsedSituation = mapObjIndexed((value, key) => {
-			if (value && typeof value === 'object' && 'nodeKind' in value) {
-				return value as ASTNode
-			}
-			return compose(
-				inlineReplacements(this.replacements),
-				disambiguateReference(this.parsedRules)
-			)(
-				parse(value, {
-					dottedName: `situation [${key}]`,
-					parsedRules: {},
-					options: this.options,
-				})
-			)
-		}, situation)
+		this.parsedSituation = Object.fromEntries(
+			Object.entries(situation).map(([key, value]) => {
+				const parsedValue =
+					value && typeof value === 'object' && 'nodeKind' in value
+						? (value as ASTNode)
+						: this.parse(value, {
+								dottedName: `situation [${key}]`,
+								parsedRules: {},
+								options: this.options,
+						  })
+				return [key, parsedValue]
+			})
+		)
 		return this
+	}
+
+	private parse(...args: Parameters<typeof parse>) {
+		return inlineReplacements(this.replacements)(
+			disambiguateReference(this.parsedRules)(parse(...args))
+		)
 	}
 
 	evaluate(expression: string | Object): EvaluatedNode {
@@ -134,16 +137,11 @@ export default class Engine<Name extends string = string> {
 			originalWarn(warning)
 		}
 		const result = this.evaluateNode(
-			compose(
-				inlineReplacements(this.replacements),
-				disambiguateReference(this.parsedRules)
-			)(
-				parse(expression, {
-					dottedName: "evaluation'''",
-					parsedRules: {},
-					options: this.options,
-				})
-			)
+			this.parse(expression, {
+				dottedName: "evaluation'''",
+				parsedRules: {},
+				options: this.options,
+			})
 		)
 		console.warn = originalWarn
 		return result

--- a/publicodes/core/source/mecanisms/condition-allof.ts
+++ b/publicodes/core/source/mecanisms/condition-allof.ts
@@ -1,4 +1,3 @@
-import { is } from 'ramda'
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
 import { mergeAllMissing } from '../evaluation'
@@ -38,7 +37,7 @@ const evaluate: EvaluationFunction<'toutes ces conditions'> = function (node) {
 }
 
 export const mecanismAllOf = (v, context) => {
-	if (!is(Array, v)) throw new Error('should be array')
+	if (!Array.isArray(v)) throw new Error('should be array')
 	const explanation = v.map((node) => parse(node, context))
 
 	return {

--- a/publicodes/core/source/mecanisms/condition-oneof.ts
+++ b/publicodes/core/source/mecanisms/condition-oneof.ts
@@ -1,4 +1,3 @@
-import { is } from 'ramda'
 import { EvaluationFunction } from '..'
 import { ASTNode, EvaluatedNode, Evaluation } from '../AST/types'
 import { mergeMissing } from '../evaluation'
@@ -57,7 +56,7 @@ const evaluate: EvaluationFunction<'une de ces conditions'> = function (node) {
 }
 
 export const mecanismOneOf = (v, context) => {
-	if (!is(Array, v)) throw new Error('should be array')
+	if (!Array.isArray(v)) throw new Error('should be array')
 	const explanation = v.map((node) => parse(node, context))
 
 	return {

--- a/publicodes/core/source/mecanisms/min.ts
+++ b/publicodes/core/source/mecanisms/min.ts
@@ -1,4 +1,3 @@
-import { min } from 'ramda'
 import { ASTNode } from '../AST/types'
 import { evaluateArray } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
@@ -17,6 +16,6 @@ export const mecanismMin = (v, context) => {
 	} as MinNode
 }
 
-const evaluate = evaluateArray<'minimum'>(min, Infinity)
+const evaluate = evaluateArray<'minimum'>((a, b) => Math.min(a, b), Infinity)
 
 registerEvaluationFunction('minimum', evaluate)

--- a/publicodes/core/source/mecanisms/operation.ts
+++ b/publicodes/core/source/mecanisms/operation.ts
@@ -1,4 +1,3 @@
-import { equals, fromPairs } from 'ramda'
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
 import { convertToDate } from '../date'
@@ -20,8 +19,8 @@ const knownOperations = {
 	'<=': [(a, b) => a <= b, '≤'],
 	'>': [(a, b) => a > b],
 	'>=': [(a, b) => a >= b, '≥'],
-	'=': [(a, b) => equals(a, b)],
-	'!=': [(a, b) => !equals(a, b), '≠'],
+	'=': [(a, b) => a === b],
+	'!=': [(a, b) => a !== b, '≠'],
 } as const
 
 export type OperationNode = {
@@ -123,7 +122,7 @@ const evaluate: EvaluationFunction<'operation'> = function (node) {
 
 registerEvaluationFunction('operation', evaluate)
 
-const operationDispatch = fromPairs(
+const operationDispatch = Object.fromEntries(
 	Object.entries(knownOperations).map(([k, [f, symbol]]) => [
 		k,
 		parseOperation(k, symbol),

--- a/publicodes/core/source/mecanisms/reduction.ts
+++ b/publicodes/core/source/mecanisms/reduction.ts
@@ -1,4 +1,3 @@
-import { max, min } from 'ramda'
 import { typeWarning } from '../error'
 import { defaultNode, evaluateObject, parseObject } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
@@ -48,12 +47,18 @@ const evaluate = evaluateObject<'allègement'>(function ({
 				? 0
 				: null
 			: serializeUnit(abattement.unit) === '%'
-			? max(
+			? Math.max(
 					0,
 					assietteValue -
-						min(plafond.nodeValue, (abattement.nodeValue / 100) * assietteValue)
+						Math.min(
+							plafond.nodeValue,
+							(abattement.nodeValue / 100) * assietteValue
+						)
 			  )
-			: max(0, assietteValue - min(plafond.nodeValue, abattement.nodeValue))
+			: Math.max(
+					0,
+					assietteValue - Math.min(plafond.nodeValue, abattement.nodeValue)
+			  )
 		: assietteValue
 	return {
 		nodeValue,

--- a/publicodes/core/source/mecanisms/situation.ts
+++ b/publicodes/core/source/mecanisms/situation.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from 'ramda'
 import { ASTNode, EvaluatedNode } from '../AST/types'
 import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
@@ -50,7 +49,7 @@ registerEvaluationFunction(parseSituation.nom, function evaluate(node) {
 		...node,
 		nodeValue: valeur.nodeValue,
 		missingVariables:
-			isEmpty(missingVariables) && valeur.nodeValue === null
+			Object.keys(missingVariables).length === 0 && valeur.nodeValue === null
 				? { [situationKey]: 1 }
 				: missingVariables,
 		...(unit !== undefined && { unit }),

--- a/publicodes/core/source/mecanisms/synchronisation.ts
+++ b/publicodes/core/source/mecanisms/synchronisation.ts
@@ -1,4 +1,3 @@
-import { path } from 'ramda'
 import { EvaluationFunction } from '..'
 import { ASTNode } from '../AST/types'
 import { registerEvaluationFunction } from '../evaluationFunctions'
@@ -15,14 +14,14 @@ export type SynchronisationNode = {
 const evaluate: EvaluationFunction<'synchronisation'> = function (node: any) {
 	const data = this.evaluateNode(node.explanation.data)
 	const valuePath = node.explanation.chemin.split(' . ')
-	const nodeValue =
-		data.nodeValue == null ? null : path(valuePath, data.nodeValue)
+	const path = (obj) => valuePath.reduce((res, prop) => res[prop], obj)
+	const nodeValue = data.nodeValue == null ? null : path(data.nodeValue)
 	// If the API gave a non null value, then some of its props may be null (the
 	// API can be composed of multiple API, some failing). Then this prop will be
 	// set to the default value defined in the API's rule
 	const safeNodeValue =
 		nodeValue == null && data.nodeValue != null
-			? path(valuePath, data.explanation.defaultValue)
+			? path(data.explanation.defaultValue)
 			: nodeValue
 	const missingVariables = {
 		...data.missingVariables,

--- a/publicodes/core/source/mecanisms/trancheUtils.ts
+++ b/publicodes/core/source/mecanisms/trancheUtils.ts
@@ -1,4 +1,3 @@
-import { evolve } from 'ramda'
 import { ASTNode, Evaluation } from '../AST/types'
 import { evaluationError, typeWarning } from '../error'
 import { mergeAllMissing } from '../evaluation'
@@ -18,13 +17,14 @@ export const parseTranches = (tranches, context): TrancheNodes => {
 			}
 			return { ...t, plafond: t.plafond ?? Infinity }
 		})
-		.map(
-			evolve({
-				taux: (node) => parse(node, context),
-				montant: (node) => parse(node, context),
-				plafond: (node) => parse(node, context),
-			})
-		)
+		.map((node) => ({
+			...node,
+			...(node.taux !== undefined ? { taux: parse(node.taux, context) } : {}),
+			...(node.montant !== undefined
+				? { montant: parse(node.montant, context) }
+				: {}),
+			plafond: parse(node.plafond, context),
+		}))
 }
 
 export function evaluatePlafondUntilActiveTranche(

--- a/publicodes/core/source/mecanisms/variations.ts
+++ b/publicodes/core/source/mecanisms/variations.ts
@@ -1,4 +1,3 @@
-import { or } from 'ramda'
 import { EvaluationFunction } from '..'
 import { ASTNode, Unit } from '../AST/types'
 import { typeWarning } from '../error'
@@ -101,8 +100,7 @@ const evaluate: EvaluationFunction<'variations'> = function (node) {
 					pureTemporal(evaluatedCondition.nodeValue)
 			)
 			evaluatedCondition.missingVariables = bonus(
-				evaluatedCondition.missingVariables,
-				true
+				evaluatedCondition.missingVariables
 			)
 			const currentConditionAlwaysFalse = !sometime(
 				(x) => x !== false,
@@ -136,6 +134,7 @@ const evaluate: EvaluationFunction<'variations'> = function (node) {
 				evaluatedConsequence.temporalValue ??
 					pureTemporal(evaluatedConsequence.nodeValue)
 			)
+			const or = (a, b) => a || b
 			return [
 				liftTemporal2(or, evaluation, currentValue),
 				[

--- a/publicodes/core/source/parse.ts
+++ b/publicodes/core/source/parse.ts
@@ -1,5 +1,4 @@
 import { Grammar, Parser } from 'nearley'
-import { isEmpty } from 'ramda'
 import { ASTNode } from './AST/types'
 import { EngineError, syntaxError } from './error'
 import grammar from './grammar.ne'
@@ -109,7 +108,7 @@ Cela vient probablement d'une erreur dans l'indentation
 	`
 		)
 	}
-	if (isEmpty(rawNode)) {
+	if (keys.length === 0) {
 		return { nodeKind: 'constant', nodeValue: null }
 	}
 

--- a/publicodes/core/source/parsePublicodes.ts
+++ b/publicodes/core/source/parsePublicodes.ts
@@ -1,4 +1,3 @@
-import { partial } from 'ramda'
 import yaml from 'yaml'
 import { ParsedRules } from '.'
 import { transformAST, traverseParsedRules } from './AST'

--- a/publicodes/core/source/replacement.tsx
+++ b/publicodes/core/source/replacement.tsx
@@ -1,4 +1,3 @@
-import { groupBy } from 'ramda'
 import { transformAST } from './AST'
 import { ASTNode } from './AST/types'
 import { InternalError, warning } from './error'
@@ -89,15 +88,15 @@ export function parseRendNonApplicable(
 export function getReplacements(
 	parsedRules: Record<string, RuleNode>
 ): Record<string, Array<ReplacementRule>> {
-	return groupBy(
-		(r: ReplacementRule) => {
+	return Object.values(parsedRules)
+		.flatMap((rule) => rule.replacements)
+		.reduce((acc, r: ReplacementRule) => {
 			if (!r.replacedReference.dottedName) {
 				throw new InternalError(r)
 			}
-			return r.replacedReference.dottedName
-		},
-		Object.values(parsedRules).flatMap((rule) => rule.replacements)
-	)
+			const key = r.replacedReference.dottedName
+			return { ...acc, [key]: [...(acc[key] ?? []), r] }
+		}, {})
 }
 
 export function inlineReplacements(

--- a/publicodes/core/source/ruleUtils.ts
+++ b/publicodes/core/source/ruleUtils.ts
@@ -1,10 +1,9 @@
-import { last, pipe, range, take } from 'ramda'
 import { syntaxError } from './error'
 import { RuleNode } from './rule'
 
 const splitName = (str: string) => str.split(' . ')
-const joinName = (strs) => strs.join(' . ')
-export const nameLeaf = pipe<string, string[], string>(splitName, last)
+const joinName = (strs: Array<string>) => strs.join(' . ')
+export const nameLeaf = (name: string) => splitName(name).slice(-1)?.[0]
 export const encodeRuleName = (name) =>
 	name
 		?.replace(/\s\.\s/g, '/')
@@ -15,13 +14,12 @@ export const decodeRuleName = (name) =>
 		.replace(/\//g, ' . ')
 		.replace(/-/g, ' ')
 		.replace(/\u2011/g, '-')
-export function ruleParents<Names extends string>(
-	dottedName: Names
-): Array<Names> {
+export function ruleParents(dottedName: string): Array<string> {
 	const fragments = splitName(dottedName) // dottedName ex. [CDD . événements . rupture]
-	return range(1, fragments.length)
-		.map((nbEl) => take(nbEl, fragments))
-		.map(joinName) //  -> [ [CDD . événements . rupture], [CDD . événements], [CDD
+	return Array(fragments.length - 1)
+		.fill(0)
+		.map((f, i) => fragments.slice(0, i + 1))
+		.map(joinName)
 		.reverse()
 }
 


### PR DESCRIPTION
Je n'ai rien contre Ramda en tant que tel mais je pense que son utilisation complexifie les choses inutilement dans le code du moteur :

* Style de code "non standard" pour un développeur JavaScript habitué de ES6+
* Certaines fonctions ont été intégrées dans la librairie standard d'ES6+ (`r.fromPairs` → `Object.fromEntries`)
* Impact sur les performances à l'évaluation (notamment pour gérer des formes currifiées des fonctions, ce qui ne nous est pas utile)
* Nécessite d'utiliser un plugin "babel" à la compilation du paquet

Nous ne faisions pas non plus une utilisation énorme de cette librairie, et il est facile de ré-écrire les différentes utilisations en JS natif avec un résultat tout aussi lisible et compréhensible à mon humble avis. Par ailleurs ramda était la seule librairie utilisée lors de l'évaluation (les autres dépendances de `publicodes`, `moo`, `nearley` et `yaml`, sont uniquement utilisées pour le parsage), ce qui veut dire que le code de l'évaluation ne dépend maintenant plus de code tiers.

Encore une fois, l'expressivité de Ramda peut-être utile à certains endroits, aucun soucis pour la garder dans le code de `mon-entreprise` et de `publicodes-react`.

Il est toujours aussi difficile de mesurer précisément l'impact sur les performances des changements, mais mes quelques mesures manuelles m'indiquent que l'impact est sensible avec une **réduction du temps de calcul de l'ordre de 30%**.