### PR TITLE
 Permettre d'explorer le recalcul dans la documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,4 @@ trim_trailing_whitespace = false
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 4
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
 	"cSpell.words": [
 		"mycompanyinfrance",
 		"smarttag"
-	]
+	],
+	"search.exclude": {
+		"**/dist": true
+	}
 }

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -942,6 +942,7 @@ dirigeant . indépendant . cotisations et contributions . début activité:
     règle: cotisations et contributions
     avec: 
       assiette des cotisations: assiette forfaitaire
+      assiette des cotisations . sans plancher: assiette forfaitaire
       situation personnelle . RSA: non
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/independant/mes-cotisations/les-etapes-de-calcul/le-mode-de-calcul/lajustement-et-la-regularisation.html

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -942,6 +942,7 @@ dirigeant . indépendant . cotisations et contributions . début activité:
     règle: cotisations et contributions
     avec: 
       assiette des cotisations: assiette forfaitaire
+      situation personnelle . RSA: non
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/independant/mes-cotisations/les-etapes-de-calcul/le-mode-de-calcul/lajustement-et-la-regularisation.html
 

--- a/mon-entreprise/source/components/ui/Card.css
+++ b/mon-entreprise/source/components/ui/Card.css
@@ -68,7 +68,8 @@
 }
 .ui__.card.plain small,
 .ui__.card.plain .notice {
-	color: rgba(255, 255, 255, 0.8);
+	opacity: 0.9;
+	color: white;
 }
 
 .ui__.card.plain .targetInput {

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -96,6 +96,7 @@ span.ui__.enumeration:not(:last-of-type)::after {
 	font-size: 85%;
 	line-height: initial;
 	padding: 0.4rem 0.6rem;
+	white-space: nowrap;
 	font-weight: bold;
 	color: white !important;
 	background: var(--darkColor);

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -205,78 +205,78 @@ exports[`calculate simulations-impot-société: prorata temporis 3`] = `
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 1`] = `"[30000,13180,16820,17883,232,16588,0,30000]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 1`] = `"[30000,13180,16820,17883,232,16588,0,30000,7072]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,14380,15620,17883,232,15388,0,30000]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,14380,15620,17883,232,15388,0,30000,8272]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10379,19621,20433,593,19028,0,30000]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10379,19621,20433,593,19028,0,30000,4272]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6730,13270,13810,0,13270,0,20000]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6730,13270,13810,0,13270,0,20000,3772]"`;
 
 exports[`calculate simulations-indépendant: Contrats Madelin 5`] = `
-"[300000,79622,220378,228521,75412,144966,0,300000]
+"[300000,79622,220378,228521,75412,144966,0,300000,9772]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-indépendant: acre 1`] = `"[73023,23023,50000,51980,8213,41787,0,73023]"`;
+exports[`calculate simulations-indépendant: acre 1`] = `"[73023,23023,50000,51980,8213,41787,0,73023,3272]"`;
 
-exports[`calculate simulations-indépendant: activité 1`] = `"[29084,9084,20000,20787,603,19397,0,29084]"`;
+exports[`calculate simulations-indépendant: activité 1`] = `"[29084,9084,20000,20787,603,19397,0,29084,3272]"`;
 
-exports[`calculate simulations-indépendant: activité 2`] = `"[29100,9100,20000,20787,603,19397,0,29100]"`;
+exports[`calculate simulations-indépendant: activité 2`] = `"[29100,9100,20000,20787,603,19397,0,29100,3288]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1372,1272,100,134,0,100,0,1372]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1372,1272,100,134,0,100,0,1372,3272]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[246,146,100,104,0,100,0,246]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[246,146,100,104,0,100,0,246,3272]"`;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 1`] = `
-"[100000,30104,69896,72608,12997,56899,0,100000]
+"[100000,30104,69896,72608,12997,56899,0,100000,3272]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 2`] = `
-"[100000,30104,69896,72608,15122,54774,0,100000]
+"[100000,30104,69896,72608,15122,54774,0,100000,3272]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
 `;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29084,9084,20000,20787,603,19397,0,29084]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29084,9084,20000,20787,603,19397,0,29084,3272]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73023,23023,50000,51980,8213,41787,0,73023]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73023,23023,50000,51980,8213,41787,0,73023,3272]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29084,9084,20000,20787,2079,17921,0,29084]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29084,9084,20000,20787,2079,17921,0,29084,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1385,615,667,0,615,0,2000]"`;
+exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1385,615,667,0,615,0,2000,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35353,3500,30497,0,50000]"`;
+exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35353,3500,30497,0,50000,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
+exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 4`] = `"[69938,22076,47862,49758,7862,40000,0,69938]"`;
+exports[`calculate simulations-indépendant: inversions 4`] = `"[69938,22076,47862,49758,7862,40000,0,69938,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596]"`;
+exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5927,13073,13585,0,13073,1000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5927,13073,13585,0,13073,1000,20000,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5624,12376,12861,0,12376,2000,20000]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5624,12376,12861,0,12376,2000,20000,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1859,1359,500,548,0,500,0,1859]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1859,1359,500,548,0,500,0,1859,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2466,1466,1000,1064,0,1000,0,2466]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2466,1466,1000,1064,0,1000,0,2466,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3075,1575,1500,1581,0,1500,0,3075]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3075,1575,1500,1581,0,1500,0,3075,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3682,1682,2000,2097,0,2000,0,3682]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3682,1682,2000,2097,0,2000,0,3682,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7427,2427,5000,5199,0,5000,0,7427]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7427,2427,5000,5199,0,5000,0,7427,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14596,4596,10000,10394,0,10000,0,14596]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14596,4596,10000,10394,0,10000,0,14596,3272]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `
-"[139593,39593,100000,103788,24909,75091,0,139593]
+"[139593,39593,100000,103788,24909,75091,0,139593,3272]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate simulations-indépendant: échelle de revenus 8`] = `
-"[1239954,239954,1000000,1033666,444476,555524,0,1239954]
+"[1239954,239954,1000000,1033666,444476,555524,0,1239954,3272]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 

--- a/mon-entreprise/test/regressions/simulations.jest.js
+++ b/mon-entreprise/test/regressions/simulations.jest.js
@@ -78,6 +78,7 @@ it('calculate simulations-indépendant', () => {
 		'dirigeant . rémunération . nette après impôt',
 		'entreprise . charges',
 		"entreprise . chiffre d'affaires",
+		'dirigeant . indépendant . cotisations et contributions . début activité',
 	]
 	runSimulations(independentSituations, targets, independantConfig.situation)
 })

--- a/publicodes/core/source/mecanisms/recalcul.ts
+++ b/publicodes/core/source/mecanisms/recalcul.ts
@@ -1,4 +1,4 @@
-import { EvaluationFunction } from '..'
+import Engine, { EvaluationFunction } from '..'
 import { ASTNode, EvaluatedNode } from '../AST/types'
 import { defaultNode } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
@@ -11,6 +11,7 @@ export type RecalculNode = {
 	explanation: {
 		recalcul: ASTNode
 		amendedSituation: Array<[ReferenceNode, ASTNode]>
+		parsedSituation?: Engine['parsedSituation']
 	}
 	nodeKind: 'recalcul'
 }
@@ -46,6 +47,7 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 				),
 		  })
 		: this
+
 	engine.cache._meta.inRecalcul = true
 	const evaluatedNode = engine.evaluate(node.explanation.recalcul)
 	engine.cache._meta.inRecalcul = false
@@ -55,7 +57,9 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 		nodeValue: evaluatedNode.nodeValue,
 		explanation: {
 			recalcul: evaluatedNode,
+			engine,
 			amendedSituation,
+			parsedSituation: engine.parsedSituation,
 		},
 		missingVariables: evaluatedNode.missingVariables,
 		...('unit' in evaluatedNode && { unit: evaluatedNode.unit }),

--- a/publicodes/ui-react/source/RuleLink.tsx
+++ b/publicodes/ui-react/source/RuleLink.tsx
@@ -1,8 +1,12 @@
+import Engine, { utils } from 'publicodes'
 import React, { useContext } from 'react'
 import emoji from 'react-easy-emoji'
-import { Link } from 'react-router-dom'
-import Engine, { utils } from 'publicodes'
-import { BasepathContext, EngineContext } from './contexts'
+import { Link, useLocation } from 'react-router-dom'
+import {
+	BasepathContext,
+	EngineContext,
+	SituationMetaContext,
+} from './contexts'
 
 const { encodeRuleName } = utils
 
@@ -14,6 +18,7 @@ type RuleLinkProps<Name extends string> = Omit<
 	engine: Engine<Name>
 	documentationPath: string
 	displayIcon?: boolean
+	situationName?: string
 	children?: React.ReactNode
 }
 
