### PR TITLE
🐛 Corrige l'erreur de conversion dans la fiche de paie

### DIFF
--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -81,6 +81,7 @@ export function Line({
 			<Value
 				linkToRule={false}
 				expression={(negative ? '- ' : '') + rule}
+				unit={displayedUnit === '€' ? '€/mois' : displayedUnit}
 				displayedUnit={displayedUnit}
 				className={className}
 				{...props}


### PR DESCRIPTION
Les avantages en nature étaient affichés en €/an lorsque la simulation était en €/an.

Toutes les valeurs sont en €/mois maintenant