### PR TITLE
Simpler condition component

### DIFF
--- a/mon-entreprise/source/components/EngineValue.tsx
+++ b/mon-entreprise/source/components/EngineValue.tsx
@@ -91,8 +91,18 @@ export function WhenApplicable({
 	children: React.ReactNode
 }) {
 	const engine = useEngine()
-	const isNotApplicable = UNSAFE_isNotApplicable(engine, dottedName)
-	if (isNotApplicable) return null
+	if (UNSAFE_isNotApplicable(engine, dottedName)) return null
+	return <>{children}</>
+}
+export function WhenNotApplicable({
+	dottedName,
+	children,
+}: {
+	dottedName: DottedName
+	children: React.ReactNode
+}) {
+	const engine = useEngine()
+	if (!UNSAFE_isNotApplicable(engine, dottedName)) return null
 	return <>{children}</>
 }
 

--- a/mon-entreprise/source/components/EngineValue.tsx
+++ b/mon-entreprise/source/components/EngineValue.tsx
@@ -69,10 +69,6 @@ export function Condition({
 	const boolValue = isNotYetDefined(value) ? defaultIfNotYetDefined : value
 
 	if (Boolean(boolValue) !== boolValue) {
-		// [XXX] - only console
-		throw new Error(
-			`[ CONDITION NON-BOOLEENNE ] dans le composant Condition: expression=${expression}`
-		)
 		console.error(
 			`[ CONDITION NON-BOOLEENNE ] dans le composant Condition: expression=${expression}`
 		)

--- a/mon-entreprise/source/components/EngineValue.tsx
+++ b/mon-entreprise/source/components/EngineValue.tsx
@@ -3,6 +3,7 @@ import Engine, {
 	formatValue,
 	PublicodesExpression,
 	isNotYetDefined,
+	UNSAFE_isNotApplicable,
 } from 'publicodes'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -82,7 +83,20 @@ export function Condition({
 	return <>{children}</>
 }
 
-export function IsAlreadyDefined({
+export function WhenApplicable({
+	dottedName,
+	children,
+}: {
+	dottedName: DottedName
+	children: React.ReactNode
+}) {
+	const engine = useEngine()
+	const isNotApplicable = UNSAFE_isNotApplicable(engine, dottedName)
+	if (isNotApplicable) return null
+	return <>{children}</>
+}
+
+export function WhenAlreadyDefined({
 	dottedName: dottedName,
 	children,
 }: {

--- a/mon-entreprise/source/components/EngineValue.tsx
+++ b/mon-entreprise/source/components/EngineValue.tsx
@@ -56,7 +56,7 @@ export default function Value<Names extends string>({
 
 type ConditionProps = {
 	expression: PublicodesExpression | ASTNode
-	defaultIfNotYetDefined: boolean
+	defaultIfNotYetDefined?: boolean
 	children: React.ReactNode
 }
 export function Condition({

--- a/mon-entreprise/source/components/EngineValue.tsx
+++ b/mon-entreprise/source/components/EngineValue.tsx
@@ -2,7 +2,6 @@ import Engine, { formatValue } from 'publicodes'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { DottedName } from 'modele-social'
-import { coerceArray } from '../utils'
 import RuleLink from './RuleLink'
 import { useEngine } from './utils/EngineContext'
 
@@ -50,16 +49,13 @@ export default function Value<Names extends string>({
 }
 
 type ConditionProps = {
-	expression:
-		| Parameters<Engine['evaluate']>[0]
-		| Parameters<Engine['evaluate']>[0][]
+	expression: Parameters<Engine['evaluate']>[0]
 	children: React.ReactNode
 }
 export function Condition({ expression, children }: ConditionProps) {
 	const engine = useEngine()
-	if (
-		!coerceArray(expression).every((expr) => engine.evaluate(expr).nodeValue)
-	) {
+	// [XXX] check strict falsity (and check that it's coherent with publicodes core)
+	if (!engine.evaluate(expression).nodeValue) {
 		return null
 	}
 	return <>{children}</>

--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -1,7 +1,7 @@
 import Value, { Condition, ValueProps } from 'Components/EngineValue'
 import RuleLink from 'Components/RuleLink'
 import { DottedName } from 'modele-social'
-import { isNotYetDefined, UNSAFE_isNotApplicable } from 'publicodes'
+import { isNotYetDefined, isNotApplicable } from 'publicodes'
 import { Trans } from 'react-i18next'
 import { useEngine } from './utils/EngineContext'
 
@@ -81,12 +81,13 @@ export function Line({
 }: LineProps) {
 	const engine = useEngine()
 
-	if (UNSAFE_isNotApplicable(engine, rule)) {
-		return null
-	}
-
 	const evaluatedNode = engine.evaluate(rule)
-	if (isNotYetDefined(evaluatedNode.nodeValue) || evaluatedNode.nodeValue === 0)
+	if (
+		isNotYetDefined(evaluatedNode.nodeValue) ||
+		// ⚠️ isNotApplicable is a bad func only here to help with further refactoring:
+		isNotApplicable(evaluatedNode.nodeValue) ||
+		evaluatedNode.nodeValue === 0
+	)
 		return null
 
 	return (

--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -33,10 +33,15 @@ export const SalaireNetSection = () => {
 			</h4>
 			<Line rule="contrat salarié . rémunération . net imposable" />
 			<Condition
-				expression={[
-					'contrat salarié . rémunération . avantages en nature',
-					'contrat salarié . frais professionnels . titres-restaurant',
-				]}
+				expression={{
+					valeur: 'oui',
+					['applicable si']: {
+						['toutes ces conditions']: [
+							'contrat salarié . rémunération . avantages en nature',
+							'contrat salarié . frais professionnels . titres-restaurant',
+						],
+					},
+				}}
 			>
 				<Line rule="contrat salarié . rémunération . net de cotisations" />
 			</Condition>

--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -1,6 +1,7 @@
 import Value, { Condition, ValueProps } from 'Components/EngineValue'
 import RuleLink from 'Components/RuleLink'
 import { DottedName } from 'modele-social'
+import { isNotYetDefined, UNSAFE_isNotApplicable } from 'publicodes'
 import { Trans } from 'react-i18next'
 import { useEngine } from './utils/EngineContext'
 
@@ -78,8 +79,16 @@ export function Line({
 	className,
 	...props
 }: LineProps) {
-	const evaluatedNode = useEngine().evaluate(rule)
-	if (evaluatedNode.nodeValue === 0) return null
+	const engine = useEngine()
+
+	if (UNSAFE_isNotApplicable(engine, rule)) {
+		return null
+	}
+
+	const evaluatedNode = engine.evaluate(rule)
+	if (isNotYetDefined(evaluatedNode.nodeValue) || evaluatedNode.nodeValue === 0)
+		return null
+
 	return (
 		<>
 			<RuleLink dottedName={rule} className={className} />

--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -2,6 +2,7 @@ import Value, { Condition, ValueProps } from 'Components/EngineValue'
 import RuleLink from 'Components/RuleLink'
 import { DottedName } from 'modele-social'
 import { Trans } from 'react-i18next'
+import { useEngine } from './utils/EngineContext'
 
 export const SalaireBrutSection = () => {
 	return (
@@ -57,7 +58,7 @@ export const SalaireNetSection = () => {
 				rule="contrat salarié . rémunération . net"
 				className="payslip__total"
 			/>
-			<Condition expression="impôt">
+			<Condition expression="impôt > 0">
 				<Line negative rule="impôt" unit="€/mois" />
 				<Line
 					className="payslip__total"
@@ -80,8 +81,10 @@ export function Line({
 	className,
 	...props
 }: LineProps) {
+	const evaluatedNode = useEngine().evaluate(rule)
+	if (evaluatedNode.nodeValue === 0) return null
 	return (
-		<Condition expression={rule}>
+		<>
 			<RuleLink dottedName={rule} className={className} />
 			<Value
 				linkToRule={false}
@@ -91,6 +94,6 @@ export function Line({
 				className={className}
 				{...props}
 			/>
-		</Condition>
+		</>
 	)
 }

--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -35,13 +35,10 @@ export const SalaireNetSection = () => {
 			<Line rule="contrat salarié . rémunération . net imposable" />
 			<Condition
 				expression={{
-					valeur: 'oui',
-					['applicable si']: {
-						['toutes ces conditions']: [
-							'contrat salarié . rémunération . avantages en nature',
-							'contrat salarié . frais professionnels . titres-restaurant',
-						],
-					},
+					['toutes ces conditions']: [
+						'contrat salarié . rémunération . avantages en nature', // bool
+						'contrat salarié . frais professionnels . titres-restaurant', // bool
+					],
 				}}
 			>
 				<Line rule="contrat salarié . rémunération . net de cotisations" />

--- a/mon-entreprise/source/components/TargetSelection.tsx
+++ b/mon-entreprise/source/components/TargetSelection.tsx
@@ -268,7 +268,7 @@ function TitreRestaurant() {
 	const dottedName =
 		'contrat salarié . frais professionnels . titres-restaurant . montant'
 	return (
-		<Condition expression={dottedName}>
+		<Condition expression={`${dottedName} > 0`}>
 			<Animate.fromTop>
 				<div className="aidesGlimpse">
 					<RuleLink dottedName={dottedName}>
@@ -313,7 +313,7 @@ function AidesGlimpse() {
 		aides
 	)
 	return (
-		<Condition expression={dottedName}>
+		<Condition expression={`${dottedName} > 0`}>
 			<Animate.fromTop>
 				<div className="aidesGlimpse">
 					<RuleLink dottedName={aideLink}>

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -1,6 +1,10 @@
 import BarChartBranch from 'Components/BarChart'
 import 'Components/Distribution.css'
-import Value, { Condition, WhenApplicable } from 'Components/EngineValue'
+import Value, {
+	Condition,
+	WhenApplicable,
+	WhenNotApplicable,
+} from 'Components/EngineValue'
 import RuleLink from 'Components/RuleLink'
 import StackedBarChart from 'Components/StackedBarChart'
 import { ThemeColorsContext } from 'Components/utils/colors'
@@ -25,15 +29,9 @@ export default function IndépendantExplanation() {
 			<WhenApplicable dottedName="dirigeant . indépendant . cotisations et contributions . début activité">
 				<CotisationsForfaitaires />
 			</WhenApplicable>
-			<Condition
-				expression={{
-					valeur: 'oui',
-					['non applicable si']:
-						'dirigeant . indépendant . cotisations et contributions . début activité',
-				}}
-			>
+			<WhenNotApplicable dottedName="dirigeant . indépendant . cotisations et contributions . début activité">
 				<CotisationsRégularisation />
-			</Condition>
+			</WhenNotApplicable>
 			<Condition expression="entreprise . activité . libérale réglementée">
 				<PLExplanation />
 			</Condition>

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -1,6 +1,6 @@
 import BarChartBranch from 'Components/BarChart'
 import 'Components/Distribution.css'
-import Value, { Condition } from 'Components/EngineValue'
+import Value, { Condition, WhenApplicable } from 'Components/EngineValue'
 import RuleLink from 'Components/RuleLink'
 import StackedBarChart from 'Components/StackedBarChart'
 import { ThemeColorsContext } from 'Components/utils/colors'
@@ -22,9 +22,9 @@ export default function IndépendantExplanation() {
 
 	return (
 		<>
-			<Condition expression="dirigeant . indépendant . cotisations et contributions . début activité">
+			<WhenApplicable dottedName="dirigeant . indépendant . cotisations et contributions . début activité">
 				<CotisationsForfaitaires />
-			</Condition>
+			</WhenApplicable>
 			<Condition
 				expression={{
 					valeur: 'oui',

--- a/mon-entreprise/source/pages/Gérer/AideDéclarationIndépendant/index.tsx
+++ b/mon-entreprise/source/pages/Gérer/AideDéclarationIndépendant/index.tsx
@@ -2,7 +2,7 @@ import { updateSituation } from 'Actions/actions'
 import Aide from 'Components/conversation/Aide'
 import { Explicable, ExplicableRule } from 'Components/conversation/Explicable'
 import RuleInput from 'Components/conversation/RuleInput'
-import Value, { Condition } from 'Components/EngineValue'
+import Value, { Condition, IsAlreadyDefined } from 'Components/EngineValue'
 import PreviousSimulationBanner from 'Components/PreviousSimulationBanner'
 import RuleLink from 'Components/RuleLink'
 import 'Components/TargetSelection.css'
@@ -155,7 +155,7 @@ export default function AideDéclarationIndépendant() {
 										<SubSection dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité" />
 
 										{/* PLNR */}
-										<Condition expression="aide déclaration revenu indépendant 2020 . nature de l'activité">
+										<IsAlreadyDefined dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité">
 											<SimpleField dottedName="entreprise . activité . débit de tabac" />
 											<SimpleField dottedName="dirigeant . indépendant . cotisations et contributions . déduction tabac" />
 											<SimpleField dottedName="dirigeant . indépendant . PL . régime général . taux spécifique retraite complémentaire" />
@@ -192,16 +192,16 @@ export default function AideDéclarationIndépendant() {
 												dottedName="dirigeant . indépendant . revenus étrangers"
 												hideTitle
 											/>
-										</Condition>
+										</IsAlreadyDefined>
 									</Condition>
 								</>
 							)}
 						</FormBlock>
 					</Animate.fromTop>
 
-					<Condition expression="aide déclaration revenu indépendant 2020 . nature de l'activité">
+					<IsAlreadyDefined dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité">
 						<Results />
-					</Condition>
+					</IsAlreadyDefined>
 					<Aide />
 				</>
 			)}

--- a/mon-entreprise/source/pages/Gérer/AideDéclarationIndépendant/index.tsx
+++ b/mon-entreprise/source/pages/Gérer/AideDéclarationIndépendant/index.tsx
@@ -2,7 +2,7 @@ import { updateSituation } from 'Actions/actions'
 import Aide from 'Components/conversation/Aide'
 import { Explicable, ExplicableRule } from 'Components/conversation/Explicable'
 import RuleInput from 'Components/conversation/RuleInput'
-import Value, { Condition, IsAlreadyDefined } from 'Components/EngineValue'
+import Value, { Condition, WhenAlreadyDefined } from 'Components/EngineValue'
 import PreviousSimulationBanner from 'Components/PreviousSimulationBanner'
 import RuleLink from 'Components/RuleLink'
 import 'Components/TargetSelection.css'
@@ -155,7 +155,7 @@ export default function AideDéclarationIndépendant() {
 										<SubSection dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité" />
 
 										{/* PLNR */}
-										<IsAlreadyDefined dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité">
+										<WhenAlreadyDefined dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité">
 											<SimpleField dottedName="entreprise . activité . débit de tabac" />
 											<SimpleField dottedName="dirigeant . indépendant . cotisations et contributions . déduction tabac" />
 											<SimpleField dottedName="dirigeant . indépendant . PL . régime général . taux spécifique retraite complémentaire" />
@@ -192,16 +192,16 @@ export default function AideDéclarationIndépendant() {
 												dottedName="dirigeant . indépendant . revenus étrangers"
 												hideTitle
 											/>
-										</IsAlreadyDefined>
+										</WhenAlreadyDefined>
 									</Condition>
 								</>
 							)}
 						</FormBlock>
 					</Animate.fromTop>
 
-					<IsAlreadyDefined dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité">
+					<WhenAlreadyDefined dottedName="aide déclaration revenu indépendant 2020 . nature de l'activité">
 						<Results />
-					</IsAlreadyDefined>
+					</WhenAlreadyDefined>
 					<Aide />
 				</>
 			)}

--- a/mon-entreprise/source/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ArtisteAuteur.tsx
@@ -36,7 +36,7 @@ function CotisationsResult() {
 	return (
 		<>
 			<CotisationsParOrganisme />
-			<Condition expression="artiste-auteur . cotisations">
+			<Condition expression="artiste-auteur . cotisations > 0">
 				<RepartitionCotisations />
 			</Condition>
 		</>

--- a/mon-entreprise/source/utils.ts
+++ b/mon-entreprise/source/utils.ts
@@ -47,10 +47,6 @@ export function mapOrApply<A, B>(fn: (a: A) => B, x: A | Array<A>) {
 	return Array.isArray(x) ? x.map(fn) : fn(x)
 }
 
-export function coerceArray<A>(x: A | Array<A>): Array<A> {
-	return Array.isArray(x) ? x : [x]
-}
-
 export function getSessionStorage() {
 	// In some browsers like Brave, even just reading the variable sessionStorage
 	// is throwing an error in the iframe, so we can't do things if sessionStorage !== undefined

--- a/publicodes/core/source/AST/types.ts
+++ b/publicodes/core/source/AST/types.ts
@@ -112,6 +112,14 @@ type EvaluationDecoration<T extends Types> = {
 	unit?: Unit
 }
 export type Types = number | boolean | string | Record<string, unknown>
-export type Evaluation<T extends Types = Types> = T | false | null
+export type NotYetDefined = null
+export function isNotYetDefined(value): value is NotYetDefined {
+	return value === null
+}
+export type NotApplicable = false
+export type Evaluation<T extends Types = Types> =
+	| T
+	| NotApplicable
+	| NotYetDefined
 export type EvaluatedNode<T extends Types = Types> = ASTNode &
 	EvaluationDecoration<T>

--- a/publicodes/core/source/AST/types.ts
+++ b/publicodes/core/source/AST/types.ts
@@ -127,9 +127,3 @@ export type Evaluation<T extends Types = Types> =
 	| NotYetDefined
 export type EvaluatedNode<T extends Types = Types> = ASTNode &
 	EvaluationDecoration<T>
-
-function testFunc(a: Types) {
-	if (isNotApplicable(a)) {
-		return 0
-	}
-}

--- a/publicodes/core/source/AST/types.ts
+++ b/publicodes/core/source/AST/types.ts
@@ -112,14 +112,24 @@ type EvaluationDecoration<T extends Types> = {
 	unit?: Unit
 }
 export type Types = number | boolean | string | Record<string, unknown>
+// TODO: type NotYetDefined & NotApplicable properly (see #14) then refactor any code depending on these:
 export type NotYetDefined = null
 export function isNotYetDefined(value): value is NotYetDefined {
 	return value === null
 }
 export type NotApplicable = false
+export function isNotApplicable(value): value is NotApplicable {
+	return typeof value === 'boolean' && value === false
+}
 export type Evaluation<T extends Types = Types> =
 	| T
 	| NotApplicable
 	| NotYetDefined
 export type EvaluatedNode<T extends Types = Types> = ASTNode &
 	EvaluationDecoration<T>
+
+function testFunc(a: Types) {
+	if (isNotApplicable(a)) {
+		return 0
+	}
+}

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -41,7 +41,7 @@ export type EvaluationOptions = Partial<{
 }>
 
 export { reduceAST, makeASTTransformer as transformAST } from './AST/index'
-export { Evaluation, Unit } from './AST/types'
+export { Evaluation, Unit, NotYetDefined, isNotYetDefined } from './AST/types'
 export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'
@@ -49,7 +49,7 @@ export { parseUnit, serializeUnit } from './units'
 export { parsePublicodes, utils }
 export { Rule, RuleNode, ASTNode, EvaluatedNode }
 
-type PublicodesExpression = string | Record<string, unknown> | number
+export type PublicodesExpression = string | Record<string, unknown> | number
 
 export type Logger = {
 	log(message: string): void

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -41,7 +41,14 @@ export type EvaluationOptions = Partial<{
 }>
 
 export { reduceAST, makeASTTransformer as transformAST } from './AST/index'
-export { Evaluation, Unit, NotYetDefined, isNotYetDefined } from './AST/types'
+export {
+	Evaluation,
+	Unit,
+	NotYetDefined,
+	isNotYetDefined,
+	NotApplicable,
+	isNotApplicable,
+} from './AST/types'
 export { capitalise0, formatValue } from './format'
 export { simplifyNodeUnit } from './nodeUnits'
 export { default as serializeEvaluation } from './serializeEvaluation'


### PR DESCRIPTION
J'ai fait ici un exercice de rendre le code consommateur de publicodes plus strict, plus stupide et moins sachant:

- dans le code mon-entreprise éviter d'utiliser `false` qui veut dire soit `non` soit `non applicable`
- en revanche continuer à utiliser `null` qui semble avoir une sémantique stricte, mais via un type guard
- ne pas hésiter à utiliser des ASTNode dans le composant Condition, plutôt que de le complexifier de manière implicite
- m'aider à comprendre l'évaluation.

Il me semble qu'il y a un soucis avec `UNSAFE_isNotApplicable`, qui parfois est `true` alors que la `nodeValue` est non-false.

Mon takeaway est (a priori) qu'il faudrait arrêter autant que possible de mélanger applicabilité et booléanitude.

Je vous laisse jeter un oeil @johangirod @mquandalle et me dire ce que vous en pensez.