### PR TITLE
Correction simulateur indépendant suite au retours Acoss

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -682,6 +682,7 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite compl
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire . assiette:
   titre: assiette retraite complémentaire
+  unité: €/an
   formule:
     le minimum de:
       - variations:
@@ -764,6 +765,8 @@ dirigeant . indépendant . assiette minimale . maladie:
   produit:
     assiette: plafond sécurité sociale temps plein
     taux: 40%
+  unité: €/an
+  arrondi: oui
   références:
     cotisations minimales: https://www.secu-independants.fr/cotisations/calcul-cotisations/cotisations-minimales/
     
@@ -774,6 +777,8 @@ dirigeant . indépendant . assiette minimale . retraite:
   produit:
     assiette: plafond sécurité sociale temps plein
     taux: 11.5%
+  unité: €/an
+  arrondi: oui
   références:
     cotisations minimales: https://www.secu-independants.fr/cotisations/calcul-cotisations/cotisations-minimales/
     
@@ -1042,7 +1047,7 @@ dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
     multiplicateur: plafond sécurité sociale temps plein
     tranches:
       - plafond: 40%
-        taux: 3.16%
+        taux: 3.17%
       - plafond: 110%
         taux: 6.35%
   note: |
@@ -1060,7 +1065,7 @@ dirigeant . indépendant . cotisations et contributions . maladie . taux progres
       - plafond: 0%
         taux: 0%
       - plafond: 40%
-        taux: 3.16%
+        taux: 3.17%
       - plafond: 110%
         taux: 6.35%
   références:

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -628,18 +628,18 @@ dirigeant . indépendant . conjoint collaborateur . assiette . pourcentage . moi
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . assiette:
   titre: assiette conjoint collaborateur
-  formule:
-    produit:
-      assiette: assiette des cotisations
-      taux: 1 / 3
-      variations:
-        - si: assiette . forfaitaire
-          alors:
-            assiette: plafond sécurité sociale temps plein
-        - si: assiette . pourcentage . moitié
-          alors:
-            taux: 50%
-        - sinon: rien
+  unité: €/an
+  produit:
+    assiette: assiette des cotisations
+    taux: 1 / 3
+    variations:
+      - si: assiette . forfaitaire
+        alors:
+          assiette: plafond sécurité sociale temps plein
+      - si: assiette . pourcentage . moitié
+        alors:
+          taux: 50%
+      # sinon rien ne change
 
 dirigeant . indépendant . conjoint collaborateur . cotisations:
   titre: Cotisations conjoint collaborateur
@@ -683,13 +683,12 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . retraite compl
 dirigeant . indépendant . conjoint collaborateur . cotisations . retraite complémentaire . assiette:
   titre: assiette retraite complémentaire
   unité: €/an
-  formule:
-    le minimum de:
-      - variations:
-          - si: entreprise . activité = 'artisanale'
-            alors: 4 * plafond sécurité sociale temps plein
-          - sinon: 3 * plafond sécurité sociale temps plein
-      - assiette retraite
+  valeur: assiette retraite
+  plafond:
+    variations:
+      - si: entreprise . activité = 'artisanale'
+        alors: 4 * plafond sécurité sociale temps plein
+      - sinon: 3 * plafond sécurité sociale temps plein
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et décès . assiette:
   titre: assiette invalidité et décès
@@ -732,8 +731,6 @@ dirigeant . indépendant . cotisations et contributions:
     C'est le montant total dû par l'indépendant au titre des cotisations et
     contributions obligatoires ainsi qu'au titre de ses cotisations facultatives
     telles que les contrats Madelin.
-
-    Ce montant inclut la réduction de cotisation "covid" en 2020.
 
   somme:
     - cotisations et contributions . cotisations
@@ -1034,43 +1031,34 @@ dirigeant . indépendant . cotisations et contributions . maladie:
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
 
-
-dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
-  # TODO: Il n'est pour l'instant pas possible de rendre non applicable une
-  # seule tranche d'un barème dans le mécanisme "taux progressif", ce qui
-  # éviterait de devoir créer 2 règles séparées avec 2 barèmes distincts.
-  applicable si: situation personnelle . RSA
-  remplace: taux progressif
-  unité: '%'
-  taux progressif:
-    assiette: assiette des cotisations
-    multiplicateur: plafond sécurité sociale temps plein
-    tranches:
-      - plafond: 40%
-        taux: 3.17%
-      - plafond: 110%
-        taux: 6.35%
-  note: |
-    Pour les indépendants au RSA, seule la réduction simple définie dans
-    le décret de calcul de la cotisation maladie est prise en compte.
-    La réduction renforcée en-dessous de 40% du plafond de la sécurité 
-    sociale ne l'est pas, car il n'y a pas d'assiette minimale.
-
    
 dirigeant . indépendant . cotisations et contributions . maladie . taux progressif:
+  description: | 
+    Le taux de la cotisations maladie est progressif en fonction du revenu déclaré. 
+  note: |
+    Pour les indépendants bénéficiant du RSA ou de la prime d'activité, seule la réduction simple 
+    définie dans le décret de calcul de la cotisation maladie est prise en compte.
+
+    La réduction en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas 
+    d'assiette minimale.
   taux progressif:
-    assiette: assiette des cotisations
+    assiette: 
+      valeur: assiette des cotisations
+      plancher: 
+        applicable si: situation personnelle . RSA
+        valeur: 40% * plafond sécurité sociale temps plein
     multiplicateur: plafond sécurité sociale temps plein
     tranches:
       - plafond: 0%
-        taux: 0%
-      - plafond: 40%
-        taux: 3.17%
+        taux: 1.35%
       - plafond: 110%
         taux: 6.35%
+  arrondi: 2 unités
+  unité: '%'
   références:
     Taux de cotisations: https://www.secu-independants.fr/cotisations/calcul-cotisations/taux-de-cotisations/
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
+
 
 dirigeant . indépendant . cotisations et contributions . retraite de base:
   barème:

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -945,13 +945,12 @@ dirigeant . indépendant . cotisations et contributions . début activité:
   recalcul: 
     règle: cotisations et contributions
     avec: 
+      maladie . taux progressif . assiette: 40% * plafond sécurité sociale temps plein 
       assiette des cotisations: assiette forfaitaire
-      assiette des cotisations . sans plancher: assiette forfaitaire
-      situation personnelle . RSA: non
+      CSG et CRDS . assiette: assiette forfaitaire 
   références:
     Fiche Urssaf: https://www.urssaf.fr/portail/home/independant/mes-cotisations/les-etapes-de-calcul/le-mode-de-calcul/lajustement-et-la-regularisation.html
 
-  
 dirigeant . indépendant . cotisations et contributions . début activité . assiette forfaitaire:
   produit: 
     assiette: PSS proratisé
@@ -1043,6 +1042,7 @@ dirigeant . indépendant . cotisations et contributions . maladie . taux progres
     d'assiette minimale.
   taux progressif:
     assiette: 
+      nom: assiette
       valeur: assiette des cotisations
       plancher: 
         applicable si: situation personnelle . RSA

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -31,8 +31,8 @@ dirigeant . rémunération . totale:
     - sinon: entreprise . chiffre d'affaires - entreprise . charges
 
 dirigeant . rémunération . nette:
-  titre: rémunération nette
-  question: Quelle est votre rémunération nette ?
+  titre: revenu net
+  question: Quelle est votre revenu net ?
   résumé: Après déduction des cotisations, contributions et charges
   somme:
     - rémunération . totale
@@ -48,7 +48,7 @@ dirigeant . rémunération . cotisations:
       alors: auto-entrepreneur . cotisations et contributions
 
 dirigeant . rémunération . imposable:
-  titre: Rémunération imposable
+  titre: revenu imposable
   variations:
     - si: assimilé salarié 
       alors: contrat salarié . rémunération . net imposable
@@ -64,7 +64,7 @@ dirigeant . rémunération . impôt:
 
 
 dirigeant . rémunération . nette après impôt:
-  titre: Rémunération après impôt
+  titre: Revenu après impôt
   unité: €/an
   arrondi: oui
   question: Quel est le revenu net après impôt souhaité ?
@@ -726,6 +726,7 @@ dirigeant . indépendant . cotisations et contributions . cotisations:
       - (- exonérations)
 
 dirigeant . indépendant . cotisations et contributions:
+  titre: cotisations et contributions sociales
   description: |
     C'est le montant total dû par l'indépendant au titre des cotisations et
     contributions obligatoires ainsi qu'au titre de ses cotisations facultatives
@@ -821,7 +822,8 @@ dirigeant . indépendant . cotisations et contributions . déduction tabac . rev
 
 dirigeant . indépendant . contrats madelin:
   titre: Contrats Madelin
