### PR TITLE
Supprime un cycle d'applicabilité

### DIFF
--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -182,26 +182,9 @@ entreprise . chiffre d'affaires . BIC:
     - service BIC 
     - vente restauration hébergement
     
-entreprise . chiffre d'affaires . franchise de TVA dépassée:
+entreprise . chiffre d'affaires . franchise de TVA: oui
 
-  description: |
-    La franchise de TVA est un dispositif qui exonère les entreprises de la
-    déclaration et du paiement de la TVA. Il s'applique en dessous d'un seuil de
-    chiffre d'affaire annuel dépendant de l'activité.
-
-    Le professionnel qui relève de ce dispositif facture ses prestations ou ses
-    ventes en hors taxe, et ne peut pas déduire la TVA de ses achats.
-  une de ces conditions:
-    - chiffre d'affaires > seuil vente + seuil service
-    - vente restauration hébergement > seuil vente
-    - service > seuil service
-  note: >
-    On prend compte ici des seuils majorés (qui s'appliquent si le seuil
-    "minoré" n'a pas été dépassé en année `n - 2`)
-  références:
-    Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F21746
-
-entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil vente:
+entreprise . chiffre d'affaires . franchise de TVA . seuil vente:
   variations:
     - si: établissement . localisation . outre-mer . Guadeloupe Réunion Martinique
       alors: 110000 €/an
@@ -209,7 +192,7 @@ entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil vente:
   références:
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F21746
 
-entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil service:
+entreprise . chiffre d'affaires . franchise de TVA . seuil service:
   variations:
     - si: établissement . localisation . outre-mer . Guadeloupe Réunion Martinique
       alors: 60000 €/an
@@ -219,13 +202,27 @@ entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil service:
   références:
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F21746
 
-entreprise . chiffre d'affaires . franchise de TVA dépassée . notification:
-  applicable si: chiffre d'affaires
+entreprise . chiffre d'affaires . franchise de TVA . dépassement:
   type: notification
-  formule: oui
+  formule:
+    une de ces conditions:
+      - chiffre d'affaires > seuil vente + seuil service
+      - vente restauration hébergement > seuil vente
+      - service > seuil service
+  résumé: |
+    Le seuil annuel de chiffre d'affaires pour la franchise de TVA est dépassé.
   description: |
-    Le seuil annuel de chiffre d'affaires pour la franchise de TVA est dépassé. [En savoir plus](/documentation/entreprise/chiffre-d'affaires/franchise-de-TVA-dépassée)
+    La franchise de TVA est un dispositif qui exonère les entreprises de la
+    déclaration et du paiement de la TVA. Il s'applique en dessous d'un seuil de
+    chiffre d'affaire annuel dépendant de l'activité.
 
