### PR TITLE
Pas d'activité partielle pour un stagiaire

### DIFF
--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -126,14 +126,13 @@ contrat salarié . frais professionnels . titres-restaurant . part déductible:
 contrat salarié . frais professionnels . titres-restaurant . nombre:
   question: Combien de titres-restaurant sont distribués au salarié ?
   arrondi: oui
-  par défaut: 
-    produit: 
-      assiette: 19 titres-restaurant/mois 
+  par défaut:
+    produit:
+      assiette: 19 titres-restaurant/mois
       facteur: temps de travail . quotité de travail
   suggestions:
-    5 repas/semaines:  5 titres-restaurant/semaines * période . semaines par mois
-    3 repas/semaine:  3 titres-restaurant/semaines * période . semaines par mois
-      
+    5 repas/semaines: 5 titres-restaurant/semaines * période . semaines par mois
+    3 repas/semaine: 3 titres-restaurant/semaines * période . semaines par mois
 
 contrat salarié . frais professionnels . titres-restaurant . montant unitaire:
   question: Quelle est la valeur unitaire du titre-restaurant ?
@@ -180,7 +179,7 @@ contrat salarié . frais professionnels . abonnement transports publics . montan
   par défaut: 0 €/mois
   description: |
     L'employeur doit prendre en charge 50% du montant dépensé par le salarié pour les transports publics lui permettant de se rendre sur son lieu de travail.
-    
+
     Cette prise en charge (dans la limite des 50% du montant) est exonérée de cotisations sociales et d'impôt sur le revenu.
 
     Dans le cas d'un temps partiel, le taux de prise en charge sera le même pour un mi-temps ou plus. En dessous, le taux de prise en charge sera proportionnel.
@@ -191,10 +190,8 @@ contrat salarié . frais professionnels . abonnement transports publics . montan
     Navigo: 75 €/mois
     Técély: 65 €/mois
     RTM: 40 €/mois
-    Tisséo: 42.50 €/mois  
+    Tisséo: 42.50 €/mois
     TBM: 42.20 €/mois
-
-
 
 contrat salarié . frais professionnels . abonnement transports publics . taux de participation employeur:
   valeur: 50%
@@ -203,7 +200,7 @@ contrat salarié . frais professionnels . abonnement transports publics . taux d
   titre: Taux de prise en charge
   valeur:
     produit:
-      assiette: 
+      assiette:
         le minimum de:
           - temps de travail . quotité de travail
           - 50%
@@ -275,9 +272,9 @@ contrat salarié . frais professionnels . transports personnels . carburant faib
   valeur: montant
   plafond:
     le minimum de:
-       - proportion déduction * 200€/an
-       - valeur: proportion déduction * 500€/an
-         abattement: abonnement transports publics . prise en charge
+      - proportion déduction * 200€/an
+      - valeur: proportion déduction * 500€/an
+        abattement: abonnement transports publics . prise en charge
 
 contrat salarié . frais professionnels . transports personnels . forfait mobilités durables:
   valeur: oui
@@ -336,9 +333,6 @@ contrat salarié . activité partielle:
     La déclaration d'activité partielle est simplifiée et l'effet est
     rétroactif.
   par défaut: non
-  rend non applicable:
-    - temps de travail . heures supplémentaires
-    - temps de travail . heures complémentaires
   références:
     déclaration employeur: https://activitepartielle.emploi.gouv.fr/aparts/
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23503
@@ -626,7 +620,7 @@ contrat salarié . CDD . CPF:
       taux: 1%
   références:
     Code du travail - Article L6322-37: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000022234996&cidTexte=LEGITEXT000006072050
-  
+
 contrat salarié . CDD . congés pris:
   question: Combien de jours de congés seront pris sur la durée du CDD (en jours ouvrés) ?
   description: |
@@ -637,10 +631,10 @@ contrat salarié . CDD . congés pris:
     la totalité: congés dus sur la durée du contrat
     la moitié: 50% * congés dus sur la durée du contrat
   par défaut: 0 jours ouvrés
-  
-contrat salarié . CDD . jours ouvrés sur la durée du contrat: 
+
+contrat salarié . CDD . jours ouvrés sur la durée du contrat:
   produit:
-    assiette: 253 jours ouvrés/an  
+    assiette: 253 jours ouvrés/an
     facteur: durée contrat
 
 contrat salarié . CDD . congés dus sur la durée du contrat:
@@ -694,7 +688,7 @@ contrat salarié . CDD . indemnité compensatrice de congés payés:
       produit:
         assiette: rémunération . assiette congés payés
         taux: 10%
-      abattement: 
+      abattement:
         nom: proportion congés pris
         unité: '%'
         valeur: congés pris / congés dus sur la durée du contrat
@@ -702,11 +696,10 @@ contrat salarié . CDD . indemnité compensatrice de congés payés:
     - nom: Méthode du maintien de salaire
       produit:
         assiette: rémunération . assiette congés payés / jours ouvrés sur la durée du contrat
-        facteur: 
+        facteur:
           nom: congés non pris
           valeur: congés dus sur la durée du contrat - congés pris
-        
-        
+
   note: |
     L'indemnité est versée à la fin du contrat, sauf si le CDD se poursuit par un CDI.
     À noter, la loi El Khomri modifie l'article L3141-12:
@@ -1287,7 +1280,6 @@ contrat salarié . rémunération . brut de base:
         - équivalent temps plein
         - dirigeant . rémunération . totale
 
-
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement
 
@@ -1766,7 +1758,7 @@ contrat salarié . rémunération . net imposable:
   description: |
     C'est la base utilisée pour calculer l'impôt sur le revenu.
   valeur:
-    nom: base 
+    nom: base
     description: Le net imposable avant les exonérations et déductions
     somme:
       - net avec revenus de remplacement
@@ -1782,8 +1774,6 @@ contrat salarié . rémunération . net imposable:
       - prévoyance . exonération fiscale
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
-
-
 
 contrat salarié . rémunération . net imposable . heures supplémentaires et complémentaires défiscalisées:
   unité: €/mois

--- a/mon-entreprise/source/pages/Simulateurs/configs/chômage-partiel.yaml
+++ b/mon-entreprise/source/pages/Simulateurs/configs/chômage-partiel.yaml
@@ -4,7 +4,6 @@ objectifs:
 objectifs cachés:
   - contrat salarié . rémunération . net
   - contrat salarié . prix du travail
-  
 
 questions:
   liste:
@@ -12,6 +11,9 @@ questions:
     - contrat salarié . temps de travail
     - contrat salarié . profession spécifique
     - établissement . localisation
+  liste noire:
+    - contrat salarié . temps de travail . heures supplémentaires
+    - contrat salarié . temps de travail . heures complémentaires
 
 unité par défaut: €/mois
 situation:


### PR DESCRIPTION
Fixes #1324

Les bugs sur les “missingVariables” ne sont vraiment pas évident à débugger. Ça serait génial de pouvoir observer facilement pour quelle raison une question est affichée ou non.