### PR TITLE
:bug: Enlève dagres (cycles check) du build de publicodes suite à un bug sur node

### DIFF
--- a/mon-entreprise/test/cycles.test.js
+++ b/mon-entreprise/test/cycles.test.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai'
-import { cyclesLib } from 'publicodes'
 import rules from 'modele-social'
+import { cyclicDependencies } from '../../publicodes/core/source/AST/graph'
 
 describe('DottedNames graph', () => {
 	it("shouldn't have cycles", () => {
-		let cyclesDependencies = cyclesLib.cyclicDependencies(rules)
+		let cyclesDependencies = cyclicDependencies(rules)
 
 		expect(
 			cyclesDependencies,

--- a/publicodes/core/package.json
+++ b/publicodes/core/package.json
@@ -26,11 +26,11 @@
 	],
 	"private": false,
 	"devDependencies": {
-		"@dagrejs/graphlib": "^2.1.4",
 		"chai": "^4.2.0",
 		"intl": "^1.2.5",
 		"typescript": "3.4.3",
-		"dedent-js":"1.0.1"
+		"dedent-js":"1.0.1",
+		"@dagrejs/graphlib": "^2.1.4"
 	},
 	"dependencies": {
 		"moo": "^0.5.1",
@@ -38,7 +38,7 @@
 		"yaml": "^1.9.2"
 	},
 	"scripts": {
-		"prepublishOnly": "yarn test && yarn run build",
+		"prepublishOnly": "yarn test && NODE_ENV=production yarn run build",
 		"clean": "rimraf dist node_modules",
 		"prepare": "yarn run rimraf dist && yarn run build",
 		"build": "yarn run webpack --config webpack.config.js && yarn run tsc",

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -39,15 +39,14 @@ export type EvaluationOptions = Partial<{
 }>
 
 export { default as mecanismsDoc } from '../../docs/mecanisms.yaml'
-export * as cyclesLib from './AST/graph'
 export { reduceAST, transformAST } from './AST/index'
 export { Evaluation, Unit } from './AST/types'
 export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
+export { default as serializeEvaluation } from './serializeEvaluation'
 export { parseUnit, serializeUnit } from './units'
 export { parsePublicodes, utils }
 export { Rule, RuleNode, ASTNode, EvaluatedNode }
-export { default as serializeEvaluation } from './serializeEvaluation'
 
 type PublicodesExpression = string | Record<string, unknown> | number
 


### PR DESCRIPTION
De toute façon, cette api n'était pas documentée, et elle ne devrait pas être disponible, mais plutôt intervenir comme une étape de vérification du parsing.

Le bug en question était une utilisation de lodash par dagres qui s'appuyait sur `window`, non utilisable sur node.