### PR TITLE
🔨 Question pour la déduction forfaitaire spécifique

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -91,7 +91,7 @@ dirigeant . assimilé salarié:
   rend non applicable:
     - contrat salarié . convention collective
     - contrat salarié . activité partielle
-    - contrat salarié . profession spécifique
+    - contrat salarié . déduction forfaitaire spécifique
     - contrat salarié . rémunération . primes
     - contrat salarié . rémunération . primes . fin d'année
     - contrat salarié . rémunération . primes . activité

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -552,59 +552,120 @@ contrat salarié . activité partielle . convention syntec:
     de chômage partielle au dessus du minimum légal et à la charge de
     l'entreprise.
   par défaut: non
-  rend non applicable:
-    # TODO: this is not working, the question is still displayed. This should be
-    # fixed but is not critical
-    - profession spécifique
 
 contrat salarié . déduction forfaitaire spécifique:
   description: >-
     Pour une liste précise de professions, l'employeur peut pratiquer une
-    déduction forfaitaire spécifique pour frais professionnels sur la base de
-    calcul des cotisations sociales.
-  applicable si:
-    toutes ces conditions:
-      - application
-      - taux > 0%
+    déduction forfaitaire spécifique (DFS) pour frais professionnels sur la base de
+    calcul des cotisations sociales. spécifique consiste en un abattement sur l'assiette
+    des cotisations sociales. Elle peut s'appliquer si le salarié supporte
+    effectivement des frais lors de son activité professionnelle.
+
+    En l’absence de frais effectivement engagés, ou si l’employeur prend en
+    charge ou rembourse la totalité des frais professionnels, il est impossible
+    d’appliquer la DFS.
   titre: assiette avec DFS
+  question: Le salarié bénéficie-t-il d'une déduction forfaitaire spécifique ?
+  par défaut: non
   remplace:
     règle: cotisations . assiette
+    par:
+      valeur: cotisations . assiette
+      abattement:
+        valeur: taux * cotisations . assiette
+        plafond: 7600 €/an
+      plancher: cotisations . assiette minimale
     sauf dans: contrat salarié . CSG et CRDS
     # TODO: ajouter pas d'abattement pour l'assurance chômage mais seulement
     # pour les journalistes. Nécessite probablement de faire un re-remplacement
     # inverse.
-  formule:
-    valeur: cotisations . assiette
-    abattement:
-      valeur: taux * cotisations . assiette
-      plafond: 7600 €/an
-    plancher: cotisations . assiette minimale
   références:
     Fiche Urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-elements-a-prendre-en-compte/les-frais-professionnels/la-deduction-forfaitaire-specifi.html
 
 contrat salarié . déduction forfaitaire spécifique . taux:
   formule:
     variations:
-      - si: profession spécifique = 'journaliste'
+      - si: profession = 'journaliste'
         alors: 20%
-      - si: profession spécifique = 'ouvrier du bâtiment'
+      - si: profession = 'ouvrier du bâtiment'
         alors: 10%
-      - si: profession spécifique = 'artiste musicien'
+      - si: profession = 'artiste musicien'
         alors: 20%
-      - si: profession spécifique = 'pilote de ligne ou personnel navigant'
+      - si: profession = 'pilote de ligne ou personnel navigant'
         alors: 30%
       - sinon: 0%
   références:
     Circulaire DSS: https://solidarites-sante.gouv.fr/fichiers/bo/2005/05-09/a0090046.htm
 
-contrat salarié . déduction forfaitaire spécifique . application:
+contrat salarié . déduction forfaitaire spécifique . profession:
+  question: Quelle est la profession du salarié pour l'application de la déduction forfaitaire spécifique ?
+  par défaut: non
+  formule:
+    une possibilité:
+      possibilités:
+        - journaliste
+        - ouvrier du bâtiment
+        - artiste musicien
+        - pilote de ligne ou personnel navigant
+      choix obligatoire: oui
+
+contrat salarié . déduction forfaitaire spécifique . profession . journaliste:
+  formule: contrat salarié . déduction forfaitaire spécifique . profession = 'journaliste'
+  icônes: ✒
   description: >-
