### PR TITLE
Manipuler les couleurs en hsl plutôt qu'en rgb 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Nous utilisons GitHub pour suivre tous les bugs et discussions sur les nouvelles
 
 ## Développement
 
-Si vous voulez participer au développement de nouvelles fonctionnalités, vous pouvez consulter la liste des «[good first issue](https://github.com/betagouv/mon-entreprise/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Anew%3A+good+first+issue%22) ». Ce sont des fonctionnalités intéressantes qui ne sont normalement pas trop complexe à implémenter. N'hésitez pas à poser toutes vos questions sur ces issues !
+Si vous voulez participer au développement de nouvelles fonctionnalités, vous pouvez consulter la liste des «[good first issue](https://github.com/betagouv/mon-entreprise/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) ». Ce sont des fonctionnalités intéressantes qui ne sont normalement pas trop complexe à implémenter. N'hésitez pas à poser toutes vos questions sur ces issues !
 
 ### Technologies
 

--- a/mon-entreprise/index.html
+++ b/mon-entreprise/index.html
@@ -66,9 +66,7 @@
 		<!-- data-helmet pour que React Helmet puisse écraser ce meta par défaut -->
 
 		<link rel="manifest" href="/manifest.webmanifest" />
-		<title>
-			<%= htmlWebpackPlugin.options.title %>
-		</title>
+		<title><%= htmlWebpackPlugin.options.title %></title>
 
 		<% for (var css in htmlWebpackPlugin.files.css) { %>
 		<link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet" />
@@ -122,7 +120,7 @@
 				width: 11px;
 				height: 11px;
 				border-radius: 50%;
-				background: rgb(41, 117, 209);
+				background: hsl(213, 67%, 49%);
 				animation-timing-function: cubic-bezier(0, 1, 1, 0);
 			}
 
@@ -185,7 +183,7 @@
 				}
 			}
 		</style>
-		<meta name="theme-color" content="#2975d1" />
+		<meta name="theme-color" content="hsl(213, 67%, 49%)" />
 	</head>
 
 	<body>
@@ -193,7 +191,12 @@
 			<img
 				src="<%= htmlWebpackPlugin.options.logo %>"
 				alt="Un service de l'État français"
-				style="width: 300px; margin: auto; margin-bottom: 0.6rem; display:block"
+				style="
+					width: 300px;
+					margin: auto;
+					margin-bottom: 0.6rem;
+					display: block;
+				"
 			/>
 			<div id="lds-ellipsis">
 				<div></div>
@@ -212,16 +215,16 @@
 			// Hack to force styled components to render styles during prerender
 			if (window.__PRERENDER_INJECTED) {
 				window.onload = () => {
-					var el = document.createElement('style');
+					var el = document.createElement('style')
 					document.head.appendChild(el)
 					var styles = document.querySelectorAll('style[data-styled]')
 					for (style of styles.values()) {
-							for (rule of style.sheet.rules) {
-								el.appendChild(document.createTextNode(rule.cssText))
-							}
+						for (rule of style.sheet.rules) {
+							el.appendChild(document.createTextNode(rule.cssText))
+						}
 					}
+				}
 			}
-			};
 		</script>
 		<!-- APP  -->
 		<div id="js"></div>
@@ -229,19 +232,31 @@
 		<!-- OUTDATED BROWSER WARNING -->
 		<div
 			id="outdated-browser"
-			style="position: fixed; top: 0; left: 0; bottom: 0; right: 0; display: none; background-color: white"
+			style="
+				position: fixed;
+				top: 0;
+				left: 0;
+				bottom: 0;
+				right: 0;
+				display: none;
+				background-color: white;
+			"
 		>
 			<div
-				style="margin: 100px auto; max-width: 800px; text-align: center; font-family: 'Montserrat', sans-serif; font-weight: 300;"
+				style="
+					margin: 100px auto;
+					max-width: 800px;
+					text-align: center;
+					font-family: 'Montserrat', sans-serif;
+					font-weight: 300;
+				"
 			>
 				<img
 					src="images/logo.svg"
 					alt="Logo mon-entreprise.fr"
-					style="width: 200px; margin-bottom: 2rem;"
+					style="width: 200px; margin-bottom: 2rem"
 				/>
-				<h1>
-					Votre navigateur n'est plus supporté.
-				</h1>
+				<h1>Votre navigateur n'est plus supporté.</h1>
 				<h2>
 					Nous vous invitons à réessayer avec un autre, ou depuis un mobile
 					récent.
@@ -250,7 +265,9 @@
 				<br />
 				<h3>
 					Si besoin, vous pouvez en installer un nouveau depuis
-					<a style="color: #2975d1" href="https://outdatedbrowser.com/fr"
+					<a
+						style="color: hsl(213, 67%, 49%)"
+						href="https://outdatedbrowser.com/fr"
 						>cette page</a
 					>
 				</h3>
