### PR TITLE
Mobilités durables

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -25,9 +25,7 @@ dirigeant . assimilé salarié:
     - contrat salarié . rémunération . primes
     - contrat salarié . rémunération . primes . fin d'année
     - contrat salarié . rémunération . primes . activité
-    - contrat salarié . frais professionnels . titres-restaurant
-    - contrat salarié . frais professionnels . abonnement transports publics
-    - contrat salarié . frais professionnels . transports personnels
+    - contrat salarié . frais professionnels
     - contrat salarié . chômage
     - contrat salarié . réduction générale
     - contrat salarié . allocations familiales . taux réduit

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -27,6 +27,7 @@ dirigeant . assimilé salarié:
     - contrat salarié . rémunération . primes . activité
     - contrat salarié . frais professionnels . titres-restaurant
     - contrat salarié . frais professionnels . abonnement transports publics
+    - contrat salarié . frais professionnels . transports personnels
     - contrat salarié . chômage
     - contrat salarié . réduction générale
     - contrat salarié . allocations familiales . taux réduit

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -26,7 +26,6 @@ dirigeant . assimilé salarié:
     - contrat salarié . rémunération . primes . fin d'année
     - contrat salarié . rémunération . primes . activité
     - contrat salarié . frais professionnels . titres-restaurant
-    - contrat salarié . frais professionnels . indemnité kilométrique vélo
     - contrat salarié . frais professionnels . abonnement transports publics
     - contrat salarié . chômage
     - contrat salarié . réduction générale

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -27,6 +27,7 @@ dirigeant . assimilé salarié:
     - contrat salarié . rémunération . primes . activité
     - contrat salarié . frais professionnels . titres-restaurant
     - contrat salarié . frais professionnels . indemnité kilométrique vélo
+    - contrat salarié . frais professionnels . abonnement transports publics
     - contrat salarié . chômage
     - contrat salarié . réduction générale
     - contrat salarié . allocations familiales . taux réduit

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -59,12 +59,13 @@ contrat salarié . frais professionnels:
 
     Les frais professionnels sont généralement exclus de la base de calcul des
     cotisations de sécurité sociale et de la CSG-CRDS, sauf en cas de
-    dépassement de plafond pour les remboursements forfaitaires (indemnité
-    kilométrique vélo, frais de panier, titres-restaurant...).
+    dépassement de plafond pour les remboursements forfaitaires (
+    frais de panier, titres-restaurant, forfait mobilités durables...).
   formule:
     somme:
       - titres-restaurant . montant . employeur
       - abonnement transports publics . prise en charge
+      - transports personnels . montant
 
 contrat salarié . frais professionnels . part déductible:
   titre: Frais professionnels déductibles
@@ -75,6 +76,7 @@ contrat salarié . frais professionnels . part déductible:
     somme:
       - titres-restaurant . part déductible
       - abonnement transports publics . prise en charge
+      - transports personnels . part déductible
 
 contrat salarié . frais professionnels . titres-restaurant:
   icônes: 🍽️
@@ -195,6 +197,115 @@ contrat salarié . frais professionnels . abonnement transports publics . prise 
   titre: Abonnement transports publics, part prise en charge par l'employeur (déductible)
   unité: €/mois
   valeur: taux de prise en charge * montant