-    La déduction forfaitaire spécifique consiste en un abattement sur l'assiette
-    des cotisations sociales. L'employeur peut renoncer à appliquer cette
-    déduction afin d'accorder plus de droits au salarié, notamment en terme de
-    retraite et d'assurance chômage.
-  titre: application de la DFS
-  formule: oui
+    Concerne les journalistes, rédacteurs, photographes, directeurs de journaux
+    Critiques dramatiques et musicaux.
+
+contrat salarié . déduction forfaitaire spécifique . profession . journaliste . réduction de taux:
+  applicable si: déduction forfaitaire spécifique . profession = 'journaliste'
+  remplace:
+    - règle: vieillesse . employeur . plafonnée . taux
+      par: vieillesse . employeur . plafonnée . taux * réduction de taux
+    - règle: vieillesse . employeur . déplafonnée . taux
+      par: vieillesse . employeur . déplafonnée . taux * réduction de taux
+    - règle: vieillesse . salarié . plafonnée . taux
+      par: vieillesse . salarié . plafonnée . taux * réduction de taux
+    - règle: vieillesse . salarié . déplafonnée . taux
+      par: vieillesse . salarié . déplafonnée . taux * réduction de taux
+
+    - règle: allocations familiales . taux
+      par: allocations familiales . taux * réduction de taux
+    - règle: établissement . taux du versement transport
+      par: établissement . taux du versement transport * réduction de taux
+    - règle: ATMP . taux
+      par: ATMP . taux * réduction de taux
+    - règle: ATMP . taux minimum
+      par: ATMP . taux minimum * réduction de taux
+  formule: 80%
+
+contrat salarié . déduction forfaitaire spécifique . profession . journaliste . abattement fiscal:
+  applicable si: déduction forfaitaire spécifique . profession = 'journaliste'
+  remplace: rémunération . net imposable
+  titre: net imposable journaliste
+  formule:
+    valeur: rémunération . net imposable
+    abattement: 7650€/an
+
+contrat salarié . déduction forfaitaire spécifique . profession . ouvrier du bâtiment:
+  icônes: 👷‍♂️
+  description: >-
+    Concerne les ouvriers du bâtiment visés aux paragraphes 1er et 2 de
+    l’article 1er du décret du 17 novembre 1936, à l’exclusion de ceux qui
+    travaillent en usine ou en atelier.
+
+contrat salarié . déduction forfaitaire spécifique . profession . artiste musicien:
+  icônes: 🎼
+  description: >-
+    Concerne les artistes musiciens, choristes, chefs d’orchestre, régisseurs de
+    théâtre
+
+contrat salarié . déduction forfaitaire spécifique . profession . pilote de ligne ou personnel navigant:
+  icônes: ✈
+  description: >-
+    Concerne les pilotes, radios, mécaniciens navigants des compagnies de
+    transports aériens ; pilotes et mécaniciens employés par les maisons de
+    construction d’avions et de moteurs pour l’essai de prototypes ; pilotes
+    moniteurs d’aéro-clubs et des écoles d’aviation civile
 
 contrat salarié . CDD . taxe forfaitaire sur les CDD d'usage:
   description: |
@@ -2511,7 +2572,7 @@ contrat salarié . réduction générale . plafond avec application de la DFS:
         recalcul:
           règle: réduction générale
           avec:
-            déduction forfaitaire spécifique . application: non
+            déduction forfaitaire spécifique: non
 
 contrat salarié . contribution d'équilibre général:
   description: >-
@@ -3354,75 +3415,6 @@ contrat salarié . taxe sur les salaires . barème:
     Nous n'implémentons pas les taux spécifiques pour l'outre-mer
   références:
     barème: https://www.service-public.fr/professionnels-entreprises/vosdroits/F22576
