### PR TITLE
Réecriture : imposition IS / IR

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -9,6 +9,78 @@ dirigeant:
         - assimilé salarié
         - indépendant
 
+dirigeant . rémunération: oui
+dirigeant . rémunération . totale:
+  titre: Total alloué à la rémunération
+  unité: €/an
+  description: superbrute
+  question: Quel est le total alloué à la rémunération du dirigeant (cotisations sociale inclues) ?
+  par défaut:
+    somme:
+      - entreprise . chiffre d'affaires 
+      - (- entreprise . charges)
+  inversion numérique:
+    avec: 
+      - nette
+      - nette après impôt
+
+  # plancher:
+  #   recalcul:
+  #     règle: dirigeant . rémunération . cotisations et contributions
+  #     avec: 
+  #       dirigeant . rémunération . nette: 0€/an
+
+dirigeant . rémunération . cotisations et contributions:
+  variations: 
+    - si: assimilé salarié
+      alors: contrat salarié . cotisations
+    - si: indépendant
+      alors: indépendant . cotisations et contributions
+    - si: auto-entrepreneur
+      alors: auto-entrepreneur . cotisations et contributions
+
+dirigeant . rémunération . cotisations et contributions . non déductibles fiscalement:
+  somme: 
+    - contrat salarié . CSG et CRDS . non déductible
+    - dirigeant . indépendant . cotisations et contributions . CSG et CRDS . non déductible
+    - dirigeant . indépendant . contrats madelin . part non-déductible fiscalement
+
+dirigeant . rémunération . imposable:
+  titre: Rémunération imposable
+  variations: 
+    - si: entreprise . imposition . IR
+      alors: entreprise . résultats . fiscal
+    - si: auto-entrepreneur
+      alors: auto-entrepreneur . impôt . revenu imposable    
+    - si: assimilé salarié
+      alors: contrat salarié . rémunération . net imposable
+    - si: indépendant
+      alors: indépendant . revenu professionnel
+
+
+dirigeant . rémunération . nette après impôt:
+  titre: Rémunération après impôt
+  unité: €/an
+  arrondi: oui
+  question: Quel est le revenu net après impôt souhaité ?
+  description: >-
+    Le revenu net après déduction de l'impôt 
+    sur le revenu et des cotisations sociales.
+  valeur: rémunération . nette - impôt
+
+dirigeant . rémunération . impôt:
+  produit:
+    assiette: imposable
+    taux: impôt . taux d'imposition
+  
+
+dirigeant . rémunération . nette:
+  titre: Rémunération
+  question: Quel montant net de cotisation sera affecté à votre rémunération ?
+  description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
+  unité: €/an
+  valeur: dirigeant . rémunération . totale - dirigeant . rémunération . cotisations et contributions
+    
 dirigeant . assimilé salarié:
   description: |
     Certains dirigeants d'entreprise (c'est notamment le cas pour les SASU) sont considérés par la sécurité sociale comme assimilés aux salariés. Ils sont alors au régime général de la sécurité sociale, avec quelques contraintes cependant. Par exemple, ils ne cotisent pas au chômage, et n'y ont donc pas droit.
@@ -18,6 +90,8 @@ dirigeant . assimilé salarié:
       par: "'CDI'"
     - règle: contrat salarié . statut cadre
       par: oui
+    - règle: contrat salarié . rémunération . total
+      par: 
   rend non applicable:
     - contrat salarié . convention collective
     - contrat salarié . activité partielle
@@ -428,36 +502,6 @@ dirigeant . auto-entrepreneur . net après impôt:
       assiette: dirigeant . auto-entrepreneur . impôt . revenu imposable
       taux: impôt . taux d'imposition
 
-dirigeant . rémunération totale:
-  synonymes:
-    - résultat d'exploitation
-    - bénéfices
-  question: Quel montant pensez-vous dégager pour votre rémunération ?
-  résumé: Dépensé par l'entreprise
-  unité: €/an
-  arrondi: oui
-  identifiant court: dirigeant-total
-  description: C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
-    Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
-
-    On peut aussi considérer que c'est la valeur monétaire du travail du dirigeant.
-  formule:
-    variations:
-      - si: indépendant
-        alors:
-          somme:
-            - indépendant . revenu net de cotisations
-            - indépendant . cotisations et contributions
-      - si: auto-entrepreneur
-        alors: entreprise . chiffre d'affaires - entreprise . charges
-      - si: assimilé salarié
-        alors:
-          somme:
-            - contrat salarié . rémunération . total
-            # TODO : ajouter la taxe sur les salaires ici.
-            # Pour l'instant commenté car elle crée une boucle à cause de la franchise de TVA
-            # - entreprise . taxe sur les salaires
-
 dirigeant . indépendant:
   rend non applicable: contrat salarié
   formule: dirigeant = 'indépendant'
@@ -566,52 +610,17 @@ dirigeant . indépendant . cotisations et contributions . aide indépendant covi
   références:
     Sécu-indépendant: https://www.secu-independants.fr/cpsti/actualites/actualites-nationales/covid-dispositifs-de-reduction-des-cotisations/
 
-dirigeant . indépendant . revenu net de cotisations:
-  identifiant court: independant-net
-  synonymes:
-    - résultat comptable
-  formule:
-    somme:
-      - valeur: revenu professionnel
-        arrondi: oui
-      - (- cotisations et contributions . CSG et CRDS . non déductible)
-      - (- contrats madelin . montant)
-  résumé: Avant déduction de l'impôt sur le revenu
-  question: Quel revenu avant impôt voulez-vous toucher ?
-  description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
-  références:
-    Cerfa 2033-sd: https://www.impots.gouv.fr/portail/files/formulaires/2033-sd/2020/2033-sd_2983.pdf
-
-dirigeant . indépendant . résultat fiscal:
-  synonymes:
-    - net imposable
-    - assiette fiscale
-  résumé: Assiette du calcul de l'impôt
-  description: Il s'agit du net imposable, assiette sur laquelle l'impôt est calculé.
-  formule: revenu professionnel - contrats madelin . part déductible fiscalement
-  références:
-    Portail Urssaf: https://www.urssaf.fr/portail/home/independant/mes-cotisations/les-etapes-de-calcul/la-declaration-sociale-des-indep/les-revenus-pris-en-compte-pour.html
-
 dirigeant . indépendant . revenu professionnel:
   unité: €/an
   titre: revenu professionnel
   description: |
     C'est le revenu net de cotisations déductibles du travailleur indépendant, qui sert de base au calcul des cotisations pour les indépendants.
