### PR TITLE
Corrige les problèmes remontées liés à l'impôt sur le revenu

### DIFF
--- a/mon-entreprise/source/components/PaySlipSections.tsx
+++ b/mon-entreprise/source/components/PaySlipSections.tsx
@@ -2,7 +2,7 @@ import Value, { Condition, ValueProps } from 'Components/EngineValue'
 import RuleLink from 'Components/RuleLink'
 import { DottedName } from 'modele-social'
 import { isNotApplicable, isNotYetDefined } from 'publicodes'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useEngine } from './utils/EngineContext'
 
 export const SalaireBrutSection = () => {
@@ -28,6 +28,7 @@ export const SalaireBrutSection = () => {
 }
 
 export const SalaireNetSection = () => {
+	const { t } = useTranslation()
 	return (
 		<div className="payslip__salarySection">
 			<h4 className="payslip__salaryTitle">
@@ -56,8 +57,13 @@ export const SalaireNetSection = () => {
 				rule="contrat salarié . rémunération . net"
 				className="payslip__total"
 			/>
-			<Condition expression="impôt > 0">
-				<Line negative rule="impôt" unit="€/mois" />
+			<Condition expression="impôt . montant > 0">
+				<Line
+					negative
+					rule="impôt . montant"
+					title={t('impôt sur le revenu')}
+					unit="€/mois"
+				/>
 				<Line
 					className="payslip__total"
 					rule="contrat salarié . rémunération . net après impôt"
@@ -69,6 +75,7 @@ export const SalaireNetSection = () => {
 
 type LineProps = {
 	rule: DottedName
+	title?: string
 	negative?: boolean
 } & Omit<ValueProps<DottedName>, 'expression'>
 
@@ -76,6 +83,7 @@ export function Line({
 	rule,
 	displayedUnit = '€',
 	negative = false,
+	title,
 	className,
 	...props
 }: LineProps) {
@@ -92,7 +100,9 @@ export function Line({
 
 	return (
 		<Condition expression={`${rule} > 0`}>
-			<RuleLink dottedName={rule} className={className} />
+			<RuleLink dottedName={rule} className={className}>
+				{title}
+			</RuleLink>
 			<Value
 				linkToRule={false}
 				expression={(negative ? '- ' : '') + rule}

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -97,17 +97,17 @@ const CotisationsSection: Partial<Record<DottedName, Array<string>>> = {
 function Distribution() {
 	const targetUnit = useSelector(targetUnitSelector)
 	const engine = useEngine()
-	const distribution = (Object.entries(
-		CotisationsSection
-	).map(([section, cotisations]) => [
-		section,
-		cotisations
-			.map((c) => engine.evaluate({ valeur: c, unité: targetUnit }))
-			.reduce(
-				(acc, evaluation) => acc + ((evaluation?.nodeValue as number) || 0),
-				0
-			),
-	]) as Array<[DottedName, number]>)
+	const distribution = (
+		Object.entries(CotisationsSection).map(([section, cotisations]) => [
+			section,
+			cotisations
+				.map((c) => engine.evaluate({ valeur: c, unité: targetUnit }))
+				.reduce(
+					(acc, evaluation) => acc + ((evaluation?.nodeValue as number) || 0),
+					0
+				),
+		]) as Array<[DottedName, number]>
+	)
 		.filter(([, value]) => value > 0)
 		.sort(([, a], [, b]) => b - a)
 

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -46,7 +46,8 @@ export default function IndépendantExplanation() {
 								color: palettes[0][0],
 							},
 							{
-								dottedName: 'impôt',
+								dottedName: 'impôt . montant',
+								title: t('impôt sur le revenu'),
 								color: palettes[1][0],
 							},
 							{
@@ -96,17 +97,17 @@ const CotisationsSection: Partial<Record<DottedName, Array<string>>> = {
 function Distribution() {
 	const targetUnit = useSelector(targetUnitSelector)
 	const engine = useEngine()
-	const distribution = (
-		Object.entries(CotisationsSection).map(([section, cotisations]) => [
-			section,
-			cotisations
-				.map((c) => engine.evaluate({ valeur: c, unité: targetUnit }))
-				.reduce(
-					(acc, evaluation) => acc + ((evaluation?.nodeValue as number) || 0),
-					0
-				),
-		]) as Array<[DottedName, number]>
-	)
+	const distribution = (Object.entries(
+		CotisationsSection
+	).map(([section, cotisations]) => [
+		section,
+		cotisations
+			.map((c) => engine.evaluate({ valeur: c, unité: targetUnit }))
+			.reduce(
+				(acc, evaluation) => acc + ((evaluation?.nodeValue as number) || 0),
+				0
+			),
+	]) as Array<[DottedName, number]>)
 		.filter(([, value]) => value > 0)
 		.sort(([, a], [, b]) => b - a)
 

--- a/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -96,7 +96,7 @@ function RevenueRepartitionSection(props: { onSeePayslip: () => void }) {
 						color: palettes[0][0],
 					},
 					{
-						dottedName: 'impôt',
+						dottedName: 'impôt . montant',
 						title: t('impôt'),
 						color: palettes[1][0],
 					},

--- a/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/AutoEntrepreneur.tsx
@@ -52,7 +52,7 @@ function Explanation() {
 						color: palettes[0][0],
 					},
 					{
-						dottedName: 'impôt',
+						dottedName: 'impôt . montant',
 						title: t('impôt'),
 						color: palettes[1][0],
 					},

--- a/publicodes/ui-react/source/mecanisms/Replacement.tsx
+++ b/publicodes/ui-react/source/mecanisms/Replacement.tsx
@@ -1,10 +1,57 @@
 import { VariationNode } from 'publicodes/source/mecanisms/variations'
+import { useState } from 'react'
+import emoji from 'react-easy-emoji'
+import Variations from './Variations'
 import Explanation from '../Explanation'
+import Overlay from '../Overlay'
+import { RuleLinkWithContext } from '../RuleLink'
+import { NodeValuePointer } from './common'
+import { EvaluatedNode } from 'publicodes/source/AST/types'
 
-export default function Replacement(node: VariationNode) {
+export default function Replacement(node: VariationNode & EvaluatedNode) {
 	const applicableReplacement = node.explanation.find(
 		(ex) => ex.satisfied
 	)?.consequence
-	const replacedNode = node.explanation.slice(-1)[0].consequence
-	return <Explanation node={applicableReplacement || replacedNode} />
+	const replacedNode = node.explanation.slice(-1)[0].consequence as {
+		dottedName: string
+	}
+
+	const [displayReplacements, changeDisplayReplacement] = useState(false)
+	return (
+		<>
+			<Explanation node={replacedNode} />
+			&nbsp;
+			{applicableReplacement && (
+				<NodeValuePointer
+					data={(applicableReplacement as any).nodeValue}
+					unit={(applicableReplacement as any).unit}
+				/>
+			)}
+			&nbsp;
+			<button
+				onClick={() => changeDisplayReplacement(true)}
+				className="ui__ simple small button"
+			>
+				{emoji('🔄')}
+			</button>
+			{displayReplacements && (
+				<Overlay onClose={() => changeDisplayReplacement(false)}>
+					<h3>Remplacement existant</h3>
+					<p>
+						Un ou plusieurs remplacements ciblent la règle{' '}
+						<RuleLinkWithContext dottedName={replacedNode.dottedName} /> à cet
+						endroit. Sa valeur est calculée selon la formule suivante :
+					</p>
+
+					<Variations {...node} />
+					<div style={{ marginTop: '1rem' }} />
+					<p>
+						<a href="https://publi.codes/documentation/principes-de-base#remplacement">
+							En savoir plus sur le remplacement dans publicodes
+						</a>
+					</p>
+				</Overlay>
+			)}
+		</>
+	)
 }

--- a/publicodes/ui-react/source/mecanisms/Variations.tsx
+++ b/publicodes/ui-react/source/mecanisms/Variations.tsx
@@ -2,13 +2,18 @@ import classnames from 'classnames'
 import { useState } from 'react'
 import emoji from 'react-easy-emoji'
 import styled from 'styled-components'
+import { EvaluatedNode } from 'publicodes/source/AST/types'
+import { VariationNode } from 'publicodes/dist/types/mecanisms/variations'
 import Explanation from '../Explanation'
 import writtenNumbers from '../writtenNumbers'
 import { CapitalizeFirstLetter, InlineMecanismName, Mecanism } from './common'
 
-export default function Variations({ nodeValue, explanation, unit }) {
-	let [expandedVariation, toggleVariation] = useState(null)
-
+export default function Variations({
+	nodeValue,
+	explanation,
+	unit,
+}: VariationNode & EvaluatedNode) {
+	const [expandedVariation, toggleVariation] = useState<null | number>(null)
 	return (
 		<StyledComponent>
 			<Mecanism

--- a/publicodes/ui-react/source/mecanisms/common.tsx
+++ b/publicodes/ui-react/source/mecanisms/common.tsx
@@ -37,7 +37,7 @@ export function ConstantNode({ nodeValue, type, fullPrecision, unit }) {
 			</span>
 		)
 	} else {
-		return <span className="value">{nodeValue}</span>
+		return <span className="value">{formatValue({ nodeValue, unit })}</span>
 	}
 }
 


### PR DESCRIPTION
1. Corrige l'affichage de répartition du revenu dû au changement de nom de la règle `impôt` vers `impôt . montant` (cf @lajarre)
2. Affiche les informations pour les remplacement actifs directement au niveau de la règle concernée (amélioration publicodes)