-
-contrat salarié . profession spécifique:
-  question: Le salarié exerce t-il l'une des professions suivantes ?
-  par défaut: non
-  formule:
-    une possibilité:
-      possibilités:
-        - journaliste
-        - ouvrier du bâtiment
-        - artiste musicien
-        - pilote de ligne ou personnel navigant
-
-contrat salarié . profession spécifique . journaliste:
-  formule: contrat salarié . profession spécifique = 'journaliste'
-  icônes: ✒
-  description: >-
-    Concerne les journalistes, rédacteurs, photographes, directeurs de journaux
-    Critiques dramatiques et musicaux.
-
-contrat salarié . profession spécifique . journaliste . réduction de taux:
-  applicable si: profession spécifique = 'journaliste'
-  remplace:
-    - règle: vieillesse . employeur . plafonnée . taux
-      par: vieillesse . employeur . plafonnée . taux * réduction de taux
-    - règle: vieillesse . employeur . déplafonnée . taux
-      par: vieillesse . employeur . déplafonnée . taux * réduction de taux
-    - règle: vieillesse . salarié . plafonnée . taux
-      par: vieillesse . salarié . plafonnée . taux * réduction de taux
-    - règle: vieillesse . salarié . déplafonnée . taux
-      par: vieillesse . salarié . déplafonnée . taux * réduction de taux
-
-    - règle: allocations familiales . taux
-      par: allocations familiales . taux * réduction de taux
-    - règle: établissement . taux du versement transport
-      par: établissement . taux du versement transport * réduction de taux
-    - règle: ATMP . taux
-      par: ATMP . taux * réduction de taux
-    - règle: ATMP . taux minimum
-      par: ATMP . taux minimum * réduction de taux
-  formule: 80%
-
-contrat salarié . profession spécifique . journaliste . abattement fiscal:
-  applicable si: profession spécifique = 'journaliste'
-  remplace: rémunération . net imposable
-  titre: net imposable journaliste
-  formule:
-    valeur: rémunération . net imposable
-    abattement: 7650€/an
-
-contrat salarié . profession spécifique . ouvrier du bâtiment:
-  icônes: 👷‍♂️
-  description: >-
-    Concerne les ouvriers du bâtiment visés aux paragraphes 1er et 2 de
-    l’article 1er du décret du 17 novembre 1936, à l’exclusion de ceux qui
-    travaillent en usine ou en atelier.
-
-contrat salarié . profession spécifique . artiste musicien:
-  icônes: 🎼
-  description: >-
-    Concerne les artistes musiciens, choristes, chefs d’orchestre, régisseurs de
-    théâtre
-
-contrat salarié . profession spécifique . pilote de ligne ou personnel navigant:
-  icônes: ✈
-  description: >-
-    Concerne les pilotes, radios, mécaniciens navigants des compagnies de
-    transports aériens ; pilotes et mécaniciens employés par les maisons de
-    construction d’avions et de moteurs pour l’essai de prototypes ; pilotes
-    moniteurs d’aéro-clubs et des écoles d’aviation civile
 
 contrat salarié . régime des impatriés:
   question: Le salarié bénéficie-t-il du régime des impatriés ?

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -3127,25 +3127,75 @@ contrat salarié . cotisations . salariales . réductions de cotisations:
   titre.en: '[automatic] pay cuts'
   titre.fr: réductions salariales
 contrat salarié . déduction forfaitaire spécifique:
-  description.en: '[automatic] For a specific list of professions, the employer
-    may make a specific flat-rate deduction for professional expenses on the
-    basis of the calculation of social security contributions.'
-  description.fr: Pour une liste précise de professions, l'employeur peut
-    pratiquer une déduction forfaitaire spécifique pour frais professionnels sur
-    la base de calcul des cotisations sociales.
+  description.en: >-
+    [automatic] For a specific list of professions, the employer can apply a
+    specific fixed deduction (DFS) for professional expenses on the basis of
+    calculation of social contributions. It can be applied if the employee
+    actually incurs expenses during his professional activity.
+
+    If no expenses are actually incurred, or if the employer pays or reimburses all of the professional expenses, the DFS cannot be applied.
+  description.fr: >-
+    Pour une liste précise de professions, l'employeur peut pratiquer une
+    déduction forfaitaire spécifique (DFS) pour frais professionnels sur la base
+    de calcul des cotisations sociales. spécifique consiste en un abattement sur
+    l'assiette des cotisations sociales. Elle peut s'appliquer si le salarié
+    supporte effectivement des frais lors de son activité professionnelle.
+
+    En l’absence de frais effectivement engagés, ou si l’employeur prend en charge ou rembourse la totalité des frais professionnels, il est impossible d’appliquer la DFS.
+  question.en: '[automatic] Does the employee benefit from a specific standard deduction?'
+  question.fr: Le salarié bénéficie-t-il d'une déduction forfaitaire spécifique ?
   titre.en: '[automatic] plate with DFS'
   titre.fr: assiette avec DFS