+
+contrat salarié . frais professionnels . transports personnels:
+  valeur: oui
+
+contrat salarié . frais professionnels . transports personnels . montant:
+  titre: Transports personnels
+  valeur:
+    somme:
+      - carburant faible émission . montant
+      - forfait mobilités durables . montant
+
+contrat salarié . frais professionnels . transports personnels . part déductible:
+  valeur:
+    somme:
+      - carburant faible émission . part déductible
+      - forfait mobilités durables . part déductible
+
+contrat salarié . frais professionnels . transports personnels . proportion déduction:
+  titre: Facteur de proportion de la déductibilité
+  valeur:
+    produit:
+      assiette:
+        le minimum de:
+          - temps de travail . quotité de travail
+          - 50%
+      taux: 200%
+  références:
+    Article R3261-14 du code du travail, version 11/05/2020: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041865023/2020-05-11/
+
+contrat salarié . frais professionnels . transports personnels . carburant faible émission:
+  valeur: oui
+
+contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant:
+  titre: Prise en charge du carburant pour véhicules électriques, hybrides rechargeables ou hydrogènes
+  question: Quel montant l'employeur prend-il en charge des dépenses en carburant pour véhicules électriques, hybrides rechargeables ou hydrogènes ?
+  unité: €/mois
+  par défaut: 0 €/mois
+  description: |
+    L'employeur peut prendre en charge tout ou partie des frais de carburant dépensés par l'employé pour son véhicule électriques, hybrides rechargeables ou hydrogènes, sur présentation de justificatif.
+
+    Cette prise en charge peut profiter d'une exonération des cotisations sociales et de l'impôt sur le revenu. Le montant maximal déductible est de 200€/mois, mais attention
+
+      - le plafond est partiellement réduit du montant de la prise en charge des frais d'abonnement aux transports publics
+
+      - cette prise en charge de carburant entre dans la même assiette que la prise en charge du forfait mobilités durables.
+
+    Dans le cas d'un temps partiel, l'avantage sera le même pour un mi-temps ou plus. En dessous, un facteur proportionnel sera appliqué.
+
+    Pour verser une prime de salaire équivalente à 200€/mois à son salarié sans ce dispositif, **l'employeur devrait débourser près de 500€ pour un salaire médian**.
+  références:
+    Articles R3261-11 à -13 du code du travail, version 11/05/2020: https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006072050/LEGISCTA000018487476/2020-05-11
+    Article 81 du code des impôts, version en vigueur au 31/12/2020: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042910732/2020-12-31/
+
+contrat salarié . frais professionnels . transports personnels . carburant faible émission . part déductible:
+  titre: Prise en charge du carburant pour véhicules électriques, hybrides rechargeables ou hydrogènes (part déductible)
+  unité: €/mois
+  valeur: montant
+  plafond:
+    le minimum de:
+       - proportion déduction * 200€/mois
+       - valeur: proportion déduction * 500€/mois
+         abattement: abonnement transports publics . prise en charge
+
+contrat salarié . frais professionnels . transports personnels . forfait mobilités durables:
+  valeur: oui
+
+contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant:
+  titre: Prise en charge des frais de transports forfait mobilités durables
+  question: Quel montant l'employeur prend-il en charge dans le cadre du forfait mobilités durables ?
+  unité: €/mois
+  par défaut: 0 €/mois
+  description: |
+    L'employeur peut prendre en charge tout ou partie des frais de déplacement liés à l'utilisation des véhicules entrant dans le cadre du forfait mobilités durables
+
+      - le vélo et vélo à assistance électrique
+
+      - le covoiturage (conducteur ou passager)
+
+      - les engins de déplacement personnels en location ou en libre-service
+
+      - l'autopartage avec des véhicules électriques, hybrides rechargeables ou hydrogènes
+
+      - les transports en commun (hors abonnement).
+
+    L'ancienne Indemnité Kilométrique Vélo entre maintenant dans ce dispositif. Elle peut être poursuivie mais son montant devra être imputé ici.
+
+    L'employeur peut prendre en charge ces frais jusqu'à 500€/mois de manière exonérée de cotisations sociales et d'impôt. Attention cependant
+
+      - le plafond est réduit du montant de la prise en charge des frais d'abonnement aux transports publics
+
+      - la prise en charge du carburant faible émission entre dans cette assiette également.
+
+    Dans le cas d'un temps partiel, l'avantage sera le même pour un mi-temps ou plus. En dessous, un facteur proportionnel sera appliqué.
+
+    Pour verser une prime de salaire équivalente à 500€/mois à son salarié sans ce dispositif, **l'employeur devrait débourser près de 800€ pour un salaire médian**.
+  références:
+    Articles R3261-13-1 à -13-2 du code du travail, version 11/05/2020: https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006072050/LEGISCTA000018487476/2020-05-11
+    Article 81 du code des impôts, version en vigueur au 31/12/2020: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042910732/2020-12-31/
+
+contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . part déductible:
+  titre: Prise en charge des frais de transports forfait mobilités durables (part déductible)
+  unité: €/mois
+  valeur: montant
+  plafond:
+    valeur: proportion déduction * 500€/mois
+    abattement:
+      somme:
+        - abonnement transports publics . prise en charge
+        - carburant faible émission . part déductible
 
 contrat salarié . activité partielle:
   question: Le salarié est-il en chômage partiel ?

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -59,12 +59,13 @@ contrat salarié . frais professionnels:
 
     Les frais professionnels sont généralement exclus de la base de calcul des
     cotisations de sécurité sociale et de la CSG-CRDS, sauf en cas de
