### PR TITLE
Améliore l'affichage des cotisations par organisme

### DIFF
--- a/mon-entreprise/source/components/ShareSimulationBanner.tsx
+++ b/mon-entreprise/source/components/ShareSimulationBanner.tsx
@@ -1,4 +1,3 @@
-import { LinkButton } from 'Components/ui/Button'
 import React, { useContext, useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'

--- a/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/IndépendantExplanation.tsx
@@ -34,7 +34,6 @@ export default function IndépendantExplanation() {
 					<CotisationsRégularisation />
 				</WhenNotApplicable>
 			</section>
-			<InstitutionsPartenaires />
 			<Condition expression="dirigeant . rémunération . nette après impôt > 0 €/an">
 				<section>
 					<h2>Répartition du revenu</h2>
@@ -59,6 +58,7 @@ export default function IndépendantExplanation() {
 					/>
 				</section>
 			</Condition>
+			<InstitutionsPartenaires />
 			<DroitsRetraite />
 			<DistributionSection>
 				<Distribution />

--- a/mon-entreprise/source/components/simulationExplanation/InstitutionsPartenaires.tsx
+++ b/mon-entreprise/source/components/simulationExplanation/InstitutionsPartenaires.tsx
@@ -1,8 +1,5 @@
-import Value, {
-	Condition,
-	WhenApplicable,
-	WhenNotApplicable,
-} from 'Components/EngineValue'
+import Value, { Condition } from 'Components/EngineValue'
+import RuleLink from 'Components/RuleLink'
 import { FromBottom } from 'Components/ui/animate'
 import Emoji from 'Components/utils/Emoji'
 import { useEngine } from 'Components/utils/EngineContext'
@@ -27,13 +24,13 @@ export default function InstitutionsPartenaires() {
 					</Trans>
 				</h2>
 				<InstitutionsTable>
-					<Condition expression="entreprise . activité . libérale réglementée">
+					<Condition expression="entreprise . activité . libérale réglementée = oui">
 						<CotisationsUrssaf rule="dirigeant . indépendant . PL . cotisations Urssaf" />
 						<CaisseRetraite />
 					</Condition>
-					<WhenNotApplicable dottedName="entreprise . activité . libérale réglementée">
+					<Condition expression="entreprise . activité . libérale réglementée = non">
 						<CotisationsUrssaf rule="dirigeant . indépendant . cotisations et contributions" />
-					</WhenNotApplicable>
+					</Condition>
 					<ImpôtsDGFIP />
 					<Condition expression="dirigeant . indépendant . PL . PAMC . participation CPAM > 0">
 						<InstitutionLine>
@@ -52,11 +49,13 @@ export default function InstitutionsPartenaires() {
 							</p>
 							<p className="ui__ lead">
 								<Emoji emoji="🎁" />{' '}
-								<Value
-									unit={unit}
-									displayedUnit="€"
-									expression="dirigeant . indépendant . PL . PAMC . participation CPAM"
-								/>
+								<RuleLink dottedName="dirigeant . indépendant . PL . PAMC . participation CPAM">
+									<Value
+										unit={unit}
+										displayedUnit="€"
+										expression="- dirigeant . indépendant . PL . PAMC . participation CPAM"
+									/>
+								</RuleLink>
 							</p>
 						</InstitutionLine>
 					</Condition>
@@ -74,7 +73,15 @@ export default function InstitutionsPartenaires() {
 	)
 }
 
-export function CotisationsUrssaf({ rule }: { rule: DottedName }) {
+type CotisationsUrssafProps = {
+	rule: DottedName
+	extraNotice?: JSX.Element
+}
+
+export function CotisationsUrssaf({
+	rule,
+	extraNotice,
+}: CotisationsUrssafProps) {
 	const unit = useSelector(targetUnitSelector)
 	return (
 		<InstitutionLine>
@@ -86,10 +93,11 @@ export function CotisationsUrssaf({ rule }: { rule: DottedName }) {
 			</InstitutionLogo>
 			<p className="ui__ notice">
 				<Trans i18nKey="simulateurs.explanation.institutions.urssaf">
-					Les cotisations recouvrées par l'Urssaf, qui servent au financement de
-					la sécurité sociale (assurance maladie, allocations familiales,
+					L’Urssaf recouvre les cotisations servant au financement de la
+					sécurité sociale (assurance maladie, allocations familiales,
 					dépendance).
-				</Trans>
+				</Trans>{' '}
+				{extraNotice}
 			</p>
 			<p className="ui__ lead">
 				<Value unit={unit} displayedUnit="€" expression={rule} />
@@ -186,7 +194,18 @@ export function InstitutionsPartenairesArtisteAuteur() {
 		<section>
 			<h3>Vos cotisations</h3>
 			<InstitutionsTable>
-				<CotisationsUrssaf rule="artiste-auteur . cotisations" />
+				<CotisationsUrssaf
+					rule="artiste-auteur . cotisations"
+					extraNotice={
+						<Condition expression="artiste-auteur . revenus . traitements et salaires > 0">
+							<Trans i18nKey="simulateurs.explanation.institutions.précompte-artiste-auteur">
+								Pour vos revenus en traitement et salaires, ces cotisations sont
+								« précomptées », c'est à dire payées à la source par le
+								diffuseur.
+							</Trans>
+						</Condition>
+					}
+				/>
 				<Condition expression="artiste-auteur . cotisations . IRCEC > 0">
 					<InstitutionLine>
 						<InstitutionLogo target="_blank" href="http://www.ircec.fr/">
@@ -233,6 +252,7 @@ const InstitutionsTable = styled.div.attrs({ className: 'ui__ card' })`
 const InstitutionLogo = styled.a`
 	img {
 		max-width: 100%;
+		max-height: 50px;
 	}
 `
 

--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -1623,9 +1623,11 @@ simulateurs:
         abatement of the micro-tax system</2>.</2>
       notice acre: The amounts indicated above are calculated without taking into
         account the ACRE start-up exemption
+      précompte-artiste-auteur: For your salary and wages income, these contributions
+        are "deducted", i.e. paid at source by the broadcaster.
       titre: Your partner institutions
-      urssaf: The contributions collected by the Urssaf, which are used to finance
-        social security (health insurance, family allowances, dependence).
+      urssaf: The Urssaf collects the contributions used to finance social security
+        (health insurance, family allowances, dependence).
   inversionFail: >-
     The amount entered results in an impossible result. This is due to a
     threshold effect in the calculation of contributions.

--- a/mon-entreprise/source/locales/ui-fr.yaml
+++ b/mon-entreprise/source/locales/ui-fr.yaml
@@ -1212,10 +1212,12 @@ simulateurs:
         l'abattement du régime micro-fiscal</2>.</2>
       notice acre: Les montants indiqués ci-dessus sont calculés sans prendre en
         compte l'exonération de début d'activité ACRE
+      précompte-artiste-auteur: Pour vos revenus en traitement et salaires, ces
+        cotisations sont « précomptées », c'est à dire payées à la source par le
+        diffuseur.
       titre: Vos institutions partenaires
-      urssaf: Les cotisations recouvrées par l'Urssaf, qui servent au financement de
-        la sécurité sociale (assurance maladie, allocations familiales,
-        dépendance).
+      urssaf: L’Urssaf recouvre les cotisations servant au financement de la sécurité
+        sociale (assurance maladie, allocations familiales, dépendance).
     pamc: <0><0>Vos institutions
       partenaires</0><1><0></0><1></1><2><0><0><0></0></0><1>En tant que
       professionnel de santé conventionné, vous bénéficiez d'une prise en charge


### PR DESCRIPTION
- Corrige l'affichage des cotisations Urssaf pour les professions
  libérales non réglementées
- Ajoute une phrase concernant le précompte des cotisations par le
  diffuseur pour les artistes auteurs. Fixes #1507
- Affiche un montant négatif pour mieux distinguer la prise en charge CPAM 
