### PR TITLE
Corrige le nom de la règle pour le montant de l'IR

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -24,7 +24,7 @@ dirigeant . rémunération . totale:
       alors:
         somme:
           - nette après impôt
-          - impôt
+          - impôt . montant
           - cotisations
         par défaut: entreprise . chiffre d'affaires - entreprise . charges
         plancher: cotisations
@@ -74,7 +74,7 @@ dirigeant . rémunération . nette après impôt:
   description: >-
     Le revenu net après déduction de l'impôt
     sur le revenu et des cotisations sociales.
-  valeur: rémunération . nette - impôt
+  valeur: rémunération . nette - impôt . montant
   résumé: Ce que vous rapporte cette activité
 
 dirigeant . assimilé salarié:

--- a/modele-social/règles/impôt.yaml
+++ b/modele-social/règles/impôt.yaml
@@ -13,7 +13,7 @@ impôt . montant:
     - impôt . dividendes . PFU
   arrondi: oui
   unité: €/an
-  titre: Montant de l'impôt sur le revenu
+  titre: Impôt sur le revenu
 
 impôt . taux d'imposition:
   formule:

--- a/mon-entreprise/source/locales/rules-en.yaml
+++ b/mon-entreprise/source/locales/rules-en.yaml
@@ -8516,8 +8516,8 @@ impôt . foyer fiscal . taux effectif:
   titre.en: '[automatic] yield rate'
   titre.fr: taux effectif
 impôt . montant:
-  titre.en: '[automatic] Amount of income tax'
-  titre.fr: Montant de l'impôt sur le revenu
+  titre.en: '[automatic] Income tax'
+  titre.fr: Impôt sur le revenu
 impôt . montant si autres revenus imposables uniquement:
   titre.en: '[automatic] Amount of tax if no dividend is received'
   titre.fr: Montant de l'impôt dans le cas où aucun dividende ne serait touché

--- a/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Indépendant.tsx
@@ -119,7 +119,7 @@ function IndépendantSimulationGoals() {
 			</Condition>
 			<SimulationGoal dottedName="dirigeant . rémunération . nette" />
 			<Condition expression="entreprise . chiffre d'affaires > 0">
-				<SimulationGoal small editable={false} dottedName="impôt" />
+				<SimulationGoal small editable={false} dottedName="impôt . montant" />
 			</Condition>
 			<SimulationGoal dottedName="dirigeant . rémunération . nette après impôt" />
 		</SimulationGoals>

--- a/mon-entreprise/test/cycles.test.js
+++ b/mon-entreprise/test/cycles.test.js
@@ -29,10 +29,7 @@ describe('DottedNames graph', () => {
 				'dirigeant . rémunération . nette après impôt',
 				'dirigeant . rémunération . nette',
 				'dirigeant . rémunération . totale',
-				'dirigeant . rémunération . impôt',
-				"impôt . taux d'imposition",
-				"impôt . taux neutre d'impôt sur le revenu",
-				"impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique",
+				'impôt . montant',
 				'impôt . revenu imposable',
 			],
 		])


### PR DESCRIPTION
Plusieurs occurrences n'avaient pas été renommées suite au changement dans #1653

Fixes #1709