-    dépassement de plafond pour les remboursement forfaitaires (indemnité
+    dépassement de plafond pour les remboursements forfaitaires (indemnité
     kilométrique vélo, frais de panier, titres-restaurant...).
   formule:
     somme:
       - indemnité kilométrique vélo . montant
       - titres-restaurant . montant . employeur
+      - abonnement transports publics . prise en charge
 
 contrat salarié . frais professionnels . part déductible:
   titre: Frais professionnels déductibles
@@ -75,6 +76,7 @@ contrat salarié . frais professionnels . part déductible:
     somme:
       - indemnité kilométrique vélo . part déductible
       - titres-restaurant . part déductible
+      - abonnement transports publics . prise en charge
 
 contrat salarié . frais professionnels . titres-restaurant:
   icônes: 🍽️
@@ -158,6 +160,43 @@ contrat salarié . frais professionnels . titres-restaurant . contrôle taux emp
   sévérité: avertissement
   formule: taux participation employeur > 60%
   description: La part employeur du titre-restaurant doit être de 60% au maximum
+
+contrat salarié . frais professionnels . abonnement transports publics:
+  icônes: 🚍
+  valeur: oui
+
+contrat salarié . frais professionnels . abonnement transports publics . montant:
+  titre: Abonnement aux transports publics
+  question: Quel montant le salarié dépense-t-il en abonnement aux transports publics chaque mois ?
+  unité: €/mois
+  par défaut: 0 €/mois
+  description: |
+    L'employeur doit prendre en charge 50% du montant dépensé par le salarié pour les transports publics lui permettant de se rendre sur son lieu de travail.
+    
+    Cette prise en charge (dans la limite des 50% du montant) est exonérée de cotisations sociales et d'impôt sur le revenu.
+
+    Dans le cas d'un temps partiel, le taux de prise en charge sera le même pour un mi-temps ou plus. En dessous, le taux de prise en charge sera proportionnel.
+  références:
+    Articles R3261-1 à -10 du code du travail, version 01/01/2009: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000020080272/2009-01-01
+    Article 81 du code des impôts, version en vigueur au 31/12/2020: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042910732/2020-12-31/
+
+contrat salarié . frais professionnels . abonnement transports publics . taux de participation employeur:
+  valeur: 50%
+
+contrat salarié . frais professionnels . abonnement transports publics . taux de prise en charge:
+  titre: Taux de prise en charge
+  valeur:
+    produit:
+      assiette: 
+        le minimum de:
+          - temps de travail . quotité de travail
+          - 50%
+      taux: 2 * taux de participation employeur
+
+contrat salarié . frais professionnels . abonnement transports publics . prise en charge:
+  titre: Abonnement transports publics, part prise en charge par l'employeur (déductible)
+  unité: €/mois
+  valeur: taux de prise en charge * montant
 
 contrat salarié . frais professionnels . indemnité kilométrique vélo:
   icônes: 🚴

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -63,7 +63,6 @@ contrat salarié . frais professionnels:
     kilométrique vélo, frais de panier, titres-restaurant...).
   formule:
     somme:
-      - indemnité kilométrique vélo . montant
       - titres-restaurant . montant . employeur
       - abonnement transports publics . prise en charge
 
@@ -74,7 +73,6 @@ contrat salarié . frais professionnels . part déductible:
     de l'impôt sur le revenu.
   formule:
     somme:
-      - indemnité kilométrique vélo . part déductible
       - titres-restaurant . part déductible
       - abonnement transports publics . prise en charge
 
@@ -197,44 +195,6 @@ contrat salarié . frais professionnels . abonnement transports publics . prise 
   titre: Abonnement transports publics, part prise en charge par l'employeur (déductible)
   unité: €/mois
   valeur: taux de prise en charge * montant
-
-contrat salarié . frais professionnels . indemnité kilométrique vélo:
-  icônes: 🚴
-  question: Le salarié profite-t-il de l'indemnité kilométrique vélo pour se rendre au travail ?
-  description: |
-    Cette indemnité n'est pour l'instant pas obligatoire.
-
-    L'employeur a le choix de la mettre en place dans son entreprise.
-
-    Pour bénéficier de l'indemnité de 200€ retenue dans ce calcul, le salarié doit faire 4km (aller-retour) de vélo pour se rendre au travail chaque jour travaillé.
-
-    Cette indemnité est cumulable avec le remboursement des frais de transport en commun s'il s'agit d'un trajet à vélo de rabattement vers une station de transport.
-
-    Cette indemnité est exonérée de cotisations sociales et d'impôt sur le revenu. Pour verser une prime de salaire équivalente à son salarié sans ce dispositif, **l'employeur devrait débourser près de 500€ pour un salaire médian**.
-  par défaut: non
-
-contrat salarié . frais professionnels . indemnité kilométrique vélo . montant:
-  titre: indemnité kilométrique vélo
-  unité: €/an
-  formule:
-    produit:
-      assiette: distance mensuelle
-      facteur: 0.25 €/km
-
-contrat salarié . frais professionnels . indemnité kilométrique vélo . part déductible:
-  titre: indemnité kilométrique vélo (déductible)
-  formule:
-    valeur: montant
-    plafond: 200 €/an
-
-contrat salarié . frais professionnels . indemnité kilométrique vélo . distance mensuelle:
-  question: >-
-    Quelle est la distance parcourue en vélo chaque mois pour le trajet domicile / travail ?
-  suggestions:
-    2 km/jour: 40 km/mois
-    5 km/jour: 100 km/mois
-    10 km/jour: 200 km/mois
-  par défaut: 80 km/mois
 
 contrat salarié . activité partielle:
   question: Le salarié est-il en chômage partiel ?

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -200,6 +200,9 @@ contrat salarié . frais professionnels . abonnement transports publics . prise 
 
 contrat salarié . frais professionnels . transports personnels:
   valeur: oui
+  non applicable si: déduction forfaitaire spécifique
+  références:
+    circ. DGT-DSS 2009-1 du 28 janvier 2009: https://www.legifrance.gouv.fr/download/file/pdf/cir_2423/CIRC
 
 contrat salarié . frais professionnels . transports personnels . montant:
   titre: Transports personnels

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -2045,7 +2045,7 @@ contrat salarié . frais professionnels:
       - the application of a specific lump-sum deduction from the salary subject to contributions; this possibility is only open to certain professions.
 
 
