### PR TITLE
Fix share links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,13 @@ yarn start
 
 L'application est exécuté sur https://localhost:8080/mon-entreprise pour la version française et http://localhost:8080/infrance pour la version anglaise.
 
+Pour activer le tracing Redux:
+
+```
+REDUX_TRACE=true yarn start
+```
+
+
 ### Messages de commit
 
 A mettre sans retenue dans les messages de commit :

--- a/mon-entreprise/source/Provider.tsx
+++ b/mon-entreprise/source/Provider.tsx
@@ -18,8 +18,17 @@ declare global {
 		__REDUX_DEVTOOLS_EXTENSION_COMPOSE__: any
 	}
 }
-
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+if (process.env.REDUX_TRACE) {
+	console.log('going to trace')
+}
+const composeEnhancers =
+	(process.env.REDUX_TRACE
+		? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ &&
+		  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+				trace: true,
+				traceLimit: 25,
+		  })
+		: window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
 
 if (
 	process.env.NODE_ENV === 'production' &&

--- a/mon-entreprise/source/components/utils/useSearchParamsSimulationSharing.ts
+++ b/mon-entreprise/source/components/utils/useSearchParamsSimulationSharing.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { SimulationConfig, Situation } from 'Reducers/rootReducer'
+import { RootState, SimulationConfig, Situation } from 'Reducers/rootReducer'
+import { useHistory } from 'react-router'
 import { useSearchParams } from 'Components/utils/useSearchParams'
 import { useEngine } from 'Components/utils/EngineContext'
 import {
@@ -18,10 +19,12 @@ type ParamName = DottedName | ShortName
 export default function useSearchParamsSimulationSharing() {
 	const [urlSituationIsExtracted, setUrlSituationIsExtracted] = useState(false)
 	const [searchParams, setSearchParams] = useSearchParams()
-	const config = useSelector(configSelector)
 	const situation = useSelector(situationSelector)
-	const engine = useEngine()
+	const config = useSelector(configSelector)
+	const simulationUrl = useSelector((state: RootState) => state.simulation?.url)
+	const currentUrl = useHistory().location.pathname
 	const dispatch = useDispatch()
+	const engine = useEngine()
 
 	const dottedNameParamName = useMemo(
 		() => getRulesParamNames(engine.getParsedRules()),
@@ -30,7 +33,11 @@ export default function useSearchParamsSimulationSharing() {
 
 	useEffect(() => {
 		const hasConfig = Object.keys(config).length > 0
-		if (!hasConfig) return
+		// TODO: this check is specific to `useSimulationConfig` and
+		// `setSimulationConfig`, so we'd prefer not doing it here. Other ideas
+		// include having the config in a provider rather than in state.
+		const configLoadedInState = simulationUrl === currentUrl
+		if (!hasConfig || !configLoadedInState) return
 
 		// On load:
 		if (!urlSituationIsExtracted) {
@@ -58,17 +65,25 @@ export default function useSearchParamsSimulationSharing() {
 			)
 
 			setUrlSituationIsExtracted(true)
-			return
 		}
+		return
 	}, [
+		currentUrl,
+		simulationUrl,
 		dispatch,
 		dottedNameParamName,
 		config,
 		searchParams,
 		setSearchParams,
-		situation,
 		urlSituationIsExtracted,
 	])
+
+	// Cleanup:
+	useEffect(() => {
+		return () => {
+			setUrlSituationIsExtracted(false)
+		}
+	}, [])
 
 	return () =>
 		getSearchParamsFromSituation(engine, situation, dottedNameParamName)

--- a/mon-entreprise/webpack.dev.js
+++ b/mon-entreprise/webpack.dev.js
@@ -19,7 +19,10 @@ module.exports = {
 	plugins: [
 		...common.plugins,
 		...HTMLPlugins(),
-		new webpack.EnvironmentPlugin({ NODE_ENV: 'development' }),
+		new webpack.EnvironmentPlugin({
+			NODE_ENV: 'development',
+			REDUX_TRACE: false,
+		}),
 		new webpack.HotModuleReplacementPlugin(),
 	],
 }


### PR DESCRIPTION
1 commit pour ajouter Redux tracing de manière optionnelle. C'est un peu utile quand on ne connaît pas bien d'où viennent les actions, mais ce n'est pas génial non car difficile de s'y retrouver avec les effects qui ne sont pas reconnaissables dans la stack trace.

1 commit pour corriger le problème quand on clicke sur un lien interne vers une page avec des paramètres de URL sharing. Le soucis était lié au fait que la config, bien que figée, soit dans le state. Ce n'est pas pratique. A long-terme, il faudrait revoir ça et mettre la config dans un provider, je pense.

cc @mquandalle 