### PR TITLE
Uniformise l'unité des arrondis

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -1016,7 +1016,7 @@ dirigeant . indépendant . cotisations et contributions . maladie:
     tranches:
       - taux: 
           valeur: taux progressif
-          arrondi: 2 unités
+          arrondi: 2 décimales
         plafond: 110%
       - taux: 6.35%
         plafond: 5

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -647,7 +647,7 @@ contrat salarié . CDD . congés dus sur la durée du contrat:
   produit:
     assiette: 25 jours ouvrés/an
     facteur: durée contrat
-  arrondi: 2 unités
+  arrondi: 2 décimales
 
 contrat salarié . CDD . contrôle congés non pris max:
   type: notification

--- a/publicodes/core/source/mecanisms/arrondi.ts
+++ b/publicodes/core/source/mecanisms/arrondi.ts
@@ -2,7 +2,9 @@ import { EvaluationFunction, simplifyNodeUnit } from '..'
 import { mergeAllMissing } from '../evaluation'
 import { registerEvaluationFunction } from '../evaluationFunctions'
 import parse from '../parse'
-import { ASTNode } from '../AST/types'
+import { ASTNode, EvaluatedNode } from '../AST/types'
+import { serializeUnit } from '../units'
+import { evaluationError } from '../error'
 
 export type ArrondiNode = {
 	explanation: {
@@ -24,6 +26,19 @@ const evaluate: EvaluationFunction<'arrondi'> = function (node) {
 	let arrondi = node.explanation.arrondi
 	if (nodeValue !== false) {
 		arrondi = this.evaluate(arrondi)
+
+		if (
+			typeof (arrondi as EvaluatedNode).nodeValue === 'number' &&
+			!serializeUnit((arrondi as EvaluatedNode).unit)?.match(/décimales?/)
+		) {
+			evaluationError(
+				this.options.logger,
+				this.cache._meta.evaluationRuleStack[0],
+				`L'unité ${serializeUnit(
+					(arrondi as EvaluatedNode).unit
+				)} de l'arrondi est inconnu. Vous devez utiliser l'unité “décimales”`
+			)
+		}
 	}
 
 	return {


### PR DESCRIPTION
J'ai remarqué que co-existaient deux écritures dans la base de règle : `arrondi: 2 unités` et `arrondi: 2 décimales`
Actuellement ça ne change rien car on se base seulement sur le fait que la `nodeValue` est un nombre, ça fonctionnerait tout aussi bien avec `arrondi: 2 nimportequoi`.

Je ne sais pas si ma modification rapide est la bonne, peut-être que c'est un peu bizarre de ce baser sur une “unité” ici. Dans tous les cas on devrait viser la cohérence de notre base de règle sur ce point.