### PR TITLE
Refact rules for translation

### DIFF
--- a/modele-social/README.md
+++ b/modele-social/README.md
@@ -2,27 +2,28 @@
 
 Ce paquet contient les règles publicodes utilisées sur https://mon-entreprise.fr
 pour le calcul des cotisations sociales, des impôts et des droits sociaux.
+
 ### Installation
+
 ```
-npm install publicodes modele-social 
+npm install publicodes modele-social
 ```
 
 ### Exemple d'utilisation
-```js
-import Engine, { formatValue } from "publicodes";
-import rules from "modele-social";
 
-const engine = new Engine(rules);
+```js
+import Engine, { formatValue } from 'publicodes'
+import rules from 'modele-social'
+
+const engine = new Engine(rules)
 
 const net = engine
-  .setSituation({
-    "contrat salarié . rémunération . brut de base": "3000 €/mois",
-  })
-  .evaluate("contrat salarié . rémunération . net");
+    .setSituation({
+        'contrat salarié . rémunération . brut de base': '3000 €/mois',
+    })
+    .evaluate('contrat salarié . rémunération . net')
 
-console.log(formatValue(net));
-
+console.log(formatValue(net))
 ```
-
 
 👉 **[Voir le tutoriel complet](https://mon-entreprise.fr/int%C3%A9gration/biblioth%C3%A8que-de-calcul)**

--- a/modele-social/règles/chômage-partiel.yaml
+++ b/modele-social/règles/chômage-partiel.yaml
@@ -1,4 +1,4 @@
-chômage partiel:
+chômage partiel: oui
 
 chômage partiel . revenu net habituel:
   formule:

--- a/mon-entreprise/source/App.tsx
+++ b/mon-entreprise/source/App.tsx
@@ -4,14 +4,13 @@ import Header from 'Components/layout/Header'
 import Route404 from 'Components/Route404'
 import 'Components/ui/index.css'
 import {
-	engineOptions,
+	engineFactory,
 	EngineProvider,
+	Rules,
 	SituationProvider,
 } from 'Components/utils/EngineContext'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import 'iframe-resizer'
-import { DottedName } from 'modele-social'
-import Engine, { Rule } from 'publicodes'
 import { useContext, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
@@ -70,16 +69,13 @@ const middlewares = [createSentryMiddleware(Sentry as any)]
 
 type RootProps = {
 	basename: ProviderProps['basename']
-	rules: Record<DottedName, Rule>
+	rules: Rules
 }
 
 export default function Root({ basename, rules }: RootProps) {
 	const { language } = useTranslation().i18n
 	const paths = constructLocalizedSitePath(language as 'fr' | 'en')
-	const engine = useMemo(() => new Engine(rules, engineOptions), [
-		rules,
-		engineOptions,
-	])
+	const engine = useMemo(() => engineFactory(rules), [rules])
 	return (
 		<Provider
 			basename={basename}

--- a/mon-entreprise/source/components/SchemeComparaison.tsx
+++ b/mon-entreprise/source/components/SchemeComparaison.tsx
@@ -9,8 +9,6 @@ import SeeAnswersButton from 'Components/conversation/SeeAnswersButton'
 import Value from 'Components/EngineValue'
 import InfoBulle from 'Components/ui/InfoBulle'
 import revenusSVG from 'Images/revenus.svg'
-import { DottedName } from 'modele-social'
-import Engine from 'publicodes'
 import { useCallback, useMemo, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
@@ -18,7 +16,7 @@ import { useSelector } from 'react-redux'
 import { situationSelector } from 'Selectors/simulationSelectors'
 import dirigeantComparaison from '../pages/Simulateurs/configs/rémunération-dirigeant.yaml'
 import './SchemeComparaison.css'
-import { engineOptions, useEngine } from './utils/EngineContext'
+import { useEngine } from './utils/EngineContext'
 import useSimulationConfig from './utils/useSimulationConfig'
 
 type SchemeComparaisonProps = {
@@ -45,13 +43,12 @@ export default function SchemeComparaison({
 		setConversationStarted,
 	])
 
-	const parsedRules = engine.getParsedRules()
 	const situation = useSelector(situationSelector)
 	const displayResult =
 		useSelector(situationSelector)['entreprise . charges'] != undefined
 	const assimiléEngine = useMemo(
 		() =>
-			new Engine<DottedName>(parsedRules, engineOptions).setSituation({
+			engine.shallowCopy().setSituation({
 				...situation,
 				dirigeant: "'assimilé salarié'",
 			}),
@@ -59,7 +56,7 @@ export default function SchemeComparaison({
 	)
 	const autoEntrepreneurEngine = useMemo(
 		() =>
-			new Engine<DottedName>(parsedRules, engineOptions).setSituation({
+			engine.shallowCopy().setSituation({
 				...situation,
 				dirigeant: "'auto-entrepreneur'",
 			}),
@@ -67,7 +64,7 @@ export default function SchemeComparaison({
 	)
 	const indépendantEngine = useMemo(
 		() =>
-			new Engine<DottedName>(parsedRules, engineOptions).setSituation({
+			engine.shallowCopy().setSituation({
 				...situation,
 				dirigeant: "'indépendant'",
 			}),

--- a/mon-entreprise/source/components/utils/EngineContext.tsx
+++ b/mon-entreprise/source/components/utils/EngineContext.tsx
@@ -1,14 +1,12 @@
-import Engine from 'publicodes'
+import Engine, { Rule } from 'publicodes'
 import React, { createContext, useContext } from 'react'
 import { DottedName } from 'modele-social'
 import i18n from '../../locales/i18n'
 
-export const EngineContext = createContext<Engine>(new Engine({}))
-export const EngineProvider = EngineContext.Provider
+export type Rules = Record<DottedName, Rule>
 
 const unitsTranslations = Object.entries(i18n.getResourceBundle('fr', 'units'))
-
-export const engineOptions = {
+const engineOptions = {
 	getUnitKey(unit: string): string {
 		const key = unitsTranslations
 			.find(([, trans]) => trans === unit)?.[0]
@@ -19,6 +17,12 @@ export const engineOptions = {
 		return i18n?.t(`units:${unit}`, { count })
 	},
 }
+export function engineFactory(rules: Rules) {
+	return new Engine(rules, engineOptions)
+}
+
+export const EngineContext = createContext<Engine>(new Engine())
+export const EngineProvider = EngineContext.Provider
 
 export function useEngine(): Engine<DottedName> {
 	return useContext(EngineContext) as Engine<DottedName>

--- a/mon-entreprise/source/pages/Simulateurs/AidesEmbauche.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AidesEmbauche.tsx
@@ -10,7 +10,7 @@ import { useSimulationProgress } from 'Components/utils/useNextQuestion'
 import { useParamsFromSituation } from 'Components/utils/useSearchParamsSimulationSharing'
 import useSimulationConfig from 'Components/utils/useSimulationConfig'
 import { DottedName } from 'modele-social'
-import Engine, { formatValue } from 'publicodes'
+import { formatValue } from 'publicodes'
 import { partition } from 'ramda'
 import { useContext } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -229,7 +229,7 @@ function Results() {
 	const progress = useSimulationProgress()
 	const baseEngine = useEngine()
 	const aidesEngines = aides.map((aide) => {
-		const engine = new Engine(baseEngine.parsedRules)
+		const engine = baseEngine.shallowCopy()
 		engine.setSituation({ ...aide.situation, ...baseEngine.parsedSituation })
 		const isActive =
 			typeof engine.evaluate(aide.dottedName).nodeValue === 'number'

--- a/mon-entreprise/test/real-rules.test.js
+++ b/mon-entreprise/test/real-rules.test.js
@@ -6,7 +6,7 @@ import rules from 'modele-social'
 // les variables dans les tests peuvent être exprimées relativement à l'espace de nom de la règle,
 // comme dans sa formule
 let parsedRules = parsePublicodes(rules)
-const engine = new Engine(parsedRules)
+const engine = new Engine(rules)
 let runExamples = (examples, rule) =>
 	examples.map((ex) => {
 		const expected = ex['valeur attendue']

--- a/mon-entreprise/test/regressions/simulations.jest.js
+++ b/mon-entreprise/test/regressions/simulations.jest.js
@@ -6,9 +6,8 @@
 // renamed the test configuration may be adapted but the persisted snapshot will remain unchanged).
 
 /* eslint-disable no-undef */
-import Engine from 'publicodes'
 import rules from '../../../modele-social'
-import { engineOptions } from '../../source/components/utils/EngineContext'
+import { engineFactory } from '../../source/components/utils/EngineContext'
 import aideDéclarationConfig from '../../source/pages/Gérer/AideDéclarationIndépendant/config.yaml'
 import artisteAuteurConfig from '../../source/pages/Simulateurs/configs/artiste-auteur.yaml'
 import autoentrepreneurConfig from '../../source/pages/Simulateurs/configs/auto-entrepreneur.yaml'
@@ -26,7 +25,7 @@ import remunerationDirigeantSituations from './simulations-rémunération-dirige
 import employeeSituations from './simulations-salarié.yaml'
 
 const roundResult = (arr) => arr.map((x) => Math.round(x))
-const engine = new Engine(rules, engineOptions)
+const engine = engineFactory(rules)
 const runSimulations = (situations, targets, baseSituation = {}) =>
 	Object.entries(situations).map(([name, situations]) =>
 		situations.forEach((situation) => {

--- a/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
+++ b/mon-entreprise/test/useSearchParamsSimulationSharing.test.js
@@ -26,14 +26,13 @@ describe('identifiant court', () => {
 })
 
 describe('useSearchParamsSimulationSharing', () => {
-	const someRules = parsePublicodes(`
+	const engine = new Engine(`
 rule with:
 	identifiant court: panta
 	formule: 0
 rule without:
 	formule: 0
 	`)
