### PR TITLE
Fix le prérendu avec styled-component

### DIFF
--- a/mon-entreprise/index.html
+++ b/mon-entreprise/index.html
@@ -208,7 +208,21 @@
 			var b = document.documentElement
 			b.setAttribute('data-useragent', navigator.userAgent)
 		</script>
-
+		<script>
+			// Hack to force styled components to render styles during prerender
+			if (window.__PRERENDER_INJECTED) {
+				window.onload = () => {
+					var el = document.createElement('style');
+					document.head.appendChild(el)
+					var styles = document.querySelectorAll('style[data-styled]')
+					for (style of styles.values()) {
+							for (rule of style.sheet.rules) {
+								el.appendChild(document.createTextNode(rule.cssText))
+							}
+					}
+			}
+			};
+		</script>
 		<!-- APP  -->
 		<div id="js"></div>
 

--- a/mon-entreprise/webpack.prod.js
+++ b/mon-entreprise/webpack.prod.js
@@ -21,6 +21,7 @@ const prerenderConfig = () => ({
 	staticDir: path.resolve('dist'),
 	renderer: new Renderer({
 		renderAfterTime: 5000,
+		inject: true,
 		skipThirdPartyRequests: true,
 	}),
 	postProcess: (context) => {


### PR DESCRIPTION
Jusqu'alors les styled-component n'étaient pas pris en compte dans le prérendu, ce qui aboutissait à un CLS très important sur nos pages. C'est maintenant réparé.

Permet d'augmenter le score lighthouse de  87% (31 à 58).

Avant : https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fmon-entreprise.fr%2Fsimulateurs%2Fsalaire-brut-net
Après : https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2F1569--mon-entreprise.netlify.app%2Fsimulateurs%2Fsalaire-brut-net