-
-    Attention : **notre calcul est fait au régime de croisière**:
-    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait relativement réduit de cotisations sociales. Il devra ensuite régulariser cette situation par rapport au revenu qu'il a vraiment perçu.
-
-    Il faut donc voir ce calcul comme *le montant qui devra de toute façon être payé* à court terme après 2 ans d'exercice.
-  formule:
-    inversion numérique:
-      avec:
-        - revenu net de cotisations
-        - résultat fiscal
-        - rémunération totale
-        - revenu net après impôt
-        - entreprise . chiffre d'affaires
-        - entreprise . chiffre d'affaires minimum
-    arrondi: oui
+  résoudre le cycle: oui 
+  somme: 
+    - rémunération . nette
+    - cotisations et contributions . CSG et CRDS
+    - contrats madelin . montant
+  arrondi: oui
 
 dirigeant . indépendant . assiette des cotisations:
   description: Il s'agit de l'assiette des cotisations sociales, nombre forcément positif
@@ -796,6 +805,7 @@ dirigeant . indépendant . cotisations et contributions:
   formule:
     somme:
       - cotisations
+      - contrats madelin . montant
       - CSG et CRDS
       - contributions spéciales
       - formation professionnelle
@@ -849,6 +859,8 @@ dirigeant . indépendant . contrats madelin:
   titre: Contrats Madelin
   question: Avez-vous souscrit à des contrats de complémentaire privée dits ("contrats Madelins")
   par défaut: non
+  références: 
+    economie.gouv.fr: https://www.economie.gouv.fr/particuliers/reduction-impot-revenu-investissements-entreprise-pme-madelin
 
 dirigeant . indépendant . contrats madelin . montant:
   titre: Somme des cotisations à contrats Madelin

--- a/modele-social/règles/déclaration-revenu-indépendant.yaml
+++ b/modele-social/règles/déclaration-revenu-indépendant.yaml
@@ -120,7 +120,7 @@ aide déclaration revenu indépendant 2020 . revenu net fiscal:
   titre: revenu net fiscal
   résumé: avant déduction des charges sociales et exonérations fiscales [A]
   unité: €/an
-  formule: dirigeant . rémunération totale
+  formule: entreprise . résultats . fiscal
 
 aide déclaration revenu indépendant 2020 . CSG déductible:
   titre: CSG déductible

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -492,11 +492,7 @@ entreprise . ACRE:
           - entreprise . durée d'activité < 3 ans
           - entreprise . date de création < 04/2020
       - entreprise . durée d'activité . en début d'année < 1 an
-  par défaut: ACRE par défaut
-  note: Les auto-entreprises crées entre le 1er janvier et le 31 décembre 2019 bénéficient d'un dispositif plus favorable, actif pendant 3 années.
-
-entreprise . ACRE par défaut:
-  formule:
+  par défaut: 
     variations:
       - si:
           toutes ces conditions:
@@ -508,6 +504,9 @@ entreprise . ACRE par défaut:
         alors: non
       - sinon: oui
 
+  note: Les auto-entreprises crées entre le 1er janvier et le 31 décembre 2019 bénéficient d'un dispositif plus favorable, actif pendant 3 années.
+
+  
 entreprise . effectif:
   unité: employé
   formule:

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -56,21 +56,9 @@ entreprise . chiffre d'affaires:
   question: Quel est votre chiffre d'affaires envisagé ?
   résumé: Montant total des recettes brutes (hors taxe)
   unité: €/an
-  variations:
-    - si: dirigeant . auto-entrepreneur
-      alors:
-        inversion numérique:
-          avec:
-            - dirigeant . auto-entrepreneur . net de cotisations
-            - dirigeant . auto-entrepreneur . net après impôt
-            - dirigeant . rémunération totale
-    - sinon: 
-        somme: 
-          - dirigeant . rémunération totale
-          - charges
-        
-      
-
+  inversion numérique:
+    avec:
+      - entreprise . charges . rémunération dirigeant
   arrondi: oui
   identifiant court: ca
 
@@ -223,18 +211,27 @@ entreprise . chiffre d'affaires . franchise de TVA dépassée . notification:
   description: |
     Le seuil annuel de chiffre d'affaires pour la franchise de TVA est dépassé. [En savoir plus](/documentation/entreprise/chiffre-d'affaires/franchise-de-TVA-dépassée)
 
-entreprise . chiffre d'affaires minimum:
-  identifiant court: entreprise-ca-min
-  description: Le montant minimum des ventes (H.T) à réaliser pour atteindre le seuil de rentabilité.
-  question: Quel est votre chiffre d'affaires minimum envisagé ?
-  unité: €/an
-  formule: chiffre d'affaires
 
-entreprise . rémunération du dirigeant:
-  description: |
-    C'est la part du chiffre d'affaires après charges qui est allouée à la rémunération du dirigeant. Plus cette part est élevée, plus la rémunération du dirigeant augmente, et plus le bénéfice de l'entreprise diminue.
-  question: Quelle part du chiffre d'affaires après charge est allouée à la rémunération du dirigeant ?
-  par défaut: 100%
+entreprise . résultats: oui
+  
+entreprise . résultats . exploitation:
+  titre: résultat d'exploitation
+  somme:
+    - chiffre d'affaires 
+    - (- charges)
+    - (- charges . rémunération dirigeant)
+
+entreprise . résultats . net:
+  titre: résultat net
+  valeur: exploitation - impôt sur les sociétés
+
+entreprise . résultats . fiscal:
+  titre: résultat fiscal
+  somme: 
+    - exploitation
+    - dirigeant . rémunération . cotisations et contributions . non déductibles fiscalement
+    - applicable si: entreprise . imposition . IR
+      valeur: dirigeant . rémunération . nette
 
 entreprise . imposition:
   question: À quel régime d'imposition l'entreprise est-elle soumise ?
@@ -269,23 +266,15 @@ entreprise . imposition . IS . notification IS non intégré:
     dividendes. L'option "Impôt sur les Sociétés" est uniquement utilisée dans
     le calcul de l'impôt sur le revenu.
 
-entreprise . bénéfice:
-  titre: Bénéfice de l'exercice
-  résumé: Imposable à l'impôt sur les sociétés
-  formule: chiffre d'affaires - charges dont rémunération dirigeant
 
-entreprise . bénéfice . information sur le report de déficit:
+entreprise . information sur le report de déficit:
   type: notification
