### PR TITLE
Inférence statique des unités

### DIFF
--- a/modele-social/règles/artiste-auteur.yaml
+++ b/modele-social/règles/artiste-auteur.yaml
@@ -6,6 +6,7 @@ artiste-auteur:
 artiste-auteur . revenus: oui
 artiste-auteur . revenus . traitements et salaires:
   titre: Revenu en traitements et salaires
+  unité: €/an
   par défaut: 0 €/an
   résumé: Le montant brut hors TVA de vos droits d'auteur (recettes précomptées)
 
@@ -166,7 +167,7 @@ artiste-auteur . cotisations . IRCEC . cotisation RAAP:
             assiette: assiette
             tranches:
               - taux: 4%
-                plafond: 
+                plafond:
                   variations:
                     - si: profession . RACD
                       alors: cotisation RACD . plafond
@@ -217,7 +218,7 @@ artiste-auteur . cotisations . IRCEC . profession . RACL:
   titre: auteur ou compositeur lyrique, dialoguiste de doublage
   description: Les auteurs et compositeurs d’œuvres musicales et les dialoguistes de doublage cotisent au RACL.
   formule: profession = 'RACL'
-        
+
 artiste-auteur . cotisations . IRCEC . régime RACL:
   question: Cotisez-vous au RACL ?
   par défaut: non
@@ -227,9 +228,9 @@ artiste-auteur . cotisations . IRCEC . cotisation RACD:
   formule:
     produit:
       assiette: assiette
-      plafond: 
+      plafond:
         nom: plafond
-        valeur: 496250 €/an 
+        valeur: 496250 €/an
       taux: 8%
     arrondi: oui
 
@@ -242,10 +243,10 @@ artiste-auteur . cotisations . IRCEC . cotisation RACL:
         - taux: 0%
           plafond: 2739 €/an
         - taux: 6.5%
-          plafond: 
+          plafond:
             nom: plafond
             valeur: 376665 €/an
-        - taux: 
+        - taux:
             nom: cotisation de solidarité
             valeur: 1.5%
     arrondi: oui

--- a/modele-social/règles/conventions-collectives/bâtiment.yaml
+++ b/modele-social/règles/conventions-collectives/bâtiment.yaml
@@ -29,11 +29,11 @@ contrat salarié . convention collective . BTP . catégorie . ouvrier . prévoya
     assiette: rémunération . brut de base
     plafond: 3 * plafond sécurité sociale
     composantes:
-      - attributs: 
+      - attributs:
           nom: employeur
           remplace: prévoyance . employeur
         taux: 1.72%
-      - attributs: 
+      - attributs:
           nom: salarié
           remplace: prévoyance . salarié
         taux: 0.87%
@@ -60,11 +60,11 @@ contrat salarié . convention collective . BTP . catégorie . etam . prévoyance
     assiette: rémunération . brut de base
     plafond: 3 * plafond sécurité sociale
     composantes:
-      - attributs: 
+      - attributs:
           nom: employeur
           remplace: prévoyance . employeur
         taux: 1.25%
-      - attributs: 
+      - attributs:
           nom: salarié
           remplace: prévoyance . salarié
         taux: 0.60%
@@ -76,7 +76,6 @@ contrat salarié . convention collective . BTP . catégorie . cadre:
   remplace:
     - règle: statut cadre
       par: oui
-
 
 contrat salarié . convention collective . BTP . catégorie . cadre . prévoyance complémentaire:
   barème:
@@ -104,7 +103,6 @@ contrat salarié . convention collective . BTP . catégorie . cadre . prévoyanc
           - taux: 50% * 3.60%
             plafond: 8
 
-
 contrat salarié . convention collective . BTP . cotisations conventionnelles:
   remplace: cotisations . patronales . conventionnelles
   formule:
@@ -113,6 +111,7 @@ contrat salarié . convention collective . BTP . cotisations conventionnelles:
       - OPPBTP
 
 contrat salarié . convention collective . BTP . congés intempéries:
+  unité: €/mois
   formule:
     produit:
       assiette: cotisations . assiette
@@ -169,6 +168,7 @@ contrat salarié . convention collective . BTP . congés intempéries . caisse d
 contrat salarié . convention collective . BTP . congés intempéries . caisse de rattachement . sud ouest:
 
 contrat salarié . convention collective . BTP . OPPBTP:
+  unité: €/mois
   formule:
     produit:
       assiette: rémunération . brut de base * 1.1314

--- a/modele-social/règles/conventions-collectives/spectacle-vivant.yaml
+++ b/modele-social/règles/conventions-collectives/spectacle-vivant.yaml
@@ -201,7 +201,7 @@ contrat salarié . intermittents du spectacle . artiste . réduction de taux . A
 
 contrat salarié . intermittents du spectacle . artiste . nombre jours travaillés:
   question: Pour combien de jours continus l'artiste est-il engagé ?
-  par défaut: 5 jours
+  par défaut: 5 jours/mois
 
 contrat salarié . intermittents du spectacle . artiste . plafond proratisé:
   applicable si: nombre jours travaillés < 5
@@ -215,7 +215,7 @@ contrat salarié . intermittents du spectacle . artiste . plafond proratisé:
   formule:
     produit:
       assiette: plafond horaire sécurité sociale
-      facteur: 12 * nombre jours travaillés
+      facteur: 12 heures/jour * nombre jours travaillés
 
 contrat salarié . intermittents du spectacle . artiste . acteur de complément:
   non applicable si: activité accessoire

--- a/modele-social/règles/conventions-collectives/sport.yaml
+++ b/modele-social/règles/conventions-collectives/sport.yaml
@@ -225,7 +225,7 @@ contrat salarié . convention collective . sport . primes:
 contrat salarié . convention collective . sport . primes . manifestation 1:
   question: Quelle prime pour la première manifestation ?
   applicable si: nombre de manifestations > 0
-  par défaut: 100 €
+  par défaut: 100 €/mois
 
 contrat salarié . convention collective . sport . primes . manifestation 1 . franchise:
   titre: franchise manifestation 1
@@ -236,7 +236,7 @@ contrat salarié . convention collective . sport . primes . manifestation 1 . fr
 contrat salarié . convention collective . sport . primes . manifestation 2:
   question: Quelle prime pour la deuxième manifestation ?
   applicable si: nombre de manifestations > 1