@@ -21,6 +26,7 @@ export function RuleLink<Name extends string>({
 	dottedName,
 	engine,
 	documentationPath,
+	situationName,
 	displayIcon = false,
 	children,
 	...props
@@ -46,7 +52,16 @@ export function RuleLink<Name extends string>({
 		throw new Error(`Unknown rule: ${dottedName}`)
 	}
 	return (
-		<Link to={newPath} {...props}>
+		<Link
+			to={{
+				pathname: newPath,
+				state: {
+					situation: engine.parsedSituation,
+					situationName,
+				},
+			}}
+			{...props}
+		>
 			{children || rule.title}{' '}
 			{displayIcon && rule.rawNode.icônes && (
 				<span>{emoji(rule.rawNode.icônes)} </span>
@@ -63,11 +78,14 @@ export function RuleLinkWithContext(
 		throw new Error('an engine should be provided in context')
 	}
 	const documentationPath = useContext(BasepathContext)
-
+	const { state } = useLocation<{ situationName?: string } | undefined>()
+	const situationName =
+		useContext(SituationMetaContext)?.name ?? state?.situationName
 	return (
 		<RuleLink
 			engine={engine}
 			documentationPath={documentationPath}
+			situationName={situationName}
 			{...props}
 		/>
 	)

--- a/publicodes/ui-react/source/contexts.tsx
+++ b/publicodes/ui-react/source/contexts.tsx
@@ -1,6 +1,12 @@
-import { createContext } from 'react'
 import Engine from 'publicodes'
+import { createContext } from 'react'
 
 export const BasepathContext = createContext<string>('/documentation')
+export const SituationMetaContext = createContext<{ name: string } | undefined>(
+	undefined
+)
 export const EngineContext = createContext<Engine<string> | null>(null)
+export const RegisterEngineContext = createContext<(engine: Engine) => void>(
+	() => {}
+)
 export const ReferencesImagesContext = createContext<Record<string, string>>({})

--- a/publicodes/ui-react/source/index.tsx
+++ b/publicodes/ui-react/source/index.tsx
@@ -1,14 +1,15 @@
 import Engine, { utils } from 'publicodes'
-import { Route } from 'react-router-dom'
+import { useCallback, useRef } from 'react'
+import { Route, useLocation } from 'react-router-dom'
 import {
 	BasepathContext,
 	EngineContext,
 	ReferencesImagesContext,
+	RegisterEngineContext,
 } from './contexts'
 import References from './rule/References'
 import RulePage from './rule/RulePage'
 const { decodeRuleName, encodeRuleName } = utils
-
 export { default as Explanation } from './Explanation'
 export { RuleLink } from './RuleLink'
 export { References }
@@ -20,30 +21,73 @@ type DocumentationProps = {
 	referenceImages?: Record<string, string>
 }
 
+function useCacheEngineBySituation(
+	defaultEngine: Engine,
+	currentSituation?: Engine['parsedSituation']
+) {
+	const registeredEngines = useRef(
+		new WeakMap().set(
+			defaultEngine.parsedSituation,
+			defaultEngine.shallowCopy()
+		)
+	)
+	const registerEngine = useCallback(
+		(engine: Engine) =>
+			registeredEngines.current.set(
+				engine.parsedSituation,
+				engine.shallowCopy()
+			),
+		[registeredEngines]
+	)
+	if (currentSituation && !registeredEngines.current.has(currentSituation)) {
+		registeredEngines.current.set(
+			currentSituation,
+			defaultEngine.shallowCopy().setSituation(currentSituation)
+		)
+	}
+	const engine = currentSituation
+		? registeredEngines.current.get(currentSituation)
+		: defaultEngine
+	return [engine, registerEngine]
+}
+
 export function Documentation({
 	documentationPath,
-	engine,
+	engine: defaultEngine,
 	referenceImages = {},
 }: DocumentationProps) {
+	const { state } = useLocation<
+		| {
+				situation?: Engine['parsedSituation']
+				situationName?: string
+		  }
+		| undefined
+	>()
+	const [engine, cacheEngine] = useCacheEngineBySituation(
+		defaultEngine,
+		state?.situation
+	)
 	return (
-		<EngineContext.Provider value={engine}>
-			<BasepathContext.Provider value={documentationPath}>
-				<ReferencesImagesContext.Provider value={referenceImages}>
-					<Route
-						path={documentationPath + '/:name+'}
-						render={({ match }) => {
-							return (
-								<RulePage
-									dottedName={decodeRuleName(match.params.name)}
-									engine={engine}
-									language={'fr'}
-								/>
-							)
-						}}
-					/>
-				</ReferencesImagesContext.Provider>
-			</BasepathContext.Provider>
-		</EngineContext.Provider>
+		<RegisterEngineContext.Provider value={cacheEngine}>
+			<EngineContext.Provider value={engine}>
+				<BasepathContext.Provider value={documentationPath}>
+					<ReferencesImagesContext.Provider value={referenceImages}>
+						<Route
+							path={documentationPath + '/:name+'}
+							render={({ match }) => {
+								return (
+									<RulePage
+										situationName={state?.situationName}
+										dottedName={decodeRuleName(match.params.name)}
+										language={'fr'}
+									/>
+								)
+							}}
+						/>
+					</ReferencesImagesContext.Provider>
+				</BasepathContext.Provider>
+			</EngineContext.Provider>
+		</RegisterEngineContext.Provider>
 	)
 }
 

--- a/publicodes/ui-react/source/mecanisms/Recalcul.tsx
+++ b/publicodes/ui-react/source/mecanisms/Recalcul.tsx
@@ -1,16 +1,36 @@
+import { useContext } from 'react'
+import {
+	EngineContext,
+	RegisterEngineContext,
+	SituationMetaContext,
+} from '../contexts'
 import Explanation from '../Explanation'
 import { RuleLinkWithContext } from '../RuleLink'
 import { Mecanism } from './common'
 
 export default function Recalcul({ nodeValue, explanation, unit }) {
+	const engine = useContext(EngineContext)
+	if (!engine) {
+		throw new Error()
+	}
+	useContext(RegisterEngineContext)(
+		engine.shallowCopy().setSituation(explanation.parsedSituation)
+	)
 	return (
 		<Mecanism name="recalcul" value={nodeValue} unit={unit}>
 			<>
 				{explanation.recalcul && (
-					<>
-						Recalcul de la valeur de <Explanation node={explanation.recalcul} />{' '}
-						avec la situation suivante :
-					</>
+					<EngineContext.Provider value={explanation.engine}>
+						<SituationMetaContext.Provider
+							value={{
+								name: 'Mécanisme recalcul',
+							}}
+						>
+							Recalcul de la valeur de{' '}
+							<Explanation node={explanation.recalcul} /> avec la situation
+							suivante :
+						</SituationMetaContext.Provider>
+					</EngineContext.Provider>
 				)}
 				<ul>
 					{explanation.amendedSituation.map(([origin, replacement]) => (

--- a/publicodes/ui-react/source/rule/Header.tsx
+++ b/publicodes/ui-react/source/rule/Header.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react'
 import { utils } from 'publicodes'
-import { RuleLinkWithContext } from '../RuleLink'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
-import Meta from './Meta'
 import { EngineContext } from '../contexts'
+import { RuleLinkWithContext } from '../RuleLink'
+import Meta from './Meta'
 
 export default function RuleHeader({ dottedName }) {
 	const engine = useContext(EngineContext)

--- a/publicodes/ui-react/source/rule/RulePage.tsx
+++ b/publicodes/ui-react/source/rule/RulePage.tsx
@@ -5,6 +5,9 @@ import Engine, {
 	utils,
 } from 'publicodes'
 import { isEmpty } from 'ramda'
+import { useContext } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { EngineContext } from '../contexts'
 import Explanation from '../Explanation'
 import { Markdown } from '../Markdown'
 import { RuleLinkWithContext } from '../RuleLink'
@@ -12,7 +15,13 @@ import RuleHeader from './Header'
 import References from './References'
 import RuleSource from './RuleSource'
 
-export default function Rule({ dottedName, engine, language }) {
+export default function Rule({ dottedName, language, situationName }) {
+	const engine = useContext(EngineContext)
+	const { pathname } = useLocation()
+
+	if (!engine) {
+		throw new Error('Engine expected')
+	}
 	if (!(dottedName in engine.getParsedRules())) {
 		return <p>Cette règle est introuvable dans la base</p>
 	}
@@ -21,7 +30,30 @@ export default function Rule({ dottedName, engine, language }) {
 	const { parent, valeur } = rule.explanation
 	return (
 		<div id="documentationRuleRoot">
+			{situationName && (
+				<div
+					className="ui__ card notice light-bg"
+					style={{
+						display: 'flex',
+						alignItems: 'baseline',
+						flexWrap: 'wrap',
+						margin: '1rem 0',
+						paddingTop: '0.4rem',
+						paddingBottom: '0.4rem',
+					}}
+				>
+					<div>
+						Vous explorez la documentation avec le contexte{' '}
+						<strong className="ui__ label">{situationName}</strong>{' '}
+					</div>
+					<div style={{ flex: 1 }} />
+					<div>
+						<Link to={pathname}>Retourner à la version de base</Link>
+					</div>
+				</div>
+			)}
 			<RuleHeader dottedName={dottedName} />
+
 			<section>
 				<Markdown source={description || question} />
 			</section>
@@ -56,6 +88,7 @@ export default function Rule({ dottedName, engine, language }) {
 			)}
 
 			<h2>Comment cette donnée est-elle calculée ?</h2>
+
 			<Explanation node={valeur} />
 			<RuleSource key={dottedName} dottedName={dottedName} engine={engine} />
 


### PR DESCRIPTION
- [x] Utiliser `engine.shallowCopy()` dans le mécnaisme `recalcul`
- [x] Permettre une `situation` dans un RuleLink (via le state de l'Url)
- [x] Ajouter le contexte en haut de la page de 

Fix #1344