-contrat salarié . déduction forfaitaire spécifique . application:
-  description.en: '[automatic] The specific flat-rate deduction consists of a
-    deduction from the social security contribution base. The employer may waive
-    this deduction in order to grant more rights to the employee, in particular
-    in terms of pension and unemployment insurance.'
-  description.fr: La déduction forfaitaire spécifique consiste en un abattement
-    sur l'assiette des cotisations sociales. L'employeur peut renoncer à
-    appliquer cette déduction afin d'accorder plus de droits au salarié,
-    notamment en terme de retraite et d'assurance chômage.
-  titre.en: '[automatic] DFS implementation'
-  titre.fr: application de la DFS
+contrat salarié . déduction forfaitaire spécifique . profession:
+  question.en:
+    "[automatic] What is the employee's occupation for the application
+    of the specific flat-rate deduction?"
+  question.fr: Quelle est la profession du salarié pour l'application de la
+    déduction forfaitaire spécifique ?
+  titre.en: '[automatic] profession'
+  titre.fr: profession
+? contrat salarié . déduction forfaitaire spécifique . profession . artiste musicien
+: description.en: '[automatic] Concerns musicians, chorus members, conductors,
+    theatre managers'
+  description.fr: Concerne les artistes musiciens, choristes, chefs d’orchestre,
+    régisseurs de théâtre
+  titre.en: '[automatic] musical artist'
+  titre.fr: artiste musicien
+contrat salarié . déduction forfaitaire spécifique . profession . journaliste:
+  description.en: '[automatic] Concerns journalists, editors, photographers,
+    newspaper editors Drama and music critics.'
+  description.fr:
+    Concerne les journalistes, rédacteurs, photographes, directeurs
+    de journaux Critiques dramatiques et musicaux.
+  titre.en: '[automatic] journalist'
+  titre.fr: journaliste
+? contrat salarié . déduction forfaitaire spécifique . profession . journaliste . abattement fiscal
+: titre.en: '[automatic] net taxable journalist'
+  titre.fr: net imposable journaliste
+? contrat salarié . déduction forfaitaire spécifique . profession . journaliste . réduction de taux
+: titre.en: '[automatic] rate reduction'
+  titre.fr: réduction de taux
+? contrat salarié . déduction forfaitaire spécifique . profession . ouvrier du bâtiment
+: description.en: '[automatic] Concerns construction workers referred to in
+    paragraphs 1 and 2 of Article 1 of the Decree of 17 November 1936, excluding
+    those working in factories or workshops.'
+  description.fr:
+    Concerne les ouvriers du bâtiment visés aux paragraphes 1er et 2
+    de l’article 1er du décret du 17 novembre 1936, à l’exclusion de ceux qui
+    travaillent en usine ou en atelier.
+  titre.en: '[automatic] construction worker'
+  titre.fr: ouvrier du bâtiment
+? contrat salarié . déduction forfaitaire spécifique . profession . pilote de ligne ou personnel navigant
+: description.en: '[automatic] Concerns pilots, radios, flight engineers of air
+    transport companies; pilots and mechanics employed by aircraft and engine
+    manufacturing companies for the testing of prototypes; pilot instructors of
+    flying clubs and civil aviation schools'
+  description.fr: Concerne les pilotes, radios, mécaniciens navigants des
+    compagnies de transports aériens ; pilotes et mécaniciens employés par les
+    maisons de construction d’avions et de moteurs pour l’essai de prototypes ;
+    pilotes moniteurs d’aéro-clubs et des écoles d’aviation civile
+  titre.en: '[automatic] airline pilot or flight attendant'
+  titre.fr: pilote de ligne ou personnel navigant
 contrat salarié . déduction forfaitaire spécifique . taux:
   titre.en: '[automatic] rates'
   titre.fr: taux
@@ -3898,54 +3948,6 @@ contrat salarié . prix du travail:
   résumé.fr: Dépensé par l'entreprise
   titre.en: labor cost
   titre.fr: Coût total
