### PR TITLE
Répare le build de publicodes

### DIFF
--- a/publicodes/core/package.json
+++ b/publicodes/core/package.json
@@ -26,7 +26,11 @@
 	],
 	"private": false,
 	"devDependencies": {
-		"@dagrejs/graphlib": "^2.1.4"
+		"@dagrejs/graphlib": "^2.1.4",
+		"chai": "^4.2.0",
+		"intl": "^1.2.5",
+		"typescript": "3.4.3",
+		"dedent-js":"1.0.1"
 	},
 	"dependencies": {
 		"moo": "^0.5.1",
@@ -38,7 +42,7 @@
 		"clean": "rimraf dist node_modules",
 		"prepare": "yarn run rimraf dist && yarn run build",
 		"build": "yarn run webpack --config webpack.config.js && yarn run tsc",
-		"test:file": "yarn mocha-webpack --webpack-config ./webpack.test.js --include test/setupIntl.js",
+		"test:file": "yarn mocha-webpack --include test/setupIntl.js --webpack-config ./webpack.test.js ",
 		"test": "yarn test:file \"./{,!(node_modules)/**/}!(webpack).test.js\""
 	},
 	"engines": {

--- a/publicodes/core/webpack.config.js
+++ b/publicodes/core/webpack.config.js
@@ -46,21 +46,26 @@ const common = {
 	},
 }
 
-const output =
-	process.env.NODE_ENV === 'production'
-		? {
-				filename: 'publicodes.min.js',
-				library: 'publicodes',
-				libraryTarget: 'global',
-		  }
-		: {
-				filename: 'index.js',
-				library: 'publicodes',
-				libraryTarget: 'umd',
-				globalObject: 'this',
-		  }
-
-module.exports = {
-	...common,
-	output,
-}
+module.exports = [
+	{
+		...common,
+		output: {
+			filename: 'index.js',
+			library: 'publicodes',
+			libraryTarget: 'umd',
+			globalObject: 'this',
+		},
+		externals:
+			// Every non-relative module is external
+			/^[a-z\-0-9]+$/,
+	},
+	// Add a .min.js version for browser in production mode
+	process.env.NODE_ENV === 'production' && {
+		...common,
+		output: {
+			filename: 'publicodes.min.js',
+			library: 'publicodes',
+			libraryTarget: 'global',
+		},
+	},
+].filter(Boolean)

--- a/publicodes/core/webpack.test.js
+++ b/publicodes/core/webpack.test.js
@@ -1,9 +1,10 @@
 const { EnvironmentPlugin } = require('webpack')
-const prodConfig = require('./webpack.config')
+const config = require('./webpack.config')
 
 module.exports = {
-	...prodConfig,
-	mode: 'development',
+	...config[0],
+	externals: [],
+	target: 'node',
 	output: {
 		devtoolFallbackModuleFilenameTemplate: '[absolute-resource-path]?[hash]',
 		devtoolModuleFilenameTemplate: '[absolute-resource-path]',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4095,7 +4095,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chai@^4.1.2:
+chai@^4.1.2, chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -5158,7 +5158,7 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
-dedent-js@^1.0.1:
+dedent-js@1.0.1, dedent-js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
   integrity sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU=
@@ -13194,6 +13194,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
 
 typescript@^3.6.4:
   version "3.9.7"


### PR DESCRIPTION
Suite à cac1d13164fce141c8c6cd7af0e3673b2ff4d531, il n'y avait plus la config pour external, et le build en mode production était à destination des navigateurs (donc plantait sur node)

> Note : Il devient urgent de fiabiliser la publication de la lib via des tests auto #1061 