-    Professional expenses are generally excluded from the basis of calculation of social security contributions and CSG-CRDS, except in the case of exceeding the ceiling for flat-rate reimbursements (bicycle mileage allowance, basket costs, restaurant vouchers, etc.).
+    Professional expenses are generally excluded from the basis of calculation of social security contributions and CSG-CRDS, except where the ceiling for lump-sum reimbursements is exceeded (bicycle mileage allowance, basket costs, meal vouchers, etc.).
   description.fr: >-
     Les frais professionnels correspondent à des dépenses engagées par le
     salarié pour les besoins de son activité professionnelle. Ces frais sont
@@ -2061,9 +2061,49 @@ contrat salarié . frais professionnels:
       - de l’application d’une déduction forfaitaire spécifique sur le salaire soumis à cotisations ; cette possibilité n’étant ouverte qu’à certaines professions.
 
 
-    Les frais professionnels sont généralement exclus de la base de calcul des cotisations de sécurité sociale et de la CSG-CRDS, sauf en cas de dépassement de plafond pour les remboursement forfaitaires (indemnité kilométrique vélo, frais de panier, titres-restaurant...).
+    Les frais professionnels sont généralement exclus de la base de calcul des cotisations de sécurité sociale et de la CSG-CRDS, sauf en cas de dépassement de plafond pour les remboursements forfaitaires (indemnité kilométrique vélo, frais de panier, titres-restaurant...).
   titre.en: '[automatic] reimbursement of expenses'
   titre.fr: remboursement de frais
+contrat salarié . frais professionnels . abonnement transports publics:
+  titre.en: '[automatic] public transport pass'
+  titre.fr: abonnement transports publics
+? contrat salarié . frais professionnels . abonnement transports publics . montant
+: description.en: >
+    [automatic] The employer must pay 50% of the amount spent by the employee on
+    public transport to work.
+
+
+    This coverage (up to 50% of the amount) is exempt from social security contributions and income tax.
+
+
+    In the case of part-time work, the rate of coverage will be the same for one half or more. Below that, the rate of coverage will be proportional.
+  description.fr: >
+    L'employeur doit prendre en charge 50% du montant dépensé par le salarié
+    pour les transports publics lui permettant de se rendre sur son lieu de
+    travail.
+
+
+    Cette prise en charge (dans la limite des 50% du montant) est exonérée de cotisations sociales et d'impôt sur le revenu.
+
+
+    Dans le cas d'un temps partiel, le taux de prise en charge sera le même pour un mi-temps ou plus. En dessous, le taux de prise en charge sera proportionnel.
+  question.en:
+    '[automatic] How much does the employee spend on a public transport
+    season ticket each month?'
+  question.fr: Quel montant le salarié dépense-t-il en abonnement aux transports
+    publics chaque mois ?
+  titre.en: '[automatic] Public transport season ticket'
+  titre.fr: Abonnement aux transports publics
+? contrat salarié . frais professionnels . abonnement transports publics . prise en charge
+: titre.en: "[automatic] Public transport season ticket, employer's share (deductible)"
+  titre.fr: Abonnement transports publics, part prise en charge par l'employeur
+    (déductible)
+? contrat salarié . frais professionnels . abonnement transports publics . taux de participation employeur
+: titre.en: '[automatic] employer participation rate'
+  titre.fr: taux de participation employeur
+? contrat salarié . frais professionnels . abonnement transports publics . taux de prise en charge
+: titre.en: Employer's share
+  titre.fr: Taux de prise en charge
 contrat salarié . frais professionnels . indemnité kilométrique vélo:
   description.en: >
     [automatic] This allowance is currently not mandatory.

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -2104,60 +2104,6 @@ contrat salarié . frais professionnels . abonnement transports publics:
 ? contrat salarié . frais professionnels . abonnement transports publics . taux de prise en charge
 : titre.en: Employer's share
   titre.fr: Taux de prise en charge
