### PR TITLE
MAJ aides à l'embauche

### DIFF
--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1986,12 +1986,19 @@ contrat salarié . aides employeur:
     Le simulateur n'intègre pas toutes les innombrables aides disponibles en France. Découvrez-les sur le [portail officiel](http://www.aides-entreprises.fr).
   formule:
     somme:
+      - aides à l'embauche
+      - activité partielle . indemnisation entreprise
+
+contrat salarié . aides employeur . aides à l'embauche:
+  description: |
+    L'État met en place des aides pour encourager l'embauche de certains publics prioritaires. Ces aides sont non cumulables entre elles.
+  formule:
+    le maximum de:
       - aide à l'embauche d'apprentis
       - aide exceptionnelle à l'embauche d'apprentis
       - aide exceptionnelle à l'embauche des jeunes
       - aide à l'embauche senior professionnalisation
       - aide à l'embauche des travailleurs handicapés
-      - activité partielle . indemnisation entreprise
       - emploi franc
 
 contrat salarié . aides employeur . aide à l'embauche d'apprentis:
@@ -2064,6 +2071,9 @@ contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeune
       - nom: jeune de moins de 26 ans
         question: Le salarié a-t-il moins de 26 ans ?
         par défaut: non
+  rend non applicable:
+    # Dispositifs moins généreux et non cumulables
+    - aide à l'embauche des travailleurs handicapés
   formule:
     produit:
       assiette: 4000 €/an
@@ -2101,13 +2111,13 @@ contrat salarié . aides employeur . emploi franc:
     multiplication:
       assiette:
         variations:
-          - nom: emploi franc+
-            si:
+          - si:
               toutes ces conditions:
                 - ancienneté . date d'embauche >= 15/10/2020
                 - ancienneté . date d'embauche <= 31/05/2021
                 - contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeunes . jeune de moins de 26 ans
             alors:
+              nom: emploi franc plus
               variations:
                 - si: CDD
                   alors: 5500 €/an
@@ -2119,6 +2129,9 @@ contrat salarié . aides employeur . emploi franc:
                 - sinon: 5000 €/an
       facteur: temps de travail . quotité de travail effective
     arrondi: oui
+  rend non applicable:
+    # Dispositifs moins généreux et non cumulables
+    - aide à l'embauche des travailleurs handicapés
   références:
     Fiche emploi franc: https://travail-emploi.gouv.fr/emploi/emplois-francs/article/embaucher-une-personne-en-emploi-franc
 

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1990,6 +1990,7 @@ contrat salarié . aides employeur:
       - aide exceptionnelle à l'embauche d'apprentis
       - aide exceptionnelle à l'embauche des jeunes
       - aide à l'embauche senior professionnalisation
+      - aide à l'embauche des travailleurs handicapés
       - activité partielle . indemnisation entreprise
       - emploi franc
 
@@ -2053,7 +2054,7 @@ contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeune
   applicable si:
     toutes ces conditions:
       - ancienneté . date d'embauche >= 01/08/2020
-      - ancienneté . date d'embauche <= 31/03/2021
+      - ancienneté . date d'embauche <= 31/05/2021
       - rémunération . brut de base <= 2 * SMIC
       - une de ces conditions:
           - CDI
@@ -2145,6 +2146,33 @@ contrat salarié . temps de travail:
       - heures supplémentaires
       - heures complémentaires
   description: En France, la base légale du travail est de 35h/semaine. Mais un grand nombre de dispositions existantes permettent de faire varier ce nombre. Vous pouvez les retrouver sur la page [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/N458) dédiée.
