### PR TITLE
Issue 1445/pdf export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 
 # Local Netlify folder
 .netlify
+
+# Webstorm (and other Jetbrains IDE)
+.idea/

--- a/mon-entreprise/source/components/Banner.tsx
+++ b/mon-entreprise/source/components/Banner.tsx
@@ -10,6 +10,7 @@ type BannerProps = {
 	hidden?: boolean
 	hideAfterFirstStep?: boolean
 	icon?: string
+	className?: string
 }
 
 export default function Banner({
@@ -17,13 +18,14 @@ export default function Banner({
 	hidden: hiddenProp = false,
 	hideAfterFirstStep = true,
 	icon,
+	className,
 }: BannerProps) {
 	const hiddenState = useSelector(firstStepCompletedSelector)
 
 	const hidden = hiddenProp || (hideAfterFirstStep && hiddenState)
 	return !hidden ? (
-		<Animate.fadeIn>
-			<div className="ui__ banner">
+		<Animate.fadeIn className={className}>
+			<div className={'ui__ banner '+ className} >
 				{icon && emoji(icon)}
 				<div className="ui__ banner-content">{children}</div>
 			</div>

--- a/mon-entreprise/source/components/BarChart.tsx
+++ b/mon-entreprise/source/components/BarChart.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { animated, config, useSpring } from 'react-spring'
 import useDisplayOnIntersecting from 'Components/utils/useDisplayOnIntersecting'
@@ -51,20 +51,21 @@ type BarChartBranchProps = {
 	maximum: number
 	description?: string
 	unit?: string
+	disableAnimation : boolean
 }
 
 export default function BarChartBranch({
-	value,
-	title,
-	icon,
-	maximum,
-	description,
-	unit,
-}: BarChartBranchProps) {
+																 value,
+																 title,
+																 icon,
+																 maximum,
+																 description,
+																 unit,
+																 disableAnimation
+															 }: BarChartBranchProps) {
 	const [intersectionRef, brancheInViewport] = useDisplayOnIntersecting({
-		threshold: 0.5,
+		threshold: 0.5
 	})
-	const { color } = useContext(ThemeColorsContext)
 	const numberToPlot = brancheInViewport ? value : 0
 	const styles = useSpring({
 		config: ANIMATION_SPRING,
@@ -75,27 +76,60 @@ export default function BarChartBranch({
 	}) as { flex: number; opacity: number } // TODO: problème avec les types de react-spring ?
 
 	return (
-		<animated.div
-			ref={intersectionRef}
-			className="distribution-chart__item"
-			style={{ opacity: styles.opacity }}
-		>
+		!disableAnimation ?
+			<animated.div
+				ref={intersectionRef}
+				className='distribution-chart__item'
+				style={{ opacity: styles.opacity }}
+			>
+				<InnerBarChartBranch value={numberToPlot} maximum={maximum} title={title}
+												unit={unit} icon={icon}
+												description={description} />
+			</animated.div>
+			:
+			<InnerBarChartBranch value={value} maximum={maximum} title={title} unit={unit} icon={icon} description={description}/>
+
+	)
+};
+
+type InnerBarChartBranchProps = {
+	title: React.ReactNode
+	icon?: string
+	maximum: number
+	description?: string
+	unit?: string
+	value: number
+}
+
+
+function InnerBarChartBranch({
+																				 value,
+																				 title,
+																				 icon,
+																				 maximum,
+																				 description,
+																				 unit,
+																			 }: InnerBarChartBranchProps) {
+
+	const { color } = useContext(ThemeColorsContext)
+	return (
+		<>
 			{icon && <BranchIcon icon={icon} />}
-			<div className="distribution-chart__item-content">
-				<p className="distribution-chart__counterparts">
-					<span className="distribution-chart__branche-name">{title}</span>
+			<div className='distribution-chart__item-content'>
+				<p className='distribution-chart__counterparts'>
+					<span className='distribution-chart__branche-name'>{title}</span>
 					<br />
 					{description && <small>{description}</small>}
 				</p>
 				<ChartItemBar
 					style={{
 						backgroundColor: color,
-						flex: styles.flex,
+						flex: value / maximum,
 					}}
-					numberToPlot={numberToPlot}
+					numberToPlot={value}
 					unit={unit}
 				/>
 			</div>
-		</animated.div>
+		</>
 	)
 }

--- a/mon-entreprise/source/components/Distribution.tsx
+++ b/mon-entreprise/source/components/Distribution.tsx
@@ -10,7 +10,11 @@ import './PaySlip'
 import { getCotisationsBySection } from './PaySlip'
 import RuleLink from './RuleLink'
 
-export default function Distribution() {
+interface DistributionProps {
+	disableAnimation: boolean
+}
+
+export default function Distribution({disableAnimation,}: DistributionProps)  {
 	const targetUnit = useSelector(targetUnitSelector)
 	const engine = useContext(EngineContext)
 	const distribution = (getCotisationsBySection(
@@ -37,6 +41,7 @@ export default function Distribution() {
 					dottedName={sectionName}
 					value={value}
 					maximum={maximum}
+					disableAnimation={disableAnimation}
 				/>
 			))}
 		</div>
@@ -47,8 +52,8 @@ type DistributionBranchProps = {
 	dottedName: DottedName
 	value: number
 	maximum: number
-
 	icon?: string
+	disableAnimation: boolean
 }
 
 export function DistributionBranch({
@@ -56,6 +61,7 @@ export function DistributionBranch({
 	value,
 	icon,
 	maximum,
+	disableAnimation,
 }: DistributionBranchProps) {
 	const branche = useContext(EngineContext).getRule(dottedName)
 
@@ -67,6 +73,7 @@ export function DistributionBranch({
 			icon={icon ?? branche.rawNode.icônes}
 			description={branche.rawNode.résumé}
 			unit="€"
+			disableAnimation={disableAnimation}
 		/>
 	)
 }

--- a/mon-entreprise/source/components/ExportSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ExportSimulationBanner.tsx
@@ -6,18 +6,20 @@ import { LinkButton } from 'Components/ui/Button'
 export default function ExportSimulationBanner() {
 
 	return (
-		<Banner hideAfterFirstStep={false} icon="🖨">
-			{
-				<Trans i18nKey="ExportSimulation.Banner">
-					Pour conserver cette simulation :{' '}
-					<LinkButton
-						onClick={() => {window.print()}}
-					>
-						Imprimer ou sauvegarder en PDF
-					</LinkButton>
-				</Trans>
-			}
-		</Banner>
+		<div className="print-display-none">
+			<Banner hideAfterFirstStep={false} icon="🖨">
+				{
+					<Trans i18nKey="ExportSimulation.Banner">
+						Pour conserver cette simulation :{' '}
+						<LinkButton
+							onClick={() => {window.print()}}
+						>
+							Imprimer ou sauvegarder en PDF
+						</LinkButton>
+					</Trans>
+				}
+			</Banner>
+		</div>
 	)
 }
 

--- a/mon-entreprise/source/components/ExportSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ExportSimulationBanner.tsx
@@ -1,0 +1,23 @@
+import React, { useContext, useEffect, useState } from 'react'
+import Banner from './Banner'
+import { Trans, useTranslation } from 'react-i18next'
+import { LinkButton } from 'Components/ui/Button'
+
+export default function ExportSimulationBanner() {
+
+	return (
+		<Banner hideAfterFirstStep={false} icon="🖨">
+			{
+				<Trans i18nKey="ExportSimulation.Banner">
+					Pour conserver cette simulation :{' '}
+					<LinkButton
+						onClick={() => {window.print()}}
+					>
+						Imprimer ou sauvegarder en PDF
+					</LinkButton>
+				</Trans>
+			}
+		</Banner>
+	)
+}
+

--- a/mon-entreprise/source/components/ExportSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ExportSimulationBanner.tsx
@@ -6,20 +6,18 @@ import { LinkButton } from 'Components/ui/Button'
 export default function ExportSimulationBanner() {
 
 	return (
-		<div className="print-display-none">
-			<Banner hideAfterFirstStep={false} icon="🖨">
-				{
-					<Trans i18nKey="ExportSimulation.Banner">
-						Pour conserver cette simulation :{' '}
-						<LinkButton
-							onClick={() => {window.print()}}
-						>
-							Imprimer ou sauvegarder en PDF
-						</LinkButton>
-					</Trans>
-				}
-			</Banner>
-		</div>
+		<Banner hideAfterFirstStep={false} icon="🖨" className='print-display-none'>
+			{
+				<Trans i18nKey="ExportSimulation.Banner">
+					Pour conserver cette simulation :{' '}
+					<LinkButton
+						onClick={() => {window.print()}}
+					>
+						Imprimer ou sauvegarder en PDF
+					</LinkButton>
+				</Trans>
+			}
+		</Banner>
 	)
 }
 

--- a/mon-entreprise/source/components/ExportSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ExportSimulationBanner.tsx
@@ -5,17 +5,24 @@ import { LinkButton } from 'Components/ui/Button'
 
 interface ExportSimulationBannerProps {
 	userWillExport:()=>void
+	disableAnimation: boolean
 }
 
-export default function ExportSimulationBanner({userWillExport} : ExportSimulationBannerProps) {
-
+export default function ExportSimulationBanner({userWillExport, disableAnimation} : ExportSimulationBannerProps) {
+	const [printRequired, setPrintRequired] = useState(false);
+	useEffect(() => {
+		if(printRequired) {
+			window.print();
+			setPrintRequired(false);
+		}
+	}, [disableAnimation])
 	return (
 		<Banner hideAfterFirstStep={false} icon="🖨" className='print-display-none'>
 			{
 				<Trans i18nKey="ExportSimulation.Banner">
 					Pour conserver cette simulation :{' '}
 					<LinkButton
-						onClick={() => {userWillExport(); window.print();}}
+						onClick={() => {setPrintRequired(true); disableAnimation ? window.print() : userWillExport(); }}
 					>
 						Imprimer ou sauvegarder en PDF
 					</LinkButton>

--- a/mon-entreprise/source/components/ExportSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ExportSimulationBanner.tsx
@@ -3,7 +3,11 @@ import Banner from './Banner'
 import { Trans, useTranslation } from 'react-i18next'
 import { LinkButton } from 'Components/ui/Button'
 
-export default function ExportSimulationBanner() {
+interface ExportSimulationBannerProps {
+	userWillExport:()=>void
+}
+
+export default function ExportSimulationBanner({userWillExport} : ExportSimulationBannerProps) {
 
 	return (
 		<Banner hideAfterFirstStep={false} icon="🖨" className='print-display-none'>
@@ -11,7 +15,7 @@ export default function ExportSimulationBanner() {
 				<Trans i18nKey="ExportSimulation.Banner">
 					Pour conserver cette simulation :{' '}
 					<LinkButton
-						onClick={() => {window.print()}}
+						onClick={() => {userWillExport(); window.print();}}
 					>
 						Imprimer ou sauvegarder en PDF
 					</LinkButton>

--- a/mon-entreprise/source/components/NewsletterRegister.tsx
+++ b/mon-entreprise/source/components/NewsletterRegister.tsx
@@ -61,7 +61,7 @@ export default function NewsletterRegister() {
 	}
 
 	return (
-		<>
+		<div className='print-display-none'>
 			<h2>
 				<Trans i18nKey="newsletter.register.titre">Restez au courant</Trans>
 			</h2>
@@ -97,6 +97,6 @@ export default function NewsletterRegister() {
 					</div>
 				</form>
 			</div>
-		</>
+		</div>
 	)
 }

--- a/mon-entreprise/source/components/PeriodSwitch.tsx
+++ b/mon-entreprise/source/components/PeriodSwitch.tsx
@@ -25,7 +25,7 @@ export default function PeriodSwitch() {
 		<div id="PeriodSwitch">
 			<span className="base ui__ small radio toggle">
 				{periods.map(({ label, unit }) => (
-					<label key={unit}>
+					<label key={unit} className={ currentUnit !== unit ? 'print-display-none' : ''}>
 						<input
 							name="defaultUnit"
 							type="radio"

--- a/mon-entreprise/source/components/PreviousSimulationBanner.tsx
+++ b/mon-entreprise/source/components/PreviousSimulationBanner.tsx
@@ -14,15 +14,17 @@ export default function PreviousSimulationBanner() {
 	const dispatch = useDispatch()
 
 	return (
-		<Banner hidden={!previousSimulation || newSimulationStarted} icon="💾">
-			<Trans i18nKey="previousSimulationBanner.info">
-				Votre précédente simulation a été sauvegardée :
-			</Trans>{' '}
-			<LinkButton onClick={() => dispatch(loadPreviousSimulation())}>
-				<Trans i18nKey="previousSimulationBanner.retrieveButton">
-					Retrouver ma simulation
-				</Trans>
-			</LinkButton>
-		</Banner>
+		<div className="print-display-none">
+			<Banner hidden={!previousSimulation || newSimulationStarted} icon="💾">
+				<Trans i18nKey="previousSimulationBanner.info">
+					Votre précédente simulation a été sauvegardée :
+				</Trans>{' '}
+				<LinkButton onClick={() => dispatch(loadPreviousSimulation())}>
+					<Trans i18nKey="previousSimulationBanner.retrieveButton">
+						Retrouver ma simulation
+					</Trans>
+				</LinkButton>
+			</Banner>
+		</div>
 	)
 }

--- a/mon-entreprise/source/components/ShareSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ShareSimulationBanner.tsx
@@ -46,48 +46,50 @@ export default function ShareSimulationBanner() {
 	}
 
 	return (
-		<Banner hideAfterFirstStep={false} icon="💬">
-			{opened ? (
-				<Animate.fromTop>
-					<div>
-						<span
-							className="ui__ close-button"
-							style={{ float: 'right' }}
-							onClick={() => setOpened(false)}
+		<div className="print-display-none">
+			<Banner hideAfterFirstStep={false} icon="💬">
+				{opened ? (
+					<Animate.fromTop>
+						<div>
+							<span
+								className="ui__ close-button"
+								style={{ float: 'right' }}
+								onClick={() => setOpened(false)}
+							>
+								&times;
+							</span>
+							<h3>
+								{t('shareSimulation.modal.title', 'Votre lien de partage')}{' '}
+							</h3>
+							<p className="ui__ notice">
+								<Trans key="shareSimulation.modal.notice">
+									Voici le lien que vous pouvez envoyer pour accéder à votre
+									simulation.
+								</Trans>
+							</p>
+							<ShareSimulationPopup url={getUrl()} />
+						</div>
+					</Animate.fromTop>
+				) : (
+					<Trans i18nKey="shareSimulation.banner">
+						Pour partager cette simulation :{' '}
+						<LinkButton
+							onClick={() => {
+								tracker.click.set({
+									chapter1: 'feature:partage',
+									type: 'action',
+									name: 'démarré',
+								})
+								tracker.dispatch()
+								startSharing()
+							}}
 						>
-							&times;
-						</span>
-						<h3>
-							{t('shareSimulation.modal.title', 'Votre lien de partage')}{' '}
-						</h3>
-						<p className="ui__ notice">
-							<Trans key="shareSimulation.modal.notice">
-								Voici le lien que vous pouvez envoyer pour accéder à votre
-								simulation.
-							</Trans>
-						</p>
-						<ShareSimulationPopup url={getUrl()} />
-					</div>
-				</Animate.fromTop>
-			) : (
-				<Trans i18nKey="shareSimulation.banner">
-					Pour partager cette simulation :{' '}
-					<LinkButton
-						onClick={() => {
-							tracker.click.set({
-								chapter1: 'feature:partage',
-								type: 'action',
-								name: 'démarré',
-							})
-							tracker.dispatch()
-							startSharing()
-						}}
-					>
-						Générer un lien dédié
-					</LinkButton>
-				</Trans>
-			)}
-		</Banner>
+							Générer un lien dédié
+						</LinkButton>
+					</Trans>
+				)}
+			</Banner>
+		</div>
 	)
 }
 

--- a/mon-entreprise/source/components/ShareSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ShareSimulationBanner.tsx
@@ -46,50 +46,48 @@ export default function ShareSimulationBanner() {
 	}
 
 	return (
-		<div className="print-display-none">
-			<Banner hideAfterFirstStep={false} icon="💬">
-				{opened ? (
-					<Animate.fromTop>
-						<div>
-							<span
-								className="ui__ close-button"
-								style={{ float: 'right' }}
-								onClick={() => setOpened(false)}
-							>
-								&times;
-							</span>
-							<h3>
-								{t('shareSimulation.modal.title', 'Votre lien de partage')}{' '}
-							</h3>
-							<p className="ui__ notice">
-								<Trans key="shareSimulation.modal.notice">
-									Voici le lien que vous pouvez envoyer pour accéder à votre
-									simulation.
-								</Trans>
-							</p>
-							<ShareSimulationPopup url={getUrl()} />
-						</div>
-					</Animate.fromTop>
-				) : (
-					<Trans i18nKey="shareSimulation.banner">
-						Pour partager cette simulation :{' '}
-						<LinkButton
-							onClick={() => {
-								tracker.click.set({
-									chapter1: 'feature:partage',
-									type: 'action',
-									name: 'démarré',
-								})
-								tracker.dispatch()
-								startSharing()
-							}}
+		<Banner hideAfterFirstStep={false} icon="💬" className='print-display-none'>
+			{opened ? (
+				<Animate.fromTop>
+					<div>
+						<span
+							className="ui__ close-button"
+							style={{ float: 'right' }}
+							onClick={() => setOpened(false)}
 						>
-							Générer un lien dédié
-						</LinkButton>
-					</Trans>
-				)}
-			</Banner>
-		</div>
+							&times;
+						</span>
+						<h3>
+							{t('shareSimulation.modal.title', 'Votre lien de partage')}{' '}
+						</h3>
+						<p className="ui__ notice">
+							<Trans key="shareSimulation.modal.notice">
+								Voici le lien que vous pouvez envoyer pour accéder à votre
+								simulation.
+							</Trans>
+						</p>
+						<ShareSimulationPopup url={getUrl()} />
+					</div>
+				</Animate.fromTop>
+			) : (
+				<Trans i18nKey="shareSimulation.banner">
+					Pour partager cette simulation :{' '}
+					<LinkButton
+						onClick={() => {
+							tracker.click.set({
+								chapter1: 'feature:partage',
+								type: 'action',
+								name: 'démarré',
+							})
+							tracker.dispatch()
+							startSharing()
+						}}
+					>
+						Générer un lien dédié
+					</LinkButton>
+				</Trans>
+			)}
+		</Banner>
 	)
 }
 

--- a/mon-entreprise/source/components/ShareSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ShareSimulationBanner.tsx
@@ -8,23 +8,23 @@ import { TrackingContext } from '../ATInternetTracking'
 import Banner from './Banner'
 import { useParamsFromSituation } from './utils/useSearchParamsSimulationSharing'
 
+export function GetUrl(){
+	const situation = useSelector(situationSelector);
+	const searchParams = useParamsFromSituation(situation);
+	searchParams.set('utm_source', 'sharing');
+	return[
+		window.location.origin,
+		window.location.pathname,
+		'?',
+		searchParams.toString(),
+	].join('');
+}
+
 export default function ShareSimulationBanner() {
 	const [opened, setOpened] = useState(false)
 	const { t } = useTranslation()
 	const tracker = useContext(TrackingContext)
-	const situation = useSelector(situationSelector)
-	const searchParams = useParamsFromSituation(situation)
-	searchParams.set('utm_source', 'sharing')
-
 	const shareAPIAvailable = !!window?.navigator?.share
-
-	const getUrl = () =>
-		[
-			window.location.origin,
-			window.location.pathname,
-			'?',
-			searchParams.toString(),
-		].join('')
 
 	const startSharing = () => {
 		if (shareAPIAvailable) {
@@ -35,7 +35,7 @@ export default function ShareSimulationBanner() {
 						'shareSimulation.navigatorShare',
 						'Ma simulation Mon Entreprise'
 					),
-					url: getUrl(),
+					url: GetUrl(),
 				})
 			} catch {
 				setOpened(true)
@@ -66,7 +66,7 @@ export default function ShareSimulationBanner() {
 								simulation.
 							</Trans>
 						</p>
-						<ShareSimulationPopup url={getUrl()} />
+						<ShareSimulationPopup url={GetUrl()} />
 					</div>
 				</Animate.fromTop>
 			) : (

--- a/mon-entreprise/source/components/Simulation.tsx
+++ b/mon-entreprise/source/components/Simulation.tsx
@@ -23,6 +23,7 @@ type SimulationProps = {
 	customEndMessages?: ConversationProps['customEndMessages']
 	showPeriodSwitch?: boolean
 	userWillExport:()=>void
+	disableAnimation: boolean
 }
 
 export default function Simulation({
@@ -32,6 +33,7 @@ export default function Simulation({
 	customEndMessages,
 	showPeriodSwitch,
 	userWillExport,
+	disableAnimation,
 }: SimulationProps) {
 	const firstStepCompleted = useSelector(firstStepCompletedSelector)
 
@@ -49,7 +51,7 @@ export default function Simulation({
 					<Animate.fromTop>
 						{results}
 						<ShareSimulationBanner />
-						<ExportSimulationBanner userWillExport={userWillExport}/>
+						<ExportSimulationBanner userWillExport={userWillExport} disableAnimation={disableAnimation}/>
 						<Questions customEndMessages={customEndMessages} />
 						<br />
 						<div className="ui__ full-width">

--- a/mon-entreprise/source/components/Simulation.tsx
+++ b/mon-entreprise/source/components/Simulation.tsx
@@ -70,7 +70,7 @@ export default function Simulation({
 									</>
 								)}
 								<div
-									className="ui__ side-block"
+									className="ui__ side-block print-display-none"
 									css={!explanations ? 'justify-content: center;' : ''}
 								>
 									<div
@@ -106,7 +106,7 @@ export function Questions({
 	const progress = useSimulationProgress()
 
 	return (
-		<>
+		<div className='print-display-none'>
 			<section className="ui__ full-width lighter-bg">
 				<div className="ui__ container">
 					<div
@@ -143,6 +143,6 @@ export function Questions({
 			{progress < 1 && (
 				<Progress progress={progress} className="ui__ full-width" />
 			)}
-		</>
+		</div>
 	)
 }

--- a/mon-entreprise/source/components/Simulation.tsx
+++ b/mon-entreprise/source/components/Simulation.tsx
@@ -14,6 +14,7 @@ import { useSelector } from 'react-redux'
 import { firstStepCompletedSelector } from 'Selectors/simulationSelectors'
 import { TrackPage } from '../ATInternetTracking'
 import SeeAnswersButton from './conversation/SeeAnswersButton'
+import ExportSimulationBanner from 'Components/ExportSimulationBanner'
 
 type SimulationProps = {
 	explanations?: React.ReactNode
@@ -46,6 +47,7 @@ export default function Simulation({
 					<Animate.fromTop>
 						{results}
 						<ShareSimulationBanner />
+						<ExportSimulationBanner />
 						<Questions customEndMessages={customEndMessages} />
 						<br />
 						<div className="ui__ full-width">

--- a/mon-entreprise/source/components/Simulation.tsx
+++ b/mon-entreprise/source/components/Simulation.tsx
@@ -22,6 +22,7 @@ type SimulationProps = {
 	children?: React.ReactNode
 	customEndMessages?: ConversationProps['customEndMessages']
 	showPeriodSwitch?: boolean
+	userWillExport:()=>void
 }
 
 export default function Simulation({
@@ -30,6 +31,7 @@ export default function Simulation({
 	children,
 	customEndMessages,
 	showPeriodSwitch,
+	userWillExport,
 }: SimulationProps) {
 	const firstStepCompleted = useSelector(firstStepCompletedSelector)
 
@@ -47,7 +49,7 @@ export default function Simulation({
 					<Animate.fromTop>
 						{results}
 						<ShareSimulationBanner />
-						<ExportSimulationBanner />
+						<ExportSimulationBanner userWillExport={userWillExport}/>
 						<Questions customEndMessages={customEndMessages} />
 						<br />
 						<div className="ui__ full-width">

--- a/mon-entreprise/source/components/StackedBarChart.tsx
+++ b/mon-entreprise/source/components/StackedBarChart.tsx
@@ -83,7 +83,31 @@ export function roundedPercentages(values: Array<number>) {
 	)
 }
 
-type StackedBarChartProps = {
+type StackedBarChartProps =
+	InnerStackedBarChartProps
+	& { disableAnimation: boolean }
+
+export function StackedBarChart({
+																	data,
+																	disableAnimation
+																}: StackedBarChartProps) {
+	const [intersectionRef, displayChart] = useDisplayOnIntersecting({
+		threshold: 0.5
+	})
+
+	const styles = useSpring({ opacity: displayChart ? 1 : 0 })
+	return (
+		!disableAnimation ?
+			<animated.div ref={intersectionRef} style={styles}>
+				<InnerStackedBarChart data={data} />
+			</animated.div>
+			:
+			<InnerStackedBarChart data={data} />
+
+	)
+}
+
+type InnerStackedBarChartProps = {
 	data: Array<{
 		color?: string
 		value: EvaluatedNode['nodeValue']
@@ -92,10 +116,7 @@ type StackedBarChartProps = {
 	}>
 }
 
-export function StackedBarChart({ data }: StackedBarChartProps) {
-	const [intersectionRef, displayChart] = useDisplayOnIntersecting({
-		threshold: 0.5,
-	})
+function InnerStackedBarChart({ data }: InnerStackedBarChartProps) {
 	const percentages = roundedPercentages(
 		data.map((d) => (typeof d.value === 'number' && d.value) || 0)
 	)
@@ -103,10 +124,8 @@ export function StackedBarChart({ data }: StackedBarChartProps) {
 		...data,
 		percentage: percentages[index],
 	}))
-
-	const styles = useSpring({ opacity: displayChart ? 1 : 0 })
 	return (
-		<animated.div ref={intersectionRef} style={styles}>
+		<>
 			<BarStack>
 				{dataWithPercentage
 					// <BarItem /> has a border so we don't want to display empty bars
@@ -131,15 +150,16 @@ export function StackedBarChart({ data }: StackedBarChartProps) {
 					</BarStackLegendItem>
 				))}
 			</BarStackLegend>
-		</animated.div>
+		</>
 	)
 }
 
 type StackedRulesChartProps = {
 	data: Array<{ color?: string; dottedName: Names; title?: string }>
+	disableAnimation: boolean
 }
 
-export default function StackedRulesChart({ data }: StackedRulesChartProps) {
+export default function StackedRulesChart({ data, disableAnimation }: StackedRulesChartProps) {
 	const engine = useEngine()
 	const targetUnit = useSelector(targetUnitSelector)
 	return (
@@ -151,6 +171,7 @@ export default function StackedRulesChart({ data }: StackedRulesChartProps) {
 				legend: <RuleLink dottedName={dottedName}>{title}</RuleLink>,
 				color,
 			}))}
+			disableAnimation={disableAnimation}
 		/>
 	)
 }

--- a/mon-entreprise/source/components/StackedBarChart.tsx
+++ b/mon-entreprise/source/components/StackedBarChart.tsx
@@ -126,7 +126,7 @@ function InnerStackedBarChart({ data }: InnerStackedBarChartProps) {
 	}))
 	return (
 		<>
-			<BarStack>
+			<BarStack className="print-background-force">
 				{dataWithPercentage
 					// <BarItem /> has a border so we don't want to display empty bars
 					// (even with width 0).
@@ -141,7 +141,7 @@ function InnerStackedBarChart({ data }: InnerStackedBarChartProps) {
 						/>
 					))}
 			</BarStack>
-			<BarStackLegend>
+			<BarStackLegend className="print-background-force">
 				{dataWithPercentage.map(({ key, percentage, color, legend }) => (
 					<BarStackLegendItem key={key}>
 						<SmallCircle style={{ backgroundColor: color }} />

--- a/mon-entreprise/source/components/layout/Footer/Footer.tsx
+++ b/mon-entreprise/source/components/layout/Footer/Footer.tsx
@@ -50,7 +50,7 @@ export default function Footer() {
 	const hrefLink = hrefLangLink[language][uri] || []
 
 	return (
-		<div className="footer-container">
+		<div className="footer-container print-display-none">
 			<Helmet>
 				{hrefLink.map(({ href, hrefLang }) => (
 					<link

--- a/mon-entreprise/source/components/layout/NewsBanner.tsx
+++ b/mon-entreprise/source/components/layout/NewsBanner.tsx
@@ -30,7 +30,7 @@ export default function NewsBanner() {
 		lastViewedRelease !== lastRelease.name && i18n.language === 'fr'
 
 	return showBanner ? (
-		<div className="ui__ banner news">
+		<div className="ui__ banner news print-display-none">
 			<span>
 				{emoji('✨')} Découvrez les nouveautés {determinant(lastRelease.name)}
 				<Link to={sitePaths.nouveautés}>{lastRelease.name.toLowerCase()}</Link>

--- a/mon-entreprise/source/components/simulationExplanation/ExportRecover.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/ExportRecover.tsx
@@ -1,0 +1,28 @@
+import { Trans} from 'react-i18next'
+import React from 'react'
+import { GetUrl } from 'Components/ShareSimulationBanner'
+
+export default function ExportRecover() {
+	return (
+		<section className="screen-display-none print-break-avoid">
+			<h2><Trans i18nKey="pages.simulateurs.print-info.title">Vous souhaitez retrouver cette simulation ?</Trans></h2>
+
+			<p>
+				<Trans i18nKey="pages.simulateurs.print-info.recover">
+					Retrouvez la, ainsi que d'autres outils d'aide à la création et à la gestion d'entreprise, sur{' '}
+					<a href={GetUrl()} target="_blank">
+						 mon-entreprise.fr
+					</a>.
+				</Trans>
+			</p>
+
+			<p>
+				<Trans i18nKey="pages.simulateurs.print-info.date">
+					Cette simulation a été effectuée le
+				</Trans>
+				{' '}{new Date().toLocaleDateString()}.
+			</p>
+
+		</section>
+	)
+}

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -20,7 +20,11 @@ import CotisationsRégularisation from './IndépendantCotisationsRégularisation
 import PLExplanation from './PLExplanation'
 import { DistributionSection } from './SalaryExplanation'
 
-export default function IndépendantExplanation() {
+interface IndépendantExplanationProps{
+	disableAnimation: boolean
+}
+
+export default function IndépendantExplanation({disableAnimation} : IndépendantExplanationProps) {
 	const { t } = useTranslation()
 	const { palettes } = useContext(ThemeColorsContext)
 
@@ -38,7 +42,7 @@ export default function IndépendantExplanation() {
 			<Condition expression="dirigeant . rémunération . nette après impôt > 0 €/an">
 				<section>
 					<h2>Répartition du revenu</h2>
-					<StackedBarChart
+					<StackedBarChart disableAnimation={disableAnimation}
 						data={[
 							{
 								dottedName: 'dirigeant . rémunération . nette après impôt',
@@ -96,8 +100,8 @@ export default function IndépendantExplanation() {
 				</ul>
 			</Trans>
 
-			<DistributionSection>
-				<Distribution />
+			<DistributionSection disableAnimation={disableAnimation}>
+				<Distribution disableAnimation={disableAnimation}/>
 			</DistributionSection>
 		</>
 	)
@@ -130,7 +134,11 @@ const CotisationsSection: Partial<Record<DottedName, Array<string>>> = {
 	],
 }
 
-function Distribution() {
+interface DistributionProps{
+	disableAnimation: boolean
+}
+
+function Distribution({disableAnimation}:DistributionProps) {
 	const targetUnit = useSelector(targetUnitSelector)
 	const engine = useEngine()
 	const distribution = (Object.entries(
@@ -158,6 +166,7 @@ function Distribution() {
 						dottedName={sectionName}
 						value={value}
 						maximum={maximum}
+						disableAnimation={disableAnimation}
 					/>
 				))}
 			</div>
@@ -169,8 +178,8 @@ type DistributionBranchProps = {
 	dottedName: DottedName
 	value: number
 	maximum: number
-
 	icon?: string
+	disableAnimation:boolean
 }
 
 function DistributionBranch({
@@ -178,6 +187,7 @@ function DistributionBranch({
 	value,
 	icon,
 	maximum,
+	disableAnimation,
 }: DistributionBranchProps) {
 	const branche = useEngine().getRule(dottedName)
 
@@ -189,6 +199,7 @@ function DistributionBranch({
 			icon={icon ?? branche.rawNode.icônes}
 			description={branche.rawNode.résumé}
 			unit="€"
+			disableAnimation={disableAnimation}
 		/>
 	)
 }

--- a/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -9,7 +9,11 @@ import { useContext, useRef } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans, useTranslation } from 'react-i18next'
 
-export default function SalaryExplanation() {
+interface SalaryExplanationProps {
+	disableAnimation: boolean
+}
+
+export default function SalaryExplanation({disableAnimation,}: SalaryExplanationProps) {
 	const payslipRef = useRef<HTMLDivElement>(null)
 
 	if (useInversionFail()) {
@@ -25,9 +29,10 @@ export default function SalaryExplanation() {
 						block: 'start',
 					})
 				}
+				disableAnimation={disableAnimation}
 			/>
 
-			<DistributionSection />
+			<DistributionSection disableAnimation={disableAnimation}/>
 			<div ref={payslipRef}>
 				<PaySlipSection />
 			</div>
@@ -56,7 +61,7 @@ export default function SalaryExplanation() {
 	)
 }
 
-function RevenueRepartitionSection(props: { onSeePayslip: () => void }) {
+function RevenueRepartitionSection(props: { onSeePayslip: () => void; disableAnimation:boolean }) {
 	const { t } = useTranslation()
 	const { palettes } = useContext(ThemeColorsContext)
 
@@ -101,6 +106,7 @@ function RevenueRepartitionSection(props: { onSeePayslip: () => void }) {
 						color: palettes[1][1],
 					},
 				]}
+				disableAnimation={props.disableAnimation}
 			/>
 		</section>
 	)
@@ -118,8 +124,10 @@ function PaySlipSection() {
 }
 
 export const DistributionSection = ({
-	children = <Distribution />,
+	disableAnimation,
+	children = <Distribution disableAnimation={disableAnimation} />,
 }: {
+	disableAnimation:boolean
 	children?: React.ReactNode
 }) => (
 	<section>

--- a/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -83,7 +83,7 @@ function RevenueRepartitionSection(props: { onSeePayslip: () => void; disableAni
 					</Trans>
 				</h2>
 				<button
-					className="ui__ small simple button"
+					className="ui__ small simple button print-display-none"
 					onClick={props.onSeePayslip}
 				>
 					{emoji('📊')} <Trans>Voir la fiche de paie</Trans>

--- a/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -114,7 +114,7 @@ function RevenueRepartitionSection(props: { onSeePayslip: () => void; disableAni
 
 function PaySlipSection() {
 	return (
-		<section>
+		<section className="print-break-avoid">
 			<h2>
 				<Trans>Fiche de paie</Trans>
 			</h2>
@@ -130,7 +130,7 @@ export const DistributionSection = ({
 	disableAnimation:boolean
 	children?: React.ReactNode
 }) => (
-	<section>
+	<section className="print-break-avoid">
 		<h2>
 			<Trans>À quoi servent mes cotisations ?</Trans>
 		</h2>
@@ -144,4 +144,5 @@ export const DistributionSection = ({
 			</Trans>
 		</p>
 	</section>
+
 )

--- a/mon-entreprise/source/components/ui/WarningBlock.tsx
+++ b/mon-entreprise/source/components/ui/WarningBlock.tsx
@@ -16,7 +16,7 @@ export default function Warning({ localStorageKey, children }: WarningProps) {
 				margin-bottom: 1rem;
 			`}
 		>
-			<p>
+			<p className={folded?'print-display-none':''}>
 				{emoji('🚩 ')}
 				<strong>
 					<Trans i18nKey="simulateurs.warning.titre">
@@ -40,7 +40,7 @@ export default function Warning({ localStorageKey, children }: WarningProps) {
 					css="padding-top: 1rem; padding-bottom: 0.4rem"
 				>
 					{children}
-					<div className="ui__ answer-group">
+					<div className="ui__ answer-group print-display-none">
 						<button
 							className="ui__ button simple small"
 							onClick={() => fold(true)}

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -219,6 +219,7 @@ input.ui__::placeholder {
 	.print-display-none {
 		display: none !important;
 	}
+
 	.ui__.toggle input[type='radio']:checked ~ * {
 		box-shadow: none;
 	}

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -219,4 +219,7 @@ input.ui__::placeholder {
 	.print-display-none {
 		display: none !important;
 	}
+	.ui__.toggle input[type='radio']:checked ~ * {
+		box-shadow: none;
+	}
 }

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -220,6 +220,19 @@ input.ui__::placeholder {
 		display: none !important;
 	}
 
+	.print-break-avoid
+	{
+		page-break-inside: avoid;
+		break-inside: avoid;
+	}
+
+	.print-background-force
+	{
+		color-adjust: exact !important;
+		-webkit-print-color-adjust: exact !important;
+		print-color-adjust: exact !important;
+	}
+
 	.ui__.toggle input[type='radio']:checked ~ * {
 		box-shadow: none;
 	}

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -214,3 +214,9 @@ input.ui__::placeholder {
 	opacity: 0.6;
 	color: grey;
 }
+
+@media print {
+	.print-display-none {
+		display: none !important;
+	}
+}

--- a/mon-entreprise/source/components/ui/index.css
+++ b/mon-entreprise/source/components/ui/index.css
@@ -214,6 +214,11 @@ input.ui__::placeholder {
 	opacity: 0.6;
 	color: grey;
 }
+@media screen{
+	.screen-display-none{
+		display: none !important;
+	}
+}
 
 @media print {
 	.print-display-none {

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -71,6 +71,8 @@ Exemples: Examples
 Exemples de simulation de salaire: Examples of salary simulations
 Exonérations: Exemptions
 Explorez notre documentation: Explore our documentation
+ExportSimulation:
+  Banner: "To save this simulation: <2>Print or export as PDF</2>"
 Faire une simulation: Launch a simulation
 Fiche de paie: Payslip
 Gestion des données personnelles: Management of personal data

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -1356,6 +1356,10 @@ pages:
         title: PAMC diet simulators
       shortname: PAMC
       title: "PAMC: contribution and income simulators"
+    print-info:
+      recover: Find it, as well as other tools to help create and manage a business on <2>mycompanyinfrance.fr</2>
+      date: This simulation was performed on
+      title: Would you like to recover this simulation?
     profession-libérale:
       meta:
         description: Net Income Calculation for Self-Employed Persons in Liberal Income

--- a/mon-entreprise/source/locales/ui-fr.yaml
+++ b/mon-entreprise/source/locales/ui-fr.yaml
@@ -24,6 +24,8 @@ En savoir plus: En savoir plus
 Entreprise Individuelle: Entreprise Individuelle
 Exonérations: Exonérations
 Explorez notre documentation: Explorez notre documentation
+ExportSimulation:
+  Banner: "Pour conserver cette simulation : <2>Imprimer ou sauvegarder en PDF</2>"
 Fiche de paie: Fiche de paie
 Gestion des données personnelles: Gestion des données personnelles
 Gérant majoritaire: Gérant majoritaire

--- a/mon-entreprise/source/locales/ui-fr.yaml
+++ b/mon-entreprise/source/locales/ui-fr.yaml
@@ -1008,6 +1008,10 @@ pages:
         title: Simulateurs régime PAMC
       shortname: PAMC
       title: "PAMC : simulateurs de cotisations et de revenu"
+    print-info:
+      recover: Retrouvez la, ainsi que d'autres outils d'aide à la création et à la gestion d'entreprise, sur <2>mon-entreprise.fr</2>
+      date: Cette simulation a été effectuée le 
+      title: Vous souhaitez retrouver cette simulation ?
     profession-libérale:
       meta:
         description: Calcul du revenu net pour les indépendants en libéral à l'impôt sur

--- a/mon-entreprise/source/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ArtisteAuteur.tsx
@@ -24,6 +24,7 @@ export default function ArtisteAuteur() {
 			<Simulation userWillExport={() => {
 				setAnimationDisabled(true)
 			}}
+									disableAnimation={animationDisabled}
 									explanations={<CotisationsResult
 										disableAnimation={animationDisabled} />}>
 				<PeriodSwitch />

--- a/mon-entreprise/source/pages/Simulateurs/ArtisteAuteur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ArtisteAuteur.tsx
@@ -9,35 +9,48 @@ import 'Components/TargetSelection.css'
 import { EngineContext, useEngine } from 'Components/utils/EngineContext'
 import useSimulationConfig from 'Components/utils/useSimulationConfig'
 import ircecSrc from 'Images/logos-caisses-retraite/ircec.jpg'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { Trans } from 'react-i18next'
 import styled from 'styled-components'
 import config from './configs/artiste-auteur.yaml'
 
 export default function ArtisteAuteur() {
 	useSimulationConfig(config)
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 
 	return (
 		<>
 			<SimulateurWarning simulateur="artiste-auteur" />
-			<Simulation explanations={<CotisationsResult />}>
+			<Simulation userWillExport={() => {
+				setAnimationDisabled(true)
+			}}
+									explanations={<CotisationsResult
+										disableAnimation={animationDisabled} />}>
 				<PeriodSwitch />
 
 				<SimulationGoals className="plain">
-					<SimulationGoal dottedName="artiste-auteur . revenus . traitements et salaires" />
-					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . recettes" />
-					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . frais réels" />
+					<SimulationGoal
+						dottedName="artiste-auteur . revenus . traitements et salaires" />
+					<SimulationGoal
+						dottedName="artiste-auteur . revenus . BNC . recettes" />
+					<SimulationGoal
+						dottedName="artiste-auteur . revenus . BNC . frais réels" />
 				</SimulationGoals>
 			</Simulation>
 		</>
 	)
 }
-function CotisationsResult() {
+
+interface CotisationResultProps{
+	disableAnimation: boolean
+}
+
+function CotisationsResult({disableAnimation}: CotisationResultProps) {
 	return (
 		<>
 			<CotisationsParOrganisme />
 			<Condition expression="artiste-auteur . cotisations > 0">
-				<RepartitionCotisations />
+				<RepartitionCotisations disableAnimation={disableAnimation}/>
 			</Condition>
 		</>
 	)
@@ -98,7 +111,11 @@ const branches = [
 	},
 ] as const
 
-function RepartitionCotisations() {
+interface RepartitionCotisationsProps{
+	disableAnimation:boolean
+}
+
+function RepartitionCotisations({disableAnimation}: RepartitionCotisationsProps) {
 	const engine = useContext(EngineContext)
 	const cotisations = branches.map((branch) => ({
 		...branch,
@@ -117,6 +134,7 @@ function RepartitionCotisations() {
 						<DistributionBranch
 							key={cotisation.dottedName}
 							maximum={maximum}
+							disableAnimation={disableAnimation}
 							{...cotisation}
 						/>
 					))}

--- a/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
@@ -15,6 +15,7 @@ export default function AutoEntrepreneur() {
 		<>
 			<SimulateurWarning simulateur="auto-entrepreneur" />
 			<Simulation userWillExport={() => {setAnimationDisabled(true)}}
+									disableAnimation={animationDisabled}
 									explanations={<Explanation disableAnimation={animationDisabled} />}>
 				<PeriodSwitch />
 				<SimulationGoals className="plain">

--- a/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
@@ -6,14 +6,16 @@ import Simulation from 'Components/Simulation'
 import { SimulationGoal, SimulationGoals } from 'Components/SimulationGoals'
 import StackedBarChart from 'Components/StackedBarChart'
 import { ThemeColorsContext } from 'Components/utils/colors'
-import { default as React, useContext } from 'react'
+import { default as React, useContext, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 export default function AutoEntrepreneur() {
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 	return (
 		<>
 			<SimulateurWarning simulateur="auto-entrepreneur" />
-			<Simulation explanations={<Explanation />}>
+			<Simulation userWillExport={() => {setAnimationDisabled(true)}}
+									explanations={<Explanation disableAnimation={animationDisabled} />}>
 				<PeriodSwitch />
 				<SimulationGoals className="plain">
 					<ChiffreAffairesActivitéMixte dottedName="dirigeant . auto-entrepreneur . chiffre d'affaires" />
@@ -36,8 +38,11 @@ export default function AutoEntrepreneur() {
 		</>
 	)
 }
+interface ExplanationProps{
+	disableAnimation: boolean
+}
 
-function Explanation() {
+function Explanation({disableAnimation}: ExplanationProps) {
 	const { t } = useTranslation()
 	const { palettes } = useContext(ThemeColorsContext)
 	return (
@@ -45,7 +50,7 @@ function Explanation() {
 			<h2>
 				<Trans>Répartition du chiffre d'affaires</Trans>
 			</h2>
-			<StackedBarChart
+			<StackedBarChart disableAnimation={disableAnimation}
 				data={[
 					{
 						dottedName: 'dirigeant . auto-entrepreneur . net après impôt',

--- a/mon-entreprise/source/pages/Simulateurs/ChômagePartiel.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ChômagePartiel.tsx
@@ -27,6 +27,7 @@ declare global {
 
 export default function ChômagePartiel() {
 	const inIframe = useContext(IsEmbeddedContext)
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 	useEffect(() => {
 		if (inIframe) {
 			return
@@ -55,7 +56,8 @@ export default function ChômagePartiel() {
 					</li>
 				</ul>
 			</Warning>
-			<Simulation userWillExport={() => {}}
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}}
+									disableAnimation={animationDisabled}
 									results={<ExplanationSection/>}
 				customEndMessages={
 					<span className="ui__ notice">Voir les résultats au-dessus</span>

--- a/mon-entreprise/source/pages/Simulateurs/ChômagePartiel.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ChômagePartiel.tsx
@@ -55,8 +55,8 @@ export default function ChômagePartiel() {
 					</li>
 				</ul>
 			</Warning>
-			<Simulation
-				results={<ExplanationSection />}
+			<Simulation userWillExport={() => {}}
+									results={<ExplanationSection/>}
 				customEndMessages={
 					<span className="ui__ notice">Voir les résultats au-dessus</span>
 				}

--- a/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
@@ -134,7 +134,7 @@ function ImpositionSwitch() {
 	return (
 		<span className="base ui__ small radio toggle">
 			{(['IR', 'IS'] as const).map((imposition) => (
-				<label key={imposition}>
+				<label key={imposition} className={ currentImposition !== imposition ? 'print-display-none' : ''}>
 					<input
 						name="entreprise . imposition"
 						type="radio"

--- a/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
@@ -10,16 +10,22 @@ import { SimulationGoal, SimulationGoals } from 'Components/SimulationGoals'
 import { useEngine } from 'Components/utils/EngineContext'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import { DottedName } from 'modele-social'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
 
-export function IndépendantPLSimulation() {
+interface IndépendantSimulationProps
+{
+	disableAnimation: boolean
+}
+
+export function IndépendantPLSimulation({disableAnimation}: IndépendantSimulationProps) {
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 	return (
 		<>
 			<SimulateurWarning simulateur="profession-libérale" />
-			<Simulation explanations={<IndépendantExplanation />}>
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}} explanations={<IndépendantExplanation disableAnimation={animationDisabled} />}>
 				<PeriodSwitch />
 				<IndépendantSimulationGoals />
 			</Simulation>
@@ -27,11 +33,12 @@ export function IndépendantPLSimulation() {
 	)
 }
 
-export function EntrepriseIndividuelle() {
+export function EntrepriseIndividuelle({disableAnimation}: IndépendantSimulationProps) {
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 	return (
 		<>
 			<SimulateurWarning simulateur="entreprise-individuelle" />
-			<Simulation explanations={<IndépendantExplanation />}>
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}} explanations={<IndépendantExplanation disableAnimation={animationDisabled}/>}>
 				<PeriodSwitch />
 				<IndépendantSimulationGoals />
 			</Simulation>
@@ -39,12 +46,13 @@ export function EntrepriseIndividuelle() {
 	)
 }
 
-export default function IndépendantSimulation() {
+export default function IndépendantSimulation({disableAnimation}: IndépendantSimulationProps) {
 	const sitePaths = useContext(SitePathsContext)
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 	return (
 		<>
 			<SimulateurWarning simulateur="indépendant" />
-			<Simulation explanations={<IndépendantExplanation />}>
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}} explanations={<IndépendantExplanation disableAnimation={animationDisabled}/>}>
 				<div
 					css={`
 						display: flex;

--- a/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
@@ -25,7 +25,9 @@ export function IndépendantPLSimulation({disableAnimation}: IndépendantSimulat
 	return (
 		<>
 			<SimulateurWarning simulateur="profession-libérale" />
-			<Simulation userWillExport={()=>{setAnimationDisabled(true)}} explanations={<IndépendantExplanation disableAnimation={animationDisabled} />}>
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}}
+									disableAnimation={animationDisabled}
+									explanations={<IndépendantExplanation disableAnimation={animationDisabled} />}>
 				<PeriodSwitch />
 				<IndépendantSimulationGoals />
 			</Simulation>
@@ -38,7 +40,9 @@ export function EntrepriseIndividuelle({disableAnimation}: IndépendantSimulatio
 	return (
 		<>
 			<SimulateurWarning simulateur="entreprise-individuelle" />
-			<Simulation userWillExport={()=>{setAnimationDisabled(true)}} explanations={<IndépendantExplanation disableAnimation={animationDisabled}/>}>
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}}
+									disableAnimation={animationDisabled}
+									explanations={<IndépendantExplanation disableAnimation={animationDisabled}/>}>
 				<PeriodSwitch />
 				<IndépendantSimulationGoals />
 			</Simulation>
@@ -52,7 +56,9 @@ export default function IndépendantSimulation({disableAnimation}: IndépendantS
 	return (
 		<>
 			<SimulateurWarning simulateur="indépendant" />
-			<Simulation userWillExport={()=>{setAnimationDisabled(true)}} explanations={<IndépendantExplanation disableAnimation={animationDisabled}/>}>
+			<Simulation userWillExport={()=>{setAnimationDisabled(true)}}
+									disableAnimation={animationDisabled}
+									explanations={<IndépendantExplanation disableAnimation={animationDisabled}/>}>
 				<div
 					css={`
 						display: flex;

--- a/mon-entreprise/source/pages/Simulateurs/Page.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Page.tsx
@@ -118,7 +118,7 @@ function NextSteps({ iframePath, nextSteps }: NextStepsProps) {
 		return null
 	}
 	return (
-		<section>
+		<section className='print-display-none'>
 			<h2 className="ui__ h h3">
 				<Trans>Ressources utiles</Trans>
 			</h2>

--- a/mon-entreprise/source/pages/Simulateurs/Page.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Page.tsx
@@ -14,6 +14,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { TrackChapter } from '../../ATInternetTracking'
 import { RessourceAutoEntrepreneur } from '../../pages/Créer/CreationChecklist'
 import useSimulatorsData, { SimulatorData } from './metadata'
+import ExportRecover from 'Components/simulationExplanation/ExportRecover'
 
 export default function PageData({
 	meta,
@@ -89,6 +90,7 @@ export default function PageData({
 				{!inIframe && (
 					<>
 						{seoExplanations}
+						<ExportRecover></ExportRecover>
 						<NextSteps
 							iframePath={privateIframe ? undefined : iframePath}
 							nextSteps={nextSteps}

--- a/mon-entreprise/source/pages/Simulateurs/Salarié.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Salarié.tsx
@@ -1,4 +1,5 @@
 import Banner from 'Components/Banner'
+import { useState } from 'react'
 import Simulation from 'Components/Simulation'
 import SalaryExplanation from 'Components/simulationExplanation/SalaryExplanation'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
@@ -7,12 +8,14 @@ import { Trans } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
 export default function SalariéSimulation() {
+	const [animationDisabled, setAnimationDisabled] = useState(false);
 	const sitePaths = useContext(SitePathsContext)
 
 	return (
 		<>
 			<Simulation
-				explanations={<SalaryExplanation />}
+				userWillExport={()=>{setAnimationDisabled(true)}}
+				explanations={<SalaryExplanation disableAnimation={animationDisabled}/>}
 				customEndMessages={
 					<>
 						<Trans i18nKey="simulation-end.hiring.text">

--- a/mon-entreprise/source/pages/Simulateurs/Salarié.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Salarié.tsx
@@ -15,6 +15,7 @@ export default function SalariéSimulation() {
 		<>
 			<Simulation
 				userWillExport={()=>{setAnimationDisabled(true)}}
+				disableAnimation={animationDisabled}
 				explanations={<SalaryExplanation disableAnimation={animationDisabled}/>}
 				customEndMessages={
 					<>

--- a/mon-entreprise/source/pages/Simulateurs/index.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/index.tsx
@@ -59,7 +59,7 @@ export default function Simulateurs() {
 					{(!lastState || lastState?.fromSimulateurs) && (
 						<Link
 							to={sitePaths.simulateurs.index}
-							className="ui__ simple small push-left button"
+							className="ui__ simple small push-left button print-display-none"
 						>
 							← <Trans>Voir les autres simulateurs</Trans>
 						</Link>

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -255,67 +255,69 @@ export function getSimulatorsData({
 			),
 			seoExplanations: (
 				<Trans i18nKey="pages.simulateurs.ei.seo explanation">
-					<h2>
-						Comment calculer le revenu net d'un dirigeant d'entreprise
-						individuelle (EI) ?
-					</h2>
-					<p>
-						Un dirigeant d'entreprise individuelle doit payer des cotisations et
-						contributions sociales à l'administration. Ces cotisations servent
-						au financement de la sécurité sociale, et ouvrent des droits
-						notamment pour la retraite et pour l'assurance maladie. Elles
-						permettent également de financer la formation professionnelle.
-					</p>
-					<p>
-						<Emoji emoji="👉" />{' '}
-						<RuleLink dottedName="dirigeant . indépendant . cotisations et contributions">
-							Voir le détail du calcul des cotisations
-						</RuleLink>
-					</p>
-					<p>
-						Il ne faut pas oublier de retrancher toutes les dépenses effectuées
-						dans le cadre de l'activité professionnelle (équipements, matières
-						premières, local, transport). Ces dernières sont déductibles du
-						résultat de l'entreprise, cela veut dire que vous ne payerez pas
-						d'impôt ou de cotisations sur leur montant (sauf si vous avez opté
-						pour l'option micro-fiscal).
-					</p>
-					<p>
-						La formule de calcul complète est donc :
-						<blockquote>
-							<strong>
-								Revenu net = Chiffres d'affaires − Dépenses professionnelles -
-								Cotisations sociales
-							</strong>
-						</blockquote>
-					</p>
-					<h2>
-						Comment calculer les cotisations sociales d'une entreprise
-						individuelle ?
-					</h2>
-					<p>
-						Le dirigeant d'une entreprise individuelle paye des cotisations
-						sociales, proportionnelle au{' '}
-						<RuleLink dottedName="entreprise . résultat fiscal">
-							résultat fiscal
-						</RuleLink>{' '}
-						de l'entreprise. Leur montant varie également en fonction du type
-						d'activité (profession libérale, artisan, commerçants, etc), où des
-						éventuelles exonérations accordées (ACRE, ZFU, RSA, etc.).
-					</p>
-					<p>
-						{' '}
-						Comme le résultat d'une entreprise n'est connu qu'à la fin de
-						l'exercice comptable, le dirigeant paye des cotisations
-						provisionnelles qui seront ensuite régularisée une fois le revenu
-						réel déclaré, l'année suivante.
-					</p>
-					<p>
-						Ce simulateur permet de calculer le montant exact des cotisations
-						sociale en partant d'un chiffre d'affaires ou d'un revenu net
-						souhaité. Vous pourrez préciser votre situation en répondant aux
-						questions s'affichant en dessous de la simulation.
-					</p>
+					<section className="print-break-avoid">
+						<h2>
+							Comment calculer le revenu net d'un dirigeant d'entreprise
+							individuelle (EI) ?
+						</h2>
+						<p>
+							Un dirigeant d'entreprise individuelle doit payer des cotisations et
+							contributions sociales à l'administration. Ces cotisations servent
+							au financement de la sécurité sociale, et ouvrent des droits
+							notamment pour la retraite et pour l'assurance maladie. Elles
+							permettent également de financer la formation professionnelle.
+						</p>
+						<p>
+							<Emoji emoji="👉" />{' '}
+							<RuleLink dottedName="dirigeant . indépendant . cotisations et contributions">
+								Voir le détail du calcul des cotisations
+							</RuleLink>
+						</p>
+						<p>
+							Il ne faut pas oublier de retrancher toutes les dépenses effectuées
+							dans le cadre de l'activité professionnelle (équipements, matières
+							premières, local, transport). Ces dernières sont déductibles du
+							résultat de l'entreprise, cela veut dire que vous ne payerez pas
+							d'impôt ou de cotisations sur leur montant (sauf si vous avez opté
+							pour l'option micro-fiscal).
+						</p>
+						<p>
+							La formule de calcul complète est donc :
+							<blockquote>
+								<strong>
+									Revenu net = Chiffres d'affaires − Dépenses professionnelles -
+									Cotisations sociales
+								</strong>
+							</blockquote>
+						</p>
+						<h2>
+							Comment calculer les cotisations sociales d'une entreprise
+							individuelle ?
+						</h2>
+						<p>
+							Le dirigeant d'une entreprise individuelle paye des cotisations
+							sociales, proportionnelle au{' '}
+							<RuleLink dottedName="entreprise . résultat fiscal">
+								résultat fiscal
+							</RuleLink>{' '}
+							de l'entreprise. Leur montant varie également en fonction du type
+							d'activité (profession libérale, artisan, commerçants, etc), où des
+							éventuelles exonérations accordées (ACRE, ZFU, RSA, etc.).
+						</p>
+						<p>
+							{' '}
+							Comme le résultat d'une entreprise n'est connu qu'à la fin de
+							l'exercice comptable, le dirigeant paye des cotisations
+							provisionnelles qui seront ensuite régularisée une fois le revenu
+							réel déclaré, l'année suivante.
+						</p>
+						<p>
+							Ce simulateur permet de calculer le montant exact des cotisations
+							sociale en partant d'un chiffre d'affaires ou d'un revenu net
+							souhaité. Vous pourrez préciser votre situation en répondant aux
+							questions s'affichant en dessous de la simulation.
+						</p>
+					</section>
 				</Trans>
 			),
 			nextSteps: ['comparaison-statuts'],
@@ -394,43 +396,45 @@ export function getSimulatorsData({
 			},
 			seoExplanations: (
 				<Trans i18nKey="pages.simulateurs.sasu.seo-explanation">
-					<h2>Comment calculer le salaire d'un dirigeant de SASU ? </h2>
-					<p>
-						Comme pour un salarié classique, le{' '}
-						<strong>dirigeant de sasu</strong> paye des cotisations sociales sur
-						la rémunération qu'il se verse. Les cotisations sont calculées de la
-						même manière que pour le salarié : elles sont décomposées en partie
-						employeur et partie salarié et sont exprimées comme un pourcentage
-						du salaire brut.
-					</p>
-					<p>
-						Le dirigeant assimilé-salarié ne paye pas de{' '}
-						<strong>cotisations chômage</strong>. Par ailleurs, il ne bénéficie
-						pas de la{' '}
-						<RuleLink dottedName="contrat salarié . réduction générale">
-							réduction générale de cotisations
-						</RuleLink>{' '}
-						ni des dispositifs encadrés par le code du travail comme les{' '}
-						<RuleLink dottedName="contrat salarié . temps de travail . heures supplémentaires">
-							heures supplémentaires
-						</RuleLink>{' '}
-						ou les primes.
-					</p>
-					<p>
-						Il peut en revanche prétendre à la{' '}
-						<RuleLink dottedName="dirigeant . assimilé salarié . réduction ACRE">
-							réduction ACRE
-						</RuleLink>{' '}
-						en debut d'activité, sous certaines conditions.
-					</p>
-					<p>
-						Vous pouvez utiliser notre simulateur pour calculer la{' '}
-						<strong>rémunération nette</strong> à partir d'un montant superbrut
-						alloué à la rémunération du dirigeant. Il vous suffit pour cela
-						saisir le montant total alloué dans la case "total chargé". La
-						simulation peut ensuite être affinée en répondant aux différentes
-						questions.
-					</p>
+					<section className="print-break-avoid">
+						<h2>Comment calculer le salaire d'un dirigeant de SASU ? </h2>
+						<p>
+							Comme pour un salarié classique, le{' '}
+							<strong>dirigeant de sasu</strong> paye des cotisations sociales sur
+							la rémunération qu'il se verse. Les cotisations sont calculées de la
+							même manière que pour le salarié : elles sont décomposées en partie
+							employeur et partie salarié et sont exprimées comme un pourcentage
+							du salaire brut.
+						</p>
+						<p>
+							Le dirigeant assimilé-salarié ne paye pas de{' '}
+							<strong>cotisations chômage</strong>. Par ailleurs, il ne bénéficie
+							pas de la{' '}
+							<RuleLink dottedName="contrat salarié . réduction générale">
+								réduction générale de cotisations
+							</RuleLink>{' '}
+							ni des dispositifs encadrés par le code du travail comme les{' '}
+							<RuleLink dottedName="contrat salarié . temps de travail . heures supplémentaires">
+								heures supplémentaires
+							</RuleLink>{' '}
+							ou les primes.
+						</p>
+						<p>
+							Il peut en revanche prétendre à la{' '}
+							<RuleLink dottedName="dirigeant . assimilé salarié . réduction ACRE">
+								réduction ACRE
+							</RuleLink>{' '}
+							en debut d'activité, sous certaines conditions.
+						</p>
+						<p>
+							Vous pouvez utiliser notre simulateur pour calculer la{' '}
+							<strong>rémunération nette</strong> à partir d'un montant superbrut
+							alloué à la rémunération du dirigeant. Il vous suffit pour cela
+							saisir le montant total alloué dans la case "total chargé". La
+							simulation peut ensuite être affinée en répondant aux différentes
+							questions.
+						</p>
+					</section>
 				</Trans>
 			),
 			nextSteps: ['is', 'comparaison-statuts'],
@@ -510,67 +514,69 @@ export function getSimulatorsData({
 			),
 			seoExplanations: (
 				<Trans i18nKey="pages.simulateurs.auto-entrepreneur.seo explanation">
-					<h2>Comment calculer le revenu net d'un auto-entrepreneur ?</h2>
-					<p>
-						Un auto-entrepreneur doit payer des cotisations et contributions
-						sociales à l'administration. Ces cotisations servent au financement
-						de la sécurité sociale, et ouvrent des droits notamment pour la
-						retraite et pour l'assurance maladie. Elles permettent également de
-						financer la formation professionnelle. Leur montant varie en
-						fonction du type d'activité.
-					</p>
-					<p>
-						<Emoji emoji="👉" />{' '}
-						<RuleLink dottedName="dirigeant . auto-entrepreneur . cotisations et contributions">
-							Voir le détail du calcul des cotisations
-						</RuleLink>
-					</p>
-					<p>
-						Il ne faut pas oublier de retrancher toutes les dépenses effectuées
-						dans le cadre de l'activité professionnelle (équipements, matières
-						premières, local, transport). Bien qu'elles ne soient pas utilisées
-						pour le calcul des cotisations et de l'impôt, elles doivent être
-						prises en compte pour vérifier si l'activité est viable
-						économiquement.
-					</p>
-					<p>
-						La formule de calcul complète est donc :
-						<blockquote>
-							<strong>
-								Revenu net = Chiffres d'affaires − Cotisations sociales −
-								Dépenses professionnelles
-							</strong>
-						</blockquote>
-					</p>
-					<h2>
-						Comment calculer l'impôt sur le revenu pour un auto-entrepreneur ?
-					</h2>
-					<p>
-						Si vous avez opté pour le versement libératoire lors de la création
-						de votre auto-entreprise, l'impôt sur le revenu est payé en même
-						temps que les cotisations sociales.
-					</p>
-					<p>
-						<Emoji emoji="👉" />{' '}
-						<RuleLink dottedName="dirigeant . auto-entrepreneur . impôt . versement libératoire . montant">
-							Voir comment est calculé le montant du versement libératoire
-						</RuleLink>
-					</p>
-					<p>
-						Sinon, vous serez imposé selon le barème standard de l'impôt sur le
-						revenu. Le revenu imposable est alors calculé comme un pourcentage
-						du chiffre d'affaires. C'est qu'on appel l'abattement forfaitaire.
-						Ce pourcentage varie en fonction du type d'activité excercé. On dit
-						qu'il est forfaitaire car il ne prends pas en compte les dépenses
-						réelles effectuées dans le cadre de l'activité.
-					</p>
-					<p>
-						<Emoji emoji="👉" />{' '}
-						<RuleLink dottedName="dirigeant . auto-entrepreneur . impôt . revenu imposable">
-							Voir le détail du calcul du revenu abattu pour un
-							auto-entrepreneur
-						</RuleLink>
-					</p>
+					<section className="print-break-avoid">
+						<h2>Comment calculer le revenu net d'un auto-entrepreneur ?</h2>
+						<p>
+							Un auto-entrepreneur doit payer des cotisations et contributions
+							sociales à l'administration. Ces cotisations servent au financement
+							de la sécurité sociale, et ouvrent des droits notamment pour la
+							retraite et pour l'assurance maladie. Elles permettent également de
+							financer la formation professionnelle. Leur montant varie en
+							fonction du type d'activité.
+						</p>
+						<p>
+							<Emoji emoji="👉" />{' '}
+							<RuleLink dottedName="dirigeant . auto-entrepreneur . cotisations et contributions">
+								Voir le détail du calcul des cotisations
+							</RuleLink>
+						</p>
+						<p>
+							Il ne faut pas oublier de retrancher toutes les dépenses effectuées
+							dans le cadre de l'activité professionnelle (équipements, matières
+							premières, local, transport). Bien qu'elles ne soient pas utilisées
+							pour le calcul des cotisations et de l'impôt, elles doivent être
+							prises en compte pour vérifier si l'activité est viable
+							économiquement.
+						</p>
+						<p>
+							La formule de calcul complète est donc :
+							<blockquote>
+								<strong>
+									Revenu net = Chiffres d'affaires − Cotisations sociales −
+									Dépenses professionnelles
+								</strong>
+							</blockquote>
+						</p>
+						<h2>
+							Comment calculer l'impôt sur le revenu pour un auto-entrepreneur ?
+						</h2>
+						<p>
+							Si vous avez opté pour le versement libératoire lors de la création
+							de votre auto-entreprise, l'impôt sur le revenu est payé en même
+							temps que les cotisations sociales.
+						</p>
+						<p>
+							<Emoji emoji="👉" />{' '}
+							<RuleLink dottedName="dirigeant . auto-entrepreneur . impôt . versement libératoire . montant">
+								Voir comment est calculé le montant du versement libératoire
+							</RuleLink>
+						</p>
+						<p>
+							Sinon, vous serez imposé selon le barème standard de l'impôt sur le
+							revenu. Le revenu imposable est alors calculé comme un pourcentage
+							du chiffre d'affaires. C'est qu'on appel l'abattement forfaitaire.
+							Ce pourcentage varie en fonction du type d'activité excercé. On dit
+							qu'il est forfaitaire car il ne prends pas en compte les dépenses
+							réelles effectuées dans le cadre de l'activité.
+						</p>
+						<p>
+							<Emoji emoji="👉" />{' '}
+							<RuleLink dottedName="dirigeant . auto-entrepreneur . impôt . revenu imposable">
+								Voir le détail du calcul du revenu abattu pour un
+								auto-entrepreneur
+							</RuleLink>
+						</p>
+					</section>
 				</Trans>
 			),
 			nextSteps: ['indépendant', 'comparaison-statuts'],
@@ -664,74 +670,76 @@ export function getSimulatorsData({
 			),
 			seoExplanations: (
 				<Trans i18nKey="pages.simulateurs.chômage-partiel.seo">
-					<h2>Comment calculer l'indemnité d'activité partielle ?</h2>
-					<p>
-						L'indemnité d'activité partielle de base est fixée par la loi à{' '}
-						<strong>70% du brut</strong>. Elle est proratisée en fonction du
-						nombre d'heures chômées. Pour un salarié à 2300 € brut mensuel, qui
-						travaille à 50% de son temps usuel, cela donne{' '}
-						<strong>2300 € × 50% × 70% = 805 €</strong>
-					</p>
-					<p>
-						A cette indemnité de base s'ajoute l'indemnité complémentaire pour
-						les salaires proches du SMIC. Ce complément intervient lorsque le
-						cumul de la rémunération et de l'indemnité de base est en dessous
-						d'un SMIC net. Ces indemnités sont prises en charge par l'employeur,
-						qui sera ensuite remboursé en parti ou en totalité par l'État.
-					</p>
-					<p>
-						👉{' '}
-						<RuleLink dottedName="contrat salarié . activité partielle . indemnités">
-							Voir le détail du calcul de l'indemnité
-						</RuleLink>
-					</p>
-					<h2>Comment calculer la part remboursée par l'État ?</h2>
-					<p>
-						L'État prend en charge une partie de l'indemnité partielle pour les
-						salaires allant jusqu'à <strong>4,5 SMIC</strong>, avec un minimum à
-						8,03€ par heures chômée. Concrètement, cela abouti à une prise en
-						charge à<strong>100%</strong> pour les salaires proches du SMIC.
-						Celle-ci diminue progressivement jusqu'à se stabiliser à{' '}
-						<strong>93%</strong> pour les salaires compris{' '}
-						<strong>entre 2000 € et 7000 €</strong> (salaire correspondant à la
-						limite de 4,5 SMIC).
-					</p>
-					<p>
-						👉{' '}
-						<RuleLink dottedName="contrat salarié . activité partielle . indemnisation entreprise">
-							Voir le détail du calcul du remboursement de l'indemnité
-						</RuleLink>
-					</p>
-					<h2>Comment déclarer une activité partielle ?</h2>
-					<p>
-						Face à la crise du coronavirus, les modalités de passage en activité
-						partielle ont été allégées. L'employeur est autorisé a placer ses
-						salariés en activité partielle avant que la demande officielle ne
-						soit déposée. Celui-ci dispose ensuite d'un délai de{' '}
-						<strong>30 jours</strong> pour se mettre en règle. Les indemnités
-						seront versées avec un effet rétro-actif débutant à la mise en place
-						du chômage partiel.
-					</p>
-					<p>
-						👉{' '}
-						<a href="https://www.service-public.fr/professionnels-entreprises/vosdroits/R31001">
-							Effectuer la demande de chômage partiel
-						</a>
-					</p>
-					<h2>
-						{' '}
-						Quelles sont les cotisations sociales à payer pour l'indemnité
-						d'activité partielle ?
-					</h2>
-					<p>
-						L'indemnité d'activité partielle est soumise à la CSG/CRDS et à une
-						contribution maladie dans certains cas. Pour en savoir plus, voir la
-						page explicative sur{' '}
-						<a href="https://www.urssaf.fr/portail/home/employeur/reduire-ou-cesser-lactivite/la-reduction-ou-la-cessation-tem/lactivite-partielle-dispositif-d/le-regime-social-de-lindemnite-d.html">
-							le site de l'Urssaf
-						</a>
-						.
-					</p>
+					<section className="print-break-avoid">
+						<h2>Comment calculer l'indemnité d'activité partielle ?</h2>
+						<p>
+							L'indemnité d'activité partielle de base est fixée par la loi à{' '}
+							<strong>70% du brut</strong>. Elle est proratisée en fonction du
+							nombre d'heures chômées. Pour un salarié à 2300 € brut mensuel, qui
+							travaille à 50% de son temps usuel, cela donne{' '}
+							<strong>2300 € × 50% × 70% = 805 €</strong>
+						</p>
+						<p>
+							A cette indemnité de base s'ajoute l'indemnité complémentaire pour
+							les salaires proches du SMIC. Ce complément intervient lorsque le
+							cumul de la rémunération et de l'indemnité de base est en dessous
+							d'un SMIC net. Ces indemnités sont prises en charge par l'employeur,
+							qui sera ensuite remboursé en parti ou en totalité par l'État.
+						</p>
+						<p>
+							👉{' '}
+							<RuleLink dottedName="contrat salarié . activité partielle . indemnités">
+								Voir le détail du calcul de l'indemnité
+							</RuleLink>
+						</p>
+						<h2>Comment calculer la part remboursée par l'État ?</h2>
+						<p>
+							L'État prend en charge une partie de l'indemnité partielle pour les
+							salaires allant jusqu'à <strong>4,5 SMIC</strong>, avec un minimum à
+							8,03€ par heures chômée. Concrètement, cela abouti à une prise en
+							charge à<strong>100%</strong> pour les salaires proches du SMIC.
+							Celle-ci diminue progressivement jusqu'à se stabiliser à{' '}
+							<strong>93%</strong> pour les salaires compris{' '}
+							<strong>entre 2000 € et 7000 €</strong> (salaire correspondant à la
+							limite de 4,5 SMIC).
+						</p>
+						<p>
+							👉{' '}
+							<RuleLink dottedName="contrat salarié . activité partielle . indemnisation entreprise">
+								Voir le détail du calcul du remboursement de l'indemnité
+							</RuleLink>
+						</p>
+						<h2>Comment déclarer une activité partielle ?</h2>
+						<p>
+							Face à la crise du coronavirus, les modalités de passage en activité
+							partielle ont été allégées. L'employeur est autorisé a placer ses
+							salariés en activité partielle avant que la demande officielle ne
+							soit déposée. Celui-ci dispose ensuite d'un délai de{' '}
+							<strong>30 jours</strong> pour se mettre en règle. Les indemnités
+							seront versées avec un effet rétro-actif débutant à la mise en place
+							du chômage partiel.
+						</p>
+						<p>
+							👉{' '}
+							<a href="https://www.service-public.fr/professionnels-entreprises/vosdroits/R31001">
+								Effectuer la demande de chômage partiel
+							</a>
+						</p>
+						<h2>
+							{' '}
+							Quelles sont les cotisations sociales à payer pour l'indemnité
+							d'activité partielle ?
+						</h2>
+						<p>
+							L'indemnité d'activité partielle est soumise à la CSG/CRDS et à une
+							contribution maladie dans certains cas. Pour en savoir plus, voir la
+							page explicative sur{' '}
+							<a href="https://www.urssaf.fr/portail/home/employeur/reduire-ou-cesser-lactivite/la-reduction-ou-la-cessation-tem/lactivite-partielle-dispositif-d/le-regime-social-de-lindemnite-d.html">
+								le site de l'Urssaf
+							</a>
+							.
+						</p>
+					</section>
 				</Trans>
 			),
 			nextSteps: ['salarié', 'aides-embauche'],
@@ -1065,35 +1073,37 @@ export function getSimulatorsData({
 			component: ISSimulation,
 			seoExplanations: (
 				<Trans i18nKey="pages.simulateurs.is.seo">
-					<h2>Comment est calculé l’impôt sur les sociétés ?</h2>
-					<p>
-						L’impôt sur les sociétés s’applique aux bénéfices réalisés par les
-						sociétés de capitaux (SA, SAS, SASU, SARL, etc.) et sur option
-						facultative pour certaines autres sociétés (EIRL, EURL, SNC, etc.).
-					</p>
-					<p>
-						Il est calculé sur la base des bénéfices réalisés en France au cours
-						de l’exercice comptable. La durée d’un exercice est normalement d’un
-						an mais il peut être plus court ou plus long (notamment en début
-						d’activité ou à la dissolution de l’entreprise). Dans ce cas le
-						barème de l’impôt est pro-ratisé en fonction de la durée de
-						l’exercice, ce qui est pris en compte dans le simulateur en
-						modifiant les dates de début et de fin de l’exercice.
-					</p>
-					<h2>Taux réduit et régimes spécifiques</h2>
-					<p>
-						Les PME réalisant moins de 7,63 millions d’euros de chiffre
-						d’affaires et dont le capital est détenu à 75% par des personnes
-						physiques bénéficient d’un taux réduit d’impôt sur les sociétés. Ce
-						taux est pris en compte sur le simulateur et il n’est pour l’instant
-						pas possible de simuler l’inéligibilité aux taux réduits.
-					</p>
-					<p>
-						Enfin il existe des régimes d’impositions spécifiques avec des taux
-						dédiés pour certains types de plus-values (cession de titres,
-						cession de brevets). Ces régimes ne sont pas intégrés dans le
-						simulateur.
-					</p>
+					<section className="print-break-avoid">
+						<h2>Comment est calculé l’impôt sur les sociétés ?</h2>
+						<p>
+							L’impôt sur les sociétés s’applique aux bénéfices réalisés par les
+							sociétés de capitaux (SA, SAS, SASU, SARL, etc.) et sur option
+							facultative pour certaines autres sociétés (EIRL, EURL, SNC, etc.).
+						</p>
+						<p>
+							Il est calculé sur la base des bénéfices réalisés en France au cours
+							de l’exercice comptable. La durée d’un exercice est normalement d’un
+							an mais il peut être plus court ou plus long (notamment en début
+							d’activité ou à la dissolution de l’entreprise). Dans ce cas le
+							barème de l’impôt est pro-ratisé en fonction de la durée de
+							l’exercice, ce qui est pris en compte dans le simulateur en
+							modifiant les dates de début et de fin de l’exercice.
+						</p>
+						<h2>Taux réduit et régimes spécifiques</h2>
+						<p>
+							Les PME réalisant moins de 7,63 millions d’euros de chiffre
+							d’affaires et dont le capital est détenu à 75% par des personnes
+							physiques bénéficient d’un taux réduit d’impôt sur les sociétés. Ce
+							taux est pris en compte sur le simulateur et il n’est pour l’instant
+							pas possible de simuler l’inéligibilité aux taux réduits.
+						</p>
+						<p>
+							Enfin il existe des régimes d’impositions spécifiques avec des taux
+							dédiés pour certains types de plus-values (cession de titres,
+							cession de brevets). Ces régimes ne sont pas intégrés dans le
+							simulateur.
+						</p>
+					</section>
 				</Trans>
 			),
 			nextSteps: ['salarié', 'comparaison-statuts'],

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -391,7 +391,9 @@ export function getSimulatorsData({
 				return (
 					<>
 						<SimulateurWarning simulateur="sasu" />
-						<Simulation userWillExport={() => {setAnimationDisabled(true)}} explanations={<SalaryExplanation disableAnimation={animationDisabled} />} />
+						<Simulation userWillExport={() => {setAnimationDisabled(true)}}
+												disableAnimation={animationDisabled}
+												explanations={<SalaryExplanation disableAnimation={animationDisabled} />} />
 					</>
 				)
 			},

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -4,7 +4,7 @@ import Simulation from 'Components/Simulation'
 import SalaryExplanation from 'Components/simulationExplanation/SalaryExplanation'
 import Emoji from 'Components/utils/Emoji'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
-import React, { useContext, useMemo } from 'react'
+import React, { useContext, useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { SimulationConfig } from 'Reducers/rootReducer'
 import { constructLocalizedSitePath } from '../../sitePaths'
@@ -387,10 +387,11 @@ export function getSimulatorsData({
 			shortName: t('pages.simulateurs.sasu.shortname', 'SASU'),
 			title: t('pages.simulateurs.sasu.title', 'Simulateur de SASU'),
 			component: function SasuSimulation() {
+				const [animationDisabled, setAnimationDisabled] = useState(false);
 				return (
 					<>
 						<SimulateurWarning simulateur="sasu" />
-						<Simulation userWillExport={()=>{}} explanations={<SalaryExplanation disableAnimation={false} />} />
+						<Simulation userWillExport={() => {setAnimationDisabled(true)}} explanations={<SalaryExplanation disableAnimation={animationDisabled} />} />
 					</>
 				)
 			},

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -244,7 +244,7 @@ export function getSimulatorsData({
 					'Entreprise individuelle (EI) : simulateur de revenus'
 				),
 			},
-			component: EntrepriseIndividuelle,
+			component:() => {return (<EntrepriseIndividuelle disableAnimation={false}/>)},
 			path: sitePaths.simulateurs['entreprise-individuelle'],
 			shortName: t('pages.simulateurs.ei.shortname', 'EI'),
 			title: t(
@@ -345,7 +345,7 @@ export function getSimulatorsData({
 					'EIRL : simulateur de revenus pour dirigeant'
 				),
 			},
-			component: IndépendantSimulation,
+			component: () => {return (<IndépendantSimulation disableAnimation={false}/>)},
 			path: sitePaths.simulateurs.eirl,
 			shortName: t('pages.simulateurs.eirl.shortname', 'EIRL'),
 			title: t('pages.simulateurs.eirl.title', "Simulateur d'EIRL"),
@@ -386,7 +386,7 @@ export function getSimulatorsData({
 				return (
 					<>
 						<SimulateurWarning simulateur="sasu" />
-						<Simulation explanations={<SalaryExplanation />} />
+						<Simulation userWillExport={()=>{}} explanations={<SalaryExplanation disableAnimation={false} />} />
 					</>
 				)
 			},
@@ -469,7 +469,7 @@ export function getSimulatorsData({
 			path: sitePaths.simulateurs.eurl,
 			shortName: t('pages.simulateurs.sasu.shortname', 'EURL'),
 			title: t('pages.simulateurs.sasu.title', "Simulateur d'EURL"),
-			component: IndépendantSimulation,
+			component: () => {return (<IndépendantSimulation disableAnimation={false}/>)},
 			nextSteps: ['is', 'comparaison-statuts'],
 		},
 		'auto-entrepreneur': {
@@ -594,7 +594,7 @@ export function getSimulatorsData({
 					"Calcul du revenu net après impôt et des cotisations à partir du chiffre d'affaires et inversement"
 				),
 			},
-			component: IndépendantSimulation,
+			component: () => {return (<IndépendantSimulation disableAnimation={false}/>)},
 			nextSteps: ['comparaison-statuts', 'is'],
 		},
 
@@ -844,7 +844,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.médecin.title',
 				'Simulateur de revenus pour médecin en libéral'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		'chirurgien-dentiste': {
 			config: dentisteConfig,
@@ -863,7 +863,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.chirurgien-dentiste.title',
 				'Simulateur de revenus pour chirurgien-dentiste en libéral'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		'sage-femme': {
 			config: sageFemmeConfig,
@@ -879,7 +879,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.sage-femme.title',
 				'Simulateur de revenus pour sage-femme en libéral'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		'auxiliaire-médical': {
 			config: auxiliaireConfig,
@@ -899,7 +899,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.auxiliaire.title',
 				'Simulateur de revenus pour auxiliaire médical en libéral'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		avocat: {
 			config: avocatConfig,
@@ -915,7 +915,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.avocat.title',
 				'Simulateur de revenus pour avocat en libéral'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		'expert-comptable': {
 			config: expertComptableConfig,
@@ -934,7 +934,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.expert-comptable.title',
 				'Simulateur de revenus pour expert comptable et commissaire aux comptes en libéral'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		'profession-libérale': {
 			config: professionLibéraleConfig,
@@ -962,7 +962,7 @@ export function getSimulatorsData({
 				'pages.simulateurs.profession-libérale.title',
 				'Simulateur de revenus pour profession libérale'
 			),
-			component: IndépendantPLSimulation,
+			component: () => {return (<IndépendantPLSimulation disableAnimation={false}/>)},
 		},
 		pamc: {
 			private: true,

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -139,74 +139,76 @@ export function getSimulatorsData({
 			shortName: t('pages.simulateurs.salarié.shortname', 'Salarié'),
 			seoExplanations: (
 				<Trans i18nKey="pages.simulateurs.salarié.seo">
-					<h2>Comment calculer le salaire net ?</h2>
-					<p>
-						Lors de l'entretien d'embauche l'employeur propose en général une
-						rémunération exprimée en « brut ». Le montant annoncé inclut ainsi
-						les cotisations salariales, qui servent à financer la protection
-						sociale du salarié et qui sont retranchées du salaire « net » perçu
-						par le salarié.
-					</p>
-					<p>
-						Vous pouvez utiliser notre simulateur pour convertir le{' '}
-						<strong>salaire brut en net</strong> : il vous suffit pour cela
-						saisir la rémunération annoncée dans la case salaire brut. La
-						simulation peut-être affinée en répondant aux différentes questions
-						(CDD, statut cadre, heures supplémentaires, temps partiel,
-						titre-restaurants, etc.).
-					</p>
-					<img
-						src={
-							language === 'fr'
-								? urlIllustrationNetBrut
-								: urlIllustrationNetBrutEn
-						}
-						alt={t(
-							'pages.simulateurs.salarié.alt-image1',
-							'Salaire net (perçu par le salarié) = Salaire brut (inscrit dans le contrat de travail) - cotisations salariales (retraite, csg, etc)'
-						)}
-						css={`
-							width: 100%;
-						`}
-					/>
-					<p>
-						Par ailleurs depuis 2019, l'
-						<RuleLink dottedName="impôt">impôt sur le revenu</RuleLink> est
-						prélevé à la source. Pour ce faire, la direction générale des
-						finances publiques (DGFiP) transmet à l'employeur le taux
-						d'imposition calculé à partir de la déclaration de revenu du
-						salarié. Si ce taux est inconnu, par exemple lors d'une première
-						année d'activité, l'employeur utilise le{' '}
-						<RuleLink dottedName="impôt . taux neutre d'impôt sur le revenu">
-							taux neutre
-						</RuleLink>
-						.
-					</p>
-					<h2>Comment calculer le coût d'embauche ?</h2>
-					<p>
-						Si vous cherchez à embaucher, vous pouvez calculer le coût total de
-						la rémunération de votre salarié, ainsi que les montants de
-						cotisations patronales et salariales correspondant. Cela vous permet
-						de définir le niveau de rémunération en connaissant le montant
-						global de charge que cela représente pour votre entreprise.
-					</p>
-					<p>
-						En plus du salaire, notre simulateur prend en compte le calcul des
-						avantages en nature (téléphone, véhicule de fonction, etc.), ainsi
-						que la mutuelle santé obligatoire.
-					</p>
-					<p>
-						Il existe des{' '}
-						<RuleLink dottedName="contrat salarié . aides employeur">
-							aides différées
-						</RuleLink>{' '}
-						à l'embauche qui ne sont pas toutes prises en compte par notre
-						simulateur, vous pouvez les retrouver sur{' '}
-						<a href="http://www.aides-entreprises.fr" target="_blank">
-							le portail officiel
-						</a>
-						.
-					</p>
+					<section className="print-break-avoid">
+						<h2>Comment calculer le salaire net ?</h2>
+						<p>
+							Lors de l'entretien d'embauche l'employeur propose en général une
+							rémunération exprimée en « brut ». Le montant annoncé inclut ainsi
+							les cotisations salariales, qui servent à financer la protection
+							sociale du salarié et qui sont retranchées du salaire « net » perçu
+							par le salarié.
+						</p>
+						<p>
+							Vous pouvez utiliser notre simulateur pour convertir le{' '}
+							<strong>salaire brut en net</strong> : il vous suffit pour cela
+							saisir la rémunération annoncée dans la case salaire brut. La
+							simulation peut-être affinée en répondant aux différentes questions
+							(CDD, statut cadre, heures supplémentaires, temps partiel,
+							titre-restaurants, etc.).
+						</p>
+						<img
+							src={
+								language === 'fr'
+									? urlIllustrationNetBrut
+									: urlIllustrationNetBrutEn
+							}
+							alt={t(
+								'pages.simulateurs.salarié.alt-image1',
+								'Salaire net (perçu par le salarié) = Salaire brut (inscrit dans le contrat de travail) - cotisations salariales (retraite, csg, etc)'
+							)}
+							css={`
+								width: 100%;
+							`}
+						/>
+						<p>
+							Par ailleurs depuis 2019, l'
+							<RuleLink dottedName="impôt">impôt sur le revenu</RuleLink> est
+							prélevé à la source. Pour ce faire, la direction générale des
+							finances publiques (DGFiP) transmet à l'employeur le taux
+							d'imposition calculé à partir de la déclaration de revenu du
+							salarié. Si ce taux est inconnu, par exemple lors d'une première
+							année d'activité, l'employeur utilise le{' '}
+							<RuleLink dottedName="impôt . taux neutre d'impôt sur le revenu">
+								taux neutre
+							</RuleLink>
+							.
+						</p>
+						<h2>Comment calculer le coût d'embauche ?</h2>
+						<p>
+							Si vous cherchez à embaucher, vous pouvez calculer le coût total de
+							la rémunération de votre salarié, ainsi que les montants de
+							cotisations patronales et salariales correspondant. Cela vous permet
+							de définir le niveau de rémunération en connaissant le montant
+							global de charge que cela représente pour votre entreprise.
+						</p>
+						<p>
+							En plus du salaire, notre simulateur prend en compte le calcul des
+							avantages en nature (téléphone, véhicule de fonction, etc.), ainsi
+							que la mutuelle santé obligatoire.
+						</p>
+						<p>
+							Il existe des{' '}
+							<RuleLink dottedName="contrat salarié . aides employeur">
+								aides différées
+							</RuleLink>{' '}
+							à l'embauche qui ne sont pas toutes prises en compte par notre
+							simulateur, vous pouvez les retrouver sur{' '}
+							<a href="http://www.aides-entreprises.fr" target="_blank">
+								le portail officiel
+							</a>
+							.
+						</p>
+					</section>
 				</Trans>
 			),
 			nextSteps: ['chômage-partiel', 'aides-embauche'],


### PR DESCRIPTION
Voici le résultat de ces deux jours de contribution.

J'ai suivi les étapes présentées durant la phase de design :
  1. Ajout du bouton "Imprimer / Sauvegarder en PDF" sur l'ensemble des simulateurs
  2. Suppression des contenus superflus génériques
  3. Suppression des contenus superflus spécifiques
  4. Mise en page particulière des contenus génériques
  5. Mise en page particulière des contenus spécifiques
  6. Ajustement de la mise en page
  7. ajout d'une section contact/date 

Comme suggéré par @mquandalle la section contact contient un lien pour retrouver la simulation pré-chargé.

Obstacle inattendu : il etait necessaire d'afficher les animations avant de pouvoir imprimer (sous peine d'imprimer des feuilles blanches). J'ai fait un choix d'implementation, mais je serais heureux de pouvoir discuter avec vous des autres possibilités et des avantages de chacune.

### Reste à faire

  1. Je n'ai pas testé le comportement sur IE/Edge
  2. La liste exhaustive des parametres choisi n'est pas imprimée. Cela pourrait être intéressant
  3. Il y a un 🐛 sur firefox. Les dernieres section de l'impression se superposent, ce qui rend le texte difficilement lisible.