-contrat salarié . frais professionnels . indemnité kilométrique vélo:
-  description.en: >
-    [automatic] This allowance is currently not mandatory.
-
-
-    The employer has the choice to implement it in his company.
-
-
-    To benefit from the €200 allowance deducted in this calculation, the employee must cycle 4km (round trip) to work each working day.
-
-
-    This allowance can be combined with the reimbursement of public transit costs if the trip is a feeder bike ride to a transit station.
-
-
-    This allowance is exempt from social security contributions and income tax. To pay an equivalent salary bonus to his employee without this scheme, **the employer would have to pay nearly €500 for a median salary**.
-  description.fr: >
-    Cette indemnité n'est pour l'instant pas obligatoire.
-
-
-    L'employeur a le choix de la mettre en place dans son entreprise.
-
-
-    Pour bénéficier de l'indemnité de 200€ retenue dans ce calcul, le salarié doit faire 4km (aller-retour) de vélo pour se rendre au travail chaque jour travaillé.
-
-
-    Cette indemnité est cumulable avec le remboursement des frais de transport en commun s'il s'agit d'un trajet à vélo de rabattement vers une station de transport.
-
-
-    Cette indemnité est exonérée de cotisations sociales et d'impôt sur le revenu. Pour verser une prime de salaire équivalente à son salarié sans ce dispositif, **l'employeur devrait débourser près de 500€ pour un salaire médian**.
-  question.en: '[automatic] Does the employee take advantage of the bicycle
-    mileage allowance to get to work?'
-  question.fr: Le salarié profite-t-il de l'indemnité kilométrique vélo pour se
-    rendre au travail ?
-  titre.en: kilometric bicycle allowance
-  titre.fr: indemnité kilométrique vélo
-? contrat salarié . frais professionnels . indemnité kilométrique vélo . distance mensuelle
-: question.en: '[automatic] What is the distance cycled each month between home and work?'
-  question.fr:
-    Quelle est la distance parcourue en vélo chaque mois pour le trajet
-    domicile / travail ?
-  suggestions.10 km/jour.en: '[automatic] 10 km/day'
-  suggestions.10 km/jour.fr: 10 km/jour
-  suggestions.2 km/jour.en: '[automatic] 2 km/day'
-  suggestions.2 km/jour.fr: 2 km/jour
-  suggestions.5 km/jour.en: '[automatic] 5 km/day'
-  suggestions.5 km/jour.fr: 5 km/jour
-  titre.en: '[automatic] monthly distance'
-  titre.fr: distance mensuelle
-contrat salarié . frais professionnels . indemnité kilométrique vélo . montant:
-  titre.en: '[automatic] bicycle kilometre allowance'
-  titre.fr: indemnité kilométrique vélo
-? contrat salarié . frais professionnels . indemnité kilométrique vélo . part déductible
-: titre.en: '[automatic] bicycle kilometre allowance (deductible)'
-  titre.fr: indemnité kilométrique vélo (déductible)
 contrat salarié . frais professionnels . part déductible:
   description.en: '[automatic] Share of expenses deducted from the social
     contribution base and for income tax calculation.'

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -2061,7 +2061,7 @@ contrat salarié . frais professionnels:
       - de l’application d’une déduction forfaitaire spécifique sur le salaire soumis à cotisations ; cette possibilité n’étant ouverte qu’à certaines professions.
 
 
-    Les frais professionnels sont généralement exclus de la base de calcul des cotisations de sécurité sociale et de la CSG-CRDS, sauf en cas de dépassement de plafond pour les remboursements forfaitaires (indemnité kilométrique vélo, frais de panier, titres-restaurant...).
+    Les frais professionnels sont généralement exclus de la base de calcul des cotisations de sécurité sociale et de la CSG-CRDS, sauf en cas de dépassement de plafond pour les remboursements forfaitaires ( frais de panier, titres-restaurant, forfait mobilités durables...).
   titre.en: '[automatic] reimbursement of expenses'
   titre.fr: remboursement de frais
 contrat salarié . frais professionnels . abonnement transports publics:
@@ -2200,6 +2200,136 @@ contrat salarié . frais professionnels . titres-restaurant . part déductible:
   suggestions.60%.fr: 60%
   titre.en: '[automatic] employer contribution rate'
   titre.fr: taux participation employeur