-  question: Avez-vous souscrit à des contrats de complémentaire privée dits "contrats Madelin"
+  question: |
+    Avez-vous souscrit à un contrat de prévoyance et / ou de retraite complémentaire privé dits « contrat Madelin »
   par défaut: non
   références: 
     economie.gouv.fr: https://www.economie.gouv.fr/particuliers/reduction-impot-revenu-investissements-entreprise-pme-madelin
@@ -848,11 +850,11 @@ dirigeant . indépendant . contrats madelin . part non-déductible fiscalement:
   formule: montant - part déductible fiscalement
 
 dirigeant . indépendant . contrats madelin . mutuelle:
-  titre: Souscription à un contrat de mutuelle Madelin
-  question: Quel est le montant que vous versez à un contrat de mutuelle Madelin ?
+  titre: Souscription à un contrat de prévoyance complémentaire Madelin
+  question: Quel est le montant que vous versez pour vos contrats Madelin de prévoyance complémentaire (santé, perte d'emploi subie) ?
   description: |
-    Si vous cotisez au titre d'un contrat de mutuelle de type loi Madelin,
-    vous pouvez déduire une partie de ces cotisations des bénéfices
+    Si vous cotisez au titre d'un contrat de prévoyance complémentaire (santé, perte d'emploi subie) 
+    de type loi Madelin, vous pouvez déduire ces cotisations des bénéfices
     imposables que vous déclarez pour votre activité non salariée.
   références:
     Fiche impôts: https://www.impots.gouv.fr/portail/particulier/questions/je-cotise-un-contrat-madelin-quel-est-mon-avantage-fiscal
@@ -881,7 +883,7 @@ dirigeant . indépendant . contrats madelin . mutuelle . plafond:
     Normalement c'est le résultat fiscal qui devrait être utilisé pour l'assiette du plafond, mais on utilise le revenu professionnel pour éviter un cycle.
 dirigeant . indépendant . contrats madelin . retraite:
   titre: Souscription à une retraite Madelin
-  question: Quel est le montant que vous versez à votre contrat Madelin retraite ?
+  question: Quel est le montant que vous versez pour votre contrat Madelin retraite complémentaire ?
   description: |
     Si vous cotisez au titre d'un contrat retraite de type loi Madelin,
     vous pouvez déduire une partie de ces cotisations des bénéfices

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -1053,8 +1053,6 @@ dirigeant . indépendant . cotisations et contributions . maladie . taux progres
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
 dirigeant . indépendant . cotisations et contributions . maladie . taux progressif:
-  description: | 
-    Le taux de la cotisations maladie est progressif en fonction du revenu déclaré. 
   taux progressif:
     assiette: 
       nom: assiette

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -705,9 +705,10 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . invalidité et
   arrondi: oui
 
 dirigeant . indépendant . conjoint collaborateur . cotisations . indemnités journalières maladie:
-  unité: €/an
   produit:
-    assiette: 40% * plafond sécurité sociale temps plein
+    assiette: 
+      valeur: 40% * plafond sécurité sociale temps plein
+      unité: €/an
     taux: cotisations et contributions . indemnités journalières maladie . taux
   arrondi: oui
 
@@ -1013,7 +1014,9 @@ dirigeant . indépendant . cotisations et contributions . maladie:
       plancher: assiette minimale . maladie
     multiplicateur: plafond sécurité sociale temps plein
     tranches:
-      - taux: taux progressif
+      - taux: 
+          valeur: taux progressif
+          arrondi: 2 unités
         plafond: 110%
       - taux: 6.35%
         plafond: 5
@@ -1030,31 +1033,38 @@ dirigeant . indépendant . cotisations et contributions . maladie:
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
 
 
-   
+dirigeant . indépendant . cotisations et contributions . maladie . taux progressif . réduction supplémentaire: 
+  description: | 
+    La réduction supplémentaire du taux maladie pour les revenu inférieurs à 40% du plafond de la sécurité sociale
+  non applicable si: situation personnelle . RSA
+  remplace: 
+    règle: taux progressif 
+    par: taux progressif - réduction supplémentaire
+  taux progressif:
+    assiette: assiette
+    multiplicateur: plafond sécurité sociale temps plein
+    tranches: 
+      - plafond: 0%
+        taux: 1.35%
+      - plafond: 40%
+        taux: 0%
+  références:
+    Taux de cotisations: https://www.secu-independants.fr/cotisations/calcul-cotisations/taux-de-cotisations/
+    décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
+
 dirigeant . indépendant . cotisations et contributions . maladie . taux progressif:
   description: | 
     Le taux de la cotisations maladie est progressif en fonction du revenu déclaré. 
-  note: |
-    Pour les indépendants bénéficiant du RSA ou de la prime d'activité, seule la réduction simple 
-    définie dans le décret de calcul de la cotisation maladie est prise en compte.
-
-    La réduction en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas 
-    d'assiette minimale.
   taux progressif:
     assiette: 
       nom: assiette
       valeur: assiette des cotisations
-      plancher: 
-        applicable si: situation personnelle . RSA
-        valeur: 40% * plafond sécurité sociale temps plein
     multiplicateur: plafond sécurité sociale temps plein
     tranches:
       - plafond: 0%
         taux: 1.35%
       - plafond: 110%
         taux: 6.35%
-  arrondi: 2 unités
-  unité: '%'
   références:
     Taux de cotisations: https://www.secu-independants.fr/cotisations/calcul-cotisations/taux-de-cotisations/
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -97,9 +97,11 @@ entreprise . chiffre d'affaires . vente restauration hébergement:
 
     ### Restauration et hébergement
     Il s’agit du chiffre d'affaires de toutes les opérations de restauration
-    ou hébergement (hors meublé de tourisme classé)
+    ou hébergement
 
-    Ces revenus sont imposable au régime BIC
+    > Note : pour les locations meublées, seules les locations de meublé de tourisme classé et de chambre d’hôte entrent dans cette catégorie hébergement ; les autres locations meublées relèvent de la catégorie « Prestations de service BIC »
+
+    Ces revenus sont imposables dans la catégorie des BIC
   références:
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32919
     définition vente de bien (impots.gouv): https://www.impots.gouv.fr/portail/professionnel/achatvente-de-biens
@@ -255,10 +257,9 @@ entreprise . imposition . IR . micro-fiscal:
   rend non applicable: dirigeant . indépendant . contrats madelin
   question: Avez-vous opté pour le régime micro-fiscal ?
   description: |
-    Avec le régime micro fiscal, les charges déductible sont estimées forfaitairement, comme un pourcentage du chiffre d'affaires.
-    Ce pourcentage dépend du type d'activité. 
-
-    Cette option permet de simplifier votre comptabilité, et peut-être avantageuse en terme de revenu dans le cas où vos charges de fonctionnement sont faibles.
+    Avec le régime micro fiscal, les charges déductibles sont estimées forfaitairement,en fonction d’un pourcentage du chiffre d’affaires. Ce pourcentage dépend du type d’activité : 71% pour les activités de vente, restauration et hébergement (location de meublé de tourisme classé et chambre d’hôte), 50% pour les prestations de service commerciales ou artisanales, 34% pour les activités libérales. 
+    
+    Cette option permet de simplifier votre comptabilité et peut être avantageuse en termes de revenu imposable et soumis à cotisations et contributions sociales dans le cas où vos charges de fonctionnement sont faibles.
   par défaut: non
 
 entreprise . imposition . IR . micro-fiscal . revenu abattu:
@@ -804,16 +805,15 @@ entreprise . activité . mixte:
 
     Par exemple, une entreprise de plomberie qui facture l'achat et la pose d'un
     robinet a une partie de son chiffre d'affaires en vente de materiel (le robinet)
-    et une partie en prestation de service (la pose)
+    et une partie en prestation de service (la pose).
 
-    Il existe trois principales familles de revenus au yeux de l'administration
-    fiscale et sociale :
+    Il existe trois catégories avec des taux d’abattement forfaitaire pour frais différents :
 