-  par défaut: 100 €
+  par défaut: 100 €/mois
 
 contrat salarié . convention collective . sport . primes . manifestation 2 . franchise:
   titre: franchise manifestation 2
@@ -247,7 +247,7 @@ contrat salarié . convention collective . sport . primes . manifestation 2 . fr
 contrat salarié . convention collective . sport . primes . manifestation 3:
   question: Quelle prime pour la troisième manifestation ?
   applicable si: nombre de manifestations > 2
-  par défaut: 100 €
+  par défaut: 100 €/mois
 
 contrat salarié . convention collective . sport . primes . manifestation 3 . franchise:
   titre: franchise manifestation 3
@@ -258,7 +258,7 @@ contrat salarié . convention collective . sport . primes . manifestation 3 . fr
 contrat salarié . convention collective . sport . primes . manifestation 4:
   question: Quelle prime pour la quatrième manifestation ?
   applicable si: nombre de manifestations > 3
-  par défaut: 100 €
+  par défaut: 100 €/mois
 
 contrat salarié . convention collective . sport . primes . manifestation 4 . franchise:
   titre: franchise manifestation 4
@@ -269,7 +269,7 @@ contrat salarié . convention collective . sport . primes . manifestation 4 . fr
 contrat salarié . convention collective . sport . primes . manifestation 5:
   question: Quelle prime pour la cinquième manifestation ?
   applicable si: nombre de manifestations > 4
-  par défaut: 100 €
+  par défaut: 100 €/mois
 
 contrat salarié . convention collective . sport . primes . manifestation 5 . franchise:
   titre: franchise manifestation 5
@@ -280,7 +280,7 @@ contrat salarié . convention collective . sport . primes . manifestation 5 . fr
 contrat salarié . convention collective . sport . primes . autres manifestations:
   question: Quelles primes pour les autres manifestations ?
   applicable si: nombre de manifestations > 5
-  par défaut: 100 €
+  par défaut: 100 €/mois
 
 contrat salarié . convention collective . sport . cotisations . franchise:
   applicable si: entreprise . effectif < 10

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -41,12 +41,12 @@ entreprise . durée d'activité:
 entreprise . durée d'activité . en fin d'année:
   titre: durée d'activité à la fin de l'année
   formule:
-    somme: 
+    somme:
       - durée:
           depuis: date de création
           jusqu'à: période . fin d'année
       - 1 jour # Le mécanisme durée n'inclue pas le dernier jour
-  
+
 entreprise . durée d'activité . en début d'année:
   titre: durée d'activité au début de l'année
   formule:
@@ -56,7 +56,7 @@ entreprise . durée d'activité . en début d'année:
 
 entreprise . chiffre d'affaires:
   question: Quel est votre chiffre d'affaires envisagé ?
-  
+
   résumé: Montant total des recettes brutes (hors taxe)
   unité: €/an
   somme:
@@ -65,26 +65,25 @@ entreprise . chiffre d'affaires:
     - dirigeant . rémunération . cotisations
     - charges
     - applicable si: entreprise . imposition . IS
-      somme: 
-          - imposition . IS . résultat net
-          - imposition . IS . impôt sur les sociétés
+      somme:
+        - imposition . IS . résultat net
+        - imposition . IS . impôt sur les sociétés
   plancher: 0€/an
   arrondi: oui
   identifiant court: CA
-
 
 entreprise . chiffre d'affaires . vente restauration hébergement:
   titre: Vente de biens, restauration, hébergement (BIC)
   résumé: Chiffre d'affaires hors taxe
   question: Quel est le chiffre d'affaires issu de la vente de biens, restauration ou hébergement ?
   unité: €/an
-  variations: 
+  variations:
     - si: activité . mixte
       alors:
-        produit: 
-          assiette: chiffre d'affaires 
+        produit:
+          assiette: chiffre d'affaires
           taux: activité . mixte . proportions . vente restauration hébergement
-    - sinon: 
+    - sinon:
         applicable si: activité . service ou vente = 'vente'
         valeur: chiffre d'affaires
   arrondi: oui
@@ -106,7 +105,6 @@ entreprise . chiffre d'affaires . vente restauration hébergement:
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32919
     définition vente de bien (impots.gouv): https://www.impots.gouv.fr/portail/professionnel/achatvente-de-biens
 
-
 entreprise . chiffre d'affaires . service BIC:
   unité: €/an
   plancher: 0€/an
@@ -123,19 +121,17 @@ entreprise . chiffre d'affaires . service BIC:
     services qui nécessite plus qu'un ordinateur pour être effectuées.
 
     **Exemples** : transports, service à la personne, réparation etc.
-  variations: 
+  variations:
     - si: activité . mixte
       alors:
-        produit: 
-          assiette: chiffre d'affaires 
+        produit:
+          assiette: chiffre d'affaires
           taux: activité . mixte . proportions . service BIC
-    - sinon: 
+    - sinon:
         applicable si: activité . service ou vente = 'service'
         valeur: chiffre d'affaires
   références:
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32919
-  
-
 
 entreprise . chiffre d'affaires . service BNC:
   titre: Autres prestations de service et activités libérales (BNC)
@@ -151,16 +147,16 @@ entreprise . chiffre d'affaires . service BNC:
     formation, enseignement, sportif
 
     Les revenus tirés de ce chiffre d'affaires sont imposable au régime BNC (bénéfices non commerciaux)
-  variations: 
+  variations:
     - si: activité . mixte
       alors:
-        produit: 
-          assiette: chiffre d'affaires 
+        produit:
+          assiette: chiffre d'affaires
           taux: activité . mixte . proportions . service BNC
-    - sinon: 
+    - sinon:
         applicable si: activité = 'libérale'
         valeur: chiffre d'affaires
-  
+
   références:
     liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales
 
@@ -179,11 +175,10 @@ entreprise . chiffre d'affaires . BIC:
     Le chiffre d'affaires correspondant au revenus imposable au titre des bénéfice industriels et commerciaux (BIC ou micro-BIC).
   unité: €/an
   somme:
-    - service BIC 
+    - service BIC
     - vente restauration hébergement
-    
-entreprise . chiffre d'affaires . franchise de TVA dépassée:
 
+entreprise . chiffre d'affaires . franchise de TVA dépassée:
   description: |
     La franchise de TVA est un dispositif qui exonère les entreprises de la
     déclaration et du paiement de la TVA. Il s'applique en dessous d'un seuil de
