### PR TITLE
Exercice 2021 par défaut

### DIFF
--- a/modele-social/règles/entreprise-établissement.yaml
+++ b/modele-social/règles/entreprise-établissement.yaml
@@ -344,11 +344,11 @@ entreprise . imposition . IR . information sur le report de déficit:
 entreprise . exercice: oui
 entreprise . exercice . début:
   type: date
-  par défaut: 01/01/2020
+  par défaut: 01/01/2021
 
 entreprise . exercice . fin:
   type: date
-  par défaut: 31/12/2020
+  par défaut: 31/12/2021
 
 entreprise . exercice . durée:
   titre: durée de l'exercice

--- a/mon-entreprise/test/regressions/__snapshots__/simulations.jest.ts.snap
+++ b/mon-entreprise/test/regressions/__snapshots__/simulations.jest.ts.snap
@@ -195,20 +195,20 @@ exports[`calculate simulations-impot-société: bénéfices 3`] = `"[300,0]"`;
 
 exports[`calculate simulations-impot-société: bénéfices 4`] = `"[3000,0]"`;
 
-exports[`calculate simulations-impot-société: bénéfices 5`] = `"[51044,0]"`;
+exports[`calculate simulations-impot-société: bénéfices 5`] = `"[48628,0]"`;
 
 exports[`calculate simulations-impot-société: bénéfices 6`] = `
-"[555044,0]
+"[525628,0]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-impot-société: bénéfices 7`] = `
-"[5595044,159457]
+"[5295628,149646]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
 exports[`calculate simulations-impot-société: prorata temporis 1`] = `
-"[275044,0]
+"[260628,0]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 


### PR DESCRIPTION
J'aurai voulu implémenter la logique suivante, mais je pense que ça n'est pas encore possible en Publicodes :

- avant le 1er juillet, utiliser les dates de l'exercice précédent par défaut
- après le 1er juillet, utiliser le 01/01 - 31/12 de l'année courante pour l'exercice par défaut

L'idée est que la liasse fiscale est à envoyer courant mai, avec la possibilité de rectifier les semaines qui suivent, donc on veut garder les dates de l'année précédente par défaut à peu près jusqu'à la mi-année.