@@ -267,15 +284,12 @@
 			</div>
 		</div>
 
-
 		<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
 		<script
 			type="module"
 			src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"
 		></script>
-		<% } %>
-
-		<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
+		<% } %> <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
 		<script nomodule src="<%= chunk %>.legacy.bundle.js"></script>
 		<% } %>
 	</body>

--- a/mon-entreprise/source/Provider.tsx
+++ b/mon-entreprise/source/Provider.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundary } from '@sentry/react'
 import { ThemeColorsProvider } from 'Components/utils/colors'
+import HSL from "Components/utils/color/HSL"
 import { SitePathProvider, SitePaths } from 'Components/utils/SitePathsContext'
 import { createBrowserHistory } from 'history'
 import i18next from 'i18next'
@@ -114,10 +115,12 @@ export default function Provider({
 	display: none !important;
 }`
 	document.body.appendChild(css)
-	const iframeCouleur =
-		new URLSearchParams(document?.location.search.substring(1)).get(
-			'couleur'
-		) ?? undefined
+	const iframeCouleurParam =
+	new URLSearchParams(document?.location.search.substring(1)).get(
+		'couleur'
+		)
+		
+	const iframeCouleur = iframeCouleurParam ? new HSL(iframeCouleurParam) : undefined
 
 	return (
 		<ErrorBoundary
@@ -146,7 +149,7 @@ export default function Provider({
 		>
 			<ReduxProvider store={store}>
 				<ThemeColorsProvider
-					color={iframeCouleur && decodeURIComponent(iframeCouleur)}
+					color={iframeCouleur}
 				>
 					<TrackingContext.Provider
 						value={

--- a/mon-entreprise/source/components/BarChart.tsx
+++ b/mon-entreprise/source/components/BarChart.tsx
@@ -89,7 +89,7 @@ export default function BarChartBranch({
 				</p>
 				<ChartItemBar
 					style={{
-						backgroundColor: color,
+						backgroundColor: color.toString(),
 						flex: styles.flex,
 					}}
 					numberToPlot={numberToPlot}

--- a/mon-entreprise/source/components/Distribution.css
+++ b/mon-entreprise/source/components/Distribution.css
@@ -70,7 +70,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	color: rgba(0, 0, 0, 0.7);
+	color: hsla(0, 0%, 0%, 0.7);
 	padding: 0.4em 0;
 	padding-right: 1em;
 	justify-content: space-evenly;
@@ -85,7 +85,7 @@
 }
 
 .distribution-chart__total {
-	border-top: 1px dotted rgba(0, 0, 0, 0.7);
+	border-top: 1px dotted hsla(0, 0%, 0%, 0.7);
 	color: black;
 	margin-top: 1em;
 	padding-top: 0.8em;
@@ -102,7 +102,7 @@
 
 .distribution-chart__total-border {
 	grid-column: 2 / span 2;
-	border-top: solid 1px rgba(0, 0, 0, 0.7);
+	border-top: solid 1px hsla(0, 0%, 0%, 0.7);
 }
 
 /* IE11 Special */

--- a/mon-entreprise/source/components/Overlay.tsx
+++ b/mon-entreprise/source/components/Overlay.tsx
@@ -83,7 +83,7 @@ const StyledOverlayWrapper = styled.div<{ offsetTop: number | null }>`
 	right: 0;
 	bottom: 0;
 	max-height: 100vh;
-	background: rgba(255, 255, 255, 0.9);
+	background: hsla(0, 0%, 100%, 0.9);
 	overflow: auto;
 	z-index: 2;
 	.overlayContent {

--- a/mon-entreprise/source/components/Route404.tsx
+++ b/mon-entreprise/source/components/Route404.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom'
 export default () => (
 	<div
 		style={{
-			color: '#333350',
+			color: 'hsl(240, 22.137%, 25.686%)',
 			margin: '15% auto',
 			width: '15em',
 			textAlign: 'center',

--- a/mon-entreprise/source/components/StackedBarChart.tsx
+++ b/mon-entreprise/source/components/StackedBarChart.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux'
 import { animated, useSpring } from 'react-spring'
 import { targetUnitSelector } from 'Selectors/simulationSelectors'
 import styled from 'styled-components'
+import HSLInterface from './utils/color/HSLInterface'
 import { useEngine } from './utils/EngineContext'
 
 const BarStack = styled.div`
@@ -38,10 +39,10 @@ const BarStackLegend = styled.div`
 `
 
 const BarStackLegendItem = styled.div`
-	color: #555;
+	color: hsl(0, 0%, 33.333%);
 	strong {
 		display: inline-block;
-		color: #111;
+		color: hsl(0, 0%, 6.667%);
 		margin-left: 8px;
 	}
 `
@@ -85,7 +86,7 @@ export function roundedPercentages(values: Array<number>) {
 
 type StackedBarChartProps = {
 	data: Array<{
-		color?: string
+		color?: HSLInterface
 		value: EvaluatedNode['nodeValue']
 		legend: React.ReactNode
 		key: string
@@ -116,7 +117,7 @@ export function StackedBarChart({ data }: StackedBarChartProps) {
 						<BarItem
 							style={{
 								width: `${percentage}%`,
-								backgroundColor: color || 'green',
+								backgroundColor: color?.toString() || 'green',
 							}}
 							key={key}
 						/>
@@ -125,7 +126,7 @@ export function StackedBarChart({ data }: StackedBarChartProps) {
 			<BarStackLegend>
 				{dataWithPercentage.map(({ key, percentage, color, legend }) => (
 					<BarStackLegendItem key={key}>
-						<SmallCircle style={{ backgroundColor: color }} />
+						<SmallCircle style={{ backgroundColor: color?.toString() }} />
 						{legend}
 						<strong>{percentage} %</strong>
 					</BarStackLegendItem>
@@ -136,7 +137,7 @@ export function StackedBarChart({ data }: StackedBarChartProps) {
 }
 
 type StackedRulesChartProps = {
-	data: Array<{ color?: string; dottedName: Names; title?: string }>
+	data: Array<{ color?: HSLInterface; dottedName: Names; title?: string }>
 }
 
 export default function StackedRulesChart({ data }: StackedRulesChartProps) {

--- a/mon-entreprise/source/components/TargetSelection.css
+++ b/mon-entreprise/source/components/TargetSelection.css
@@ -29,7 +29,7 @@
 }
 
 #targetSelection .targets > li {
-	border-top: 1px dashed rgba(255, 255, 255, 0.6);
+	border-top: 1px dashed #ffffff99;
 	padding: 0.8rem 1rem;
 	margin-left: -1rem;
 	margin-right: -1rem;
@@ -50,7 +50,7 @@
 }
 #targetSelection .targets > li .guide-lecture {
 	flex: 1;
-	border-bottom: 1px dashed rgba(255, 255, 255, 0.25);
+	border-bottom: 1px dashed #ffffff40;
 	margin-left: 1rem;
 }
 
@@ -126,7 +126,7 @@
 	width: 5.5em;
 	max-width: 7.5em;
 	text-align: right;
-	background: rgba(255, 255, 255, 0.2);
+	background: #ffffff33;
 	padding: 0.2rem 0.6rem;
 	border-radius: 0.3rem;
 	border: 1px solid;
@@ -159,7 +159,7 @@
 	padding: 0.2rem 0.6rem;
 
 	background: transparent;
-	border: 1px dashed rgba(255, 255, 255, 0.5);
+	border: 1px dashed #ffffff80;
 	border-radius: 0.3rem;
 
 	font-size: inherit;

--- a/mon-entreprise/source/components/TargetSelection.tsx
+++ b/mon-entreprise/source/components/TargetSelection.tsx
@@ -202,8 +202,8 @@ function TargetInputOrValue({
 						{!isFocused && <AnimatedTargetValue value={value} />}
 						<CurrencyInput
 							style={{
-								color: colors.textColor,
-								borderColor: colors.textColor,
+								color: colors.textColor.toString(),
+								borderColor: colors.textColor.toString(),
 							}}
 							debounce={750}
 							name={target.dottedName}

--- a/mon-entreprise/source/components/conversation/Explicable.tsx
+++ b/mon-entreprise/source/components/conversation/Explicable.tsx
@@ -58,7 +58,7 @@ export function Explicable({ children }: { children: React.ReactNode }) {
 					vertical-align: middle;
 					font-size: 110% !important;
 					> img {
-						border: 1px solid rgba(255, 255, 255, 0.7) !important;
+						border: 1px solid hsla(0, 0%, 100%, 0.7) !important;
 						border-radius: 0.1rem;
 					}
 				`}

--- a/mon-entreprise/source/components/conversation/conversation.css
+++ b/mon-entreprise/source/components/conversation/conversation.css
@@ -19,7 +19,7 @@
 }
 
 .step.question .variant > ul {
-	border-right: 1px dashed #333;
+	border-right: 1px dashed hsl(0, 0%, 20%);
 	text-align: right;
 	padding-right: 0.6em;
 	padding-top: 0.6em;

--- a/mon-entreprise/source/components/conversation/select/SelectTauxRisque.js
+++ b/mon-entreprise/source/components/conversation/select/SelectTauxRisque.js
@@ -91,7 +91,7 @@ function SelectComponent({ onChange, onSubmit, options }) {
 							css={`
 								width: 10%;
 								min-width: 3em;
-								color: #333;
+								color: hsl(0, 0%, 20%);
 							`}
 						>
 							<span>{option['Taux net'] + ' %'}</span>
@@ -101,7 +101,7 @@ function SelectComponent({ onChange, onSubmit, options }) {
 								width: 20%;
 								font-size: 85%;
 								background-color: #ddd;
-								color: #333;
+								color: hsl(0, 0%, 20%);
 								border-radius: 0.25em;
 								padding: 0.5em;
 								text-align: center;

--- a/mon-entreprise/source/components/ui/Button/button.css
+++ b/mon-entreprise/source/components/ui/Button/button.css
@@ -30,22 +30,22 @@
 	cursor: pointer;
 
 	/* ie11 */
-	border-color: rgb(41, 117, 209);
+	border-color: hsl(213, 67%, 49%);
 	border-color: var(--color);
 	/* ie11 */
-	color: rgb(41, 117, 209);
+	color: hsl(213, 67%, 49%);
 	color: var(--color);
 	background-image: linear-gradient(
 		50deg,
-		rgba(39, 69, 195, 0.87) 5%,
-		rgb(41, 117, 209) 50%,
-		rgba(255, 255, 255, 0.52) 55%
+		hsla(228, 67%, 46%, 0.87) 5%,
+		hsl(213, 67%, 49%) 50%,
+		hsla(0, 0%, 100%, 0.52) 55%
 	);
 	background-image: linear-gradient(
 		50deg,
 		var(--color) 5%,
 		var(--lightColor) 50%,
-		rgba(255, 255, 255, 0.52) 55%
+		hsla(0, 0%, 100%, 0.52) 55%
 	);
 	background-size: 280%;
 	background-position-x: 99%;
@@ -53,9 +53,9 @@
 .ui__.button.plain {
 	background-image: linear-gradient(
 		50deg,
-		rgba(39, 69, 195, 0.87) 5%,
-		rgb(41, 117, 209) 50%,
-		rgba(41, 117, 209, 0.9) 55%
+		hsla(228, 67%, 46%, 0.87) 5%,
+		hsl(213, 67%, 49%) 50%,
+		hsla(213, 67%, 49%, 0.9) 55%
 	);
 	background-image: linear-gradient(
 		50deg,
@@ -121,7 +121,7 @@
 .ui__.link-button {
 	text-decoration: underline;
 	text-underline-offset: 4px;
-	color: rgb(41, 117, 209);
+	color: hsl(213, 67%, 49%);
 	color: var(--color);
 }
 .ui__.link-button.active {
@@ -134,7 +134,7 @@
 }
 .ui__.dashed-button {
 	border-bottom: 1px dashed;
-	border-color: rgb(41, 117, 209);
+	border-color: hsl(213, 67%, 49%);
 	border-color: var(--color);
 	padding: 0.15em 0em;
 }

--- a/mon-entreprise/source/components/ui/Card.css
+++ b/mon-entreprise/source/components/ui/Card.css
@@ -1,6 +1,6 @@
 .ui__.card {
-	box-shadow: 0 1px 3px rgba(41, 117, 209, 0.12),
-		0 1px 2px rgba(41, 117, 209, 0.24);
+	box-shadow: 0 1px 3px hsla(213, 67%, 49%, 0.122),
+		0 1px 2px hsla(213, 67%, 49%, 0.24);
 	padding-left: 1rem;
 	padding-right: 1rem;
 	background: white;
@@ -19,7 +19,11 @@
 .ui__.card.plain {
 	color: white;
 	color: var(--textColor);
-	background: linear-gradient(60deg, #215da6 0%, #297da1 100%);
+	background: linear-gradient(
+		60deg,
+		hsl(213, 67%, 39%) 0%,
+		hsl(198, 59%, 40%) 100%
+	);
 	background: linear-gradient(60deg, var(--darkColor) 0%, var(--color) 100%);
 }
 .ui__.card.plain h1,
@@ -88,9 +92,9 @@
 	-webkit-user-drag: none;
 }
 .ui__.interactive.card:hover {
-	box-shadow: 0px 2px 4px -1px rgba(41, 117, 209, 0.2),
-		0px 4px 5px 0px rgba(41, 117, 209, 0.14),
-		0px 1px 10px 0px rgba(41, 117, 209, 0.12);
+	box-shadow: 0px 2px 4px -1px hsla(213, 67%, 49%, 0.2),
+		0px 4px 5px 0px hsla(213, 67%, 49%, 0.141),
+		0px 1px 10px 0px hsla(213, 67%, 49%, 0.12);
 	opacity: inherit !important;
 }
 .ui__.ui__.interactive.card:active {

--- a/mon-entreprise/source/components/ui/Checkbox/index.css
+++ b/mon-entreprise/source/components/ui/Checkbox/index.css
@@ -18,7 +18,7 @@
 	width: 2.2em;
 	height: 2.2em;
 	border-radius: 50%;
-	background: rgba(34, 50, 84, 0.03);
+	background: hsla(221, 42%, 23%, 0.03);
 	opacity: 0;
 	transition: opacity 0.2s ease;
 }

--- a/mon-entreprise/source/components/ui/InfoBulle.css
+++ b/mon-entreprise/source/components/ui/InfoBulle.css
@@ -32,9 +32,9 @@
 	background-color: white;
 	transition: opacity 0.2s, transform 0.2s;
 	opacity: 0;
-	box-shadow: 0px 2px 4px -1px rgba(41, 117, 209, 0.2),
-		0px 4px 5px 0px rgba(41, 117, 209, 0.14),
-		0px 1px 10px 0px rgba(41, 117, 209, 0.12);
+	box-shadow: 0px 2px 4px -1px hsla(213, 67%, 49%, 0.2),
+		0px 4px 5px 0px hsla(213, 67%, 49%, 0.14),
+		0px 1px 10px 0px hsla(213, 67%, 49%, 0.12);
 	pointer-events: none;
 	transform: translate(2.8ex, -5px);
 }

--- a/mon-entreprise/source/components/ui/SocialIcon.tsx
+++ b/mon-entreprise/source/components/ui/SocialIcon.tsx
@@ -62,7 +62,7 @@ export default function SocialIcon({ media }: { media: keyof typeof icons }) {
 			<g>
 				<path d={icons[media].icon} style={{ fill: 'transparent' }} />
 			</g>
-			<g style={{ fill: color }}>
+			<g style={{ fill: color.toString() }}>
 				<path d={icons[media].mask} />
 			</g>
 		</svg>

--- a/mon-entreprise/source/components/ui/Toggle.css
+++ b/mon-entreprise/source/components/ui/Toggle.css
@@ -49,7 +49,7 @@
 	vertical-align: middle;
 	border-radius: 100%;
 	cursor: pointer;
-	box-shadow: 0 0 0px 2px rgb(41, 117, 209);
+	box-shadow: 0 0 0px 2px hsl(213, 67%, 49%);
 	box-shadow: 0 0 0px 2px var(--color);
 	transition: all 0.1s;
 	border: 0.4em solid white;

--- a/mon-entreprise/source/components/ui/Typography.css
+++ b/mon-entreprise/source/components/ui/Typography.css
@@ -26,7 +26,7 @@ html {
 
 body {
 	font-weight: 400;
-	color: #040e19;
+	color: hsl(211, 72%, 6%);
 	color: var(--darkColor);
 	font-family: 'Roboto', sans-serif;
 }
@@ -113,7 +113,7 @@ a {
 	padding: none;
 	text-decoration: underline;
 	text-underline-offset: 4px;
-	color: rgb(41, 117, 209);
+	color: hsl(213, 67%, 49%);
 	color: var(--color);
 }
 
@@ -136,7 +136,7 @@ textarea {
 
 small,
 .ui__.notice {
-	color: rgba(0, 0, 0, 0.6);
+	color: hsla(0, 0%, 0%, 0.6);
 	color: var(--lighterTextColor);
 	font-size: 85%;
 	line-height: 1.5rem;

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -7,9 +7,9 @@
 @import './Layout.css';
 
 :root {
-	--color: rgb(41, 117, 209);
-	--darkColor: rgb(24, 69, 123);
-	--textColor: rgb(24, 69, 123);
+	--color: hsl(213, 67%, 49%);
+	--darkColor: hsl(213, 67%, 29%);
+	--textColor: hsl(213, 67%, 29%);
 }
 @media (min-width: 400px) {
 	:focus:not(:active):not(input) {
@@ -56,11 +56,11 @@ blockquote {
 }
 
 .ui__.dark-bg {
-	background-color: #3b3945;
+	background-color: hsl(250, 10%, 25%);
 }
 
 .ui__.dark-bg * {
-	color: #f3f3f3;
+	color: hsl(0, 0%, 95%);
 }
 
 .ui__.light-border {
@@ -131,13 +131,13 @@ span.ui__.enumeration:not(:last-of-type)::after {
 	font-family: monospace;
 	margin: 0 0.2rem;
 	padding: 0 0.2rem;
-	box-shadow: 0px 1px 1px 1px #d9d9d9, 0 0 0 1px #d9d9d9;
+	box-shadow: 0px 1px 1px 1px hsl(0, 0%, 85%), 0 0 0 1px hsl(0, 0%, 85%);
 	border-radius: 0.2rem;
 }
 
 pre.ui__.code {
-	color: rgb(197, 200, 198);
-	text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;
+	color: hsl(140, 3%, 78%);
+	text-shadow: hsla(0, 0%, 0%, 0.3) 0px 1px;
 	font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
 	direction: ltr;
 	text-align: left;
@@ -151,12 +151,12 @@ pre.ui__.code {
 	margin: 0.5em 0px;
 	overflow: auto;
 	border-radius: 0.3em;
-	background: rgb(29, 31, 33);
+	background: hsl(210, 6%, 12%);
 }
 
 pre.ui__.code > code {
-	color: rgb(197, 200, 198);
-	text-shadow: rgba(0, 0, 0, 0.3) 0px 1px;
+	color: hsl(140, 3%, 78%);
+	text-shadow: hsla(0, 0%, 0%, 0.3) 0px 1px;
 	font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
 	direction: ltr;
 	text-align: left;

--- a/mon-entreprise/source/components/ui/reset.css
+++ b/mon-entreprise/source/components/ui/reset.css
@@ -52,7 +52,7 @@ label {
 
 button {
 	background: none;
-	border: 1px solid #222;
+	border: 1px solid hsl(0, 0%, 13%);
 	border-radius: 0.2em;
 	padding: 0 1em;
 }

--- a/mon-entreprise/source/components/utils/color/HSL.ts
+++ b/mon-entreprise/source/components/utils/color/HSL.ts
@@ -1,0 +1,83 @@
+import HSLInterface from './HSLInterface';
+import convert from 'color-convert';
+
+/**
+ * Class for manipulate HSL Color
+ */
+
+export default class HSL implements HSLInterface {
+	a?: number;
+	h = 0;
+	l = 0;
+	s = 0;
+
+	constructor(color?: string | number[]) {
+		if (color) {
+			if (typeof color === 'string') {
+				this.fromString(color);
+			} else {
+				this.fromArray(color);
+			}
+		}
+	}
+
+	/**
+	 * Import hsl or hex from string
+	 * @param color
+	 */
+	fromString(color: string) {
+		return color.match(/hsl(a)?\(/) ? this.fromHsl(color) : this.fromHex(color)
+	}
+
+	/**
+	 * import hsl from array
+	 * @param color
+	 */
+	fromArray(color: number[]) {
+		this.h = Number(color[0]) || 0;
+		this.s = Number(color[1]) || 0;
+		this.l = Number(color[2]) || 0;
+		this.a = Number(color[3]) || undefined;
+	}
+
+	/**
+	 * Import hsl from string
+	 * @param color
+	 */
+	private fromHsl(color: string) {
+		console.log('fromHsl : ', color)
+		const arrayColor = color.match(/(\d+(\.\d+)?)+/g) || [];
+		this.h = Number(arrayColor[0]) || 0;
+		this.s = Number(arrayColor[1]) / 100 || 0;
+		this.l = Number(arrayColor[2]) / 100 || 0;
+		this.a = Number(arrayColor[3]) || undefined;
+	}
+
+	/**
+	 * Import hex from string
+	 * @param color
+	 */
+	private fromHex(color: string) {
+		console.log('fromHex : ', color)
+		const arrayColor = convert.hex.hsl(color);
+
+		this.h = Number(arrayColor[0]) || 0;
+		this.s = Number(arrayColor[1]) / 100 || 0;
+		this.l = Number(arrayColor[2]) / 100 || 0;
+	}
+
+	/**
+	 * Cast to string
+	 * @returns
+	 */
+	toString(): string {
+		const h = this.h.toFixed(2);
+		const s = (this.s * 100).toFixed(2);
+		const l = (this.l * 100).toFixed(2);
+		const a = this.a?.toFixed(2);
+
+		return this.a === undefined
+			? `hsl(${h}, ${s}%, ${l}%)`
+			: `hsla(${h}, ${s}%, ${l}%, ${a})`;
+	}
+}

--- a/mon-entreprise/source/components/utils/color/HSLInterface.ts
+++ b/mon-entreprise/source/components/utils/color/HSLInterface.ts
@@ -1,0 +1,6 @@
+export default interface HSLInterface {
+  a?: number;
+  h: number;
+  l: number;
+  s: number;
+}

--- a/mon-entreprise/source/pages/Dev/ColorPicker.tsx
+++ b/mon-entreprise/source/pages/Dev/ColorPicker.tsx
@@ -1,15 +1,17 @@
-import { ChromePicker, ChromePickerProps } from 'react-color'
+import HSL from "Components/utils/color/HSL"
+import HSLInterface from "Components/utils/color/HSLInterface"
+import { ChromePicker, HSLColor } from 'react-color'
 
 type ColorPickerProps = {
-	color: ChromePickerProps['color']
-	onChange: (color: string) => void
+	color: HSLInterface
+	onChange: (color: HSLInterface) => void
 }
 
 export default function ColorPicker({ color, onChange }: ColorPickerProps) {
 	return (
 		<ChromePicker
-			color={color}
-			onChangeComplete={(color) => onChange(color.hex)}
+			color={color as HSLColor}
+			onChangeComplete={(color) => onChange(Object.assign(new HSL(), color.hsl))}
 		/>
 	)
 }

--- a/mon-entreprise/source/pages/Dev/IntegrationTest.tsx
+++ b/mon-entreprise/source/pages/Dev/IntegrationTest.tsx
@@ -1,3 +1,5 @@
+import HSL from "Components/utils/color/HSL"
+import HSLInterface from "Components/utils/color/HSLInterface"
 import { lazy, useState, useRef, useEffect, Suspense, useMemo } from 'react'
 import useSimulatorsData from '../Simulateurs/metadata'
 const LazyColorPicker = lazy(() => import('./ColorPicker'))
@@ -12,7 +14,8 @@ export default function IntegrationTest() {
 		[simulators]
 	)
 	const [currentModule, setCurrentModule] = useState(integrableModuleNames[0])
-	const [color, setColor] = useState('#005aa1')
+	const baseColor: HSLInterface = new HSL([206.46, 1, 0.31569]);
+	const [color, setColor] = useState(baseColor)
 	const [version, setVersion] = useState(0)
 	const domNode = useRef<HTMLDivElement>(null)
 	useEffect(() => {
@@ -20,7 +23,7 @@ export default function IntegrationTest() {
 		script.id = 'script-monentreprise'
 		script.src = window.location.origin + '/simulateur-iframe-integration.js'
 		script.dataset.module = currentModule
-		script.dataset.couleur = color
+		script.dataset.couleur = color.toString()
 		if (domNode.current) {
 			domNode.current.innerHTML = ''
 			domNode.current.appendChild(script)
@@ -38,7 +41,7 @@ export default function IntegrationTest() {
 
 			<h2>Quelle couleur ?</h2>
 			<Suspense fallback={<div>Chargement...</div>}>
-				<LazyColorPicker color={color} onChange={setColor} />
+				<LazyColorPicker color={color} onChange={ setColor } />
 			</Suspense>
 
 			<button

--- a/mon-entreprise/source/pages/Gérer/DemandeMobilite/EndBlock.tsx
+++ b/mon-entreprise/source/pages/Gérer/DemandeMobilite/EndBlock.tsx
@@ -81,7 +81,7 @@ export default function EndBlock({ fields, isMissingValues }: EndBlockProps) {
 					>
 						<SignaturePad
 							height={200}
-							options={{ penColor: darkColor }}
+							options={{ penColor: darkColor.toString() }}
 							ref={signatureRef}
 						/>
 					</div>

--- a/mon-entreprise/source/pages/Gérer/DemandeMobilite/PDFDocument.tsx
+++ b/mon-entreprise/source/pages/Gérer/DemandeMobilite/PDFDocument.tsx
@@ -101,7 +101,7 @@ Font.register({
 const styles = StyleSheet.create({
 	body: {
 		paddingTop: 35,
-		color: '#18457B',
+		color: 'hsl(212.727, 67.347%, 28.823%)',
 		lineHeight: 1.5,
 		paddingBottom: 65,
 		paddingHorizontal: 35,

--- a/mon-entreprise/source/pages/Simulateurs/ChômagePartiel.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ChômagePartiel.tsx
@@ -291,7 +291,7 @@ const ResultTable = styled.table`
 	}
 
 	td {
-		border-top: 1px solid rgba(0, 0, 0, 0.1);
+		border-top: 1px solid hsla(0, 0%, 0%, 0.098);
 		padding: 0.8rem 1rem 0;
 	}
 

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -2,6 +2,7 @@ import RuleLink from 'Components/RuleLink'
 import SimulateurWarning from 'Components/SimulateurWarning'
 import Simulation from 'Components/Simulation'
 import SalaryExplanation from 'Components/simulationExplanation/SalaryExplanation'
+import HSL from "Components/utils/color/HSL"
 import Emoji from 'Components/utils/Emoji'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import React, { useContext, useMemo } from 'react'
@@ -75,7 +76,7 @@ export type SimulatorData = Record<
 			ogTitle?: string
 			ogDescription?: string
 			ogImage?: string
-			color?: string
+			color?: HSL
 		}
 		tracking:
 			| {
@@ -1001,7 +1002,7 @@ export function getSimulatorsData({
 					'pages.simulateurs.aides-embauche.meta.description',
 					'Découvrez les principales aides à l’embauche et estimez leur montant en répondant à quelques questions.'
 				),
-				color: '#11965f',
+				color: new HSL([155.188, 0.796, 0.327]),
 			},
 			path: sitePaths.simulateurs['aides-embauche'],
 			iframePath: 'aides-embauche',
@@ -1053,7 +1054,7 @@ export function getSimulatorsData({
 					'pages.simulateurs.is.meta.description',
 					'Calculez votre impôt sur les sociétés'
 				),
-				color: '#E71D66',
+				color: new HSL([338.317, 0.808, 0.51]),
 			},
 			shortName: t('pages.simulateurs.is.meta.title', 'Impôt sur les sociétés'),
 			title: t(

--- a/mon-entreprise/source/pages/Stats/Chart.tsx
+++ b/mon-entreprise/source/pages/Stats/Chart.tsx
@@ -40,16 +40,16 @@ type VisitsChartProps = {
 	data: Data
 }
 const Palette = [
-	'#1ea0f5',
-	'#697ad5',
-	'#b453b6',
-	'#ff2d96',
-	'#fd667f',
-	'#fc9e67',
-	'#fad750',
-	'#bed976',
-	'#82da9d',
-	'#46dcc3',
+	'hsl(203.721, 91.489%, 53.922%)',
+	'hsl(230.555, 56.25%, 62.353%)',
+	'hsl(298.788, 40.408%, 51.961%)',
+	'hsl(330, 100%, 58.824%)',
+	'hsl(350.066, 97.419%, 69.608%)',
+	'hsl(22.148, 96.129%, 69.608%)',
+	'hsl(47.647, 94.4445%, 64.706%)',
+	'hsl(76.364, 56.571%, 65.686%)',
+	'hsl(138.409, 54.321%, 68.235%)',
+	'hsl(170, 68.182%, 56.863%)',
 ]
 
 export default function VisitsChart({
@@ -80,7 +80,7 @@ export default function VisitsChart({
 
 	function getColor(i: number): string {
 		if (!colored) {
-			return [lighterColor, lightColor, darkColor][i % 3]
+			return [lighterColor, lightColor, darkColor][i % 3].toString()
 		}
 		return Palette[i % Palette.length]
 	}

--- a/mon-entreprise/source/pages/integration/Iframe.tsx
+++ b/mon-entreprise/source/pages/integration/Iframe.tsx
@@ -1,4 +1,5 @@
 import Overlay from 'Components/Overlay'
+import HSLInterface from 'Components/utils/color/HSLInterface'
 import {
 	ThemeColorsContext,
 	ThemeColorsProvider,
@@ -51,7 +52,7 @@ function IntegrationCustomizer() {
 	}, [currentModule])
 
 	const { color: defaultColor } = useContext(ThemeColorsContext)
-	const [color, setColor] = useState(defaultColor)
+	const [ color, setColor ] = useState(defaultColor)
 	return (
 		<section>
 			<h2>
@@ -116,7 +117,7 @@ function IntegrationCustomizer() {
 							{emoji('🎨')}
 						</h3>
 						<Suspense fallback={<div>Chargement...</div>}>
-							<LazyColorPicker color={color} onChange={setColor} />
+							<LazyColorPicker color={color} onChange={ setColor } />
 						</Suspense>
 						<h3>
 							<Trans i18nKey="pages.développeurs.code.titre">
@@ -295,7 +296,7 @@ function EnSavoirPlusCSP() {
 
 type IntegrationCodeProps = {
 	module?: string
-	color?: string
+	color?: HSLInterface
 }
 
 function IntegrationCode({
@@ -324,17 +325,17 @@ function IntegrationCode({
 				display: block;
 				font-size: 80%;
 				padding: 1em;
-				background: #f8f8f8;
+				background: hsl(0, 0%, 97.255%);
 				margin: auto;
 				margin-bottom: 1em;
 				overflow: auto;
 				line-height: 1.6em;
-				box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05),
-					-1px 1px 1px rgba(0, 0, 0, 0.02);
+				box-shadow: 0 1px 1px hsla(0, 0%, 0%, 0.05),
+					-1px 1px 1px hsla(0, 0%, 0%, 0.02);
 
 				em {
 					font-weight: 300;
-					color: black;
+					color: hsl(0, 0%, 0%);
 				}
 
 				:before {
@@ -344,10 +345,10 @@ function IntegrationCode({
 					right: 0;
 					border-width: 0 16px 16px 0;
 					border-style: solid;
-					border-color: #e8e8e8 white;
+					border-color: hsl(0, 0%, 90.98%) white;
 				}
 				#scriptColor {
-					color: #2975d1;
+					color: hsl(212.857, 67.2%, 49.02%);
 				}
 			`}
 		>
@@ -365,7 +366,7 @@ function IntegrationCode({
 				<>
 					<br />
 					<em>data-couleur</em>="
-					<span id="scriptColor">{color}</span>"
+					<span id="scriptColor">{color.toString()}</span>"
 				</>
 			) : (
 				''

--- a/mon-entreprise/source/reducers/rootReducer.ts
+++ b/mon-entreprise/source/reducers/rootReducer.ts
@@ -1,4 +1,5 @@
 import { Action } from 'Actions/actions'
+import HSLInterface from 'Components/utils/color/HSLInterface'
 import { getCompanySituation } from 'Components/utils/useSimulationConfig'
 import { DottedName } from 'modele-social'
 import { Names } from 'modele-social/dist/names'
@@ -51,7 +52,7 @@ export type SimulationConfig = Partial<{
 	questions: Partial<Record<QuestionsKind, Array<DottedName>>>
 	branches: Array<{ nom: string; situation: SimulationConfig['situation'] }>
 	'unité par défaut': string
-	color: string
+	color: HSLInterface
 }>
 
 export type Situation = Partial<Record<DottedName, any>>


### PR DESCRIPTION
Suite à l'issue #1517 

Création d'une class HSL pour manipulation .
Modification des hexa et rgb dans le code.

Pas de modification de publicode.
Contrôles visuels fait dans l'appli (notamment outil d'intégration).