@@ -214,7 +209,7 @@ entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil service:
     - si: établissement . localisation . outre-mer . Guadeloupe Réunion Martinique
       alors: 60000 €/an
     - si: dirigeant . indépendant . PL . métier = 'avocat'
-      alors: 44500 €
+      alors: 44500 €/an
     - sinon: 36500 €/an
   références:
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F21746
@@ -226,14 +221,12 @@ entreprise . chiffre d'affaires . franchise de TVA dépassée . notification:
   description: |
     Le seuil annuel de chiffre d'affaires pour la franchise de TVA est dépassé. [En savoir plus](/documentation/entreprise/chiffre-d'affaires/franchise-de-TVA-dépassée)
 
-
 entreprise . résultat fiscal:
   unité: €/an
-  somme: 
+  somme:
     - chiffre d'affaires
     - (- charges)
     - (- charges . dirigeant)
-    
 
 entreprise . imposition:
   question: Comment l'entreprise est-elle imposée ?
@@ -284,19 +277,18 @@ entreprise . imposition . IR . micro-fiscal . revenu abattu:
           taux: 50%
         - assiette: entreprise . chiffre d'affaires . service BNC
           taux: 34%
-    plancher: 
-      variations: 
-        - si: entreprise . activité . mixte 
+    plancher:
+      variations:
+        - si: entreprise . activité . mixte
           alors: 610 €/an
         - sinon: 305 €/an
-
 
 entreprise . imposition . IR . micro-fiscal . alerte seuil dépassés:
   type: notification
   sévérité: avertissement
   formule: chiffre d'affaires . seuil micro dépassé
   description: Le seuil annuel de chiffre d'affaires pour le régime micro-fiscal est dépassé. [En savoir plus](/documentation/entreprise/chiffre-d'affaires/seuil-micro-dépassé)
-  
+
 entreprise . chiffre d'affaires . seuil micro dépassé:
   applicable si: imposition . IR
   description: |
@@ -338,7 +330,6 @@ entreprise . chiffre d'affaires . seuil micro dépassé:
     - entreprise . chiffre d'affaires > 176200 €/an
     - entreprise . chiffre d'affaires . service > 72600 €/an
 
-
 entreprise . imposition . IR . information sur le report de déficit:
   non applicable si: micro-fiscal
   type: notification