-contrat salarié . profession spécifique:
-  question.en: '[automatic] Does the employee work in one of the following professions?'
-  question.fr: Le salarié exerce t-il l'une des professions suivantes ?
-  titre.en: '[automatic] specific profession'
-  titre.fr: profession spécifique
-contrat salarié . profession spécifique . artiste musicien:
-  description.en: '[automatic] Concerns musicians, choir members, conductors,
-    theatre managers, etc.'
-  description.fr: Concerne les artistes musiciens, choristes, chefs d’orchestre,
-    régisseurs de théâtre
-  titre.en: '[automatic] musical artist'
-  titre.fr: artiste musicien
-contrat salarié . profession spécifique . journaliste:
-  description.en: '[automatic] Concerns journalists, editors, photographers,
-    newspaper directors Dramatic and music critics.'
-  description.fr:
-    Concerne les journalistes, rédacteurs, photographes, directeurs
-    de journaux Critiques dramatiques et musicaux.
-  titre.en: '[automatic] journalist'
-  titre.fr: journaliste
-contrat salarié . profession spécifique . journaliste . abattement fiscal:
-  titre.en: '[automatic] net taxable journalist'
-  titre.fr: net imposable journaliste
-contrat salarié . profession spécifique . journaliste . réduction de taux:
-  titre.en: '[automatic] rate reduction'
-  titre.fr: réduction de taux
-contrat salarié . profession spécifique . ouvrier du bâtiment:
-  description.en: '[automatic] Concerns the construction workers referred to in
-    paragraphs 1 and 2 of Article 1 of the Decree of 17 November 1936, excluding
-    those working in factories or workshops.'
-  description.fr:
-    Concerne les ouvriers du bâtiment visés aux paragraphes 1er et 2
-    de l’article 1er du décret du 17 novembre 1936, à l’exclusion de ceux qui
-    travaillent en usine ou en atelier.
-  titre.en: '[automatic] construction worker'
-  titre.fr: ouvrier du bâtiment
-contrat salarié . profession spécifique . pilote de ligne ou personnel navigant:
-  description.en:
-    '[automatic] Concerns pilots, radio operators, flight engineers
-    of air transport companies; pilots and mechanics employed by aircraft and
-    engine construction companies to test prototypes; pilot instructors of
-    flying clubs and civil aviation schools.'
-  description.fr: Concerne les pilotes, radios, mécaniciens navigants des
-    compagnies de transports aériens ; pilotes et mécaniciens employés par les
-    maisons de construction d’avions et de moteurs pour l’essai de prototypes ;
-    pilotes moniteurs d’aéro-clubs et des écoles d’aviation civile
-  titre.en: '[automatic] airline pilot or flight crew'
-  titre.fr: pilote de ligne ou personnel navigant
 contrat salarié . professionnalisation:
   description.en: >
     [automatic] The professionalization contract is a work-study contract

--- a/mon-entreprise/source/pages/Simulateurs/configs/chômage-partiel.yaml
+++ b/mon-entreprise/source/pages/Simulateurs/configs/chômage-partiel.yaml
@@ -10,7 +10,6 @@ questions:
   liste:
     - contrat salarié . activité partielle
     - contrat salarié . temps de travail
-    - contrat salarié . profession spécifique
     - établissement . localisation
 
 unité par défaut: €/mois

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -826,7 +826,7 @@ exports[`calculate simulations-salarié: effectif 3`] = `"[2527,0,2000,1561,1527
 
 exports[`calculate simulations-salarié: effectif 4`] = `"[2527,0,2000,1561,1527]"`;
 
-exports[`calculate simulations-salarié: frais pro - DFS 1`] = `"[2227,0,2000,1630,1630]"`;
+exports[`calculate simulations-salarié: frais pro - DFS 1`] = `"[2196,0,2000,1630,1630]"`;
 
 exports[`calculate simulations-salarié: frais pro - DFS 2`] = `"[2318,0,2000,1584,1549]"`;
 
@@ -834,7 +834,7 @@ exports[`calculate simulations-salarié: frais pro - DFS 3`] = `"[2248,0,2000,16
 
 exports[`calculate simulations-salarié: frais pro - DFS 4`] = `"[2232,0,2000,1612,1563]"`;
 