-    - [Ventes de biens, restauration et hébergement (BIC)](/documentation/entreprise/chiffre-d'affaires/vente-restauration-hébergement)
-    - [Prestation de service commerciale ou artisanale (BIC)](/documentation/entreprise/chiffre-d'affaires/prestations-de-service-BIC)
-    - [Autres prestation de service et activité libérale (BNC)](/documentation/entreprise/chiffre-d'affaires/prestations-de-service-BNC)
+    - [Ventes de biens, restauration et hébergement (BIC)](/documentation/entreprise/chiffre-d'affaires/vente-restauration-hébergement) (abattement de 71%)
+    - [Prestation de service commerciale ou artisanale (BIC)](/documentation/entreprise/chiffre-d'affaires/service-BIC) (abattement de 50%)
+    - [Autres prestation de service et activité libérale (BNC)](/documentation/entreprise/chiffre-d'affaires/service-BNC) (abattement de 34%)
 
-    Si votre entreprise a des activités correspondants à plus d'un type de
+    Si votre entreprise a des activités correspondants à plusieurs catégories de
     revenus, répondez oui à cette question.
 
 entreprise . activité . mixte . proportions:

--- a/modele-social/règles/profession-libérale.yaml
+++ b/modele-social/règles/profession-libérale.yaml
@@ -177,19 +177,20 @@ dirigeant . indépendant . PL . maladie:
       - régime général
       - PAMC
   remplace: cotisations et contributions . maladie
-  formule:
-    produit:
-      assiette: indépendant . assiette des cotisations
-      taux:
-        taux progressif:
-          assiette: indépendant . assiette des cotisations
-          multiplicateur: plafond sécurité sociale temps plein
-          tranches:
-            - plafond: 0%
-              taux: 1.5%
-            - plafond: 110%
-              taux: 6.5%
-    arrondi: oui
+  produit:
+    assiette:
+      valeur: assiette des cotisations
+      plancher: assiette minimale . maladie
+    taux:
+      taux progressif:
+        assiette: assiette des cotisations
+        multiplicateur: plafond sécurité sociale temps plein
+        tranches:
+          - plafond: 0%
+            taux: 1.5%
+          - plafond: 110%
+            taux: 6.5%
+  arrondi: oui
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/taux-de-cotisations
     guide urssaf (pdf): https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Diaporama_PL_statuts_hors_AE_et_PAM.pdf

--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -204,6 +204,7 @@ protection sociale . retraite . complémentaire salarié . points acquis:
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F15396
 
 protection sociale . retraite . complémentaire indépendants:
+  acronyme: RCI
   non applicable si:
     toutes ces conditions:
       - entreprise . activité = 'libérale'
@@ -225,8 +226,7 @@ protection sociale . retraite . complémentaire indépendants . points acquis:
   valeur: dirigeant . indépendant . cotisations et contributions . retraite complémentaire / prix d'achat du point
 
 protection sociale . retraite . complémentaire indépendants . prix d'achat du point:
-  formule: 17.515 €/point
-  notes: il s'agit du prix d'achat 2018 (la valeur pour 2019 sur le site secu-independants.fr est marquée comme N.C)
+  formule: 17.765 €/point
   références:
     secu-independants.fr: https://www.secu-independants.fr/baremes/baremes-2018/baremesprestations-maladie-maternite/?reg=ile-de-france-centre&ae=oui
 

--- a/mon-entreprise/source/components/SimulateurWarning.tsx
+++ b/mon-entreprise/source/components/SimulateurWarning.tsx
@@ -45,7 +45,8 @@ export default function SimulateurWarning({
 					<li>
 						<Trans i18nKey="simulateurs.warning.urssaf">
 							Les calculs sont indicatifs. Ils ne se substituent pas aux
-							décomptes réels de l’Urssaf, du fisc ou autre.
+							décomptes réels de l’Urssaf, de l’administration fiscale ou de
+							toute autre organisme.
 						</Trans>
 					</li>
 				)}
@@ -88,8 +89,8 @@ export default function SimulateurWarning({
 				{['indépendant', 'profession-libérale'].includes(simulateur) && (
 					<li>
 						<Trans i18nKey="simulateurs.warning.année-courante">
-							Le montant des cotisations est calculé pour un revenu sur l'année
-							2020.
+							Le montant calculé correspond aux cotisations de l’année 2021
+							(pour un revenu 2021).
 						</Trans>
 					</li>
 				)}

--- a/mon-entreprise/source/components/StackedBarChart.tsx
+++ b/mon-entreprise/source/components/StackedBarChart.tsx
@@ -29,6 +29,7 @@ const BarStackLegend = styled.div`
 	display: flex;
 	margin-top: 10px;
 	flex-direction: column;
+	justify-content: space-between;
 
 	@media (min-width: 800px) {
 		flex-direction: row;
@@ -37,9 +38,7 @@ const BarStackLegend = styled.div`
 `
 
 const BarStackLegendItem = styled.div`
-	flex: 1 1 0px;
 	color: #555;
-
 	strong {
 		display: inline-block;
 		color: #111;

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -37,7 +37,7 @@ export default function IndépendantExplanation() {
 			</Condition>
 			<Condition expression="dirigeant . rémunération . nette après impôt > 0 €/an">
 				<section>
-					<h2>Répartition de la rémunération totale</h2>
+					<h2>Répartition du revenu</h2>
 					<StackedBarChart
 						data={[
 							{
@@ -52,7 +52,6 @@ export default function IndépendantExplanation() {
 							{
 								dottedName:
 									'dirigeant . indépendant . cotisations et contributions',
-								title: t('Cotisations'),
 								color: palettes[1][1],
 							},
 						]}

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -6399,28 +6399,17 @@ dirigeant . indépendant . cotisations et contributions . maladie:
   description.fr: >
     Le taux de la cotisations maladie est progressif en fonction du revenu
     déclaré.
-  note.en: >
-    [automatic] For self-employed persons receiving the RSA or the activity
-    allowance, only the simple reduction 
-
-    defined in the decree for calculating the health contribution is taken into account.
-
-
-    The reduction below 40% of the social security ceiling is not, because there is no minimum 
-
-    minimum base.
-  note.fr: >
-    Pour les indépendants bénéficiant du RSA ou de la prime d'activité, seule la
-    réduction simple 
-
-    définie dans le décret de calcul de la cotisation maladie est prise en compte.
-
-
-    La réduction en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas 
-
-    d'assiette minimale.
   titre.en: '[automatic] progressive rate'
   titre.fr: taux progressif
+? dirigeant . indépendant . cotisations et contributions . maladie . taux progressif . réduction supplémentaire
+: description.en: >
+    [automatic] Additional reduction of the sickness rate for income below 40%
+    of the social security ceiling
+  description.fr: >
+    La réduction supplémentaire du taux maladie pour les revenu inférieurs à 40%
+    du plafond de la sécurité sociale
+  titre.en: '[automatic] further reduction'
+  titre.fr: réduction supplémentaire
 ? dirigeant . indépendant . cotisations et contributions . maladie domiciliation fiscale étranger
 : description.en:
     '[automatic] In return for the CSG exemption, contributors have

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -6106,8 +6106,6 @@ dirigeant . indépendant . cotisations et contributions:
     C'est le montant total dû par l'indépendant au titre des cotisations et
     contributions obligatoires ainsi qu'au titre de ses cotisations facultatives
     telles que les contrats Madelin.
-
-    Ce montant inclut la réduction de cotisation "covid" en 2020.
   note.en: |
     [automatic] Unlike contributions, contributions are not reintroduced
     for the calculation of the CSG/CRDS. They also do not benefit from the
@@ -6394,21 +6392,34 @@ dirigeant . indépendant . cotisations et contributions . maladie:
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nous avons retenue.
   titre.en: '[automatic] disease'
   titre.fr: maladie
-dirigeant . indépendant . cotisations et contributions . maladie . taux RSA:
-  note.en: |
-    [automatic] For RSA freelancers, only the simple reduction defined in
-    the decree for calculating the health contribution is taken into account.
-    The reinforced reduction below 40% of the security ceiling 
-    social is not, because there is no minimum base.
-  note.fr: |
-    Pour les indépendants au RSA, seule la réduction simple définie dans
-    le décret de calcul de la cotisation maladie est prise en compte.
-    La réduction renforcée en-dessous de 40% du plafond de la sécurité 
-    sociale ne l'est pas, car il n'y a pas d'assiette minimale.
-  titre.en: '[automatic] RSA rate'
-  titre.fr: taux RSA
 ? dirigeant . indépendant . cotisations et contributions . maladie . taux progressif
-: titre.en: '[automatic] progressive rate'
+: description.en: >
+    [automatic] The rate of the health contribution is progressive according to
+    the declared income.
+  description.fr: >
+    Le taux de la cotisations maladie est progressif en fonction du revenu
+    déclaré.
+  note.en: >
+    [automatic] For self-employed persons receiving the RSA or the activity
+    allowance, only the simple reduction 
+
+    defined in the decree for calculating the health contribution is taken into account.
+
+
+    The reduction below 40% of the social security ceiling is not, because there is no minimum 
+
+    minimum base.
+  note.fr: >
+    Pour les indépendants bénéficiant du RSA ou de la prime d'activité, seule la
+    réduction simple 
+
+    définie dans le décret de calcul de la cotisation maladie est prise en compte.
+
+
+    La réduction en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas 
+
+    d'assiette minimale.
+  titre.en: '[automatic] progressive rate'
   titre.fr: taux progressif
 ? dirigeant . indépendant . cotisations et contributions . maladie domiciliation fiscale étranger
 : description.en:

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -6393,13 +6393,7 @@ dirigeant . indépendant . cotisations et contributions . maladie:
   titre.en: '[automatic] disease'
   titre.fr: maladie
 ? dirigeant . indépendant . cotisations et contributions . maladie . taux progressif
-: description.en: >
-    [automatic] The rate of the health contribution is progressive according to
-    the declared income.
-  description.fr: >
-    Le taux de la cotisations maladie est progressif en fonction du revenu
-    déclaré.
-  titre.en: '[automatic] progressive rate'
+: titre.en: '[automatic] progressive rate'
   titre.fr: taux progressif
 ? dirigeant . indépendant . cotisations et contributions . maladie . taux progressif . réduction supplémentaire
 : description.en: >

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -6024,11 +6024,12 @@ dirigeant . indépendant . conjoint collaborateur . cotisations . assiette:
 : titre.en: basic retirement
   titre.fr: retraite de base
 dirigeant . indépendant . contrats madelin:
-  question.en:
-    '[automatic] Have you subscribed to private supplementary insurance
-    contracts known as "Madelin contracts"?'
-  question.fr: Avez-vous souscrit à des contrats de complémentaire privée dits
-    "contrats Madelin"
+  question.en: >
+    [automatic] Have you subscribed to a private provident and/or supplementary
+    pension contract known as a "Madelin contract"?
+  question.fr: >
+    Avez-vous souscrit à un contrat de prévoyance et / ou de retraite
+    complémentaire privé dits « contrat Madelin »
   titre.en: Madelin Contracts
   titre.fr: Contrats Madelin
 dirigeant . indépendant . contrats madelin . montant:
@@ -6036,20 +6037,25 @@ dirigeant . indépendant . contrats madelin . montant:
   titre.fr: Somme des cotisations à contrats Madelin
 dirigeant . indépendant . contrats madelin . mutuelle:
   description.en: >
-    [automatic] If you contribute under a mutual insurance contract such as the
-    Madelin law,
+    [automatic] If you contribute to a supplementary insurance contract (health,
+    loss of employment) 
 
-    you can deduct part of these contributions from your profits; and
+    under the Madelin law, you can deduct these contributions from the taxable profits
 
-    taxable persons that you declare for your self-employed activity.
-  description.fr: |
-    Si vous cotisez au titre d'un contrat de mutuelle de type loi Madelin,
-    vous pouvez déduire une partie de ces cotisations des bénéfices
+    that you declare for your self-employed activity.
+  description.fr: >
+    Si vous cotisez au titre d'un contrat de prévoyance complémentaire (santé,
+    perte d'emploi subie) 
+
+    de type loi Madelin, vous pouvez déduire ces cotisations des bénéfices
+
     imposables que vous déclarez pour votre activité non salariée.
-  question.en: '[automatic] How much do you pay to a Madelin Mutual contract?'
-  question.fr: Quel est le montant que vous versez à un contrat de mutuelle Madelin ?
-  titre.en: '[automatic] Subscription to a Madelin mutual insurance contract'
-  titre.fr: Souscription à un contrat de mutuelle Madelin
+  question.en: '[automatic] How much do you pay for your Madelin supplementary
+    insurance policies (health, sudden loss of employment)?'
+  question.fr: Quel est le montant que vous versez pour vos contrats Madelin de
+    prévoyance complémentaire (santé, perte d'emploi subie) ?
+  titre.en: '[automatic] Subscribing to a Madelin supplementary insurance contract'
+  titre.fr: Souscription à un contrat de prévoyance complémentaire Madelin
 dirigeant . indépendant . contrats madelin . mutuelle . plafond:
   note.en: >
     [automatic] Normally it is the tax result that should be used for the cap
@@ -6078,8 +6084,10 @@ dirigeant . indépendant . contrats madelin . retraite:
     Si vous cotisez au titre d'un contrat retraite de type loi Madelin,
     vous pouvez déduire une partie de ces cotisations des bénéfices
     imposables que vous déclarez pour votre activité non salariée.
-  question.en: '[automatic] How much do you pay into your Madelin retraite contract?'
-  question.fr: Quel est le montant que vous versez à votre contrat Madelin retraite ?
+  question.en: '[automatic] How much do you pay for your Madelin supplementary
+    pension contract?'
+  question.fr: Quel est le montant que vous versez pour votre contrat Madelin
+    retraite complémentaire ?
   titre.en: '[automatic] Madelin Retirement Subscription'
   titre.fr: Souscription à une retraite Madelin
 dirigeant . indépendant . contrats madelin . retraite . plafond:
@@ -6108,8 +6116,8 @@ dirigeant . indépendant . cotisations et contributions:
     À la différence des cotisations, les contributions ne sont pas réintroduites
     pour le calcul de la CSG/CRDS. Elles ne bénéficient pas non plus de la
     réduction ACRE.
-  titre.en: all contributions
-  titre.fr: cotisations et contributions
+  titre.en: '[automatic] social contributions'
+  titre.fr: cotisations et contributions sociales
 dirigeant . indépendant . cotisations et contributions . CSG et CRDS:
   titre.en: CSG and CRDS
   titre.fr: CSG et CRDS
@@ -6524,18 +6532,18 @@ dirigeant . rémunération . cotisations:
   titre.en: '[automatic] contributions'
   titre.fr: cotisations
 dirigeant . rémunération . imposable:
-  titre.en: '[automatic] Taxable remuneration'
-  titre.fr: Rémunération imposable
+  titre.en: '[automatic] taxable income'
+  titre.fr: revenu imposable
 dirigeant . rémunération . impôt:
   titre.en: '[automatic] tax'
   titre.fr: impôt
 dirigeant . rémunération . nette:
-  question.en: '[automatic] What is your net pay?'
-  question.fr: Quelle est votre rémunération nette ?
+  question.en: '[automatic] What is your net income?'
+  question.fr: Quelle est votre revenu net ?
   résumé.en: '[automatic] After deduction of contributions and expenses'
   résumé.fr: Après déduction des cotisations, contributions et charges
-  titre.en: '[automatic] net pay'
-  titre.fr: rémunération nette
+  titre.en: '[automatic] net income'
+  titre.fr: revenu net
 dirigeant . rémunération . nette après impôt:
   description.en: '[automatic] The net income after deduction of income tax and
     social security contributions.'
@@ -6545,8 +6553,8 @@ dirigeant . rémunération . nette après impôt:
   question.fr: Quel est le revenu net après impôt souhaité ?
   résumé.en: '[automatic] What you get from this activity'
   résumé.fr: Ce que vous rapporte cette activité
-  titre.en: '[automatic] After-tax compensation'
-  titre.fr: Rémunération après impôt
+  titre.en: '[automatic] After-tax income'
+  titre.fr: Revenu après impôt
 dirigeant . rémunération . totale:
   description.en: >
     [automatic] This is what the company spends in total for the remuneration of
@@ -6760,33 +6768,31 @@ entreprise . activité . libérale réglementée:
 entreprise . activité . mixte:
   description.en: >
     [automatic] It is possible to have several activities with different types
-    of income
+    of income for the same
 
-    different for the same company. 
-
-
-    For example, a plumbing company that charges for the purchase and installation of a
-
-    robinet has a part of its turnover in sales of equipment (the tap)
-
-    and a part in service provision (the installation)
+    for the same company. 
 
 
-    There are three main families of income in the eyes of the administration
+    For example, a plumbing company that charges for the purchase and installation of a faucet
 
-    fiscal and social :
+    faucet has a part of its turnover in sale of material (the faucet)
 
-
-    - (Sales of goods, restaurants and accommodation (BIC))(/documentation/enterprise/turnover/sales-restaurants and accommodation)
-
-    - Commercial or craft services (BIC)](/documentation/enterprise/turnover/ BIC services)
-
-    - (Other services and liberal activity (NCBs))(/documentation/enterprise/turnover/services- NCBs)
+    and a part in service provision (the installation).
 
 
-    If your company has activities that correspond to more than one type of
+    There are three categories with different standard expense allowance rates:
 
-    returned, answer yes to this question.
+
+    - [Sales of goods, catering and accommodation (BIC)](/documentation/company/turnover/sales-restoration-accommodation) (71% allowance)
+
+    - Commercial or artisanal services (BIC)](/documentation/company/turnover/service-BIC) (50% deduction)
+
+    - Other services and liberal activities (BNC)](/documentation/company/turnover/service-BNC) (34% deduction)
+
+
+    If your company has activities corresponding to several categories of income, answer yes to this
+
+    answer yes to this question.
   description.fr: >
     Il est possible d'avoir plusieurs activités avec des types de revenus
 
@@ -6797,22 +6803,20 @@ entreprise . activité . mixte:
 
     robinet a une partie de son chiffre d'affaires en vente de materiel (le robinet)
 
-    et une partie en prestation de service (la pose)
+    et une partie en prestation de service (la pose).
 
 
-    Il existe trois principales familles de revenus au yeux de l'administration
-
-    fiscale et sociale :
+    Il existe trois catégories avec des taux d’abattement forfaitaire pour frais différents :
 
 
-    - [Ventes de biens, restauration et hébergement (BIC)](/documentation/entreprise/chiffre-d'affaires/vente-restauration-hébergement)
+    - [Ventes de biens, restauration et hébergement (BIC)](/documentation/entreprise/chiffre-d'affaires/vente-restauration-hébergement) (abattement de 71%)
 
-    - [Prestation de service commerciale ou artisanale (BIC)](/documentation/entreprise/chiffre-d'affaires/prestations-de-service-BIC)
+    - [Prestation de service commerciale ou artisanale (BIC)](/documentation/entreprise/chiffre-d'affaires/service-BIC) (abattement de 50%)
 
-    - [Autres prestation de service et activité libérale (BNC)](/documentation/entreprise/chiffre-d'affaires/prestations-de-service-BNC)
+    - [Autres prestation de service et activité libérale (BNC)](/documentation/entreprise/chiffre-d'affaires/service-BNC) (abattement de 34%)
 
 
-    Si votre entreprise a des activités correspondants à plus d'un type de
+    Si votre entreprise a des activités correspondants à plusieurs catégories de
 
     revenus, répondez oui à cette question.
   question.en: '[automatic] Does your company have several types of activities?'
@@ -7130,28 +7134,48 @@ entreprise . chiffre d'affaires . seuil micro dépassé:
   titre.en: '[automatic] micro threshold exceeded'
   titre.fr: seuil micro dépassé
 entreprise . chiffre d'affaires . vente restauration hébergement:
-  description.en: |
-    [automatic] ### Sale of goods 
-    This is the turnover of all operations involving
-    transfer of ownership of tangible property, i.e., property with a
+  description.en: >
+    [automatic] Sale of goods 
+
+    This is the turnover of all transactions involving
+
+    transfer of ownership of a tangible asset, i.e. an asset that has a physical
+
     material existence. 
 
-    ### Catering and hosting
-    This is the turnover of all catering operations.
-    or lodging (except classified tourist accommodation)
 
-    This income is taxable under the BIC regime
-  description.fr: |
+    Catering and accommodation
+
+    This is the turnover of all catering and accommodation operations
+
+    or accommodation
+
+
+    Note: for furnished rentals, only classified furnished tourist accommodation and guest rooms are included in this accommodation category; other furnished rentals are included in the "Provision of BIC services" category
+
+
+    This income is taxable in the BIC category
+  description.fr: >
     ### Vente de biens 
+
     Il s’agit du chiffre d'affaires de toutes les opérations comportant
+
     transfert de propriété d'un bien corporel, c'est-à-dire un bien ayant une
+
     existence matérielle. 
 
-    ### Restauration et hébergement
-    Il s’agit du chiffre d'affaires de toutes les opérations de restauration
-    ou hébergement (hors meublé de tourisme classé)
 
-    Ces revenus sont imposable au régime BIC
+    ### Restauration et hébergement
+
+    Il s’agit du chiffre d'affaires de toutes les opérations de restauration
+
+    ou hébergement
+
+
+    > Note : pour les locations meublées, seules les locations de meublé de tourisme classé et de chambre d’hôte entrent dans cette catégorie hébergement ; les autres locations meublées relèvent de la catégorie « Prestations de service BIC »
+
+
+    Ces revenus sont imposables dans la catégorie des BIC
   question.en: '[automatic] What is the turnover from the sale of goods, food or
     accommodation?'
   question.fr: Quel est le chiffre d'affaires issus de la vente de bien,
@@ -7357,20 +7381,24 @@ entreprise . imposition . IR . information sur le report de déficit:
 entreprise . imposition . IR . micro-fiscal:
   description.en: >
     [automatic] With the micro tax system, the deductible expenses are estimated
-    as a percentage of the turnover.
+    on a flat rate basis, according to a percentage of the turnover. This
+    percentage depends on the type of activity: 71% for sales, catering and
+    accommodation (rental of classified furnished tourist accommodation and
+    guest rooms), 50% for commercial or craft services, 34% for liberal
+    activities. 
 
-    This percentage depends on the type of activity. 
 
-
-    This option allows you to simplify your accounting, and can be advantageous in terms of income if your operating costs are low.
+    This option allows you to simplify your accounting and can be advantageous in terms of taxable income and subject to social security contributions if your operating expenses are low.
   description.fr: >
-    Avec le régime micro fiscal, les charges déductible sont estimées
-    forfaitairement, comme un pourcentage du chiffre d'affaires.
+    Avec le régime micro fiscal, les charges déductibles sont estimées
+    forfaitairement,en fonction d’un pourcentage du chiffre d’affaires. Ce
+    pourcentage dépend du type d’activité : 71% pour les activités de vente,
+    restauration et hébergement (location de meublé de tourisme classé et
+    chambre d’hôte), 50% pour les prestations de service commerciales ou
+    artisanales, 34% pour les activités libérales. 
 
-    Ce pourcentage dépend du type d'activité. 
 
-
-    Cette option permet de simplifier votre comptabilité, et peut-être avantageuse en terme de revenu dans le cas où vos charges de fonctionnement sont faibles.
+    Cette option permet de simplifier votre comptabilité et peut être avantageuse en termes de revenu imposable et soumis à cotisations et contributions sociales dans le cas où vos charges de fonctionnement sont faibles.
   question.en: '[automatic] Have you opted for the micro-tax system?'
   question.fr: Avez-vous opté pour le régime micro-fiscal ?
   titre.en: '[automatic] micro-tax'

--- a/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
@@ -1,6 +1,6 @@
 import { batchUpdateSituation } from 'Actions/actions'
 import { Explicable } from 'Components/conversation/Explicable'
-import { Condition } from 'Components/EngineValue'
+import { Condition, WhenAlreadyDefined } from 'Components/EngineValue'
 import PeriodSwitch from 'Components/PeriodSwitch'
 import SimulateurWarning from 'Components/SimulateurWarning'
 import Simulation from 'Components/Simulation'
@@ -103,9 +103,9 @@ export default function AutoEntrepreneur() {
 						dottedName="dirigeant . auto-entrepreneur . cotisations et contributions"
 					/>
 					<SimulationGoal dottedName="dirigeant . auto-entrepreneur . net de cotisations" />
-					<Condition expression="entreprise . chiffre d'affaires">
+					<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
 						<SimulationGoal small editable={false} dottedName="impôt" />
-					</Condition>
+					</WhenAlreadyDefined>
 					<SimulationGoal dottedName="dirigeant . auto-entrepreneur . net après impôt" />
 				</SimulationGoals>
 			</Simulation>

--- a/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
@@ -103,7 +103,7 @@ export default function AutoEntrepreneur() {
 						dottedName="dirigeant . auto-entrepreneur . cotisations et contributions"
 					/>
 					<SimulationGoal dottedName="dirigeant . auto-entrepreneur . net de cotisations" />
-					<Condition expression="impôt > 0">
+					<Condition expression="entreprise . chiffre d'affaires">
 						<SimulationGoal small editable={false} dottedName="impôt" />
 					</Condition>
 					<SimulationGoal dottedName="dirigeant . auto-entrepreneur . net après impôt" />

--- a/mon-entreprise/source/pages/Simulateurs/IndépendantSimulation.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/IndépendantSimulation.tsx
@@ -100,7 +100,7 @@ function IndépendantSimulationGoals() {
 				/>
 			</Condition>
 			<SimulationGoal dottedName="dirigeant . rémunération . nette" />
-			<Condition expression="impôt > 0">
+			<Condition expression="entreprise . chiffre d'affaires">
 				<SimulationGoal small editable={false} dottedName="impôt" />
 			</Condition>
 			<SimulationGoal dottedName="dirigeant . rémunération . nette après impôt" />

--- a/mon-entreprise/source/pages/Simulateurs/IndépendantSimulation.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/IndépendantSimulation.tsx
@@ -1,6 +1,6 @@
 import { updateSituation } from 'Actions/actions'
 import Banner from 'Components/Banner'
-import { Condition } from 'Components/EngineValue'
+import { Condition, WhenAlreadyDefined } from 'Components/EngineValue'
 import PeriodSwitch from 'Components/PeriodSwitch'
 import SimulateurWarning from 'Components/SimulateurWarning'
 import Simulation from 'Components/Simulation'
@@ -100,9 +100,9 @@ function IndépendantSimulationGoals() {
 				/>
 			</Condition>
 			<SimulationGoal dottedName="dirigeant . rémunération . nette" />
-			<Condition expression="entreprise . chiffre d'affaires">
+			<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
 				<SimulationGoal small editable={false} dottedName="impôt" />
-			</Condition>
+			</WhenAlreadyDefined>
 			<SimulationGoal dottedName="dirigeant . rémunération . nette après impôt" />
 		</SimulationGoals>
 	)

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -6,15 +6,15 @@ exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[913,1965]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[300,715]"`;
 
-exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `"[1537,2270]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `"[1487,2220]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `"[606,1339]"`;
 
 exports[`calculate aide-déclaration-indépendant: IJSS (indemnité sécurité sociale) 1`] = `"[11409,14535]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[86,214]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[82,210]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[1061,1476]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[1021,1436]"`;
 
 exports[`calculate aide-déclaration-indépendant: aide covid 2020 1`] = `"[9021,11468]"`;
 
@@ -45,18 +45,18 @@ exports[`calculate aide-déclaration-indépendant: international 2`] = `"[11875,
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[11365,14660]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[1533,1963]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[1368,1798]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[11369,14649]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[1534,1949]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[1369,1784]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `
 "[11369,14649]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[1534,1949]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[1369,1784]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 7`] = `
 "[9454,12734]
@@ -64,22 +64,22 @@ Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA d�
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `
-"[1264,1392]
+"[1042,1170]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `
-"[1264,1424]
+"[1042,1202]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1267,1459]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1067,1259]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[1305,1529]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[1110,1334]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[1534,1949]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[1369,1784]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[2303,3036]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[2204,2937]"`;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `
 "[20929,27392]
@@ -211,7 +211,7 @@ exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,143
 
 exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10381,19619,20431,874,18745,0,30000,4559]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6754,13246,13786,0,13246,0,20000,4059]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6732,13268,13809,0,13268,0,20000,4059]"`;
 
 exports[`calculate simulations-indépendant: Contrats Madelin 5`] = `
 "[300000,79622,220378,228521,82429,137949,0,300000,10059]
@@ -224,18 +224,18 @@ exports[`calculate simulations-indépendant: activité 1`] = `"[29086,9086,20000
 
 exports[`calculate simulations-indépendant: activité 2`] = `"[29102,9102,20000,20787,931,19069,0,29102,3575]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1617,1517,100,141,0,100,0,1617,3559]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1375,1275,100,135,0,100,0,1375,3559]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[246,146,100,104,0,100,0,246,3211]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[244,144,100,104,0,100,0,244,3211]"`;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 1`] = `
-"[100000,30104,69896,72608,15122,54774,0,100000,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
+"[100000,30105,69895,72609,15123,54772,0,100000,3559]
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 2`] = `
-"[100000,30104,69896,72608,15122,54774,0,100000,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
+"[100000,30105,69895,72609,15123,54772,0,100000,3559]
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29086,9086,20000,20787,603,19397,0,29086,3559]"`;
@@ -244,31 +244,31 @@ exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73023
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29086,9086,20000,20787,2079,17921,0,29086,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1581,419,471,0,419,0,2000,3559]"`;
+exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1386,614,666,0,614,0,2000,3559]"`;
 
 exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16004,33996,35351,4611,29385,0,50000,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 3`] = `"[14687,4687,10000,10396,0,10000,0,14687,3559]"`;
+exports[`calculate simulations-indépendant: inversions 3`] = `"[14597,4597,10000,10394,0,10000,0,14597,3559]"`;
 
 exports[`calculate simulations-indépendant: inversions 4`] = `"[72181,22762,49419,51376,9419,40000,0,72181,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 5`] = `"[14687,4687,10000,10396,0,10000,1000,15687,3559]"`;
+exports[`calculate simulations-indépendant: inversions 5`] = `"[14597,4597,10000,10394,0,10000,1000,15597,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5959,13041,13554,0,13041,1000,20000,3559]"`;
+exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5929,13071,13584,0,13071,1000,20000,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5664,12336,12821,0,12336,2000,20000,3559]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5627,12373,12860,0,12373,2000,20000,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[2097,1597,500,554,0,500,0,2097,3559]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1861,1361,500,548,0,500,0,1861,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2697,1697,1000,1070,0,1000,0,2697,3559]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2466,1466,1000,1064,0,1000,0,2466,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3298,1798,1500,1587,0,1500,0,3298,3559]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3075,1575,1500,1581,0,1500,0,3075,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3897,1897,2000,2103,0,2000,0,3897,3559]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3683,1683,2000,2097,0,2000,0,3683,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7595,2595,5000,5203,0,5000,0,7595,3559]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7428,2428,5000,5199,0,5000,0,7428,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14687,4687,10000,10396,0,10000,0,14687,3559]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14597,4597,10000,10394,0,10000,0,14597,3559]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `
 "[139593,39593,100000,103788,28472,71528,0,139593,3559]
@@ -280,17 +280,17 @@ exports[`calculate simulations-indépendant: échelle de revenus 8`] = `
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[2873,0,2373,500,0,500]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[3147,0,2647,500,0,500]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[3433,0,2433,1000,0,1000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 2`] = `"[3708,0,2708,1000,0,1000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[3994,0,2494,1500,0,1500]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 3`] = `"[4267,0,2767,1500,0,1500]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[4554,0,2554,2000,0,2000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 4`] = `"[4827,0,2827,2000,0,2000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[7987,0,2987,5000,0,5000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 5`] = `"[8245,0,3245,5000,0,5000]"`;
 
-exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14244,0,4244,10000,0,10000]"`;
+exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14422,0,4422,10000,0,10000]"`;
 
 exports[`calculate simulations-professions-libérales: CIPAV 7`] = `
 "[146241,0,46241,100000,28546,71454]
@@ -318,7 +318,7 @@ exports[`calculate simulations-professions-libérales: avocat 2`] = `
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5049,14951,85,14866]"`;
+exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5076,14924,81,14843]"`;
 
 exports[`calculate simulations-professions-libérales: expert-comptable 2`] = `
 "[50000,0,14877,35123,4949,30174]
@@ -499,46 +499,46 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,19619,0,14540,4,28]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13246,0,9776,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13268,0,9793,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `
 "[0,220378,0,57407,4,56]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13146,0,9726,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13168,0,9743,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13746,0,10026,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13768,0,10043,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14555,0,null,4,0]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14515,0,null,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13734,0,10017,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13758,0,10035,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13746,0,10026,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13768,0,10043,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13746,0,10026,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13768,0,10043,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6695,0,4886,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6794,0,4956,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13746,0,10026,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13768,0,10043,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 1`] = `
-"[0,-1267,0,0,3,21]
+"[0,-1045,0,0,3,21]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 2`] = `
-"[0,-448,0,0,3,21]
+"[0,-226,0,0,3,21]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,419,0,331,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,614,0,468,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,2918,0,2142,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3083,0,2257,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6695,0,4886,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6794,0,4956,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13746,0,10026,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13768,0,10043,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33996,0,24810,4,48]"`;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -10,29 +10,29 @@ exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `"[1487,2220]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `"[606,1339]"`;
 
-exports[`calculate aide-déclaration-indépendant: IJSS (indemnité sécurité sociale) 1`] = `"[11408,14534]"`;
+exports[`calculate aide-déclaration-indépendant: IJSS (indemnité sécurité sociale) 1`] = `"[11409,14535]"`;
 
 exports[`calculate aide-déclaration-indépendant: RSA 1`] = `"[86,214]"`;
 
-exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[1060,1475]"`;
+exports[`calculate aide-déclaration-indépendant: RSA 2`] = `"[1061,1476]"`;
 
-exports[`calculate aide-déclaration-indépendant: aide covid 2020 1`] = `"[9020,11467]"`;
+exports[`calculate aide-déclaration-indépendant: aide covid 2020 1`] = `"[9021,11468]"`;
 
 exports[`calculate aide-déclaration-indépendant: aide covid 2020 2`] = `"[0,119]"`;
 
 exports[`calculate aide-déclaration-indépendant: aide covid 2020 3`] = `"[33,183]"`;
 
-exports[`calculate aide-déclaration-indépendant: aide covid 2020 4`] = `"[7546,9433]"`;
+exports[`calculate aide-déclaration-indépendant: aide covid 2020 4`] = `"[7548,9435]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[14092,17407]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[14093,17408]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[13578,16893]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[13577,16892]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[11461,14776]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[11462,14777]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[14097,17392]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[14098,17393]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[11461,14776]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[11462,14777]"`;
 
 exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[5651,8931]"`;
 
@@ -41,45 +41,45 @@ exports[`calculate aide-déclaration-indépendant: international 1`] = `
 Notifications affichées : impôt . domiciliation étranger non implémentée"
 `;
 
-exports[`calculate aide-déclaration-indépendant: international 2`] = `"[11875,13245]"`;
+exports[`calculate aide-déclaration-indépendant: international 2`] = `"[11876,13246]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[11362,14657]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[11363,14658]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[1366,1796]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[1368,1798]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[11367,14647]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[11368,14648]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[1368,1783]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[1369,1784]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `
-"[11367,14647]
+"[11368,14648]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[1368,1783]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[1369,1784]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 7`] = `
-"[9453,12733]
+"[9454,12734]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `
-"[1041,1169]
+"[1042,1170]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `
-"[1041,1201]
+"[1042,1202]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1066,1258]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1067,1259]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[1109,1333]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[1110,1334]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[1368,1783]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[1369,1784]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[2203,2936]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[2204,2937]"`;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `
 "[20929,27392]
@@ -205,13 +205,13 @@ exports[`calculate simulations-impot-société: prorata temporis 3`] = `
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 1`] = `"[30000,13180,16820,17883,467,16353,0,30000,7072]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 1`] = `"[30000,13181,16819,17881,467,16352,0,30000,7072]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,14380,15620,17883,467,15153,0,30000,8272]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,14381,15619,17881,467,15152,0,30000,8272]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10379,19621,20433,875,18746,0,30000,4272]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10381,19619,20431,874,18745,0,30000,4272]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6730,13270,13810,0,13270,0,20000,3772]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6732,13268,13808,0,13268,0,20000,3772]"`;
 
 exports[`calculate simulations-indépendant: Contrats Madelin 5`] = `
 "[300000,79622,220378,228521,82429,137949,0,300000,9772]
@@ -220,55 +220,55 @@ Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA d�
 
 exports[`calculate simulations-indépendant: acre 1`] = `"[73023,23023,50000,51980,9600,40400,0,73023,3272]"`;
 
-exports[`calculate simulations-indépendant: activité 1`] = `"[29084,9084,20000,20787,931,19069,0,29084,3272]"`;
+exports[`calculate simulations-indépendant: activité 1`] = `"[29085,9085,20000,20787,931,19069,0,29085,3272]"`;
 
-exports[`calculate simulations-indépendant: activité 2`] = `"[29100,9100,20000,20787,931,19069,0,29100,3288]"`;
+exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,931,19069,0,29101,3288]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1372,1272,100,134,0,100,0,1372,3272]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1373,1273,100,134,0,100,0,1373,3272]"`;
 
 exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[246,146,100,104,0,100,0,246,3272]"`;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 1`] = `
-"[100000,30104,69896,72608,15122,54774,0,100000,3272]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
+"[100000,30105,69895,72609,15123,54772,0,100000,3272]
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 2`] = `
-"[100000,30104,69896,72608,15122,54774,0,100000,3272]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
+"[100000,30105,69895,72609,15123,54772,0,100000,3272]
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29084,9084,20000,20787,603,19397,0,29084,3272]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29085,9085,20000,20787,603,19397,0,29085,3272]"`;
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73023,23023,50000,51980,8213,41787,0,73023,3272]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29084,9084,20000,20787,2079,17921,0,29084,3272]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29085,9085,20000,20787,2079,17921,0,29085,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1385,615,667,0,615,0,2000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1386,614,666,0,614,0,2000,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35353,4612,29385,0,50000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,4611,29386,0,50000,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 3`] = `"[14596,4596,10000,10394,0,10000,0,14596,3272]"`;
+exports[`calculate simulations-indépendant: inversions 3`] = `"[14597,4597,10000,10394,0,10000,0,14597,3272]"`;
 
 exports[`calculate simulations-indépendant: inversions 4`] = `"[72181,22762,49419,51376,9419,40000,0,72181,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 5`] = `"[14596,4596,10000,10394,0,10000,1000,15596,3272]"`;