@@ -349,7 +340,7 @@ entreprise . imposition . IR . information sur le report de déficit:
 
     [Voir les règles fiscales détaillées](https://bofip.impots.gouv.fr/bofip/2003-PGP.html/identifiant%3DBOI-BIC-DEF-20-10-20170301)
   références:
-    bofip: https://bofip.impots.gouv.fr/bofip/2003-PGP.html/identifiant%3DBOI-BIC-DEF-20-10-20170301 
+    bofip: https://bofip.impots.gouv.fr/bofip/2003-PGP.html/identifiant%3DBOI-BIC-DEF-20-10-20170301
 
 entreprise . exercice: oui
 entreprise . exercice . début:
@@ -395,7 +386,6 @@ entreprise . imposition . IS:
   valeur: imposition = 'IS'
   titre: Impôt sur les sociétés
 
-
 entreprise . imposition . IS . résultat imposable:
   titre: Résultat de l'exercice
   résumé: Imposable à l'impôt sur les sociétés
@@ -408,7 +398,6 @@ entreprise . imposition . IS . information sur le report de déficit:
   description: |
     Les déficits subits au cours d'un exercice peuvent être reportés sur les exercices suivants (report en avant), ou sur le seul exercice précédent (report en arrière).
 
-    
 entreprise . imposition . IS . résultat net:
   résumé: Après déduction des charges et de l'impôt sur les société
   somme:
@@ -417,7 +406,7 @@ entreprise . imposition . IS . résultat net:
     - (- dirigeant . rémunération . totale)
     - (- impôt sur les sociétés)
   par défaut: 0€
-  
+
 entreprise . imposition . IS . impôt sur les sociétés:
   unité: €/an
   formule:
@@ -538,16 +527,14 @@ entreprise . charges:
     Charges déductibles ou non du résultat fiscal d'une entreprise: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31973
   par défaut: 0 €/an
 
-     
-
 entreprise . charges . dirigeant:
   titre: Charges déductibles dirigeant
   description: Les montants liés à la rémunération du dirigeant qui sont déductibles d'impôt.
-  variations: 
-    - si: imposition . IS 
+  variations:
+    - si: imposition . IS
       alors: dirigeant . rémunération . totale
     # Note : le cas de dirigeant AS à l'IR n'est pas géré
-    # - si: dirigeant . assimilé salarié 
+    # - si: dirigeant . assimilé salarié
     #   alors: 0€/an
     - sinon: # TNS dans entreprise à l'IR
         valeur: dirigeant . indépendant . cotisations et contributions
@@ -829,26 +816,25 @@ entreprise . activité . mixte . proportions:
   description: Part des différentes activités dans le chiffre d'affaires
   titre: proportion activité
   unité: '%'
-  somme: 
+  somme:
     - nom: service BIC
-      par défaut: 
+      par défaut:
         variations:
           - si: activité = 'libérale'
             alors: 0
           - sinon: 50%
     - nom: service BNC
-      par défaut: 
+      par défaut:
         variations:
           - si: activité = 'libérale'
             alors: 2 / 3
           - sinon: 0
     - nom: vente restauration hébergement
-      par défaut: 
+      par défaut:
         variations:
           - si: activité = 'libérale'
             alors: 1 / 3
           - sinon: 50%
-        
 
 entreprise . activité . libérale réglementée:
   question: Est-ce une activité libérale réglementée ?
@@ -906,7 +892,7 @@ entreprise . activité . débit de tabac:
       chemin: nom
 
 établissement . taux du versement transport:
-  unité: "%"
+  unité: '%'
   formule:
     synchronisation:
       data: localisation

--- a/modele-social/règles/impôt.yaml
+++ b/modele-social/règles/impôt.yaml
@@ -32,7 +32,7 @@ impôt . méthode de calcul:
   # applicable si: revenu imposable > 0
   # bizarrement, cette condition ne semble pas marcher, on se résout donc à utiliser une version plus "hacky" et moins proche de la loi. Elle posera problème le jour où l'on aura a calculer l'impot avec plusieurs sources de revenu
   non applicable si: dirigeant . auto-entrepreneur . impôt . versement libératoire
-  par défaut: 
+  par défaut:
     nom: par défaut
     valeur: "'barème standard'"
   formule:
@@ -70,11 +70,11 @@ impôt . méthode de calcul . prélèvement à la source:
 impôt . revenu imposable:
   description: |
     C'est le revenu à prendre en compte pour calculer l'impôt avec un taux moyen d'imposition (neutre ou personnalisé).
-  variations: 
+  variations:
     - si: dirigeant
       alors: dirigeant . rémunération . imposable
-    - sinon: 
-        valeur: contrat salarié . rémunération . net imposable      
+    - sinon:
+        valeur: contrat salarié . rémunération . net imposable
         abattement: abattement contrat court
 
 impôt . revenu imposable . abattement contrat court:
@@ -254,7 +254,6 @@ impôt . taux personnalisé:
       - votre espace personnel [impots.gouv.fr](https://impots.gouv.fr)
   unité: '%'
 
-
 # TODO: "foyer fiscal" should be in its own top level namespace, but we put it
 # in the "impôt" namespace to have a better questions ordering
 impôt . foyer fiscal:
@@ -283,6 +282,7 @@ impôt . foyer fiscal . situation de famille . veuf:
 
 impôt . foyer fiscal . enfants à charge:
   question: Combien d'enfants sont à charge du foyer fiscal ?
+  unité: enfants
   par défaut: 0 enfants
 
 impôt . foyer fiscal . nombre de parts:
@@ -339,13 +339,13 @@ impôt . foyer fiscal . nombre de parts . majoration personne veuve avec enfant:
 
 impôt . foyer fiscal . taux effectif:
   unité: '%'
-  variations: 
+  variations:
     - si: impôt à payer = 0
-      alors: 0% 
-    - sinon: impôt à payer / revenu imposable 
-
+      alors: 0%
+    - sinon: impôt à payer / revenu imposable
 
 impôt . foyer fiscal . revenu imposable:
+  unité: €/an # TODO : should be infered
   formule:
     somme:
       - revenu d'activité abattu
@@ -366,7 +366,7 @@ impôt . foyer fiscal . revenu imposable . revenu d'activité abattu:
         alors: contrat salarié . rémunération . net imposable
       - si: entreprise . imposition = 'IS'
         alors: dirigeant . rémunération . imposable
-  abattement: 
+  abattement:
     valeur: 10% * assiette
     # A VÉRIFIER: calculé à la main en revalorisant le taux 2020
     # HISTORIQUE 2020: 12627€
@@ -524,5 +524,5 @@ impôt . domiciliation étranger non implémentée:
   formule: situation personnelle . domiciliation fiscale à l'étranger
   type: notification
   niveau: avertissement
-  description: | 
+  description: |
     La retenue à la source pour les non-résident n'est pas encore implémentée. Pour en savoir plus, se référer à la [documentation fiscale](https://www.impots.gouv.fr/portail/international-particulier/je-suis-non-resident-dois-je-declarer-des-revenus-et-payer-des-impots-en)

--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -44,9 +44,9 @@ protection sociale . retraite:
       - On ne prend pas en compte les caisses de retraite des professions libérales réglementées (les 10 sections de la Cnavpl et la Cnbf)
       - On ne calcule pas le nombre de trimestres validés par année
 
-protection sociale . retraite . plr: 
+protection sociale . retraite . plr:
   applicable si:
-    toutes ces conditions: 
+    toutes ces conditions:
       - entreprise . activité . libérale réglementée
       - dirigeant . indépendant . PL . option régime général = non
   remplace: retraite

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -126,14 +126,13 @@ contrat salarié . frais professionnels . titres-restaurant . part déductible:
 contrat salarié . frais professionnels . titres-restaurant . nombre:
   question: Combien de titres-restaurant sont distribués au salarié ?
   arrondi: oui
-  par défaut: 
-    produit: 
-      assiette: 19 titres-restaurant/mois 
+  par défaut:
+    produit:
+      assiette: 19 titres-restaurant/mois
       facteur: temps de travail . quotité de travail
   suggestions:
-    5 repas/semaines:  5 titres-restaurant/semaines * période . semaines par mois
-    3 repas/semaine:  3 titres-restaurant/semaines * période . semaines par mois
-      
+    5 repas/semaines: 5 titres-restaurant/semaines * période . semaines par mois
+    3 repas/semaine: 3 titres-restaurant/semaines * période . semaines par mois
 
 contrat salarié . frais professionnels . titres-restaurant . montant unitaire:
   question: Quelle est la valeur unitaire du titre-restaurant ?
@@ -180,7 +179,7 @@ contrat salarié . frais professionnels . abonnement transports publics . montan
   par défaut: 0 €/mois
   description: |
     L'employeur doit prendre en charge 50% du montant dépensé par le salarié pour les transports publics lui permettant de se rendre sur son lieu de travail.
-    
+
     Cette prise en charge (dans la limite des 50% du montant) est exonérée de cotisations sociales et d'impôt sur le revenu.
 
     Dans le cas d'un temps partiel, le taux de prise en charge sera le même pour un mi-temps ou plus. En dessous, le taux de prise en charge sera proportionnel.
@@ -191,10 +190,8 @@ contrat salarié . frais professionnels . abonnement transports publics . montan
     Navigo: 75 €/mois
     Técély: 65 €/mois
     RTM: 40 €/mois
-    Tisséo: 42.50 €/mois  
+    Tisséo: 42.50 €/mois
     TBM: 42.20 €/mois
-
-
 
 contrat salarié . frais professionnels . abonnement transports publics . taux de participation employeur:
   valeur: 50%
@@ -203,7 +200,7 @@ contrat salarié . frais professionnels . abonnement transports publics . taux d
   titre: Taux de prise en charge
   valeur:
     produit:
-      assiette: 
+      assiette:
         le minimum de:
           - temps de travail . quotité de travail
           - 50%
@@ -275,9 +272,9 @@ contrat salarié . frais professionnels . transports personnels . carburant faib
   valeur: montant
   plafond:
     le minimum de:
-       - proportion déduction * 200€/an
-       - valeur: proportion déduction * 500€/an
-         abattement: abonnement transports publics . prise en charge
+      - proportion déduction * 200€/an
+      - valeur: proportion déduction * 500€/an
+        abattement: abonnement transports publics . prise en charge
 
 contrat salarié . frais professionnels . transports personnels . forfait mobilités durables:
   valeur: oui
@@ -336,9 +333,9 @@ contrat salarié . activité partielle:
     La déclaration d'activité partielle est simplifiée et l'effet est
     rétroactif.
   par défaut: non
-  rend non applicable:
-    - temps de travail . heures supplémentaires
-    - temps de travail . heures complémentaires
+  # rend non applicable:
+  #   - temps de travail . heures supplémentaires
+  #   - temps de travail . heures complémentaires
   références:
     déclaration employeur: https://activitepartielle.emploi.gouv.fr/aparts/
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23503
@@ -640,7 +637,7 @@ contrat salarié . CDD . CPF:
       taux: 1%
   références:
     Code du travail - Article L6322-37: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000022234996&cidTexte=LEGITEXT000006072050
-  
+
 contrat salarié . CDD . congés pris:
   question: Combien de jours de congés seront pris sur la durée du CDD (en jours ouvrés) ?
   description: |
@@ -651,10 +648,10 @@ contrat salarié . CDD . congés pris:
     la totalité: congés dus sur la durée du contrat
     la moitié: 50% * congés dus sur la durée du contrat
   par défaut: 0 jours ouvrés
-  
-contrat salarié . CDD . jours ouvrés sur la durée du contrat: 
+
+contrat salarié . CDD . jours ouvrés sur la durée du contrat:
   produit:
-    assiette: 253 jours ouvrés/an  
+    assiette: 253 jours ouvrés/an
     facteur: durée contrat
 
 contrat salarié . CDD . congés dus sur la durée du contrat:
@@ -708,7 +705,7 @@ contrat salarié . CDD . indemnité compensatrice de congés payés:
       produit:
         assiette: rémunération . assiette congés payés
         taux: 10%
-      abattement: 
+      abattement:
         nom: proportion congés pris
         unité: '%'
         valeur: congés pris / congés dus sur la durée du contrat
@@ -716,11 +713,10 @@ contrat salarié . CDD . indemnité compensatrice de congés payés:
     - nom: Méthode du maintien de salaire
       produit:
         assiette: rémunération . assiette congés payés / jours ouvrés sur la durée du contrat
-        facteur: 
+        facteur:
           nom: congés non pris
           valeur: congés dus sur la durée du contrat - congés pris
-        
-        
+
   note: |
     L'indemnité est versée à la fin du contrat, sauf si le CDD se poursuit par un CDI.
     À noter, la loi El Khomri modifie l'article L3141-12:
@@ -1236,6 +1232,7 @@ contrat salarié . cotisations . assiette:
     L'assiette des cotisations sociales est la base de calcul d'un grand nombre de cotisations sur le travail salarié. Elle comprend notamment les rémunérations en espèces (salaire de base, indemnité, primes...) et les avantages en nature (logement, véhicule...).
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/la-base-de-calcul.html
+  unité: €/mois
   formule:
     valeur: rémunération . brut
     abattement:
@@ -1300,7 +1297,6 @@ contrat salarié . rémunération . brut de base:
         - rémunération . net après impôt
         - équivalent temps plein
         - dirigeant . rémunération . totale
-
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement
@@ -1463,6 +1459,7 @@ contrat salarié . rémunération . brut:
   # et de retraite complémentaire on ne ré-intègre ici que la part employeur
   # (car la part salarié est déjà comptabilisé dans `rémunération . brut de
   # base` dont elle vient en déduction).
+  unité: €/mois
   somme:
     - rémunération . brut de base
     - avantages en nature . montant
@@ -1478,6 +1475,7 @@ contrat salarié . rémunération . brut:
 contrat salarié . rémunération . heures supplémentaires:
   titre: rémunération heures supplémentaires
   description: La rémunération relative aux heures supplémentaires
+  unité: €/mois
   formule:
     produit:
       assiette: taux horaire . heures supplémentaires
@@ -1489,6 +1487,7 @@ contrat salarié . rémunération . heures supplémentaires:
 contrat salarié . rémunération . heures complémentaires:
   titre: rémunération heures complémentaires
   description: La rémunération relative aux heures complémentaires
+  unité: €/mois
   formule:
     produit:
       assiette: taux horaire . heures supplémentaires
@@ -1636,6 +1635,7 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
 contrat salarié . rémunération . avantages en nature . nourriture . repas par mois:
   question: >
     Combien de repas par mois sont payés par l'entreprise ?
+  unité: repas/mois
   par défaut: 21 repas/mois
   suggestions:
     1 par jour: 21 repas/mois
@@ -1780,7 +1780,7 @@ contrat salarié . rémunération . net imposable:
   description: |
     C'est la base utilisée pour calculer l'impôt sur le revenu.
   valeur:
-    nom: base 
+    nom: base
     description: Le net imposable avant les exonérations et déductions
     somme:
       - net avec revenus de remplacement
@@ -1796,8 +1796,6 @@ contrat salarié . rémunération . net imposable:
       - prévoyance . exonération fiscale
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
-
-
 
 contrat salarié . rémunération . net imposable . heures supplémentaires et complémentaires défiscalisées:
   unité: €/mois
@@ -2269,6 +2267,7 @@ contrat salarié . temps de travail . heures supplémentaires:
   titre: Nombre d'heures supplémentaires
   non applicable si: temps partiel
   question: Combien d'heures supplémentaires (non récupérées en repos) sont effectuées par mois ?
+  unité: heure/mois
   par défaut: 0 heure/mois
   suggestions:
     aucune: 0 heure/mois
@@ -2318,6 +2317,7 @@ contrat salarié . temps de travail . heures complémentaires:
     durée légale ou conventionnelle du travail.
   applicable si: temps partiel
   question: Combien d'heures complémentaires (non récupérées en repos) sont effectuées par mois ?
+  unité: heure/mois
   par défaut: 0 heure/mois
 
 contrat salarié . temps de travail . contrôle heures complémentaires 10 pourcents:
@@ -2347,7 +2347,6 @@ contrat salarié . temps de travail . heures complémentaires . majoration:
   formule:
     barème:
       assiette: heures complémentaires
-      mutliplicateur:
       tranches:
         - taux: 10%
           plafond: seuil légal

--- a/publicodes/core/source/AST/types.ts
+++ b/publicodes/core/source/AST/types.ts
@@ -26,6 +26,7 @@ import { UnitéNode } from '../mecanisms/unité'
 import { VariationNode } from '../mecanisms/variations'
 import { ReferenceNode } from '../reference'
 import { ReplacementRule } from '../replacement'
+import { UnitConversionNode } from '../nodeUnits'
 import { RuleNode } from '../rule'
 
 export type ConstantNode = {
@@ -64,8 +65,10 @@ export type ASTNode = (
 	| UnitéNode
 	| VariationNode
 	| ConstantNode
+	| UnitConversionNode
 	| ReplacementRule
 ) & {
+	unit?: Unit
 	isDefault?: boolean
 	visualisationKind?: string
 	rawNode?: string | Record<string, unknown>
@@ -109,7 +112,7 @@ export type Unit = {
 type EvaluationDecoration<T extends Types> = {
 	nodeValue: Evaluation<T>
 	missingVariables: Record<string, number>
-	unit?: Unit
+	unit?: Unit // TODO: to remove
 }
 export type Types = number | boolean | string | Record<string, unknown>
 // TODO: type NotYetDefined & NotApplicable properly (see #14) then refactor any code depending on these:

--- a/publicodes/core/source/evaluation.ts
+++ b/publicodes/core/source/evaluation.ts
@@ -33,39 +33,13 @@ export const mergeMissing = (
 export const mergeAllMissing = (missings: Array<EvaluatedNode | ASTNode>) =>
 	missings.map(collectNodeMissing).reduce(mergeMissing, {})
 
-function convertNodesToSameUnit(this: Engine, nodes, mecanismName) {
-	const firstNodeWithUnit = nodes.find((node) => !!node.unit)
-	if (!firstNodeWithUnit) {
-		return nodes
-	}
-	return nodes.map((node) => {
-		try {
-			return convertNodeToUnit(firstNodeWithUnit.unit, node)
-		} catch (e) {
-			warning(
-				this.options.logger,
-				this.cache._meta.evaluationRuleStack[0],
-				`Les unités des éléments suivants sont incompatibles entre elles : \n\t\t${
-					node?.name || node?.rawNode
-				}\n\t\t${firstNodeWithUnit?.name || firstNodeWithUnit?.rawNode}'`,
-				e
-			)
-			return node
-		}
-	})
-}
-
 export const evaluateArray: <NodeName extends NodeKind>(
 	reducer,
 	start
 ) => EvaluationFunction<NodeName> = (reducer, start) =>
 	function (node: any) {
 		const evaluate = this.evaluate.bind(this)
-		const evaluatedNodes = convertNodesToSameUnit.call(
-			this,
-			node.explanation.map(evaluate),
-			node.name
-		)
+		const evaluatedNodes = node.explanation.map(evaluate)
 		const values = evaluatedNodes.map(({ nodeValue }) => nodeValue)
 		const nodeValue = values.some((value) => value === null)
 			? null

--- a/publicodes/core/source/grammarFunctions.js
+++ b/publicodes/core/source/grammarFunctions.js
@@ -38,8 +38,10 @@ export let number = ([{ value }]) => ({
 })
 
 export let numberWithUnit = (value) => ({
-	...number(value),
-	unité: value[2].value,
+	constantWithUnit: {
+		...number(value).constant,
+		unit: value[2].value,
+	},
 })
 
 export let date = ([{ value }]) => {

--- a/publicodes/core/source/mecanisms/inversion.ts
+++ b/publicodes/core/source/mecanisms/inversion.ts
@@ -63,7 +63,7 @@ export const evaluateInversion: EvaluationFunction<'inversion'> = function (
 		this.resetCache()
 		this.cache._meta = { ...originalCache._meta }
 		this.parsedSituation[node.explanation.ruleToInverse] = {
-			unit: unit,
+			parsedUnit: unit,
 			nodeKind: 'unité',
 			explanation: {
 				nodeKind: 'constant',

--- a/publicodes/core/source/mecanisms/résoudre-référence-circulaire.ts
+++ b/publicodes/core/source/mecanisms/résoudre-référence-circulaire.ts
@@ -28,7 +28,7 @@ export const evaluateRésoudreRéférenceCirculaire: EvaluationFunction<'résoud
 		this.resetCache()
 
 		this.parsedSituation[node.explanation.ruleToSolve] = {
-			unit: unit,
+			parsedUnit: unit,
 			nodeKind: 'unité',
 			explanation: {
 				nodeKind: 'constant',

--- a/publicodes/core/source/mecanisms/sum.tsx
+++ b/publicodes/core/source/mecanisms/sum.tsx
@@ -12,6 +12,7 @@ export type SommeNode = {
 
 export const mecanismSum = (v, context) => {
 	const explanation = v.map((node) => parse(node, context))
+
 	return {
 		explanation,
 		nodeKind: 'somme',

--- a/publicodes/core/source/mecanisms/unité.ts
+++ b/publicodes/core/source/mecanisms/unité.ts
@@ -5,18 +5,18 @@ import parse from '../parse'
 import { convertUnit, parseUnit } from '../units'
 
 export type UnitéNode = {
-	unit: Unit
+	parsedUnit: Unit
 	explanation: ASTNode
 	nodeKind: 'unité'
 }
 
 export default function parseUnité(v, context): UnitéNode {
 	const explanation = parse(v.valeur, context)
-	const unit = parseUnit(v.unité, context.getUnitKey)
+	const parsedUnit = parseUnit(v.unité, context.getUnitKey)
 
 	return {
 		explanation,
-		unit,
+		parsedUnit,
 		nodeKind: parseUnité.nom,
 	}
 }
@@ -27,11 +27,11 @@ registerEvaluationFunction(parseUnité.nom, function evaluate(node) {
 	const valeur = this.evaluate(node.explanation)
 
 	let nodeValue = valeur.nodeValue
-	if (nodeValue !== false && 'unit' in node) {
+	if (nodeValue !== false) {
 		try {
 			nodeValue = convertUnit(
 				valeur.unit,
-				node.unit,
+				node.parsedUnit,
 				valeur.nodeValue as number
 			)
 		} catch (e) {

--- a/publicodes/core/source/mecanisms/variations.ts
+++ b/publicodes/core/source/mecanisms/variations.ts
@@ -97,21 +97,8 @@ const evaluate: EvaluationFunction<'variations'> = function (node) {
 					previousConditions,
 				]
 			}
-			let evaluatedConsequence = this.evaluate(consequence)
-			if (unit) {
-				try {
-					evaluatedConsequence = convertNodeToUnit(unit, evaluatedConsequence)
-				} catch (e) {
-					warning(
-						this.options.logger,
-						this.cache._meta.evaluationRuleStack[0],
-						`L'unité de la branche n° ${
-							i + 1
-						} du mécanisme 'variations' n'est pas compatible avec celle d'une branche précédente`,
-						e
-					)
-				}
-			}
+			const evaluatedConsequence = this.evaluate(consequence)
+
 			return [
 				currentCondition && evaluatedConsequence.nodeValue,
 				[

--- a/publicodes/core/source/nodeUnits.ts
+++ b/publicodes/core/source/nodeUnits.ts
@@ -1,5 +1,12 @@
-import { EvaluatedNode, Unit } from './AST/types'
-import { convertUnit, simplifyUnit } from './units'
+import { ASTNode, EvaluatedNode, Unit } from './AST/types'
+import { registerEvaluationFunction } from './evaluationFunctions'
+import {
+	conversionFactor,
+	convertUnit,
+	inferUnit,
+	serializeUnit,
+	simplifyUnit,
+} from './units'
 
 export function simplifyNodeUnit(node) {
 	if (!node.unit) {
@@ -10,6 +17,7 @@ export function simplifyNodeUnit(node) {
 	return convertNodeToUnit(unit, node)
 }
 
+// TODO: to remove (runtime conversion)
 export function convertNodeToUnit<Node extends EvaluatedNode = EvaluatedNode>(
 	to: Unit | undefined,
 	node: Node
@@ -23,3 +31,192 @@ export function convertNodeToUnit<Node extends EvaluatedNode = EvaluatedNode>(
 		unit: to,
 	}
 }
+
+export const inferNodeUnit = (parsedRules, stack) => {
+	const unimplementedMecanisms = new Set()
+	const rec = (node: ASTNode) => {
+		if (node.unit) {
+			return node
+		}
+		switch (node.nodeKind) {
+			case 'rule': {
+				if (stack.includes(node.dottedName)) {
+					console.log('cycle', stack)
+					stack.shift()
+					return node
+				}
+				stack.unshift(node.dottedName)
+				const valeur = rec(node.explanation.valeur)
+				parsedRules[node.dottedName] = {
+					...node,
+					explanation: { ...node.explanation, valeur },
+					unit: valeur.unit,
+				}
+				stack.shift()
+				return parsedRules[node.dottedName]
+			}
+
+			case 'toutes ces conditions':
+			case 'constant':
+				return node
+
+			case 'arrondi':
+			case 'applicable si':
+			case 'non applicable si':
+			case 'nom dans la situation': {
+				const valeur = rec(node.explanation.valeur)
+				return {
+					...node,
+					explanation: { ...node.explanation, valeur },
+					unit: valeur.unit,
+				}
+			}
+			case 'par défaut': {
+				const unit =
+					rec(node.explanation.valeur).unit ??
+					rec(node.explanation.parDéfaut).unit
+				return { ...node, unit }
+			}
+
+			case 'somme':
+			case 'maximum':
+			case 'minimum': {
+				const explanation = staticListOfSameUnit(
+					node.explanation.map((n) => rec(n))
+				)
+				return { ...node, explanation, unit: explanation[0].unit }
+			}
+
+			case 'produit': {
+				const assiette =
+					node.explanation.assiette && rec(node.explanation.assiette)
+				const facteur =
+					node.explanation.facteur && rec(node.explanation.facteur)
+				const taux = node.explanation.taux && rec(node.explanation.taux)
+				const plafond =
+					node.explanation.plafond && rec(node.explanation.plafond)
+				const unit = inferUnit(
+					'*',
+					[assiette, taux, facteur].map((el) => el.unit)
+				)
+
+				return { ...node, explanation: { assiette, facteur, taux }, unit }
+			}
+
+			case 'barème':
+				return { ...node, unit: rec(node.explanation.assiette).unit }
+
+			case 'plancher':
+			case 'plafond':
+				return {
+					...node,
+					unit: rec(node.explanation.valeur).unit,
+				}
+
+			case 'operation':
+				if (node.operationKind === '+' || node.operationKind === '-') {
+					const node1 = rec(node.explanation[0])
+					const node2 = staticConvertNodeToUnit(
+						rec(node.explanation[1]),
+						node1.unit
+					)
+					return { ...node, explanation: [node1, node2], unit: node1.unit }
+				} else if (node.operationKind === '*' || node.operationKind === '/') {
+					const node1 = rec(node.explanation[0])
+					const node2 = rec(node.explanation[1])
+					return {
+						...node,
+						explanation: [node1, node2],
+						unit: inferUnit(node.operationKind, [node1.unit, node2.unit]),
+					}
+				} else {
+					return node
+				}
+
+			case 'variations': {
+				const explanation = staticListOfSameUnit(
+					node.explanation.map(({ consequence }) => rec(consequence))
+				).map((consequence, i) => ({ ...node.explanation[i], consequence }))
+				return {
+					...node,
+					explanation,
+					unit: explanation[explanation.length - 1].consequence.unit,
+				}
+			}
+
+			case 'abattement': {
+				const assiette = rec(node.explanation.assiette)
+				let abattement = rec(node.explanation.abattement)
+				const percentageAbattement = serializeUnit(abattement.unit) === '%'
+				if (!percentageAbattement) {
+					abattement = staticConvertNodeToUnit(abattement, assiette.unit)
+				}
+				return {
+					...node,
+					explanation: { assiette, abattement },
+					unit: assiette.unit,
+				}
+			}
+
+			case 'unité':
+				return staticConvertNodeToUnit(rec(node.explanation), node.parsedUnit)
+
+			case 'reference':
+				if (node.dottedName) {
+					return { ...node, unit: rec(parsedRules[node.dottedName]).unit }
+				} else {
+					return node
+				}
+		}
+		unimplementedMecanisms.add(node.nodeKind)
+		return node
+	}
+	// console.log(unimplementedMecanisms)
+	return rec
+}
+
+export function staticListOfSameUnit(nodes: Array<ASTNode>) {
+	return nodes.map((node, i) =>
+		i === 0 ? node : staticConvertNodeToUnit(node, nodes[0].unit!)
+	)
+}
+
+export type UnitConversionNode = {
+	nodeKind: 'unit-conversion'
+	factor: number
+	unit: Unit
+	explanation: ASTNode
+}
+
+export function staticConvertNodeToUnit(node: ASTNode, unit: Unit) {
+	let factor
+	try {
+		if (node.unit) {
+			factor = conversionFactor(node.unit, unit)
+		}
+	} catch {
+		// console.log('error')
+		return { ...node, unit }
+	}
+	if (factor === 1) {
+		return { ...node, unit }
+	}
+	return {
+		nodeKind: 'unit-conversion',
+		factor,
+		unit,
+		explanation: node,
+	}
+}
+
+registerEvaluationFunction('unit-conversion', function evaluate(node) {
+	const evaluatedNode = this.evaluate(node.explanation)
+	const nodeValue =
+		typeof evaluatedNode.nodeValue === 'number'
+			? node.factor * evaluatedNode.nodeValue
+			: evaluatedNode.nodeValue
+	return {
+		...evaluatedNode,
+		nodeValue,
+	} as any
+})

--- a/publicodes/core/source/parse.ts
+++ b/publicodes/core/source/parse.ts
@@ -32,6 +32,7 @@ import variations, { devariate } from './mecanisms/variations'
 import { Context } from './parsePublicodes'
 import parseReference from './reference'
 import parseRule from './rule'
+import { parseUnit } from './units'
 
 export default function parse(rawNode, context: Context): ASTNode {
 	if (rawNode == null) {
@@ -211,6 +212,10 @@ const parseFunctions = {
 		fullPrecision: true,
 		nodeValue: v.nodeValue,
 		nodeKind: 'constant',
+	}),
+	constantWithUnit: (v, context) => ({
+		...parseFunctions['constant'](v),
+		unit: parseUnit(v.unit, context.getUnitKey),
 	}),
 }
 

--- a/publicodes/core/source/parsePublicodes.ts
+++ b/publicodes/core/source/parsePublicodes.ts
@@ -1,6 +1,7 @@
 import yaml from 'yaml'
 import { ParsedRules, Logger } from '.'
 import { makeASTTransformer, traverseParsedRules } from './AST'
+import { inferNodeUnit } from './nodeUnits'
 import parse from './parse'
 import { getReplacements, inlineReplacements } from './replacement'
 import { Rule, RuleNode } from './rule'
@@ -70,6 +71,30 @@ export default function parsePublicodes(
 	// TODO STEP 6: check for cycle
 
 	// TODO STEP 7: type check
+	const stack = []
+	const inferRuleUnit = inferNodeUnit(parsedRules, stack)
+	try {
+		Object.values(parsedRules).forEach((parsedRule) => {
+			inferRuleUnit(parsedRule)
+		})
+	} catch (e) {
+		console.error('erreur dans ', stack[0])
+		throw e
+	}
+
+	// temp
+	// const stats = { totalNodes: 0, nodesWithUnit: 0 }
+	// traverseParsedRules(
+	// 	makeASTTransformer((node) => {
+	// 		stats.totalNodes++
+	// 		if (node.unit) {
+	// 			stats.nodesWithUnit++
+	// 		}
+	// 		return undefined
+	// 	}),
+	// 	parsedRules
+	// )
+	// console.table(stats)
 
 	return parsedRules
 }

--- a/publicodes/core/source/rule.ts
+++ b/publicodes/core/source/rule.ts
@@ -111,6 +111,7 @@ export default function parseRule(
 		),
 		nodeKind: 'rule',
 		explanation,
+		unit: explanation.valeur.unit,
 		rawNode: rawRule,
 		virtualRule: !!context.dottedName,
 	} as RuleNode

--- a/publicodes/core/source/units.ts
+++ b/publicodes/core/source/units.ts
@@ -211,6 +211,30 @@ export function convertUnit(
 	)
 }
 
+export function conversionFactor(from: Unit, to: Unit) {
+	if (!areUnitConvertible(from, to)) {
+		throw new Error(
+			`Impossible de convertir l'unité '${serializeUnit(
+				from
+			)}' en '${serializeUnit(to)}'`
+		)
+	}
+
+	const [fromSimplified, factorTo] = simplifyUnitWithValue(from || noUnit)
+	const [toSimplified, factorFrom] = simplifyUnitWithValue(to || noUnit)
+	return round(
+		(factorTo / factorFrom) *
+			unitsConversionFactor(
+				fromSimplified.numerators,
+				toSimplified.numerators
+			) *
+			unitsConversionFactor(
+				toSimplified.denominators,
+				fromSimplified.denominators
+			)
+	)
+}
+
 const convertibleUnitClasses = unitClasses(convertTable)
 type unitClasses = Array<Set<string>>
 type ConvertTable = { readonly [index: string]: number }


### PR DESCRIPTION
L'inférence d'unité est actuellement réalisée lors de l'évaluation alors qu'elle peut-être faite de manière statique :

```js
> parse("10 €/mois * 2 mois")
{
  type: 'produit', unit: '€', operands: [
    { type: 'constant', value: '10', unit: '€/mois' },
    { type: 'constant', value: '2', unit: 'mois' }
  ]
}
```

Pour les conversions automatiques, il faut ajouter un noeud dans l'AST :

```js
> parse("100 €/an + 2 €/mois")
{
  type: 'somme', unit: '€/mois', operands: [
    { type: 'constant', value: '100', unit: '€/an' },
    { type: 'conversion', factor: 12, unit: '€/an', operand: { type: 'constant', value: '2', unit: '€/mois' }}
  ]
}
```

Lors de l'évaluation le mécanisme "conversion" effectue un simple produit `factor × nodeValue` sans chercher à recalculer le facteur de conversion.

Cela doit permettre :
- des meilleures performances, car on ne calcule les facteurs de conversion qu'une seule fois et non plus à chaque évaluation (gain estimé de ~20% par évaluation)
- une vérification statique de la cohérence d'unité #1142 

Sur l'implémentation une difficulté concerne le parsage des "références" car au moment où l'on tombe sur une référence on ne connaît pas encore son unité (la règle correspondante n'est peut-être pas encore parsée). Je vois deux solutions possibles :
- soit parser les règles dans l'ordre topologie (ie, quand on tombe sur une référence on va directement parser la référence)
- soit faire l'inférence d'unité dans une passe séparée en partant des feuilles et en transformant l'arbre entier

J'ai une préférence pour la première solution mais ça peut être bien d'en discuter.
