### PR TITLE
:bug: Correction d'un exemple publicodes

### DIFF
--- a/publicodes/docs/principes-de-base.md
+++ b/publicodes/docs/principes-de-base.md
@@ -309,10 +309,10 @@ robot de cuisine:
     valeur: oui
 
 temps original:
-    formule: a + b
+    formule: temps de préparation + temps de cuisson # résultat : 40 min
 
 temps modifié:
-    formule: a + b
+    formule: temps de préparation + temps de cuisson # résultat : 30 min
 ```
 
 > [En savoir plus sur les remplacements](/manuel#remplacement)


### PR DESCRIPTION
Autre point : le lien "    En savoir plus sur les remplacements" fait référence à https://publi.codes/manuel#remplacement
Mais cette page est inexistante, je ne sais pas où elle est passée.