### PR TITLE
Taux neutre non applicable pour les indépendants

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -8,6 +8,7 @@ dirigeant:
         - auto-entrepreneur
         - assimilé salarié
         - indépendant
+  rend non applicable: impôt . méthode de calcul . taux neutre
 
 dirigeant . rémunération: oui
 dirigeant . rémunération . totale:

--- a/mon-entreprise/source/components/conversation/Question.tsx
+++ b/mon-entreprise/source/components/conversation/Question.tsx
@@ -1,8 +1,15 @@
 import classnames from 'classnames'
 import { useDebounce } from 'Components/utils'
+import { useEngine } from 'Components/utils/EngineContext'
 import { Markdown } from 'Components/utils/markdown'
 import { DottedName } from 'modele-social'
-import { EvaluatedNode, Rule, RuleNode, serializeEvaluation } from 'publicodes'
+import {
+	EvaluatedNode,
+	Rule,
+	RuleNode,
+	serializeEvaluation,
+	UNSAFE_isNotApplicable,
+} from 'publicodes'
 import { References } from 'publicodes-react'
 import {
 	createContext,
@@ -70,6 +77,7 @@ export default function Question({
 		},
 		[onSubmit, onChange, setCurrentSelection]
 	)
+	const engine = useEngine()
 
 	const debouncedSelection = useDebounce(currentSelection, 300)
 	useEffect(() => {
@@ -150,6 +158,7 @@ export default function Question({
 									{renderChildren({ children } as Choice)}
 								</li>
 							) : (
+								!UNSAFE_isNotApplicable(engine, dottedName) &&
 								!hiddenOptions.includes(dottedName as DottedName) && (
 									<li key={dottedName} className="variantLeaf">
 										<RadioLabel


### PR DESCRIPTION
Note : La logique d'applicabilité sur les réponses ne fonctionne pas car il faut toujours un parent qui vaut `oui`. Ainsi `contrat salarié . CDI` est considéré comme non applicable et l'option n'est pas affichée avec cette modification.

Je n'ai pas de quickfix en tête, j'ai l'impression qu'il faut restructurer le code pour l'applicabilité https://github.com/betagouv/publicodes/issues/14 