-exports[`calculate simulations-salarié: frais pro - DFS 5`] = `"[2425,0,2000,1590,1590]"`;
+exports[`calculate simulations-salarié: frais pro - DFS 5`] = `"[2466,0,2000,1561,1527]"`;
 
 exports[`calculate simulations-salarié: frais pro - DFS 6`] = `"[1768,0,1700,1363,1363]"`;
 
@@ -870,7 +870,7 @@ exports[`calculate simulations-salarié: frais pro - transports personnels seul 
 
 exports[`calculate simulations-salarié: frais pro - transports personnels seul 5`] = `"[4397,0,3200,2548,2349]"`;
 
-exports[`calculate simulations-salarié: frais pro - transports personnels seul 6`] = `"[4125,0,3200,2624,2422]"`;
+exports[`calculate simulations-salarié: frais pro - transports personnels seul 6`] = `"[4125,0,3200,2583,2381]"`;
 
 exports[`calculate simulations-salarié: heures supplémentaires et complémentaires 1`] = `"[2570,0,2000,1636,1601]"`;
 

--- a/mon-entreprise/test/regressions/simulations-salarié.yaml
+++ b/mon-entreprise/test/regressions/simulations-salarié.yaml
@@ -313,7 +313,7 @@ frais pro - transports personnels seul:
   - contrat salarié . rémunération . brut de base: 3200 €/mois
     contrat salarié . frais professionnels . transports personnels . carburant faible émission . montant: 200€/an
     contrat salarié . frais professionnels . transports personnels . forfait mobilités durables . montant: 300€/an
-    contrat salarié . déduction forfaitaire spécifique . application: oui
+    contrat salarié . déduction forfaitaire spécifique: oui
     contrat salarié . déduction forfaitaire spécifique . taux: 20%
 
 
@@ -333,21 +333,27 @@ frais pro - abo transports + transports personnels:
 
 frais pro - DFS:
   - contrat salarié . rémunération . brut de base: 2000 €/mois
-    contrat salarié . profession spécifique: "'journaliste'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'journaliste'"
   - contrat salarié . rémunération . brut de base: 2000 €/mois
-    contrat salarié . profession spécifique: "'ouvrier du bâtiment'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'ouvrier du bâtiment'"
   - contrat salarié . rémunération . brut de base: 2000 €/mois
-    contrat salarié . profession spécifique: "'artiste musicien'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'artiste musicien'"
   - contrat salarié . rémunération . brut de base: 2000 €/mois
-    contrat salarié . profession spécifique: "'pilote de ligne ou personnel navigant'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'pilote de ligne ou personnel navigant'"
   - contrat salarié . rémunération . brut de base: 2000 €/mois
-    contrat salarié . profession spécifique: "'journaliste'"
-    contrat salarié . déduction forfaitaire spécifique . application: non
+    contrat salarié . déduction forfaitaire spécifique: non
+    contrat salarié . déduction forfaitaire spécifique . profession: "'journaliste'"
   # Test des taux réduits journalistes et abattement fiscal
   - contrat salarié . rémunération . brut de base: 1700 €/mois
-    contrat salarié . profession spécifique: "'journaliste'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'journaliste'"
   - contrat salarié . rémunération . brut de base: 2600 €/mois
-    contrat salarié . profession spécifique: "'journaliste'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'journaliste'"
 
 activité partielle:
   - contrat salarié . rémunération . brut de base: 1560 €/mois
@@ -368,7 +374,8 @@ activité partielle:
     contrat salarié . temps de travail . temps partiel . heures par semaine: 28 heures/semaine
   - contrat salarié . rémunération . brut de base: 4000 €/mois
     contrat salarié . activité partielle: oui
-    contrat salarié . profession spécifique: "'journaliste'"
+    contrat salarié . déduction forfaitaire spécifique: oui
+    contrat salarié . déduction forfaitaire spécifique . profession: "'journaliste'"
   - contrat salarié . rémunération . brut de base: 2000 €/mois
     contrat salarié . activité partielle: oui
     contrat salarié . activité partielle . convention syntec: oui


### PR DESCRIPTION
Le bulletin officielle de la sécurité sociale à introduit un changement de doctrine sur le recours à la déduction forfaitaire spécifique.
Celui-ci est maintenant plus contraint, et il vaut mieux demandé si le salarié est concerné par ce dispositif au lieu de l'appliquer automatiquement si il appartient à l'une des professions concernées.

Fixes #1572