+    Le professionnel qui relève de ce dispositif facture ses prestations ou ses
+    ventes en hors taxe, et ne peut pas déduire la TVA de ses achats.
+  note: >
+    On prend compte ici des seuils majorés (qui s'appliquent si le seuil
+    "minoré" n'a pas été dépassé en année `n - 2`)
+  références:
+    Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F21746
 
 entreprise . résultat fiscal:
   unité: €/an

--- a/modele-social/règles/profession-libérale.yaml
+++ b/modele-social/règles/profession-libérale.yaml
@@ -355,7 +355,7 @@ dirigeant . indépendant . PL . PAMC:
   rend non applicable:
     - cotisations et contributions . indemnités journalières maladie
     - conjoint collaborateur
-    - entreprise . chiffre d'affaires . franchise de TVA dépassée
+    - entreprise . chiffre d'affaires . franchise de TVA
     - dirigeant . indépendant . revenus étrangers
     - dirigeant . indépendant . cotisations et contributions . maladie domiciliation fiscale étranger
   formule: oui

--- a/mon-entreprise/source/components/Notifications.tsx
+++ b/mon-entreprise/source/components/Notifications.tsx
@@ -1,12 +1,14 @@
 import { hideNotification } from 'Actions/actions'
 import animate from 'Components/ui/animate'
 import { useEngine, useInversionFail } from 'Components/utils/EngineContext'
+import { DottedName } from 'modele-social'
 import Engine, { RuleNode } from 'publicodes'
 import emoji from 'react-easy-emoji'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
 import './Notifications.css'
+import RuleLink from './RuleLink'
 import { Markdown } from './utils/markdown'
 import { ScrollToElement } from './utils/Scroll'
 
@@ -15,8 +17,9 @@ import { ScrollToElement } from './utils/Scroll'
 // the "sévérité" attribute. The notification will only be displayed if the
 // publicodes rule is applicable.
 type Notification = {
-	dottedName: RuleNode['dottedName']
+	dottedName: DottedName
 	description: RuleNode['rawNode']['description']
+	résumé?: RuleNode['rawNode']['description']
 	sévérité: 'avertissement' | 'information'
 }
 
@@ -27,9 +30,10 @@ export function getNotifications(engine: Engine) {
 				rule.rawNode['type'] === 'notification' &&
 				!!engine.evaluate(rule.dottedName).nodeValue
 		)
-		.map(({ dottedName, rawNode: { sévérité, description } }) => ({
+		.map(({ dottedName, rawNode: { sévérité, résumé, description } }) => ({
 			dottedName,
 			sévérité,
+			résumé,
 			description,
 		}))
 }
@@ -45,7 +49,7 @@ export default function Notifications() {
 	const messages: Array<Notification> = inversionFail
 		? [
 				{
-					dottedName: 'inversion fail',
+					dottedName: 'inversion fail' as any,
 					description: t(
 						'simulateurs.inversionFail',
 						'Le montant saisi abouti à un résultat impossible. Cela est dû à un effet de seuil dans le calcul des cotisations.\n\nNous vous invitons à réessayer en modifiant légèrement le montant renseigné (quelques euros de plus par exemple).'
@@ -59,14 +63,19 @@ export default function Notifications() {
 	return (
 		<div id="notificationsBlock">
 			<ul style={{ margin: 0, padding: 0 }}>
-				{messages.map(({ sévérité, dottedName, description }) =>
+				{messages.map(({ sévérité, dottedName, résumé, description }) =>
 					hiddenNotifications?.includes(dottedName) ? null : (
 						<animate.fromTop key={dottedName}>
 							<li>
 								<div className="notification">
 									{emoji(sévérité == 'avertissement' ? '⚠️' : '💁🏻')}
 									<div className="notificationText ui__ card">
-										<Markdown source={description} />
+										<Markdown source={résumé ?? description} />{' '}
+										{résumé && (
+											<RuleLink dottedName={dottedName}>
+												<Trans>En savoir plus</Trans>
+											</RuleLink>
+										)}
 										<button
 											className="hide"
 											aria-label="close"

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -7585,14 +7585,22 @@ entreprise . chiffre d'affaires . BIC:
     bénéfice industriels et commerciaux (BIC ou micro-BIC).
   titre.en: '[automatic] BIC'
   titre.fr: BIC
-entreprise . chiffre d'affaires . franchise de TVA dépassée:
-  description.en: |
-    [automatic] The VAT exemption is a device that exempts businesses from the
-    declaration and payment of VAT. It applies below a threshold of
-    annual turnover depending on the activity.
+entreprise . chiffre d'affaires . franchise de TVA:
+  titre.en: '[automatic] VAT exemption'
+  titre.fr: franchise de TVA
+entreprise . chiffre d'affaires . franchise de TVA . dépassement:
+  description.en: >
+    [automatic] The VAT exemption is a system that exempts companies from
+    declaring and paying
 
-    The professional covered by this scheme shall invoice his services or his
-    sales excluding tax, and cannot deduct VAT from its purchases.
+    declaration and payment of VAT. It applies below a threshold of
+
+    depending on the activity.
+
+
+    The professional who falls under this system invoices his services or sales without tax, and cannot
+
+    and cannot deduct VAT from their purchases.
   description.fr: |
     La franchise de TVA est un dispositif qui exonère les entreprises de la
     déclaration et du paiement de la TVA. Il s'applique en dessous d'un seuil de
@@ -7601,27 +7609,21 @@ entreprise . chiffre d'affaires . franchise de TVA dépassée:
     Le professionnel qui relève de ce dispositif facture ses prestations ou ses
     ventes en hors taxe, et ne peut pas déduire la TVA de ses achats.
   note.en: >
-    [automatic] The increased thresholds (which apply if the "reduced" threshold
-    was not exceeded in year `n - 2`) are taken into account here.
+    [automatic] We take into account here the increased thresholds (which apply
+    if the "reduced" threshold has not been exceeded in year `n - 2`)
   note.fr: >
     On prend compte ici des seuils majorés (qui s'appliquent si le seuil
     "minoré" n'a pas été dépassé en année `n - 2`)
-  titre.en: '[automatic] VAT exemption exceeded'
-  titre.fr: franchise de TVA dépassée
-entreprise . chiffre d'affaires . franchise de TVA dépassée . notification:
-  description.en: >
+  résumé.en: |
     [automatic] The annual turnover threshold for VAT exemption is exceeded.
-    More information](/documentation/enterprise/turnover/exceeded VAT exemption)
-  description.fr: >
+  résumé.fr: |
     Le seuil annuel de chiffre d'affaires pour la franchise de TVA est dépassé.
-    [En savoir
-    plus](/documentation/entreprise/chiffre-d'affaires/franchise-de-TVA-dépassée)
-  titre.en: '[automatic] notification'
-  titre.fr: notification
-entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil service:
-  titre.en: '[automatic] service threshold'
+  titre.en: '[automatic] overtaking'
+  titre.fr: dépassement
+entreprise . chiffre d'affaires . franchise de TVA . seuil service:
+  titre.en: '[automatic] threshold service'
   titre.fr: seuil service
-entreprise . chiffre d'affaires . franchise de TVA dépassée . seuil vente:
+entreprise . chiffre d'affaires . franchise de TVA . seuil vente:
   titre.en: '[automatic] sales threshold'
   titre.fr: seuil vente
 entreprise . chiffre d'affaires . service:

--- a/mon-entreprise/source/pages/Simulateurs/ImpôtSociété.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/ImpôtSociété.tsx
@@ -21,8 +21,7 @@ const ISConfig = {
 		'entreprise . imposition': "'IS'",
 		'entreprise . imposition . IS . impôt sur les sociétés . éligible taux réduit':
 			'oui',
-		"entreprise . chiffre d'affaires . franchise de TVA dépassée . notification":
-			'non',
+		"entreprise . chiffre d'affaires . franchise de TVA": 'non',
 	},
 } as SimulationConfig
 

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.js.snap
@@ -74,12 +74,12 @@ exports[`calculate aide-déclaration-indépendant: échelle de revenus 6`] = `"[
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 7`] = `
 "[20929,100000,69895,0,1,1,0]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate aide-déclaration-indépendant: échelle de revenus 8`] = `
 "[106448,1000000,802634,0,1,1,0]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-artiste-auteur: bnc 1`] = `"[1230]"`;
@@ -156,12 +156,12 @@ exports[`calculate simulations-auto-entrepreneur: échelle de revenus 8`] = `"[8
 
 exports[`calculate simulations-auto-entrepreneur: échelle de revenus 9`] = `
 "[114830,1236,100000,3996,96004]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-auto-entrepreneur: échelle de revenus 10`] = `
 "[1148303,12359,1000000,131938,868062]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IR . micro-fiscal . alerte seuil dépassés"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement, entreprise . imposition . IR . micro-fiscal . alerte seuil dépassés"
 `;
 
 exports[`calculate simulations-impot-société: bénéfices 1`] = `
@@ -179,27 +179,27 @@ exports[`calculate simulations-impot-société: bénéfices 5`] = `"[51044,0]"`;
 
 exports[`calculate simulations-impot-société: bénéfices 6`] = `
 "[555044,0]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-impot-société: bénéfices 7`] = `
 "[5595044,159457]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-impot-société: prorata temporis 1`] = `
 "[275044,0]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-impot-société: prorata temporis 2`] = `
 "[277936,0]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-impot-société: prorata temporis 3`] = `
 "[272981,0]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: acre 1`] = `"[73023,23023,50000,51980,9600,40400,0,73023,3559]"`;
@@ -220,7 +220,7 @@ exports[`calculate simulations-indépendant: conjoint collaborateur 5`] = `"[752
 
 exports[`calculate simulations-indépendant: conjoint collaborateur 6`] = `
 "[652233,152233,500000,517707,220771,279229,0,652233,4487]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: cotisations facultatives 1`] = `"[30000,13181,16819,17881,467,16352,0,30000,3559]"`;
@@ -233,12 +233,12 @@ exports[`calculate simulations-indépendant: cotisations facultatives 4`] = `"[2
 
 exports[`calculate simulations-indépendant: cotisations facultatives 5`] = `
 "[300000,79622,220378,228521,82429,137949,0,300000,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: cotisations facultatives 6`] = `
 "[300000,83122,216878,225021,80854,136024,0,300000,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: cotisations minimales 1`] = `"[1375,1275,100,135,0,100,0,1375,3559]"`;
@@ -247,12 +247,12 @@ exports[`calculate simulations-indépendant: cotisations minimales 2`] = `"[244,
 
 exports[`calculate simulations-indépendant: imposition à l'IS 1`] = `
 "[100000,30105,69895,72609,15123,54772,0,100000,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: imposition à l'IS 2`] = `
 "[100000,30105,69895,72609,15123,54772,0,100000,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: impôt sur le revenu 1`] = `"[29086,9086,20000,20787,603,19397,0,29086,3559]"`;
@@ -289,12 +289,12 @@ exports[`calculate simulations-indépendant: échelle de revenus 6`] = `"[14597,
 
 exports[`calculate simulations-indépendant: échelle de revenus 7`] = `
 "[139593,39593,100000,103788,28472,71528,0,139593,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-indépendant: échelle de revenus 8`] = `
 "[1239954,239954,1000000,1033666,473591,526409,0,1239954,3559]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: CIPAV 1`] = `"[3147,0,2647,500,0,500]"`;
@@ -311,12 +311,12 @@ exports[`calculate simulations-professions-libérales: CIPAV 6`] = `"[14422,0,44
 
 exports[`calculate simulations-professions-libérales: CIPAV 7`] = `
 "[146241,0,46241,100000,28546,71454]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: CIPAV 8`] = `
 "[1238004,0,238004,1000000,473565,526435]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: auxiliaire médical 1`] = `"[30000,0,7733,22267,1297,20970]"`;
@@ -327,19 +327,19 @@ exports[`calculate simulations-professions-libérales: auxiliaire médical 3`] =
 
 exports[`calculate simulations-professions-libérales: avocat 1`] = `
 "[50000,0,11181,38819,6058,32761]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: avocat 2`] = `
 "[50000,0,11821,38179,5866,32313]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: expert-comptable 1`] = `"[20000,0,5076,14924,81,14843]"`;
 
 exports[`calculate simulations-professions-libérales: expert-comptable 2`] = `
 "[50000,0,14877,35123,4949,30174]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: médecin 1`] = `"[50000,0,10817,39183,6167,33016]"`;
@@ -352,7 +352,7 @@ exports[`calculate simulations-professions-libérales: médecin 4`] = `"[400000,
 
 exports[`calculate simulations-professions-libérales: médecin 5`] = `
 "[120000,0,26977,93023,25393,67630]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-professions-libérales: médecin 6`] = `"[50000,0,10663,39337,6213,33124]"`;
@@ -468,7 +468,7 @@ exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): Con
 
 exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): Contrats Madelin 5`] = `
 "[0,274318,274318,20568,4,56]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification, entreprise . imposition . IR . micro-fiscal . alerte seuil dépassés"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement, entreprise . imposition . IR . micro-fiscal . alerte seuil dépassés"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): Contrats Madelin 6`] = `"[0,17852,17852,2973,3,8]"`;
@@ -505,7 +505,7 @@ exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): éc
 
 exports[`calculate simulations-rémunération-dirigeant (auto-entrepreneur): échelle de rémunération 8`] = `
 "[0,87085,87085,14500,4,40]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): ACRE 1`] = `"[0,8392,0,6077,4,21]"`;
@@ -524,7 +524,7 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 5`] = `
 "[0,220378,0,57407,4,56]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): Contrats Madelin 6`] = `"[0,13168,0,9743,4,21]"`;
@@ -567,7 +567,7 @@ exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle
 
 exports[`calculate simulations-rémunération-dirigeant (indépendant): échelle de rémunération 8`] = `
 "[0,69895,0,36204,4,56]
-Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA dépassée . notification"
+Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-salarié: CCN HCR 1`] = `


### PR DESCRIPTION
Les règles sur la franchise de TVA était écrite d'une manière où le
parent pouvait rendre l'enfant non applicable (via la désactivation de
branche) et en même temps l'enfant rendre le parent non applicable (par
dépendance directe dans les conditions d'applicabilité du parent).

Je n'ai pas très bien compris pourquoi ce comportement fonctionnait
actuellement, ni pourquoi ma modification
https://github.com/betagouv/publicodes/pull/66 le casse, mais dans tous
les cas il est préférable de ne pas avoir de “cycle d'applicabilité”.