+contrat salarié . frais professionnels . transports personnels:
+  titre.en: '[automatic] personal transports'
+  titre.fr: transports personnels
+? contrat salarié . frais professionnels . transports personnels . carburant faible émission
+: titre.en: '[automatic] low emission fuel'
+  titre.fr: carburant faible émission
+? contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant
+: description.en: >
+    [automatic] The employer may cover all or part of the fuel costs incurred by
+    the employee for his electric, plug-in hybrid or hydrogen vehicle, upon
+    presentation of proof.
+
+
+    This support can benefit from an exemption from social security contributions and income tax. The maximum deductible amount is 200€/month, but please note that
+
+      - the ceiling shall be partially reduced by the amount by which the cost of public transport season tickets is covered
+
+      - this fuel coverage is on the same basis as the coverage of the sustainable mobility package.
+
+    In the case of part time, the advantage will be the same for one half time or more. Below that, a proportional factor will be applied.
+
+
+    To pay a salary bonus equivalent to 200€/month to his employee without this scheme, **the employer would have to pay nearly 500€ for a median salary**.
+  description.fr: >
+    L'employeur peut prendre en charge tout ou partie des frais de carburant
+    dépensés par l'employé pour son véhicule électriques, hybrides rechargeables
+    ou hydrogènes, sur présentation de justificatif.
+
+
+    Cette prise en charge peut profiter d'une exonération des cotisations sociales et de l'impôt sur le revenu. Le montant maximal déductible est de 200€/mois, mais attention
+
+      - le plafond est partiellement réduit du montant de la prise en charge des frais d'abonnement aux transports publics
+
+      - cette prise en charge de carburant entre dans la même assiette que la prise en charge du forfait mobilités durables.
+
+    Dans le cas d'un temps partiel, l'avantage sera le même pour un mi-temps ou plus. En dessous, un facteur proportionnel sera appliqué.
+
+
+    Pour verser une prime de salaire équivalente à 200€/mois à son salarié sans ce dispositif, **l'employeur devrait débourser près de 500€ pour un salaire médian**.
+  question.en: '[automatic] How much does the employer pay for fuel expenses for
+    electric, plug-in hybrid or hydrogen vehicles?'
+  question.fr: Quel montant l'employeur prend-il en charge des dépenses en
+    carburant pour véhicules électriques, hybrides rechargeables ou hydrogènes ?
+  titre.en: '[automatic] Fuel support for electric, plug-in hybrid or hydrogen vehicles'
+  titre.fr: Prise en charge du carburant pour véhicules électriques, hybrides
+    rechargeables ou hydrogènes
+? contrat salarié . frais professionnels . transports personnels . carburant faible émission . part déductible
+: titre.en: '[automatic] Fuel support for electric, plug-in hybrid or hydrogen
+    vehicles (deductible portion)'
+  titre.fr: Prise en charge du carburant pour véhicules électriques, hybrides
+    rechargeables ou hydrogènes (part déductible)
+? contrat salarié . frais professionnels . transports personnels . forfait mobilités durables
+: titre.en: '[automatic] sustainable mobility package'
+  titre.fr: forfait mobilités durables
+? contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant
+: description.en: >
+    [automatic] The employer may cover all or part of the travel expenses
+    related to the use of vehicles included in the sustainable mobility package.
+
+      - the bicycle and electric bicycle
+
+      - carpooling (driver or passenger)
+
+      - personal mobility equipment for hire or self-service
+
+      - car-sharing with electric, plug-in hybrid or hydrogen vehicles
+
+      - public transport (excluding season tickets).
+
+    The old Bicycle Mileage Allowance now fits into this scheme. It can be sued but the amount will have to be charged here.
+
+
+    The employer can cover these costs up to 500€/month tax- and social security contributions exempt. However, please note
+
+      - the ceiling shall be reduced by the amount by which the cost of public transport season tickets is covered
+
+      - Low-emission fuel handling also fits into this trim.
+
+    In the case of part time, the advantage will be the same for one half time or more. Below that, a proportional factor will be applied.
+
+
+    To pay a salary bonus equivalent to 500€/month to his employee without this scheme, **the employer would have to pay nearly 800€ for a median salary**.
+  description.fr: >
+    L'employeur peut prendre en charge tout ou partie des frais de déplacement
+    liés à l'utilisation des véhicules entrant dans le cadre du forfait
+    mobilités durables
+
+      - le vélo et vélo à assistance électrique
+
+      - le covoiturage (conducteur ou passager)
+
+      - les engins de déplacement personnels en location ou en libre-service
+
+      - l'autopartage avec des véhicules électriques, hybrides rechargeables ou hydrogènes
+
+      - les transports en commun (hors abonnement).
+
+    L'ancienne Indemnité Kilométrique Vélo entre maintenant dans ce dispositif. Elle peut être poursuivie mais son montant devra être imputé ici.
+
+
+    L'employeur peut prendre en charge ces frais jusqu'à 500€/mois de manière exonérée de cotisations sociales et d'impôt. Attention cependant
+
+      - le plafond est réduit du montant de la prise en charge des frais d'abonnement aux transports publics
+
+      - la prise en charge du carburant faible émission entre dans cette assiette également.
+
+    Dans le cas d'un temps partiel, l'avantage sera le même pour un mi-temps ou plus. En dessous, un facteur proportionnel sera appliqué.
+
+
+    Pour verser une prime de salaire équivalente à 500€/mois à son salarié sans ce dispositif, **l'employeur devrait débourser près de 800€ pour un salaire médian**.
+  question.en: '[automatic] How much does the employer pay as part of the
+    sustainable mobility package?'
+  question.fr: Quel montant l'employeur prend-il en charge dans le cadre du
+    forfait mobilités durables ?
+  titre.en: '[automatic] Coverage of transport costs for sustainable mobility packages'
+  titre.fr: Prise en charge des frais de transports forfait mobilités durables
+? contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . part déductible
+: titre.en: '[automatic] Coverage of fixed-price transport costs for sustainable
+    mobility (deductible part)'
+  titre.fr: Prise en charge des frais de transports forfait mobilités durables
+    (part déductible)
+contrat salarié . frais professionnels . transports personnels . montant:
+  titre.en: '[automatic] Personal transport'
+  titre.fr: Transports personnels
+? contrat salarié . frais professionnels . transports personnels . part déductible
+: titre.en: '[automatic] deductible portion'
+  titre.fr: part déductible
+? contrat salarié . frais professionnels . transports personnels . proportion déduction
+: titre.en: '[automatic] Deductibility Proportion Factor'
+  titre.fr: Facteur de proportion de la déductibilité
 contrat salarié . intermittents du spectacle:
   question.en: To which "intermittent" status is the employee attached?
   question.fr: A quel statut d'intermittent est rattaché l'employé ?

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -645,7 +645,7 @@ Notifications affichées : contrat salarié . CDD . information"
 `;
 
 exports[`calculate simulations-salarié: cdd 3`] = `
-"[3404,0,2400,1987,1906]
+"[3381,0,2400,1967,1887]
 Notifications affichées : contrat salarié . CDD . information"
 `;
 
@@ -679,12 +679,6 @@ exports[`calculate simulations-salarié: frais pro - DFS 5`] = `"[2425,0,2000,15
 exports[`calculate simulations-salarié: frais pro - DFS 6`] = `"[1768,0,1700,1363,1363]"`;
 
 exports[`calculate simulations-salarié: frais pro - DFS 7`] = `"[3287,0,2600,2125,2092]"`;