+exports[`calculate simulations-indépendant: inversions 5`] = `"[14597,4597,10000,10394,0,10000,1000,15597,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5927,13073,13585,0,13073,1000,20000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5929,13071,13584,0,13071,1000,20000,3272]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5624,12376,12861,0,12376,2000,20000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5627,12373,12860,0,12373,2000,20000,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1859,1359,500,548,0,500,0,1859,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1860,1360,500,548,0,500,0,1860,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2466,1466,1000,1064,0,1000,0,2466,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2468,1468,1000,1064,0,1000,0,2468,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3075,1575,1500,1581,0,1500,0,3075,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3076,1576,1500,1581,0,1500,0,3076,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3682,1682,2000,2097,0,2000,0,3682,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3683,1683,2000,2097,0,2000,0,3683,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7427,2427,5000,5199,0,5000,0,7427,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7428,2428,5000,5199,0,5000,0,7428,3272]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14596,4596,10000,10394,0,10000,0,14596,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14597,4597,10000,10394,0,10000,0,14597,3272]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `
 "[139593,39593,100000,103788,28472,71528,0,139593,3272]
@@ -491,54 +491,54 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 1`]
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 2`] = `"[0,16871,0,12270,4,24]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `"[0,22331,0,16308,4,32]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `"[0,22330,0,16308,4,32]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,16820,0,13327,4,24]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,16819,0,13326,4,24]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,15620,0,13327,4,24]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,15619,0,13326,4,24]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,19621,0,14602,4,28]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,19619,0,14601,4,28]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13270,0,9835,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13268,0,9834,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `
 "[0,220378,0,57933,4,56]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13170,0,9785,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13168,0,9784,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13770,0,10085,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13768,0,10084,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14555,0,null,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13758,0,10076,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13757,0,10075,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13770,0,10085,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13768,0,10084,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13770,0,10085,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13768,0,10084,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6795,0,4976,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6794,0,4976,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13770,0,10085,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13768,0,10084,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 1`] = `
-"[0,-1044,0,0,3,21]
+"[0,-1045,0,0,3,21]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 2`] = `
-"[0,-225,0,0,3,21]
+"[0,-226,0,0,3,21]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,615,0,471,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,614,0,470,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3084,0,2266,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3083,0,2266,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6795,0,4976,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6794,0,4976,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13770,0,10085,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13768,0,10084,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33997,0,24913,4,48]"`;
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -6,7 +6,7 @@ exports[`calculate aide-déclaration-indépendant: ACRE 2`] = `"[913,1965]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 3`] = `"[300,715]"`;
 
-exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `"[1487,2220]"`;
+exports[`calculate aide-déclaration-indépendant: ACRE 4`] = `"[1537,2270]"`;
 
 exports[`calculate aide-déclaration-indépendant: ACRE 5`] = `"[606,1339]"`;
 
@@ -22,41 +22,41 @@ exports[`calculate aide-déclaration-indépendant: aide covid 2020 2`] = `"[0,11
 
 exports[`calculate aide-déclaration-indépendant: aide covid 2020 3`] = `"[33,183]"`;
 
-exports[`calculate aide-déclaration-indépendant: aide covid 2020 4`] = `"[7548,9435]"`;
+exports[`calculate aide-déclaration-indépendant: aide covid 2020 4`] = `"[7546,9433]"`;
 
 exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 1`] = `"[14093,17408]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[13577,16892]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 2`] = `"[11933,15248]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[11462,14777]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 3`] = `"[11933,15248]"`;
 
 exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 4`] = `"[14098,17393]"`;
 
-exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[11462,14777]"`;
+exports[`calculate aide-déclaration-indépendant: conjoint collaborateur 5`] = `"[11461,14776]"`;
 
-exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[5651,8931]"`;
+exports[`calculate aide-déclaration-indépendant: débit de tabac 1`] = `"[5652,8932]"`;
 
 exports[`calculate aide-déclaration-indépendant: international 1`] = `
 "[14610,14713]
 Notifications affichées : impôt . domiciliation étranger non implémentée"
 `;
 