-	const engine = new Engine(someRules)
 	const dottedNameParamName = getRulesParamNames(engine.getParsedRules())
 
 	describe('getSearchParamsFromSituation', () => {
@@ -92,7 +91,7 @@ rule without:
 })
 
 describe('useSearchParamsSimulationSharing hook', () => {
-	const someRules = parsePublicodes(`
+	const parsedRules = parsePublicodes(`
 rule with:
 	identifiant court: panta
 	formule: 0
@@ -100,9 +99,7 @@ rule without:
 	formule: 0
 	`)
 
-	const dottedNameParamName = getRulesParamNames(
-		new Engine(someRules).getParsedRules()
-	)
+	const dottedNameParamName = getRulesParamNames(parsedRules)
 	let setSearchParams
 
 	beforeEach(() => {

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -59,10 +59,12 @@ type Options = {
 	getUnitKey?: getUnitKey
 	formatUnit?: formatUnit
 }
+
 export type EvaluationFunction<Kind extends NodeKind = NodeKind> = (
 	this: Engine,
 	node: ASTNode & { nodeKind: Kind }
 ) => ASTNode & { nodeKind: Kind } & EvaluatedNode
+
 export type ParsedRules<Name extends string> = Record<
 	Name,
 	RuleNode & { dottedName: Name }

--- a/publicodes/core/test/inversion.test.js
+++ b/publicodes/core/test/inversion.test.js
@@ -51,7 +51,7 @@ describe('inversions', () => {
               assiette: brut
               taux: 77%
 
-        brut:          
+        brut:
           formule:
             inversion numérique:
               unité: €
@@ -147,7 +147,7 @@ describe('inversions', () => {
           formule:
             produit:
               assiette: assiette
-              taux: 
+              taux:
                 variations:
                   - si: cadre
                     alors: 80%

--- a/publicodes/ui-react/source/mecanisms/common.tsx
+++ b/publicodes/ui-react/source/mecanisms/common.tsx
@@ -64,7 +64,7 @@ export const NodeValuePointer = ({ data, unit }: NodeValuePointerProps) => {
 			}}
 		>
 			{formatValue(simplifyNodeUnit({ nodeValue: data, unit }), {
-				formatUnit: engine?.options?.formatUnit,
+				formatUnit: engine?.getOptions()?.formatUnit,
 			})}
 		</small>
 	)


### PR DESCRIPTION
Ceci est suite à quelques investigations que j'avais faites la semaine derniere pour simplifier le code du parsing pour m'aider à bosser sur la traduction en EN.

J'ai parti-pris contre le polymorphisme de l'argument principal du constructeur de l'Engine. J'ai donc proposé une solution que je pense simple. Vu que l'arg type ParsedRules n'était pas documenté, pour moi c'est ok pour les utilisateurs de Publicodes.

J'ai investigué aussi une autre approche, trop complexe pour l'instant mais qui risque de revenir sur le devant de la scène plus tard pour mieux séparer l'API publique du moteur par rapport aux internals. Je partage donc mes remarques.  
J'ai essayé de voir si je ne pouvais pas faire de `Engine` l'API publique, et séparer les internals dans une classe `EngineCore` par exemple, avec de la composition (`Engine.core` de type `EngineCore`, ensuite yapluka). Je pense que ça peut plutôt bien marcher, et a l'avantage de garder `Engine` relativement inchangée.  
L'utilité immédiate n'est pas évidente, donc je ne propose pas un tel changement. En revanche ça m'a fait voir de façon claire que l'utilisation des constructeurs en js/ts est vraiment limitante. Par ex aujourd'hui il est impossible de revenir en arrière (sans faire de breaking change sur l'API de `Engine`, notamment le constructeur) si on veut essayer d'avoir une sorte de base-class (ou plutôt une "core-class", car je suis contre l'héritance, par défaut) avec le _constructeur trivial_ (vous savez, le constructeur qui prend les arguments et qui les "pose" dans les attributs :). Or une classe de base avec constructeur trivial est ultra utile, notamment pour construire la ducplication de manière encore plus explicite que ce que j'ai fait (cf. le 1er commit).  
Tout ceci est lié à la manière dont les constructeurs fonctionnent et l'obligation qu'on a, en js/ts, de passer par le constructeur pour instancier (ça parait évident? bah en Python il n'y a pas de `new` par ex, et on instancie par n'importe quelle classmethod/staticmethod, strictement impossible en js). Ce qui me pousse à partir de maintnant à favoriser les factories et/ou les staticmethods pour faire de l'instanciation _avec logique_, et garder le constructeur trivial _sans logique_.  
Au final, il m'est donc paru clair qu'il fallait retirer au plus vite le polymorphisme de l'argument.