### PR TITLE
🤖 Supprime les index Algolia temporaires lorsque les PR sont fermées

### DIFF
--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,0 +1,24 @@
+name: PR clean up
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deploy-context:
+    runs-on: ubuntu-18.04
+    outputs:
+      env-name: ${{ steps.deploy-env.outputs.name }}
+    steps:
+      - id: deploy-env
+        run: echo "::set-output name=name::${{ github.event.number || '${GITHUB_REF#refs/*/}' }}"
+
+  algolia-rm-temp-index:
+    needs: deploy-context
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Remove temporary algolia index
+        run: yarn workspace mon-entreprise algolia:clean
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
+          ALGOLIA_INDEX_PREFIX: monentreprise-${{needs.deploy-context.outputs.env-name}}-

--- a/mon-entreprise/package.json
+++ b/mon-entreprise/package.json
@@ -134,6 +134,7 @@
 		"serve:dev:mon-entreprise": "PORT=5000 serve --config serve.mon-entreprise.json --no-clipboard",
 		"serve:dev:publicodes": "PORT=5002 serve --config serve.publicodes.json --no-clipboard",
 		"serve:dev:mycompanyinfrance": "PORT=5001 serve --config serve.infrance.json --no-clipboard",
-		"algolia:update": "node scripts/search/update-data.js"
+		"algolia:update": "node scripts/search/update-data.js",
+		"algolia:clean": "node scripts/search/clean.js"
 	}
 }

--- a/mon-entreprise/scripts/search/clean.js
+++ b/mon-entreprise/scripts/search/clean.js
@@ -1,0 +1,17 @@
+require('dotenv').config()
+
+const algoliasearch = require('algoliasearch')
+
+const {
+	ALGOLIA_APP_ID,
+	ALGOLIA_ADMIN_KEY,
+	ALGOLIA_INDEX_PREFIX = '',
+} = process.env
+
+const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_KEY)
+
+const rulesIndex = client.initIndex(`${ALGOLIA_INDEX_PREFIX}rules`)
+const simulateursIndex = client.initIndex(`${ALGOLIA_INDEX_PREFIX}simulateurs`)
+
+rulesIndex.delete()
+simulateursIndex.delete()


### PR DESCRIPTION
Depuis la mise en place de la nouvelle recherche qui utilise Algolia, on créé des index pour chaque PR. Or nous avons un quota, ce qui peut empecher de nouveaux index d'etre créé et entrainer l'échec des tests. Cette nouvelle PR créé une nouvelle action Github qui s'execute quand une PR est fermée (merged ou pas) et qui supprime l'index temporaire de cette PR.