+
+contrat salarié . aides employeur . aide à l'embauche des travailleurs handicapés:
+  non applicable si: aides employeur . emploi franc
+  description: >-
+    Dans le cadre du plan de relance, le gouvernement a décidé de créer une aide
+    à l’embauche visant à favoriser l’emploi des personnes en situation de
+    handicap quel que soit leur âge.
+  applicable si:
+    toutes ces conditions:
+      - nom: situation de handicap
+        question: Le salarié a-t'il la reconnaissance de travailleur handicapé (RQTH) ?
+        par défaut: non
+      - ancienneté . date d'embauche >= 01/09/2020
+      - ancienneté . date d'embauche <= 30/06/2021
+      - rémunération . brut de base <= 2 * SMIC
+      - une de ces conditions:
+          - CDI
+          - toutes ces conditions:
+              - CDD
+              - CDD . durée contrat >= 3 mois
+  formule:
+    produit:
+      assiette: 4000 €/an
+      facteur: temps de travail . quotité de travail effective
+    arrondi: oui
+  références:
+    Plan \#1jeune1solution: https://travail-emploi.gouv.fr/le-ministere-en-action/relance-activite/plan-1jeune-1solution/aide-embauche-jeunes
 
 contrat salarié . temps de travail . temps effectif:
   formule:

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -2029,7 +2029,7 @@ contrat salarié . aides employeur . aide exceptionnelle à l'embauche d'apprent
           - apprentissage
           - professionnalisation . jeune de moins de 30 ans
       - ancienneté . date d'embauche >= 01/07/2020
-      - ancienneté . date d'embauche <= 28/02/2021
+      - ancienneté . date d'embauche <= 31/12/2021
       - temps de travail . temps effectif > 0 heures/mois
   formule:
     variations:
@@ -2094,19 +2094,18 @@ contrat salarié . aides employeur . emploi franc:
     - *embauche en CDI* : 5000€/an pendant 3 ans, soit un total de 15 000€
     - *embauche en CDD d'au moins 6 mois* : 2 500€/an pendant 2 ans, soit 5 000€ au maximum
 
