### PR TITLE
Corrige le seuil micro-bnc

### DIFF
--- a/.github/workflows/zammad-bot.yaml
+++ b/.github/workflows/zammad-bot.yaml
@@ -3,6 +3,8 @@ name: Message du robot Zammad
 on:
   issues:
     types: [closed]
+  pull_request:
+    types: [closed]
 
 jobs:
   comment-when-issue-close:

--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -326,9 +326,13 @@ entreprise . chiffre d'affaires . seuil micro dépassé:
     Bofip (dépassement micro-bic): https://bofip.impots.gouv.fr/bofip/1802-PGP.html
     autoentrepreneur.urssaf.fr: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html
   unité: €/an
+  # TODO: les seuils micro sont dupliqués à plusieurs endroits (artiste-auteur .
+  # revenus . BNC . contrôle micro-bnc, tableau de la comparaison de régime,
+  # économie collaborative). Il faudrait référencer la même valeur partout où
+  # elle est utilisée.
   une de ces conditions:
     - entreprise . chiffre d'affaires > 176200 €/an
-    - entreprise . chiffre d'affaires . service > 72500 €/an
+    - entreprise . chiffre d'affaires . service > 72600 €/an
 
 
 entreprise . imposition . IR . information sur le report de déficit:

--- a/mon-entreprise/source/components/SchemeComparaison.tsx
+++ b/mon-entreprise/source/components/SchemeComparaison.tsx
@@ -267,7 +267,7 @@ export default function SchemeComparaison({
 								<div className="auto">
 									<Trans>Oui</Trans>
 									<small>
-										(72 500 € en services / 176 200 € en vente de biens,
+										(72 600 € en services / 176 200 € en vente de biens,
 										restauration ou hébergement)
 									</small>
 								</div>

--- a/mon-entreprise/source/locales/ui-fr.yaml
+++ b/mon-entreprise/source/locales/ui-fr.yaml
@@ -203,7 +203,7 @@ comparaisonRégimes:
     tagline: La protection sociale à la carte
   mutuelle: <0>Mutuelle santé<1></1></0><1>Obligatoire</1><2>Fortement conseillée</2>
   plafondCA: <0>Plafond de chiffre
-    d'affaires</0><1><0>Non</0></1><2><0>Oui</0><1>(72 500 € en services / 176
+    d'affaires</0><1><0>Non</0></1><2><0>Oui</0><1>(72 600 € en services / 176
     200 € en vente de biens, restauration ou hébergement)</1></2>
   retraite: <0>Retraite</0>
   retraiteEstimation:


### PR DESCRIPTION
Edit : en plus ce sont les seuils 2021 sur les revenus de 2020. Logiquement on devrait utiliser les seuils de l'année suivante, mais les connaît-on ?