### PR TITLE
🐛 documentation : Le worker n'est pas disponible au chargement

### DIFF
--- a/mon-entreprise/source/components/SearchBar.tsx
+++ b/mon-entreprise/source/components/SearchBar.tsx
@@ -92,15 +92,18 @@ export default function SearchBar({
 	)
 
 	useEffect(() => {
+		if (!worker) return
+
 		worker.postMessage({
 			rules: searchIndex,
 		})
 
 		worker.onmessage = ({ data: results }: any) => setResults(results)
+
 		return () => {
 			worker.onmessage = null
 		}
-	}, [searchIndex, setResults])
+	}, [worker, searchIndex, setResults])
 
 	return (
 		<>


### PR DESCRIPTION
Ceci crée une erreur au runtime, car la méthode postMessage n'est pas
forcément disponible. Le correctif ajoute un test de présence de la valeur de
`worker` et la dépendance à useEffect.

Actuellement sur le site avec Chrome (v91) :

<img width="1392" alt="Screenshot 2021-06-28 at 11 39 08" src="https://user-images.githubusercontent.com/393765/123615339-80118500-d805-11eb-87e7-3973d69d412c.png">

