### PR TITLE
✨ Improve stats typing and naming

### DIFF
--- a/mon-entreprise/scripts/fetch-stats.js
+++ b/mon-entreprise/scripts/fetch-stats.js
@@ -247,7 +247,14 @@ async function main() {
 		const visitesMois = await fetchMonthlyVisits()
 		const satisfaction = uniformiseData(
 			flattenPage(await fetchApi(buildSatisfactionQuery()))
-		)
+		).map((page) => {
+			// eslint-disable-next-line no-unused-vars
+			const { date, ...satisfactionPage } = {
+				month: new Date(new Date(page.date).setDate(1)),
+				...page,
+			}
+			return satisfactionPage
+		})
 		const retoursUtilisateurs = await fetchUserFeedbackIssues()
 		writeInDataDir('stats.json', {
 			visitesJours,

--- a/mon-entreprise/source/pages/Stats/types.ts
+++ b/mon-entreprise/source/pages/Stats/types.ts
@@ -1,5 +1,3 @@
-import statsJson from '../../data/stats.json'
-
 // Generated using app.quicktype.io
 
 export interface StatsStruct {
@@ -22,14 +20,18 @@ export interface Closed {
 }
 
 export interface BasePage {
-	date: string
+	date?: string
+	month?: string
 	nombre: number
 	page_chapter1: string
 	page_chapter2: PageChapter2
 	page_chapter3: string
 }
-export type Page = BasePage & { page: string }
-export type PageSatisfaction = BasePage & { click: SatisfactionLevel }
+export type Page = BasePage & { page: string; date: string }
+export type PageSatisfaction = BasePage & {
+	month: string
+	click: SatisfactionLevel
+}
 
 export enum SatisfactionLevel {
 	Bien = 'bien',


### PR DESCRIPTION
* Only make month available in satisfaction items in stats.json.
* Clean up GlobalStats.

(suite à la PR https://github.com/betagouv/mon-entreprise/pull/1690#pullrequestreview-747360452)