### PR TITLE
:hammer: corrige la formule de l'Acre pour les SASU

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -116,26 +116,33 @@ dirigeant . assimilé salarié:
 
 dirigeant . assimilé salarié . réduction ACRE:
   applicable si: entreprise . ACRE
-  formule:
-    produit:
-      assiette:
+  non applicable si: contrat salarié . cotisations . assiette > 100% * plafond sécurité sociale temps plein
+  variations:
+    - si: contrat salarié . cotisations . assiette <= 75% * plafond sécurité sociale temps plein
+      alors:
         somme:
           - contrat salarié . maladie
           - contrat salarié . allocations familiales
           - contrat salarié . vieillesse
-      taux: taux
+    - sinon:
+        produit:
+          assiette: assiette taux réduit
+          taux: (plafond sécurité sociale temps plein - contrat salarié . cotisations . assiette) / (25% * plafond sécurité sociale temps plein)
 
-dirigeant . assimilé salarié . réduction ACRE . taux:
-  titre: taux ACRE
-  formule:
-    taux progressif:
-      assiette: contrat salarié . cotisations . assiette
-      multiplicateur: plafond sécurité sociale temps plein
-      tranches:
-        - plafond: 75%
-          taux: 100%
-        - plafond: 100%
-          taux: 0%
+  références:
+    urssaf.fr: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/laccre/quelles-exonerations.html#FilAriane
+
+dirigeant . assimilé salarié . réduction ACRE . assiette taux réduit:
+  recalcul:
+    règle:
+      somme:
+        - contrat salarié . maladie
+        - contrat salarié . allocations familiales
+        - contrat salarié . vieillesse
+    avec:
+      contrat salarié . cotisations . assiette: 75% * plafond sécurité sociale temps plein
+      entreprise . ACRE: non
+      contrat salarié . maladie . employeur . contribution solidarité autonomie: non
 
 dirigeant . assimilé salarié . réduction ACRE . notification taux annuel:
   formule: oui

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -5057,6 +5057,9 @@ dirigeant . assimilé salarié:
 dirigeant . assimilé salarié . réduction ACRE:
   titre.en: '[automatic] ACRE reduction'
   titre.fr: réduction ACRE
+dirigeant . assimilé salarié . réduction ACRE . assiette taux réduit:
+  titre.en: '[automatic] base reduced rate'
+  titre.fr: assiette taux réduit
 dirigeant . assimilé salarié . réduction ACRE . notification taux annuel:
   description.en: >
     [automatic] The ACRE rate used is an annual average. The
@@ -5067,9 +5070,6 @@ dirigeant . assimilé salarié . réduction ACRE . notification taux annuel:
     simulateur ne prends pas encore en compte le calcul de l'ACRE mois par mois.
   titre.en: '[automatic] notification annual rate'
   titre.fr: notification taux annuel
-dirigeant . assimilé salarié . réduction ACRE . taux:
-  titre.en: '[automatic] ACRE rate'
-  titre.fr: taux ACRE
 dirigeant . auto-entrepreneur:
   description.en: >
     Self-enterprise is a simplified sole proprietorship. At the beginning


### PR DESCRIPTION
On utilise désormais la formule officielle, qui se base sur le montant des cotisations pour un revenu de 75% du PASS
(pour les revenu entre 75% et 100% du pass)