-exports[`calculate aide-déclaration-indépendant: international 2`] = `"[11876,13246]"`;
+exports[`calculate aide-déclaration-indépendant: international 2`] = `"[11875,13245]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[11363,14658]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 1`] = `"[11365,14660]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[1368,1798]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 2`] = `"[1533,1963]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[11368,14648]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 3`] = `"[11369,14649]"`;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[1369,1784]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 4`] = `"[1534,1949]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 5`] = `
-"[11368,14648]
+"[11369,14649]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[1369,1784]"`;
+exports[`calculate aide-déclaration-indépendant: nature de l'activité 6`] = `"[1534,1949]"`;
 
 exports[`calculate aide-déclaration-indépendant: nature de l'activité 7`] = `
 "[9454,12734]
@@ -64,22 +64,22 @@ Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA d�
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 1`] = `
-"[1042,1170]
+"[1264,1392]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 2`] = `
-"[1042,1202]
+"[1264,1424]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1067,1259]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 3`] = `"[1267,1459]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[1110,1334]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 4`] = `"[1305,1529]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[1369,1784]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 5`] = `"[1534,1949]"`;
 
-exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[2204,2937]"`;
+exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[2303,3036]"`;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `
 "[20929,27392]
@@ -205,78 +205,78 @@ exports[`calculate simulations-impot-société: prorata temporis 3`] = `
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 1`] = `"[30000,13181,16819,17881,467,16352,0,30000,7072]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 1`] = `"[30000,13181,16819,17881,467,16352,0,30000,7359]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,14381,15619,17881,467,15152,0,30000,8272]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 2`] = `"[30000,14381,15619,17881,467,15152,0,30000,8559]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10381,19619,20431,874,18745,0,30000,4272]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 3`] = `"[30000,10381,19619,20431,874,18745,0,30000,4559]"`;
 
-exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6732,13268,13808,0,13268,0,20000,3772]"`;
+exports[`calculate simulations-indépendant: Contrats Madelin 4`] = `"[20000,6754,13246,13786,0,13246,0,20000,4059]"`;
 
 exports[`calculate simulations-indépendant: Contrats Madelin 5`] = `
-"[300000,79622,220378,228521,82429,137949,0,300000,9772]
+"[300000,79622,220378,228521,82429,137949,0,300000,10059]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-indépendant: acre 1`] = `"[73023,23023,50000,51980,9600,40400,0,73023,3272]"`;
+exports[`calculate simulations-indépendant: acre 1`] = `"[73023,23023,50000,51980,9600,40400,0,73023,3559]"`;
 
-exports[`calculate simulations-indépendant: activité 1`] = `"[29085,9085,20000,20787,931,19069,0,29085,3272]"`;
+exports[`calculate simulations-indépendant: activité 1`] = `"[29086,9086,20000,20787,931,19069,0,29086,3559]"`;
 
-exports[`calculate simulations-indépendant: activité 2`] = `"[29101,9101,20000,20787,931,19069,0,29101,3288]"`;
+exports[`calculate simulations-indépendant: activité 2`] = `"[29102,9102,20000,20787,931,19069,0,29102,3575]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1373,1273,100,134,0,100,0,1373,3272]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1617,1517,100,141,0,100,0,1617,3559]"`;
 
-exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[246,146,100,104,0,100,0,246,3272]"`;
+exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[246,146,100,104,0,100,0,246,3211]"`;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 1`] = `
-"[100000,30105,69895,72609,15123,54772,0,100000,3272]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+"[100000,30104,69896,72608,15122,54774,0,100000,3559]
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
 `;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 2`] = `
-"[100000,30105,69895,72609,15123,54772,0,100000,3272]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+"[100000,30104,69896,72608,15122,54774,0,100000,3559]
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IS . information sur le report de déficit"
 `;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29085,9085,20000,20787,603,19397,0,29085,3272]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29086,9086,20000,20787,603,19397,0,29086,3559]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73023,23023,50000,51980,8213,41787,0,73023,3272]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 2`] = `"[73023,23023,50000,51980,8213,41787,0,73023,3559]"`;
 
-exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29085,9085,20000,20787,2079,17921,0,29085,3272]"`;
+exports[`calculate simulations-indépendant: impôt sur le revenu 3`] = `"[29086,9086,20000,20787,2079,17921,0,29086,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1386,614,666,0,614,0,2000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 1`] = `"[2000,1581,419,471,0,419,0,2000,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16003,33997,35352,4611,29386,0,50000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 2`] = `"[50000,16004,33996,35351,4611,29385,0,50000,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 3`] = `"[14597,4597,10000,10394,0,10000,0,14597,3272]"`;
+exports[`calculate simulations-indépendant: inversions 3`] = `"[14687,4687,10000,10396,0,10000,0,14687,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 4`] = `"[72181,22762,49419,51376,9419,40000,0,72181,3272]"`;
+exports[`calculate simulations-indépendant: inversions 4`] = `"[72181,22762,49419,51376,9419,40000,0,72181,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 5`] = `"[14597,4597,10000,10394,0,10000,1000,15597,3272]"`;
+exports[`calculate simulations-indépendant: inversions 5`] = `"[14687,4687,10000,10396,0,10000,1000,15687,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5929,13071,13584,0,13071,1000,20000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 6`] = `"[19000,5959,13041,13554,0,13041,1000,20000,3559]"`;
 
-exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5627,12373,12860,0,12373,2000,20000,3272]"`;
+exports[`calculate simulations-indépendant: inversions 7`] = `"[18000,5664,12336,12821,0,12336,2000,20000,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[1860,1360,500,548,0,500,0,1860,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 1`] = `"[2097,1597,500,554,0,500,0,2097,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2468,1468,1000,1064,0,1000,0,2468,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 2`] = `"[2697,1697,1000,1070,0,1000,0,2697,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3076,1576,1500,1581,0,1500,0,3076,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 3`] = `"[3298,1798,1500,1587,0,1500,0,3298,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3683,1683,2000,2097,0,2000,0,3683,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 4`] = `"[3897,1897,2000,2103,0,2000,0,3897,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7428,2428,5000,5199,0,5000,0,7428,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 5`] = `"[7595,2595,5000,5203,0,5000,0,7595,3559]"`;
 
-exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14597,4597,10000,10394,0,10000,0,14597,3272]"`;
+exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14687,4687,10000,10396,0,10000,0,14687,3559]"`;
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `
-"[139593,39593,100000,103788,28472,71528,0,139593,3272]
+"[139593,39593,100000,103788,28472,71528,0,139593,3559]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
 exports[`calculate simulations-indépendant: échelle de revenus 8`] = `
-"[1239954,239954,1000000,1033666,473591,526409,0,1239954,3272]
+"[1239954,239954,1000000,1033666,473591,526409,0,1239954,3559]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
@@ -487,63 +487,63 @@ exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): éc
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 1`] = `"[0,8392,0,6102,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 1`] = `"[0,8392,0,6077,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 2`] = `"[0,16871,0,12270,4,24]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 2`] = `"[0,16871,0,12220,4,24]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `"[0,22330,0,16308,4,32]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 3`] = `"[0,22330,0,16241,4,32]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,16819,0,13326,4,24]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 1`] = `"[0,16819,0,13265,4,24]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,15619,0,13326,4,24]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 2`] = `"[0,15619,0,13265,4,24]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,19619,0,14601,4,28]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 3`] = `"[0,19619,0,14540,4,28]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13268,0,9834,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 4`] = `"[0,13246,0,9776,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `
-"[0,220378,0,57933,4,56]
+"[0,220378,0,57407,4,56]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13168,0,9784,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13146,0,9726,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13768,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 1`] = `"[0,13746,0,10026,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 2`] = `"[0,14555,0,null,4,0]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13757,0,10075,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 3`] = `"[0,13734,0,10017,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13768,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 4`] = `"[0,13746,0,10026,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13768,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): activités 5`] = `"[0,13746,0,10026,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6794,0,4976,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 1`] = `"[0,6695,0,4886,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13768,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): avec charges 2`] = `"[0,13746,0,10026,4,21]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 1`] = `
-"[0,-1045,0,0,3,21]
+"[0,-1267,0,0,3,21]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 2`] = `
-"[0,-226,0,0,3,21]
+"[0,-448,0,0,3,21]
 Notifications affichées : entreprise . imposition . IR . information sur le report de déficit"
 `;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,614,0,470,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 3`] = `"[0,419,0,331,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,3083,0,2266,3,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 4`] = `"[0,2918,0,2142,3,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6794,0,4976,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 5`] = `"[0,6695,0,4886,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13768,0,10084,4,21]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 6`] = `"[0,13746,0,10026,4,21]"`;
 
-exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33997,0,24913,4,48]"`;
+exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 7`] = `"[0,33996,0,24810,4,48]"`;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 8`] = `
-"[0,69895,0,36428,4,56]
+"[0,69895,0,36204,4,56]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
 `;
 

--- a/publicodes/core/source/mecanisms/recalcul.ts
+++ b/publicodes/core/source/mecanisms/recalcul.ts
@@ -18,7 +18,7 @@ export type RecalculNode = {
 
 const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 	if (this.cache._meta.inRecalcul) {
-		return (defaultNode(false) as any) as RecalculNode & EvaluatedNode
+		return (defaultNode(null) as any) as RecalculNode & EvaluatedNode
 	}
 
 	const amendedSituation = node.explanation.amendedSituation


### PR DESCRIPTION
Fix #1531 

En attente de validation DNRTI

### Questions ouvertes dans les retours : 

> la saisie d’un montant de charge est-elle pertinente, sachant que le montant de charges reconnupour l’IR et l’assiette sociale est un montant forfaitaire ? est ce qu’il ne faudrait pas forcer lemontant forfaitaire dans la zone « charges » ?

Le montant de charge permet de faire la comparaison avec l'option micro activé ou non. Si des charges sont spécifiée avec l'option micro, elle seront déduite du revenu final, comme charge non déductible. On peut imaginer cependant cacher le champs si l'option micro est activé et que ce dernier est vide.

> Pour le calcul du taux maladie vous n’appliquez pas la dégressivité du taux pour un revenu inférieur à 110% . En cas de RSA, seule la réduction pour revenu inférieur à 40% ne s’applique pas ce qui devrait faire un taux de 1,42% or, dans le calcul vous prenez en compte 3,16 %.

Si seule la réduction en dessous de 40% ne s'applique pas, logiquement, le taux appliqué est donc le plancher de la réduction supérieur. Soit 3.17% (cf  https://www.secu-independants.fr/cotisations/calcul-cotisations/taux-de-cotisations/). Je n'arrive pas à comprendre comment est calculé le taux de 1,42%. Par ailleurs, le taux indiqué dans la page secu-independants.fr est 3.17%, et non 3.16%, nous avons donc mis à jour ce taux.


EDIT: C'est validé :tada: 