-
-exports[`calculate simulations-salarié: frais pro - IKV 1`] = `"[4368,0,3200,2530,2334]"`;
-
-exports[`calculate simulations-salarié: frais pro - IKV 2`] = `"[4347,0,3200,2511,2314]"`;
-
-exports[`calculate simulations-salarié: frais pro - IKV 3`] = `"[2752,0,2151,1681,1630]"`;
 
 exports[`calculate simulations-salarié: frais pro - abonnement transports publics 1`] = `"[4347,0,3200,2511,2314]"`;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -645,7 +645,7 @@ Notifications affichées : contrat salarié . CDD . information"
 `;
 
 exports[`calculate simulations-salarié: cdd 3`] = `
-"[3381,0,2400,1967,1887]
+"[3881,0,2400,2467,2387]
 Notifications affichées : contrat salarié . CDD . information"
 `;
 
@@ -680,21 +680,35 @@ exports[`calculate simulations-salarié: frais pro - DFS 6`] = `"[1768,0,1700,13
 
 exports[`calculate simulations-salarié: frais pro - DFS 7`] = `"[3287,0,2600,2125,2092]"`;
 
-exports[`calculate simulations-salarié: frais pro - abonnement transports publics 1`] = `"[4347,0,3200,2511,2314]"`;
+exports[`calculate simulations-salarié: frais pro - abo transports + transports personnels 1`] = `"[4847,0,3200,3011,2814]"`;
 
-exports[`calculate simulations-salarié: frais pro - abonnement transports publics 2`] = `"[4387,0,3200,2551,2354]"`;
+exports[`calculate simulations-salarié: frais pro - abo transports + transports personnels 2`] = `"[13021,0,3200,7448,6004]"`;
 
-exports[`calculate simulations-salarié: frais pro - abonnement transports publics 3`] = `"[5097,0,3200,3261,3064]"`;
+exports[`calculate simulations-salarié: frais pro - abo transports + transports personnels 3`] = `"[8529,0,3200,6405,6105]"`;
 
-exports[`calculate simulations-salarié: frais pro - abonnement transports publics 4`] = `"[4387,0,3200,2551,2354]"`;
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 1`] = `"[4387,0,3200,2551,2354]"`;
 
-exports[`calculate simulations-salarié: frais pro - abonnement transports publics 5`] = `"[4363,0,3200,2527,2330]"`;
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 2`] = `"[5097,0,3200,3261,3064]"`;
+
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 3`] = `"[4387,0,3200,2551,2354]"`;
+
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 4`] = `"[4363,0,3200,2527,2330]"`;
 
 exports[`calculate simulations-salarié: frais pro - titres restaurant 1`] = `"[2506,0,2000,1521,1487]"`;
 
 exports[`calculate simulations-salarié: frais pro - titres restaurant 2`] = `"[4308,0,3000,2134,1944]"`;
 
 exports[`calculate simulations-salarié: frais pro - titres restaurant 3`] = `"[2550,0,2000,1493,1458]"`;
