### PR TITLE
Retire l'exclusion de tracking pour Safari

### DIFF
--- a/mon-entreprise/source/Tracker.ts
+++ b/mon-entreprise/source/Tracker.ts
@@ -15,13 +15,6 @@ type MatomoAction =
 type PushArgs = [MatomoAction, ...Array<string | number>]
 type PushType = (args: PushArgs) => void
 
-const ua = window.navigator.userAgent
-// https://chromium.googlesource.com/chromium/src.git/+/master/docs/ios/user_agent.md
-const iOSSafari =
-	(!!/iPad/i.exec(ua) || !!/iPhone/i.exec(ua)) &&
-	!!/WebKit/i.exec(ua) &&
-	!/CriOS/i.exec(ua)
-
 export default class Tracker {
 	push: PushType
 	debouncedPush: PushType
@@ -30,13 +23,7 @@ export default class Tracker {
 
 	constructor(
 		pushFunction: PushType = (args) => {
-			// There is an issue with the way Safari handle cookies in iframe, cf.
-			// https://gist.github.com/iansltx/18caf551baaa60b79206. We could probably
-			// do better but for now we don't track action of iOs Safari user in
-			// iFrame -- to avoid errors in the number of visitors in our stats.
-			if (!(iOSSafari && inIframe)) {
-				window._paq.push(args)
-			}
+			window._paq.push(args)
 		}
 	) {
 		if (typeof window !== 'undefined') window._paq = window._paq || []


### PR DESCRIPTION
Probablement plus nécessaire depuis le passage à AT Internet, bien que ça reste à vérifier