-    > Dans le cadre du plan "France Relance", le dispositif est revalorisé pour
-    une embauche jusqu'au 31 janvier 2021.
-
     [🗺 Vérifier l'éligibilité d'une adresse](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
   applicable si: éligible
   formule:
     multiplication:
       assiette:
         variations:
-          - si:
+          - nom: emploi franc+
+            si:
               toutes ces conditions:
                 - ancienneté . date d'embauche >= 15/10/2020
-                - ancienneté . date d'embauche <= 31/03/2021
+                - ancienneté . date d'embauche <= 31/05/2021
+                - contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeunes . jeune de moins de 26 ans
             alors:
               variations:
                 - si: CDD

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -1254,6 +1254,15 @@ contrat salarié . aides employeur . aide à l'embauche d'apprentis:
     demandeur d'emploi de plus de 45 ans en contrat de professionnalisation.
   titre.en: '[automatic] senior professionalization hiring assistance'
   titre.fr: aide à l'embauche senior professionnalisation
+contrat salarié . aides employeur . aides à l'embauche:
+  description.en: >
+    [automatic] The State provides aid to encourage the hiring of certain
+    priority groups. This aid cannot be combined with other aid.
+  description.fr: >
+    L'État met en place des aides pour encourager l'embauche de certains publics
+    prioritaires. Ces aides sont non cumulables entre elles.
+  titre.en: '[automatic] hiring aids'
+  titre.fr: aides à l'embauche
 contrat salarié . aides employeur . emploi franc:
   description.en: >
     [automatic] Deferred aid paid by Pôle emploi for the hiring of a job seeker

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -1236,6 +1236,15 @@ contrat salarié . aides employeur . aide à l'embauche d'apprentis:
     Une fois les démarches d'enregistrement effectuées, l'aide est versée automatiquement tous les mois.
   titre.en: aid to hire apprentices
   titre.fr: aide à l'embauche d'apprentis
+? contrat salarié . aides employeur . aide à l'embauche des travailleurs handicapés
+: description.en: '[automatic] As part of the recovery plan, the government has
+    decided to create a recruitment aid aimed at encouraging the employment of
+    people with disabilities, regardless of their age.'
+  description.fr: Dans le cadre du plan de relance, le gouvernement a décidé de
+    créer une aide à l’embauche visant à favoriser l’emploi des personnes en
+    situation de handicap quel que soit leur âge.
+  titre.en: '[automatic] aid for the recruitment of disabled workers'
+  titre.fr: aide à l'embauche des travailleurs handicapés
 ? contrat salarié . aides employeur . aide à l'embauche senior professionnalisation
 : description.en: |
     [automatic] Employers can get €2,000 for the hiring of an

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -1247,24 +1247,19 @@ contrat salarié . aides employeur . aide à l'embauche d'apprentis:
   titre.fr: aide à l'embauche senior professionnalisation
 contrat salarié . aides employeur . emploi franc:
   description.en: >
-    [automatic] Deferred assistance paid by Pôle emploi for hiring a job seeker
+    [automatic] Deferred aid paid by Pôle emploi for the hiring of a job seeker
 
-    registered with Pôle Emploi and living in a priority district of the city
+    registered with Pôle Emploi and residing in a priority neighbourhood of the city
 
     (QPV).
 
 
-    - *Hiring on permanent contracts*: €5,000/year for 3 years, i.e. a total of €15,000
+    - Hiring on a permanent contract*: €5000/year for 3 years, i.e. a total of €15,000
 
-    - * hiring on a fixed-term contract of at least 6 months*: 2,500€/year for 2 years, i.e. 5,000€ maximum
-
-
-    &gt; As part of the "France Relance" plan, the scheme is being upgraded to
-
-    hiring until January 31, 2021.
+    - Hiring on a fixed-term contract of at least 6 months*: €2,500/year for 2 years, i.e. a maximum of €5,000
 
 
-    [🗺 Check address eligibility](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
+    [🗺 Check the eligibility of an address](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
   description.fr: >
     Aide différée versée par Pôle emploi pour l'embauche d'un demandeur d'emploi
 
@@ -1276,11 +1271,6 @@ contrat salarié . aides employeur . emploi franc:
     - *embauche en CDI* : 5000€/an pendant 3 ans, soit un total de 15 000€
 
     - *embauche en CDD d'au moins 6 mois* : 2 500€/an pendant 2 ans, soit 5 000€ au maximum
-
-
-    > Dans le cadre du plan "France Relance", le dispositif est revalorisé pour
-
-    une embauche jusqu'au 31 janvier 2021.
 
 
     [🗺 Vérifier l'éligibilité d'une adresse](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -1003,6 +1003,8 @@ pages:
         emploi franc: For the hiring of a young person from a priority district of the
           city (QPV). The aid can be up to €17,000 over three years.<1></1>The
           aid is paid every <3>6 months</3> by Pôle Emploi.
+        handicapé: For the recruitment of a disabled worker.<1></1>The aid is paid
+          <3>quarterly</3> by the Agence de services et de paiement (ASP).
         jeune: For the hiring of a young person under the age of 26 on a permanent
           contract or for a fixed-term contract of at least 3 months.<1></1>The
           aid is paid <3>quarterly</3> by the Services and Payment Agency (ASP).

--- a/mon-entreprise/source/pages/Simulateurs/AidesEmbauche.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AidesEmbauche.tsx
@@ -88,6 +88,25 @@ const aides = [
 		),
 	},
 	{
+		title: 'Travailleur handicapé',
+		dottedName:
+			"contrat salarié . aides employeur . aide à l'embauche des travailleurs handicapés",
+		situation: {
+			"contrat salarié . aides employeur . aide à l'embauche des travailleurs handicapés . situation de handicap":
+				'oui',
+		},
+		dateFin: new Date('2021/06/30'),
+		versement: <Trans>trimestriel</Trans>,
+		description: (
+			<Trans i18nKey="pages.simulateurs.aides-embauche.aides.handicapé">
+				Pour l’embauche d’un travailleur en situation de handicap.
+				<br />
+				L’aide est versée <strong>trimestriellement</strong> par l’Agence de
+				services et de paiement (ASP).
+			</Trans>
+		),
+	},
+	{
 		title: "Demandeur d'emploi de 45 ans ou plus",
 		dottedName:
 			"contrat salarié . aides employeur . aide à l'embauche senior professionnalisation",
@@ -133,6 +152,7 @@ const config = {
 			'contrat salarié . temps de travail . heures complémentaires',
 			'contrat salarié . rémunération',
 			'contrat salarié . aides employeur . emploi franc . éligible',
+			"contrat salarié . aides employeur . aide à l'embauche des travailleurs handicapés . situation de handicap",
 			'contrat salarié . professionnalisation . jeune de moins de 30 ans',
 			'contrat salarié . professionnalisation . salarié de 45 ans et plus',
 		],

--- a/mon-entreprise/source/pages/Simulateurs/AidesEmbauche.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AidesEmbauche.tsx
@@ -38,7 +38,7 @@ const aides = [
 			'contrat salarié . professionnalisation . jeune de moins de 30 ans':
 				'oui',
 		},
-		dateFin: new Date('2020/02/28'),
+		dateFin: new Date('2021/12/31'),
 		versement: <Trans>mensuel</Trans>,
 		description: (
 			<Trans i18nKey="pages.simulateurs.aides-embauche.aides.apprenti">
@@ -58,7 +58,7 @@ const aides = [
 			"contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeunes . jeune de moins de 26 ans":
 				'oui',
 		},
-		dateFin: new Date('2020/03/31'),
+		dateFin: new Date('2021/05/31'),
 		versement: <Trans>trimestriel</Trans>,
 		description: (
 			<Trans i18nKey="pages.simulateurs.aides-embauche.aides.jeune">
@@ -76,7 +76,7 @@ const aides = [
 		situation: {
 			'contrat salarié . aides employeur . emploi franc . éligible': 'oui',
 		},
-		dateFin: new Date('2020/03/31'),
+		dateFin: new Date('2021/05/31'),
 		versement: <Trans>tous les 6 mois</Trans>,
 		description: (
 			<Trans i18nKey="pages.simulateurs.aides-embauche.aides.emploi franc">
@@ -210,13 +210,16 @@ function Results() {
 	const baseEngine = useEngine()
 	const aidesEngines = aides.map((aide) => {
 		const engine = new Engine(baseEngine.parsedRules)
+		engine.setSituation({ ...aide.situation, ...baseEngine.parsedSituation })
+		const isActive =
+			typeof engine.evaluate(aide.dottedName).nodeValue === 'number'
 		const situation = { ...baseEngine.parsedSituation, ...aide.situation }
-		engine.setSituation(situation)
-		return { ...aide, situation, engine }
+		return { ...aide, situation, isActive }
 	})
-	const [aidesActives, aidesInactives] = partition(({ dottedName, engine }) => {
-		return typeof engine.evaluate(dottedName).nodeValue === 'number'
-	}, aidesEngines)
+	const [aidesActives, aidesInactives] = partition(
+		({ isActive }) => isActive,
+		aidesEngines
+	)
 
 	return progress === 0 ? (
 		<>

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -597,6 +597,8 @@ Notifications affichées : contrat salarié . CDD . information"
 
 exports[`calculate simulations-salarié: aides 5`] = `"[1883,0,2000,1561,1527]"`;
 
+exports[`calculate simulations-salarié: aides 6`] = `"[2133,0,2000,1561,1527]"`;
+
 exports[`calculate simulations-salarié: aides embauche covid 1`] = `
 "[1237,0,1500,1165,1165]
 Notifications affichées : contrat salarié . rémunération . contrôle smic"

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -113,6 +113,7 @@ aides:
   - contrat salarié . rémunération . brut de base: 2000 €/mois
     contrat salarié . aides employeur . emploi franc . éligible: oui
     contrat salarié . ancienneté . date d'embauche: 01/11/2020
+    contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeunes . jeune de moins de 26 ans: oui
 
 aides embauche covid:
   - contrat salarié . ancienneté . date d'embauche: 01/08/2020

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -114,6 +114,11 @@ aides:
     contrat salarié . aides employeur . emploi franc . éligible: oui
     contrat salarié . ancienneté . date d'embauche: 01/11/2020
     contrat salarié . aides employeur . aide exceptionnelle à l'embauche des jeunes . jeune de moins de 26 ans: oui
+  # travailleur handicapé
+  - contrat salarié . rémunération . brut de base: 2000 €/mois
+    contrat salarié . ancienneté . date d'embauche: 01/03/2021
+    contrat salarié . aides employeur . aide à l'embauche des travailleurs handicapés . situation de handicap: oui
+
 
 aides embauche covid:
   - contrat salarié . ancienneté . date d'embauche: 01/08/2020


### PR DESCRIPTION
Prolongement des aides suivantes :
- jeune de -26 ans
- apprenti ou contrat pro -30 ans
- emploi-franc+

Ajout de l'aide pour les travailleurs handicapés, fix #1183