-  formule: bénéfice < 0 €/an
+  formule: résultats . fiscal < 0 €/an
   # TODO: Support des références dans les notifications
   description: |
     Les déficits subits au cours d'un exercice peuvent être reportés sur les exercices suivants (report en avant), ou sur le seul exercice précédent (report en arrière).
 
     [Plus d'infos sur service-public.fr](https://www.service-public.fr/professionnels-entreprises/vosdroits/F23628)
-
-entreprise . résultat net:
-  résumé: Ce qu'il reste après impôt sur les sociétés
-  formule: bénéfice - impôt sur les sociétés
 
 entreprise . exercice:
 
@@ -328,11 +317,12 @@ entreprise . exercice . durée maximale:
   formule: durée >= 24 mois
   description: La durée maximale d'un exercice comptable est de 24 mois.
 
-entreprise . impôt sur les sociétés:
+entreprise . résultats . impôt sur les sociétés:
+  applicable si: imposition . IS
   unité: €/an
   formule:
     barème:
-      assiette: bénéfice
+      assiette: résultats . fiscal
       multiplicateur: prorata temporis
       variations:
         - si: exercice . début >= 01/01/2022
@@ -374,22 +364,22 @@ entreprise . impôt sur les sociétés:
     Fiche impots.gouv.fr: https://www.impots.gouv.fr/portail/international-professionnel/impot-sur-les-societes
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23575
 
-entreprise . impôt sur les sociétés . plafond taux réduit 1:
+entreprise . résultats . impôt sur les sociétés . plafond taux réduit 1:
   applicable si: éligible taux réduit
   valeur: 38120 €/an
 
-entreprise . impôt sur les sociétés . plafond taux réduit 2:
+entreprise . résultats . impôt sur les sociétés . plafond taux réduit 2:
   applicable si: éligible taux réduit
   valeur: 500000 €/an
 
-entreprise . impôt sur les sociétés . éligible taux réduit:
+entreprise . résultats . impôt sur les sociétés . éligible taux réduit:
   formule:
     toutes ces conditions:
       - chiffre d'affaires <= 7630 k€/an * prorata temporis
       - nom: capital détenu au moins à 75 pourcents par des personnes physiques
         valeur: oui
 
-entreprise . impôt sur les sociétés . prorata temporis:
+entreprise . résultats . impôt sur les sociétés . prorata temporis:
   description: |
     Lorsque la durée de l’exercice n'est pas égale à un an, on pro-ratise les
     plafonds utilisés dans le barème de l'impôt sur les sociétés.
@@ -402,7 +392,7 @@ entreprise . impôt sur les sociétés . prorata temporis:
   références:
     Bofip: https://bofip.impots.gouv.fr/bofip/2065-PGP.html/identifiant%3DBOI-IS-LIQ-20-20-20180801
 
-entreprise . impôt sur les sociétés . contribution sociale:
+entreprise . résultats . impôt sur les sociétés . contribution sociale:
   # description: |
   #   La contribution sociale sur les bénéfices est un impôt distinct de l'impôt sur les sociétés. Son montant n'est pas déductible des résultats.
 
@@ -419,9 +409,6 @@ entreprise . impôt sur les sociétés . contribution sociale:
         abattement: 763000 €/an * prorata temporis
   références:
     Bofip: https://bofip.impots.gouv.fr/bofip/3492-PGP.html/identifiant%3DBOI-IS-AUT-10-20-20130318
-
-entreprise . charges dont rémunération dirigeant:
-  formule: charges + dirigeant . rémunération totale
 
 entreprise . charges:
   synonymes:
@@ -451,6 +438,10 @@ entreprise . charges:
   références:
     Charges déductibles ou non du résultat fiscal d'une entreprise: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31973
   par défaut: 0 €/an
+
+entreprise . charges . rémunération dirigeant:
+  titre: Rémunération du dirigeant (dont cotisations sociales)
+  valeur: dirigeant . rémunération . totale
 
 entreprise . ACRE:
   description: >-

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -492,7 +492,11 @@ entreprise . ACRE:
           - entreprise . durée d'activité < 3 ans
           - entreprise . date de création < 04/2020
       - entreprise . durée d'activité . en début d'année < 1 an
-  par défaut: 
+  par défaut: ACRE par défaut
+  note: Les auto-entreprises crées entre le 1er janvier et le 31 décembre 2019 bénéficient d'un dispositif plus favorable, actif pendant 3 années.
+
+entreprise . ACRE par défaut:
+  formule:
     variations:
       - si:
           toutes ces conditions:
@@ -504,9 +508,6 @@ entreprise . ACRE:
         alors: non
       - sinon: oui
 
-  note: Les auto-entreprises crées entre le 1er janvier et le 31 décembre 2019 bénéficient d'un dispositif plus favorable, actif pendant 3 années.
-
-  
 entreprise . effectif:
   unité: employé
   formule:

--- a/modele-social/règles/impôt.yaml
+++ b/modele-social/règles/impôt.yaml
@@ -70,8 +70,7 @@ impôt . revenu imposable:
     C'est le revenu à prendre en compte pour calculer l'impôt avec un taux moyen d'imposition (neutre ou personnalisé).
   somme:
       - contrat salarié . rémunération . net imposable
-      - dirigeant . indépendant . résultat fiscal
-      - dirigeant . auto-entrepreneur . impôt . revenu imposable
+      - dirigeant . rémunération . imposable
   abattement: abattement contrat court
 
 impôt . revenu imposable . abattement contrat court:
@@ -251,27 +250,6 @@ impôt . taux personnalisé:
       - votre espace personnel [impots.gouv.fr](https://impots.gouv.fr)
   unité: '%'
 
-revenus net de cotisations:
-  résumé: Avant impôt
-  unité: €/an
-  question: Quel revenu avant impôt voulez-vous toucher ?
-  description: |
-    Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
-  formule:
-    somme:
-      - contrat salarié . rémunération . net
-      - dirigeant . indépendant . revenu net de cotisations
-      - dirigeant . auto-entrepreneur . net de cotisations
-
-revenu net après impôt:
-  unité: €/an
-  résumé: Disponible sur votre compte en banque
-  question: Quel revenu voulez-vous toucher ?
-  identifiant court: net-apres-impot
-  description: |
-    Il s'agit du revenu net de charges, cotisations et d'impôts.
-    Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
-  formule: revenus net de cotisations - impôt
 
 # TODO: "foyer fiscal" should be in its own top level namespace, but we put it
 # in the "impôt" namespace to have a better questions ordering
@@ -364,28 +342,29 @@ impôt . foyer fiscal . revenu imposable:
   formule:
     somme:
       - revenu d'activité abattu
-      - dirigeant . auto-entrepreneur . impôt . revenu imposable
-      - valeur: dirigeant . indépendant . résultat fiscal
-        applicable si: entreprise . imposition . IR
+      - applicable si: entreprise . imposition . IR
+        valeur: dirigeant . rémunération . imposable
       - autres revenus imposables
 
 impôt . foyer fiscal . revenu imposable . revenu d'activité abattu:
-  description: Dans le cas général, l'impôt est calculé après l'application d'un abattement forfaitaire fixe. Chacun peut néanmoins opter pour la déclaration de ses *frais réels*, qui viendront remplacer ce forfait par défaut.
-  formule:
-    valeur [ref assiette]:
-      somme:
-        - contrat salarié . rémunération . net imposable
-        - valeur: dirigeant . indépendant . résultat fiscal
-          applicable si: entreprise . imposition . IS
-    abattement: 
-      valeur: 10% * assiette
-      # A VÉRIFIER: calculé à la main en revalorisant le taux 2020
-      # HISTORIQUE 2020: 12627€
-      # 12627€ × (1 + 0,2%)
-      plafond: 12652 €/an
-      # HISTORIQUE 2020: 441€
-      # 441€ × (1 + 0,2%)
-      plancher: 442 €/an
+  description: |
+    Dans le cas général, l'impôt est calculé après l'application d'un abattement forfaitaire fixe. Chacun peut néanmoins opter pour la déclaration de ses *frais réels*, qui viendront remplacer ce forfait par défaut.
+  valeur:
+    nom: assiette
+    variations:
+      - si: dirigeant = non
+        alors: contrat salarié . rémunération . net imposable
+      - si: entreprise . imposition . IS
+        alors: dirigeant . rémunération . imposable
+  abattement: 
+    valeur: 10% * assiette
+    # A VÉRIFIER: calculé à la main en revalorisant le taux 2020
+    # HISTORIQUE 2020: 12627€
+    # 12627€ × (1 + 0,2%)
+    plafond: 12652 €/an
+    # HISTORIQUE 2020: 441€
+    # 441€ × (1 + 0,2%)
+    plancher: 442 €/an
   références:
     Frais professionnels - forfait ou frais réels: https://www.service-public.fr/particuliers/vosdroits/F1989
 

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1285,9 +1285,6 @@ contrat salarié . rémunération . brut de base:
         - rémunération . net
         - rémunération . net après impôt
         - équivalent temps plein
-        - dirigeant . rémunération totale
-        - entreprise . chiffre d'affaires
-        - entreprise . chiffre d'affaires minimum
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -30,13 +30,13 @@ export default function IndépendantExplanation() {
 				<PLExplanation />
 			</Condition>
 			<AidesCovid aidesRule="dirigeant . indépendant . cotisations et contributions . aides covid 2020" />
-			<Condition expression="revenu net après impôt > 0 €/an">
+			<Condition expression="dirigeant . rémunération . nette après impôt > 0 €/an">
 				<section>
 					<h2>Répartition de la rémunération totale</h2>
 					<StackedBarChart
 						data={[
 							{
-								dottedName: 'revenu net après impôt',
+								dottedName: 'dirigeant . rémunération . nette après impôt',
 								title: t('Revenu disponible'),
 								color: palettes[0][0],
 							},

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -6139,9 +6139,7 @@ entreprise . ACRE:
   question.fr: Votre entreprise bénéficie-t-elle de l'ACRE ?
   titre.en: ACRE
   titre.fr: ACRE
-entreprise . ACRE par défaut:
-  titre.en: '[automatic] default ACRE'
-  titre.fr: ACRE par défaut
+
 entreprise . activité:
   description.en: '[automatic] Your type of activity will determine a large part
     of the contribution, contribution and tax calculations.'

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -6049,7 +6049,7 @@ dirigeant . indépendant . résultat fiscal:
   résumé.fr: Assiette du calcul de l'impôt
   titre.en: fiscal earnings
   titre.fr: résultat fiscal
-dirigeant . rémunération totale:
+dirigeant . rémunération . totale:
   description.en: >-
     This is what the company spends in total for the director income. This
     "super gross" remuneration includes all social security contributions to be

--- a/mon-entreprise/source/pages/Gérer/AideDéclarationIndépendant/index.tsx
+++ b/mon-entreprise/source/pages/Gérer/AideDéclarationIndépendant/index.tsx
@@ -41,13 +41,13 @@ export default function AideDéclarationIndépendant() {
 	const setCurrentIncome = useCallback(
 		(currentIncome) => {
 			dispatch(
-				updateSituation('dirigeant . rémunération totale', currentIncome)
+				updateSituation('dirigeant . rémunération . totale', currentIncome)
 			)
 		},
 		[dispatch, updateSituation]
 	)
 	const displayForm =
-		engine.evaluate('dirigeant . rémunération totale').nodeValue !== null
+		engine.evaluate('dirigeant . rémunération . totale').nodeValue !== null
 
 	return (
 		<div>
@@ -110,7 +110,7 @@ export default function AideDéclarationIndépendant() {
 			</Trans>
 			<BigInput>
 				<RuleInput
-					dottedName="dirigeant . rémunération totale"
+					dottedName="dirigeant . rémunération . totale"
 					onChange={setCurrentIncome}
 					autoFocus
 				/>

--- a/mon-entreprise/source/pages/Simulateurs/configs/dirigeant-sasu.yaml
+++ b/mon-entreprise/source/pages/Simulateurs/configs/dirigeant-sasu.yaml
@@ -11,7 +11,7 @@ objectifs:
     nom: Mon entreprise
     objectifs:
       - entreprise . charges
-      - entreprise . chiffre d'affaires minimum
+      - entreprise . chiffre d'affaires
 
 questions:
   à l'affiche:

--- a/mon-entreprise/source/pages/Simulateurs/configs/indépendant.yaml
+++ b/mon-entreprise/source/pages/Simulateurs/configs/indépendant.yaml
@@ -2,17 +2,17 @@ objectifs:
   - icône: 👩‍💼
     nom: Mon revenu
     objectifs:
-      - dirigeant . rémunération totale
-      - dirigeant . indépendant . cotisations et contributions
-      - dirigeant . indépendant . revenu net de cotisations
-      - dirigeant . indépendant . revenu professionnel
-      - impôt
-      - revenu net après impôt
+      - dirigeant . rémunération . totale
+      - dirigeant . rémunération . cotisations et contributions
+      - dirigeant . rémunération . nette
+      - dirigeant . rémunération . impôt
+      - dirigeant . rémunération . nette après impôt
   - icône: 🏢
     nom: Mon entreprise
     objectifs:
+      - entreprise . chiffre d'affaires
       - entreprise . charges
-      - entreprise . chiffre d'affaires minimum
+      - entreprise . charges . rémunération dirigeant
 
 questions:
   à l'affiche:

--- a/mon-entreprise/source/pages/Simulateurs/configs/rémunération-dirigeant.yaml
+++ b/mon-entreprise/source/pages/Simulateurs/configs/rémunération-dirigeant.yaml
@@ -11,7 +11,7 @@ objectifs:
 
 questions:
   liste:
-    - dirigeant . rémunération totale
+    - dirigeant . rémunération
     - entreprise . charges
     - entreprise . activité
 unité par défaut: €/an

--- a/mon-entreprise/test/cycles.test.js
+++ b/mon-entreprise/test/cycles.test.js
@@ -28,7 +28,7 @@ describe('DottedNames graph', () => {
 
 		// 	Cycle doesn't occur in real life. Will fix in next PR.
 		// ⬇️  entreprise . chiffre d'affaires
-		// ⬇️  dirigeant . rémunération totale
+		// ⬇️  dirigeant . rémunération . totale
 		// ⬇️  entreprise . chiffre d'affaires
 	})
 })

--- a/mon-entreprise/test/regressions/aide-déclaration-indépendants.yaml
+++ b/mon-entreprise/test/regressions/aide-déclaration-indépendants.yaml
@@ -1,83 +1,83 @@
 échelle de revenus:
-  - dirigeant . rémunération totale: 500 €/an
-  - dirigeant . rémunération totale: 1000 €/an
-  - dirigeant . rémunération totale: 1500 €/an
-  - dirigeant . rémunération totale: 2000 €/an
-  - dirigeant . rémunération totale: 5000 €/an
-  - dirigeant . rémunération totale: 10000 €/an
-  - dirigeant . rémunération totale: 100000 €/an
-  - dirigeant . rémunération totale: 1000000 €/an
+  - dirigeant . rémunération . totale: 500 €/an
+  - dirigeant . rémunération . totale: 1000 €/an
+  - dirigeant . rémunération . totale: 1500 €/an
+  - dirigeant . rémunération . totale: 2000 €/an
+  - dirigeant . rémunération . totale: 5000 €/an
+  - dirigeant . rémunération . totale: 10000 €/an
+  - dirigeant . rémunération . totale: 100000 €/an
+  - dirigeant . rémunération . totale: 1000000 €/an
 
 nature de l'activité:
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'artisanale'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'artisanale'"
-    dirigeant . rémunération totale: 5000 €/an
+    dirigeant . rémunération . totale: 5000 €/an
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'commerciale ou industrielle'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'commerciale ou industrielle'"
-    dirigeant . rémunération totale: 5000 €/an
+    dirigeant . rémunération . totale: 5000 €/an
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'libérale'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'libérale'"
-    dirigeant . rémunération totale: 5000 €/an
+    dirigeant . rémunération . totale: 5000 €/an
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'libérale'"
     entreprise . date de création: 06/04/2020
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
     dirigeant . indépendant . PL . régime général . taux spécifique retraite complémentaire: oui
 
 débit de tabac:
   - aide déclaration revenu indépendant 2020 . nature de l'activité: "'commerciale ou industrielle'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
     entreprise . activité . débit de tabac: oui
     dirigeant . indépendant . cotisations et contributions . déduction tabac: 30000 €/an
 
 RSA:
   - situation personnelle . RSA: oui
-    dirigeant . rémunération totale: 500 €/an
+    dirigeant . rémunération . totale: 500 €/an
   - situation personnelle . RSA: oui
-    dirigeant . rémunération totale: 5000 €/an
+    dirigeant . rémunération . totale: 5000 €/an
 
 conjoint collaborateur:
   - dirigeant . indépendant . conjoint collaborateur: oui
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - dirigeant . indépendant . conjoint collaborateur: oui
     dirigeant . indépendant . conjoint collaborateur . assiette: "'revenu sans partage'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - dirigeant . indépendant . conjoint collaborateur: oui
     dirigeant . indépendant . conjoint collaborateur . assiette: "'revenu avec partage'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - dirigeant . indépendant . conjoint collaborateur: oui
     aide déclaration revenu indépendant 2020 . nature de l'activité: "'artisanale'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - dirigeant . indépendant . conjoint collaborateur: oui
     dirigeant . indépendant . conjoint collaborateur . assiette: "'revenu avec partage'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
     dirigeant . indépendant . conjoint collaborateur . assiette . pourcentage: "'moitié'"
 
 IJSS (indemnité sécurité sociale):
   - dirigeant . indépendant . IJSS: oui
     dirigeant . indépendant . IJSS . total: 10000 €/an
     dirigeant . indépendant . IJSS . imposable: 8000 €/an
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
 
 ACRE:
   - aide déclaration revenu indépendant 2020 . ACRE: oui
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - aide déclaration revenu indépendant 2020 . ACRE: oui
-    dirigeant . rémunération totale: 15000 €/an
+    dirigeant . rémunération . totale: 15000 €/an
   - aide déclaration revenu indépendant 2020 . ACRE: oui
-    dirigeant . rémunération totale: 5000 €/an
+    dirigeant . rémunération . totale: 5000 €/an
   - aide déclaration revenu indépendant 2020 . ACRE: oui
     entreprise . date de création: 01/07/2019
-    dirigeant . rémunération totale: 10000 €/an
+    dirigeant . rémunération . totale: 10000 €/an
   - aide déclaration revenu indépendant 2020 . ACRE: oui
     entreprise . date de création: 01/07/2020
-    dirigeant . rémunération totale: 10000 €/an
+    dirigeant . rémunération . totale: 10000 €/an
 
 international:
   - situation personnelle . domiciliation fiscale à l'étranger: oui
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - dirigeant . indépendant . revenus étrangers: oui
     dirigeant . indépendant . revenus étrangers . montant: 30000€/an
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an

--- a/mon-entreprise/test/regressions/simulations-indépendant.yaml
+++ b/mon-entreprise/test/regressions/simulations-indépendant.yaml
@@ -9,15 +9,15 @@
   - dirigeant . indépendant . revenu net de cotisations: 1000000 €/an
 
 inversions:
-  - dirigeant . rémunération totale: 2000 €/an
-  - dirigeant . rémunération totale: 50000 €/an
-  - revenu net après impôt: 10000 €/an
-  - revenu net après impôt: 40000 €/an
-  - revenu net après impôt: 10000 €/an
+  - dirigeant . rémunération . totale: 2000 €/an
+  - dirigeant . rémunération . totale: 50000 €/an
+  - dirigeant . rémunération . nette après impôt: 10000 €/an
+  - dirigeant . rémunération . nette après impôt: 40000 €/an
+  - dirigeant . rémunération . nette après impôt: 10000 €/an
     entreprise . charges: 1000 €/an
-  - entreprise . chiffre d'affaires minimum: 20000 €/an
+  - entreprise . chiffre d'affaires: 20000 €/an
     entreprise . charges: 1000 €/an
-  - entreprise . chiffre d'affaires minimum: 20000 €/an
+  - entreprise . chiffre d'affaires: 20000 €/an
     entreprise . charges: 2000 €/an
 
 cotisations minimales:

--- a/mon-entreprise/test/regressions/simulations-professions-libérales.yaml
+++ b/mon-entreprise/test/regressions/simulations-professions-libérales.yaml
@@ -1,77 +1,77 @@
 médecin:
   - dirigeant . indépendant . PL . métier: "'santé . médecin'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - # Secteur 2 dépassement honoraire
     dirigeant . indépendant . PL . métier: "'santé . médecin'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
     dirigeant . indépendant . PL . métier . secteur médecin: "'S2'"
     dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 20%
   - # Secteur 2 avec dépassement honoraire et grosse rémunération
     dirigeant . indépendant . PL . métier: "'santé . médecin'"
-    dirigeant . rémunération totale: 300000 €/an
+    dirigeant . rémunération . totale: 300000 €/an
     dirigeant . indépendant . PL . métier . secteur médecin: "'S2'"
     dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 50%
   - # Secteur 2 avec grosse rémunération et activité non conventionnée
     dirigeant . indépendant . PL . métier: "'santé . médecin'"
-    dirigeant . rémunération totale: 400000 €/an
+    dirigeant . rémunération . totale: 400000 €/an
     dirigeant . indépendant . PL . métier . secteur médecin: "'S2'"
     dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 50%
     dirigeant . indépendant . PL . PAMC . proportion recette activité non conventionnée: 40%
   - # Non conventionné
     dirigeant . indépendant . PL . métier: "'santé . médecin'"
-    dirigeant . rémunération totale: 120000 €/an
+    dirigeant . rémunération . totale: 120000 €/an
     dirigeant . indépendant . PL . métier . secteur médecin: "'non conventionné'"
   - # < 2 ans exercice
     entreprise . date de création: 01/01/2021
     dirigeant . indépendant . PL . métier: "'santé . médecin'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
 
 sage-femme:
   - dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - # Réduction retraite complémentaire
     dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
-    dirigeant . rémunération totale: 20000 €/an
+    dirigeant . rémunération . totale: 20000 €/an
   - # Exonération RID
     dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
-    dirigeant . rémunération totale: 4000 €/an
+    dirigeant . rémunération . totale: 4000 €/an
   - # Classe A
     dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
-    dirigeant . rémunération totale: 20000 €/an
+    dirigeant . rémunération . totale: 20000 €/an
     dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe: "'A'"
   - # Classe B
     dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
-    dirigeant . rémunération totale: 20000 €/an
+    dirigeant . rémunération . totale: 20000 €/an
     dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe: "'B'"
   - # Classe C
     dirigeant . indépendant . PL . métier: "'santé . sage-femme'"
-    dirigeant . rémunération totale: 20000 €/an
+    dirigeant . rémunération . totale: 20000 €/an
     dirigeant . indépendant . PL . CARCDSF . sage-femme . RID . classe: "'C'"
 
 auxiliaire médical:
   - dirigeant . indépendant . PL . métier: "'santé . auxiliaire médical'"
-    dirigeant . rémunération totale: 30000 €/an
+    dirigeant . rémunération . totale: 30000 €/an
   - # Dépassement honoraire
     dirigeant . indépendant . PL . métier: "'santé . auxiliaire médical'"
-    dirigeant . rémunération totale: 30000 €/an
+    dirigeant . rémunération . totale: 30000 €/an
     dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 20%
   - # Grosse rémunération
     dirigeant . indépendant . PL . métier: "'santé . auxiliaire médical'"
-    dirigeant . rémunération totale: 300000 €/an
+    dirigeant . rémunération . totale: 300000 €/an
     dirigeant . indépendant . PL . PAMC . dépassement d'honoraire moyen: 100%
 
 avocat:
   - dirigeant . indépendant . PL . métier: "'avocat'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
   - dirigeant . indépendant . PL . métier: "'avocat'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
     entreprise . durée d'activité . en fin d'année: 6 ans
 
 expert-comptable:
   - dirigeant . indépendant . PL . métier: "'expert-comptable'"
-    dirigeant . rémunération totale: 20000 €/an
+    dirigeant . rémunération . totale: 20000 €/an
   - dirigeant . indépendant . PL . métier: "'expert-comptable'"
-    dirigeant . rémunération totale: 50000 €/an
+    dirigeant . rémunération . totale: 50000 €/an
 
 CIPAV:
   - dirigeant . indépendant . revenu net de cotisations: 500 €/an

--- a/mon-entreprise/test/regressions/simulations-rémunération-dirigeant.yaml
+++ b/mon-entreprise/test/regressions/simulations-rémunération-dirigeant.yaml
@@ -1,42 +1,42 @@
 échelle de rémunération:
-  - dirigeant . rémunération totale: 100 €/an
-  - dirigeant . rémunération totale: 1000 €/an
-  - dirigeant . rémunération totale: 2000 €/an
-  - dirigeant . rémunération totale: 5000 €/an
-  - dirigeant . rémunération totale: 10000 €/an
-  - dirigeant . rémunération totale: 20000 €/an
-  - dirigeant . rémunération totale: 50000 €/an
-  - dirigeant . rémunération totale: 100000 €/an
+  - dirigeant . rémunération . totale: 100 €/an
+  - dirigeant . rémunération . totale: 1000 €/an
+  - dirigeant . rémunération . totale: 2000 €/an
+  - dirigeant . rémunération . totale: 5000 €/an
+  - dirigeant . rémunération . totale: 10000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
+  - dirigeant . rémunération . totale: 50000 €/an
+  - dirigeant . rémunération . totale: 100000 €/an
 
 avec charges:
-  - dirigeant . rémunération totale: 10000 €/an
+  - dirigeant . rémunération . totale: 10000 €/an
     entreprise . charges: 2000 €/an
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . charges: 15000 €/an
 
 ACRE:
-  - dirigeant . rémunération totale: 10000 €/an
+  - dirigeant . rémunération . totale: 10000 €/an
     entreprise . date de création: 01/01/2021
     entreprise . ACRE: oui
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . date de création: 01/01/2021
     entreprise . ACRE: oui
-  - dirigeant . rémunération totale: 30000 €/an
+  - dirigeant . rémunération . totale: 30000 €/an
     entreprise . date de création: 01/06/2020
     entreprise . ACRE: oui
 
 activités:
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . activité: "'libérale'"
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . activité: "'libérale'"
     entreprise . activité . libérale réglementée: oui
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . activité: "'artisanale'"
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . activité: "'commerciale ou industrielle'"
     entreprise . activité . service ou vente: "'vente'"
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . activité: "'commerciale ou industrielle'"
     entreprise . activité . service ou vente: "'service'"
 
@@ -44,35 +44,35 @@ Contrats Madelin:
   # Cas retraite: la cotisation Madelin est inferieure au plafond => le revenu net de
   # cotisations (résultat comptable) n'est pas affecté car l'assiette des
   # cotisations ne change pas:
-  - dirigeant . rémunération totale: 30000 €/an
+  - dirigeant . rémunération . totale: 30000 €/an
     entreprise . charges: 10000 €/an
     dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 3800 €/an # plafond: 10% PSS donc environ 4100 
   # Cas retraite: la cotisation Madelin est supérieure au plafond => le revenu net de
   # cotisations est affecté car l'assiette des cotisations est plus élevée
-  - dirigeant . rémunération totale: 30000 €/an
+  - dirigeant . rémunération . totale: 30000 €/an
     entreprise . charges: 10000 €/an
     dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 5000 €/an # plafond: 10% PSS donc environ 4100 
   # Cas mutuelle
-  - dirigeant . rémunération totale: 30000 €/an
+  - dirigeant . rémunération . totale: 30000 €/an
     entreprise . charges: 10000 €/an
     dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 1000 €/an
   # Cas global madelin faible
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . charges: 1000 €/an
     dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 200 €/an
     dirigeant . indépendant . contrats madelin . retraite: 300 €/an
   # Cas global madelin grand (plafonds calculés différemment)
-  - dirigeant . rémunération totale: 300000 €/an
+  - dirigeant . rémunération . totale: 300000 €/an
     entreprise . charges: 15000 €/an
     dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 1500 €/an
     dirigeant . indépendant . contrats madelin . retraite: 5000 €/an
   # Cas charges plus faibles que total madelin
-  - dirigeant . rémunération totale: 20000 €/an
+  - dirigeant . rémunération . totale: 20000 €/an
     entreprise . charges: 500 €/an
     dirigeant . indépendant . contrats madelin: oui
     dirigeant . indépendant . contrats madelin . mutuelle: 300 €/an

--- a/publicodes/core/source/AST/index.ts
+++ b/publicodes/core/source/AST/index.ts
@@ -114,6 +114,8 @@ const traverseASTNode: TraverseFunction<NodeKind> = (fn, node) => {
 			return traverseArrayNode(fn, node)
 		case 'durée':
 			return traverseDuréeNode(fn, node)
+		case 'résoudre cycle':
+			return traverseRésoudreCycleNode(fn, node)
 		case 'inversion':
 			return traverseInversionNode(fn, node)
 		case 'operation':
@@ -258,6 +260,17 @@ const traversePlancherNode: TraverseFunction<'plancher'> = (fn, node) => ({
 	explanation: {
 		valeur: fn(node.explanation.valeur),
 		plancher: fn(node.explanation.plancher),
+	},
+})
+
+const traverseRésoudreCycleNode: TraverseFunction<'résoudre cycle'> = (
+	fn,
+	node
+) => ({
+	...node,
+	explanation: {
+		...node.explanation,
+		valeur: fn(node.explanation.valeur),
 	},
 })
 

--- a/publicodes/core/source/AST/types.ts
+++ b/publicodes/core/source/AST/types.ts
@@ -1,24 +1,23 @@
 import { AbattementNode } from '../mecanisms/abattement'
 import { ApplicableSiNode } from '../mecanisms/applicable'
 import { ArrondiNode } from '../mecanisms/arrondi'
-import { OperationNode } from '../mecanisms/operation'
 import { BarèmeNode } from '../mecanisms/barème'
-import { ReferenceNode } from '../reference'
-import { RuleNode } from '../rule'
 import { TouteCesConditionsNode } from '../mecanisms/condition-allof'
 import { UneDeCesConditionsNode } from '../mecanisms/condition-oneof'
 import { DuréeNode } from '../mecanisms/durée'
 import { GrilleNode } from '../mecanisms/grille'
 import { InversionNode } from '../mecanisms/inversion'
 import { MaxNode } from '../mecanisms/max'
-import { PlafondNode } from '../mecanisms/plafond'
 import { MinNode } from '../mecanisms/min'
 import { NonApplicableSiNode } from '../mecanisms/nonApplicable'
+import { PossibilityNode } from '../mecanisms/one-possibility'
+import { OperationNode } from '../mecanisms/operation'
 import { ParDéfautNode } from '../mecanisms/parDéfaut'
+import { PlafondNode } from '../mecanisms/plafond'
 import { PlancherNode } from '../mecanisms/plancher'
 import { ProductNode } from '../mecanisms/product'
 import { RecalculNode } from '../mecanisms/recalcul'
-import { PossibilityNode } from '../mecanisms/one-possibility'
+import { RésoudreCycleNode } from '../mecanisms/résoudre-le-cycle'
 import { SituationNode } from '../mecanisms/situation'
 import { SommeNode } from '../mecanisms/sum'
 import { SynchronisationNode } from '../mecanisms/synchronisation'
@@ -26,7 +25,9 @@ import { TauxProgressifNode } from '../mecanisms/tauxProgressif'
 import { UnitéNode } from '../mecanisms/unité'
 import { VariableTemporelleNode } from '../mecanisms/variableTemporelle'
 import { VariationNode } from '../mecanisms/variations'
+import { ReferenceNode } from '../reference'
 import { ReplacementRule } from '../replacement'
+import { RuleNode } from '../rule'
 import { Temporal } from '../temporal'
 
 export type ConstantNode = {
@@ -57,6 +58,7 @@ export type ASTNode = (
 	| PlancherNode
 	| ProductNode
 	| RecalculNode
+	| RésoudreCycleNode
 	| SituationNode
 	| SommeNode
 	| SynchronisationNode

--- a/publicodes/core/source/mecanisms/inversion.ts
+++ b/publicodes/core/source/mecanisms/inversion.ts
@@ -1,9 +1,9 @@
-import parse from '../parse'
 import { EvaluationFunction } from '..'
 import { ConstantNode, Unit } from '../AST/types'
 import { mergeMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import { convertNodeToUnit } from '../nodeUnits'
+import parse from '../parse'
 import { Context } from '../parsePublicodes'
 import { ReferenceNode } from '../reference'
 import uniroot from '../uniroot'
@@ -139,9 +139,9 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 
 	// // Uncomment to display the two attempts and their result
 	// console.table([{ x: x1, y: y1 }, { x: x2, y: y2 }])
-	// console.log('iteration:', inversionNumberOfIterations)
+	console.log('iteration inversion:', inversionNumberOfIterations)
 	this.cache = originalCache
-	this.parsedSituation = originalSituation
+	// this.parsedSituation = originalSituation
 	return {
 		...node,
 		unit,

--- a/publicodes/core/source/mecanisms/résoudre-le-cycle.ts
+++ b/publicodes/core/source/mecanisms/résoudre-le-cycle.ts
@@ -1,0 +1,109 @@
+import { EvaluationFunction } from '..'
+import { ASTNode, ConstantNode, Unit } from '../AST/types'
+import { registerEvaluationFunction } from '../evaluationFunctions'
+import parse from '../parse'
+import { Context } from '../parsePublicodes'
+import uniroot from '../uniroot'
+import { UnitéNode } from './unité'
+
+export type RésoudreCycleNode = {
+	explanation: {
+		ruleToSolve: string
+		valeur: ASTNode
+	}
+	nodeKind: 'résoudre cycle'
+}
+
+export const evaluateRésoudreCycle: EvaluationFunction<'résoudre cycle'> = function (
+	node
+) {
+	const originalCache = this.cache
+	let inversionNumberOfIterations = 0
+
+	const evaluateWithValue = (
+		n: number,
+		unit: Unit = { numerators: [], denominators: [] }
+	) => {
+		inversionNumberOfIterations++
+		this.resetCache()
+		this.cache._meta = { ...originalCache._meta }
+
+		this.parsedSituation[node.explanation.ruleToSolve] = {
+			unit: unit,
+			nodeKind: 'unité',
+			explanation: {
+				nodeKind: 'constant',
+				nodeValue: n,
+				type: 'number',
+			} as ConstantNode,
+		} as UnitéNode
+		return this.evaluate(node.explanation.valeur)
+	}
+
+	let nodeValue: number | null | undefined = null
+
+	const x0 = -1000000
+	let valeur = evaluateWithValue(x0)
+	const y0 = valeur.nodeValue as number
+	const unit = valeur.unit
+
+	const missingVariables = valeur.missingVariables
+
+	if (y0 !== null) {
+		// The `uniroot` function parameter. It will be called with its `min` and
+		// `max` arguments, so we can use our cached nodes if the function is called
+		// with the already computed x1 or x2.
+		const test = (x: number): number => {
+			if (x === x0) {
+				return y0 - x0
+			}
+			valeur = evaluateWithValue(x, unit)
+			const y = valeur.nodeValue
+			return (y as number) - x
+		}
+
+		const defaultMin = -1_000_000
+		const defaultMax = 100_000_000
+
+		nodeValue = uniroot(test, defaultMin, defaultMax, 0.1, 50, 1)
+	}
+	if (nodeValue === undefined) {
+		nodeValue = null
+		this.cache._meta.inversionFail = true
+	}
+
+	// // Uncomment to display the two attempts and their result
+	// console.table([{ x: x1, y: y1 }, { x: x2, y: y2 }])
+	console.log(
+		'iteration:',
+		inversionNumberOfIterations,
+		originalCache.nodes.size
+	)
+	originalCache.nodes.forEach((v, k) => this.cache.nodes.set(k, v))
+	// delete this.parsedSituation[node.explanation.ruleToSolve]
+	return {
+		...node,
+		unit,
+		nodeValue,
+		explanation: {
+			...node.explanation,
+			valeur,
+			inversionNumberOfIterations,
+		},
+		missingVariables,
+	}
+}
+
+export default function parseRésoudreCycle(v, context: Context) {
+	return {
+		explanation: {
+			ruleToSolve: context.dottedName,
+			valeur: parse(v.valeur, context),
+		},
+		nodeKind: 'résoudre cycle',
+	} as RésoudreCycleNode
+}
+
+parseRésoudreCycle.nom = 'résoudre le cycle'
+
+registerEvaluationFunction('résoudre cycle', evaluateRésoudreCycle)

--- a/publicodes/core/source/parse.ts
+++ b/publicodes/core/source/parse.ts
@@ -22,6 +22,7 @@ import plafond from './mecanisms/plafond'
 import plancher from './mecanisms/plancher'
 import { mecanismProduct } from './mecanisms/product'
 import { mecanismRecalcul } from './mecanisms/recalcul'
+import résoudreCycle from './mecanisms/résoudre-le-cycle'
 import situation from './mecanisms/situation'
 import { mecanismSum } from './mecanisms/sum'
 import { mecanismSynchronisation } from './mecanisms/synchronisation'
@@ -156,6 +157,7 @@ const chainableMecanisms = [
 	plafond,
 	parDéfaut,
 	situation,
+	résoudreCycle,
 	abattement,
 ]
 function parseChainedMecanisms(rawNode, context: Context): ASTNode {

--- a/publicodes/core/test/mécanismes/résoudre-le-cycle.yaml
+++ b/publicodes/core/test/mécanismes/résoudre-le-cycle.yaml
@@ -1,0 +1,18 @@
+fx: 
+x:
+  résoudre le cycle: oui
+  valeur: fx
+  exemples:
+    - nom: affine
+      situation: 
+        fx: 200 - x 
+      valeur attendue: 100
+    - nom: quadratique
+      situation: 
+        fx: x * x - 4 * x + 5
+      valeur attendue: 0.011 #Not 0 because of the tolerance of uniroot function
+
+résoudre cycle dans remplacement:
+  remplace: 
+    règle: fx
+    par: fx / 2 + 5

--- a/publicodes/ui-react/source/Explanation.tsx
+++ b/publicodes/ui-react/source/Explanation.tsx
@@ -1,8 +1,10 @@
-import { ConstantNode, Leaf } from './mecanisms/common'
+import { useContext } from 'react'
+import { EngineContext } from './contexts'
 import Abattement from './mecanisms/Abattement'
 import ApplicableSi from './mecanisms/Applicable'
 import Arrondi from './mecanisms/Arrondi'
 import Barème from './mecanisms/Barème'
+import { ConstantNode, Leaf } from './mecanisms/common'
 import Composantes from './mecanisms/Composantes'
 import Durée from './mecanisms/Durée'
 import Grille from './mecanisms/Grille'
@@ -19,6 +21,7 @@ import Recalcul from './mecanisms/Recalcul'
 import Replacement from './mecanisms/Replacement'
 import ReplacementRule from './mecanisms/ReplacementRule'
 import Rule from './mecanisms/Rule'
+import RésoudreCycle from './mecanisms/RésoudreCycle'
 import Situation from './mecanisms/Situation'
 import Somme from './mecanisms/Somme'
 import Synchronisation from './mecanisms/Synchronisation'
@@ -28,8 +31,6 @@ import UneDeCesConditions from './mecanisms/UneDeCesConditions'
 import UnePossibilité from './mecanisms/UnePossibilité'
 import Unité from './mecanisms/Unité'
 import Variations from './mecanisms/Variations'
-import { useContext } from 'react'
-import { EngineContext } from './contexts'
 
 const UIComponents = {
 	constant: ConstantNode,
@@ -61,6 +62,7 @@ const UIComponents = {
 	'toutes ces conditions': ToutesCesConditions,
 	'une de ces conditions': UneDeCesConditions,
 	'une possibilité': UnePossibilité,
+	'résoudre cycle': RésoudreCycle,
 	unité: Unité,
 	'variable temporelle': () => '[variable temporelle]',
 	variations: Variations,

--- a/publicodes/ui-react/source/mecanisms/RésoudreCycle.tsx
+++ b/publicodes/ui-react/source/mecanisms/RésoudreCycle.tsx
@@ -1,0 +1,16 @@
+import Explanation from '../Explanation'
+import { Mecanism } from './common'
+
+export default function MecanismRésoudreCycle({ explanation }) {
+	return (
+		<Mecanism name="résoudre le cycle" value={explanation.valeur}>
+			<p>
+				{' '}
+				Cette valeur a été retrouvé en résolvant le cycle dans la formule ci
+				dessous :{' '}
+			</p>
+
+			<Explanation node={explanation.valeur} />
+		</Mecanism>
+	)
+}


### PR DESCRIPTION
### Principes
1. Unifier les règles pour les différentes forme juridique / sociale
2. Se rapprocher au plus près des définitions comptables / juridique
3. Remettre les calculs dans le bon sens (revenu pro / total en fonction du CA et non l'inverse)
4. Implémenter correctement IS / IR
5. Revoir la présentation des formulaire indépendant et dirigeant SASU pour refléter la différence IS / IR 
6. (objectif secondaire) Enlever les référence à l'entreprise dans contrat salarié

### Nouveautés publicodes : 
- [x] Un mécanisme `résoudre le cycle` qui permet de calculer les formules avec un cycle identifié : https://github.com/betagouv/mon-entreprise/pull/1459/files#diff-46222c63c481f4721e3e3da23f265c061a92149e22902b707e55dc92a6480871R618-R623
- [ ] Une détection de cycle au runtime afin d'éviter les "too much recursion" un peu cryptique
- [ ] La possibilité de définir des inversions avec des valeurs calculée (?) -> Un peu flou à réflechir encore