### PR TITLE
:bug: Corrige la formule de la loi madelin

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -558,7 +558,7 @@ dirigeant . indépendant . revenu net de cotisations:
       - valeur: revenu professionnel
         arrondi: oui
       - (- cotisations et contributions . CSG et CRDS . non déductible)
-      - (- contrats madelin . part non-déductible fiscalement)
+      - (- contrats madelin . montant)
   résumé: Avant déduction de l'impôt sur le revenu
   question: Quel revenu avant impôt voulez-vous toucher ?
   description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
@@ -571,10 +571,7 @@ dirigeant . indépendant . résultat fiscal:
     - assiette fiscale
   résumé: Assiette du calcul de l'impôt
   description: Il s'agit du net imposable, assiette sur laquelle l'impôt est calculé.
-  formule:
-    somme:
-      - revenu professionnel
-      - contrats madelin . montant
+  formule: revenu professionnel - contrats madelin . part déductible fiscalement
   références:
     Portail Urssaf: https://www.urssaf.fr/portail/home/independant/mes-cotisations/les-etapes-de-calcul/la-declaration-sociale-des-indep/les-revenus-pris-en-compte-pour.html
 
@@ -883,7 +880,7 @@ dirigeant . indépendant . contrats madelin . mutuelle . plafond:
   formule:
     somme:
       - produit:
-          assiette: résultat fiscal
+          assiette: revenu professionnel
           taux: 3.75%
       - produit:
           assiette: plafond sécurité sociale temps plein
@@ -895,7 +892,8 @@ dirigeant . indépendant . contrats madelin . mutuelle . plafond:
   références:
     Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029042287&cidTexte=LEGITEXT000006069577&dateTexte=20140530
     Réassurez-moi: https://reassurez-moi.fr/guide/pro/tns/plafond#le_plafond_de_deduction_madelin_pour_une_mutuelle_santenbsp
-
+  note: |
+    Normalement c'est le résultat fiscal qui devrait être utilisé pour l'assiette du plafond, mais on utilise le revenu professionnel pour éviter un cycle.
 dirigeant . indépendant . contrats madelin . retraite:
   titre: Souscription à une retraite Madelin
   question: Quel est le montant que vous versez à votre contrat Madelin retraite ?
@@ -914,7 +912,7 @@ dirigeant . indépendant . contrats madelin . retraite . plafond:
   formule:
     le maximum de:
       - barème:
-          assiette: résultat fiscal
+          assiette: revenu professionnel
           multiplicateur: plafond sécurité sociale temps plein
           tranches:
             - taux: 10%
@@ -927,6 +925,8 @@ dirigeant . indépendant . contrats madelin . retraite . plafond:
   références:
     Bofip: https://bofip.impots.gouv.fr/bofip/1124-PGP.html
     LegiFiscal: https://www.legifiscal.fr/impots-personnels/impot-revenu/deduction-des-contrats-madelin-retraite.html
+  note: |
+    Normalement c'est le résultat fiscal qui devrait être utilisé pour l'assiette du plafond, mais on utilise le revenu professionnel pour éviter un cycle.
 
 dirigeant . indépendant . cotisations et contributions . indemnités journalières maladie:
   description: |

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -5461,6 +5461,13 @@ dirigeant . indépendant . contrats madelin . mutuelle:
   titre.en: '[automatic] Subscription to a Madelin mutual insurance contract'
   titre.fr: Souscription à un contrat de mutuelle Madelin
 dirigeant . indépendant . contrats madelin . mutuelle . plafond:
+  note.en: >
+    [automatic] Normally it is the tax result that should be used for the cap
+    base, but business income is used to avoid a cycle.
+  note.fr: >
+    Normalement c'est le résultat fiscal qui devrait être utilisé pour
+    l'assiette du plafond, mais on utilise le revenu professionnel pour éviter
+    un cycle.
   titre.en: ceiling
   titre.fr: plafond
 dirigeant . indépendant . contrats madelin . part déductible fiscalement:
@@ -5486,6 +5493,13 @@ dirigeant . indépendant . contrats madelin . retraite:
   titre.en: '[automatic] Madelin Retirement Subscription'
   titre.fr: Souscription à une retraite Madelin
 dirigeant . indépendant . contrats madelin . retraite . plafond:
+  note.en: >
+    [automatic] Normally it is the tax result that should be used for the cap
+    base, but business income is used to avoid a cycle.
+  note.fr: >
+    Normalement c'est le résultat fiscal qui devrait être utilisé pour
+    l'assiette du plafond, mais on utilise le revenu professionnel pour éviter
+    un cycle.
   titre.en: ceiling
   titre.fr: plafond
 dirigeant . indépendant . cotisations et contributions:

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -453,20 +453,23 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`]
 Notifications affichées : dirigeant . indépendant . avertissement base forfaitaire"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,20621,0,15102,4,29]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,19388,0,16984,4,33]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,20621,0,15102,4,29]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,18995,0,17577,4,34]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,20621,0,15102,4,29]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,20297,0,15600,4,30]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13814,0,10116,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13656,0,10367,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `
-"[0,226878,0,57933,4,56]
+"[0,225725,0,57933,4,56]
 Notifications affichées : entreprise . seuil de franchise de TVA dépassé"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13814,0,10116,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `
+"[0,13624,0,10417,4,21]
+Notifications affichées : dirigeant . indépendant . contrats madelin . contrôle montant charges"
+`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,14555,0,0,0,0]"`;
 

--- a/mon-entreprise/test/regressions/simulations-rémunération-dirigeant.yaml
+++ b/mon-entreprise/test/regressions/simulations-rémunération-dirigeant.yaml
@@ -47,28 +47,34 @@ Contrats Madelin:
   # cotisations ne change pas:
   - dirigeant . rémunération totale: 30000 €/an
     entreprise . charges: 10000 €/an
+    dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 3800 €/an # plafond: 10% PSS donc environ 4100 
   # Cas retraite: la cotisation Madelin est supérieure au plafond => le revenu net de
   # cotisations est affecté car l'assiette des cotisations est plus élevée
   - dirigeant . rémunération totale: 30000 €/an
     entreprise . charges: 10000 €/an
+    dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 5000 €/an # plafond: 10% PSS donc environ 4100 
   # Cas mutuelle
   - dirigeant . rémunération totale: 30000 €/an
     entreprise . charges: 10000 €/an
+    dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 1000 €/an
   # Cas global madelin faible
   - dirigeant . rémunération totale: 20000 €/an
     entreprise . charges: 1000 €/an
+    dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 200 €/an
     dirigeant . indépendant . contrats madelin . retraite: 300 €/an
   # Cas global madelin grand (plafonds calculés différemment)
   - dirigeant . rémunération totale: 300000 €/an
     entreprise . charges: 15000 €/an
+    dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 1500 €/an
     dirigeant . indépendant . contrats madelin . retraite: 5000 €/an
   # Cas charges plus faibles que total madelin
   - dirigeant . rémunération totale: 20000 €/an
     entreprise . charges: 500 €/an
+    dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 300 €/an
     dirigeant . indépendant . contrats madelin . retraite: 300 €/an


### PR DESCRIPTION
J'ignore pourquoi, mais notre formule était fausse : les cotisations madelins n'étaient pas intégrées dans le revenu professionnel.