### PR TITLE
Cypress external integrations

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -173,7 +173,6 @@ jobs:
             integrationFolder: mon-entreprise
             baseUrl: ${{ needs.deploy-context.outputs.fr_url }}
             language: fr
-            test-external: ${{ needs.deploy-context.outputs.env-name == 'master' }}
           - site: en
             integrationFolder: mon-entreprise
             baseUrl: ${{ needs.deploy-context.outputs.en_url }}
@@ -197,7 +196,7 @@ jobs:
             ~/.cache/Cypress
             node_modules
           key: cypress-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-      - run: npm i cypress cypress-plugin-tab
+      - run: node mon-entreprise/scripts/get-cypress-packages.js | xargs npm i
       - name: Test mon-entreprise
         uses: cypress-io/github-action@v2
         with:
@@ -209,14 +208,3 @@ jobs:
           env: language=${{ matrix.language }}
         env:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-        
-      - name: Test external integration
-        if: matrix.test-external
-        uses: cypress-io/github-action@v2
-        with:
-          install: false
-          working-directory: mon-entreprise
-          record: true
-          tag: external-integration
-          config: integrationFolder=cypress/integration/external,baseUrl=${{ matrix.baseUrl }}
-          

--- a/.github/workflows/test-external-integrations.yaml
+++ b/.github/workflows/test-external-integrations.yaml
@@ -31,3 +31,15 @@ jobs:
           record: true
           tag: external-integration
           config: integrationFolder=cypress/integration/external,baseUrl=https://mon-entreprise.fr
+
+      - name: e2e tests with external API calls
+        uses: cypress-io/github-action@v2
+        with:
+          install: false
+          working-directory: mon-entreprise
+          # List here all the specs that are making external API calls:
+          spec: cypress/integration/mon-entreprise/gérer.js
+          record: true
+          tag: external-integration
+          config: integrationFolder=cypress/integration/mon-entreprise,baseUrl=https://mon-entreprise.fr
+          env: record_http= # prevent stubbing

--- a/.github/workflows/test-external-integrations.yaml
+++ b/.github/workflows/test-external-integrations.yaml
@@ -1,0 +1,33 @@
+name: Test external integrations
+on:
+  schedule:
+    - cron: '47 3,15 * * *'
+
+jobs:
+  test-external-integrations:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        # Custom cache as we do not care about installing all the other dependancies
+        with:
+          path: |
+            ~/.cache/Cypress
+            node_modules
+          key: cypress-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - run: node mon-entreprise/scripts/get-cypress-packages.js | xargs npm i
+
+      - name: Test external integration
+        uses: cypress-io/github-action@v2
+        with:
+          install: false
+          working-directory: mon-entreprise
+          record: true
+          tag: external-integration
+          config: integrationFolder=cypress/integration/external,baseUrl=https://mon-entreprise.fr

--- a/mon-entreprise/cypress/integration/mon-entreprise/gérer.js
+++ b/mon-entreprise/cypress/integration/mon-entreprise/gérer.js
@@ -44,7 +44,9 @@ const waitResponses = (responses) => {
 	}
 }
 
-describe('Manage page test', function () {
+describe(`Manage page test (${
+	writeFixtures ? 'record mode' : 'stubbed mode'
+})`, function () {
 	let responses = {}
 	const hostnamesToRecord = ['entreprise.data.gouv.fr', 'geo.api.gouv.fr']
 	beforeEach(() => {

--- a/mon-entreprise/package.json
+++ b/mon-entreprise/package.json
@@ -43,6 +43,7 @@
 		"autoprefixer": "^9.7.6",
 		"babel-plugin-styled-components": "^1.10.7",
 		"copy-webpack-plugin": "^4.5.2",
+		"cypress": "^7.4.0",
 		"cypress-plugin-tab": "^1.0.5",
 		"eslint-plugin-react": "^7.12.4",
 		"html-webpack-plugin": "^3.2.0",

--- a/mon-entreprise/scripts/get-cypress-packages.js
+++ b/mon-entreprise/scripts/get-cypress-packages.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+
+const packages = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`))
+
+console.log('cypress@' + packages.devDependencies.cypress)
+for (const key of Object.keys(packages.devDependencies).filter(
+	(k) => k !== 'cypress' && k.startsWith('cypress')
+)) {
+	console.log(key + '@' + packages.devDependencies[key])
+}

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
 	},
 	"optionalDependencies": {
 		"bundlesize": "^0.18.0",
-		"cypress": "^7.4.0",
 		"prerender-spa-plugin": "^3.4.0"
 	},
 	"scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2378,9 +2378,9 @@
   integrity sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
 
 "@types/node@^14.14.31":
-  version "14.17.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.1.tgz#5e07e0cb2ff793aa7a1b41deae76221e6166049f"
-  integrity sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw==
+  version "14.17.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.2.tgz#1e94476db57ec93a372c7f7d29aa5707cfb92339"
+  integrity sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
En lien avec #1588, le but est de tester les intégration extérieures (API notamment) de manière indépendante du cycle de CI/CD lié aux pull-requests, donc sous forme de cron.

Caveat: le `on:sechedule` ne semble pas fonctionner pour l'instant, donc pour tester j'ai laissé un `on:push` dans un commit que je supprimerai. Peut-être il faut attendre que ça soit mergé dans master pour que le schedule fonctionne…?