+
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 1`] = `"[4847,0,3200,3011,2814]"`;
+
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 2`] = `"[4847,0,3200,3011,2814]"`;
+
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 3`] = `"[12963,0,3200,7416,5979]"`;
+
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 4`] = `"[4847,0,3200,3011,2814]"`;
+
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 5`] = `"[4959,0,3200,2945,2661]"`;
 
 exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 1`] = `"[2570,0,2000,1636,1601]"`;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -710,6 +710,8 @@ exports[`calculate simulations-salarié: frais pro - transports personnels seul 
 
 exports[`calculate simulations-salarié: frais pro - transports personnels seul 5`] = `"[4959,0,3200,2945,2661]"`;
 
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 6`] = `"[4125,0,3200,3083,2881]"`;
+
 exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 1`] = `"[2570,0,2000,1636,1601]"`;
 
 exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 2`] = `"[2529,0,2000,1606,1572]"`;

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -686,6 +686,16 @@ exports[`calculate simulations-salarié: frais pro - IKV 2`] = `"[4347,0,3200,25
 
 exports[`calculate simulations-salarié: frais pro - IKV 3`] = `"[2752,0,2151,1681,1630]"`;
 
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 1`] = `"[4347,0,3200,2511,2314]"`;
+
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 2`] = `"[4387,0,3200,2551,2354]"`;
+
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 3`] = `"[5097,0,3200,3261,3064]"`;
+
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 4`] = `"[4387,0,3200,2551,2354]"`;
+
+exports[`calculate simulations-salarié: frais pro - abonnement transports publics 5`] = `"[4363,0,3200,2527,2330]"`;
+
 exports[`calculate simulations-salarié: frais pro - titres restaurant 1`] = `"[2506,0,2000,1521,1487]"`;
 
 exports[`calculate simulations-salarié: frais pro - titres restaurant 2`] = `"[4308,0,3000,2134,1944]"`;

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -71,7 +71,6 @@ cdd:
     contrat salarié . rémunération . brut de base: 2400 €/mois
     contrat salarié . CDD . durée contrat: 10 mois
     contrat salarié . temps de travail . heures supplémentaires: 5 heures/mois
-    contrat salarié . frais professionnels . indemnité kilométrique vélo: oui
     contrat salarié . rémunération . avantages en nature . montant: 200 €/mois
   - contrat salarié: "'CDD'"
     contrat salarié . rémunération . brut de base: 2400 €/mois
@@ -284,13 +283,6 @@ frais pro - abonnement transports publics:
     contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
     contrat salarié . temps de travail . quotité de travail: 20%
 
-frais pro - IKV:
-  - contrat salarié . rémunération . brut de base: 3200 €/mois
-    contrat salarié . frais professionnels . indemnité kilométrique vélo: oui
-  - contrat salarié . rémunération . brut de base: 3200 €/mois
-    contrat salarié . frais professionnels . indemnité kilométrique vélo . distance mensuelle: 200 km/mois
-  - contrat salarié . rémunération . net après impôt: 1630 €/mois
-    contrat salarié . frais professionnels . indemnité kilométrique vélo . distance mensuelle: 30 km/mois
 
 frais pro - DFS:
   - contrat salarié . rémunération . brut de base: 2000 €/mois

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -71,6 +71,9 @@ cdd:
     contrat salarié . rémunération . brut de base: 2400 €/mois
     contrat salarié . CDD . durée contrat: 10 mois
     contrat salarié . temps de travail . heures supplémentaires: 5 heures/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 100€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 360€/mois
     contrat salarié . rémunération . avantages en nature . montant: 200 €/mois
   - contrat salarié: "'CDD'"
     contrat salarié . rémunération . brut de base: 2400 €/mois
@@ -272,7 +275,6 @@ frais pro - titres restaurant:
 
 frais pro - abonnement transports publics:
   - contrat salarié . rémunération . brut de base: 3200 €/mois
-  - contrat salarié . rémunération . brut de base: 3200 €/mois
     contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
   - contrat salarié . rémunération . brut de base: 3200 €/mois
     contrat salarié . frais professionnels . abonnement transports publics . montant: 1500€/mois
@@ -283,6 +285,37 @@ frais pro - abonnement transports publics:
     contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
     contrat salarié . temps de travail . quotité de travail: 20%
 
+frais pro - transports personnels seul:
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 500€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 1000€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 5000€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/mois
+    contrat salarié . temps de travail . quotité de travail: 50%
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/mois
+    contrat salarié . temps de travail . quotité de travail: 20%
+
+frais pro - abo transports + transports personnels:
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 100€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 360€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 1000€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 5000€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 7000€/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/mois
 
 frais pro - DFS:
   - contrat salarié . rémunération . brut de base: 2000 €/mois

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -302,6 +302,12 @@ frais pro - transports personnels seul:
     contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/mois
     contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/mois
     contrat salarié . temps de travail . quotité de travail: 20%
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/mois
+    contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/mois
+    contrat salarié . déduction forfaitaire spécifique . application: oui
+    contrat salarié . déduction forfaitaire spécifique . taux: 20%
+
 
 frais pro - abo transports + transports personnels:
   - contrat salarié . rémunération . brut de base: 3200 €/mois

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -271,6 +271,19 @@ frais pro - titres restaurant:
     contrat salarié . frais professionnels . titres-restaurant: oui
     contrat salarié . frais professionnels . titres-restaurant . taux participation employeur: 55%
 
+frais pro - abonnement transports publics:
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 1500€/mois
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
+    contrat salarié . temps de travail . quotité de travail: 50%
+  - contrat salarié . rémunération . brut de base: 3200 €/mois
+    contrat salarié . frais professionnels . abonnement transports publics . montant: 80€/mois
+    contrat salarié . temps de travail . quotité de travail: 20%
+
 frais pro - IKV:
   - contrat salarié . rémunération . brut de base: 3200 €/mois
     contrat salarié . frais professionnels . indemnité kilométrique vélo: oui


### PR DESCRIPTION
Introduction en plus des abonnements transports car nécessaire pour les règles mobilités durables.

Questionnements:

- Je ne suis pas confiant en mon interprétation du [R3261-14](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041865023/2020-05-11): j'ai proratisé les plafonds via la variable `transports personnels . proportion déduction`
- Il est écrit dans l'[article L3261-3](https://www.legifrance.gouv.fr/codes/id/LEGIARTI000039785085/2020-01-01/) "Le bénéfice de cette prise en charge ne peut être cumulé avec celle prévue à l'article L. 3261-2.". Autrement dit on ne peut pas cumuler les avantages forfait mobilités durables avec l'abonnement transports. Alors que le CGI dit le contraire [article 81 19°ter](https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042910732/2020-12-31/). Je crois comprendre que la loi dit juste "c'est pas aussi simple que ça, ne vous avisez pas à littéralement cumuler a + b", là où le CGI dit "en fait vous pouvez cumuler d'une manière plus subtile".

closes #919