### PR TITLE
Affiche le nombre de réponses aux utilisateurs sur la page stats

### DIFF
--- a/mon-entreprise/scripts/fetch-stats.js
+++ b/mon-entreprise/scripts/fetch-stats.js
@@ -193,6 +193,19 @@ async function fetchMonthlyVisits() {
 	return { pages, site }
 }
 
+async function fetchUserAnswersStats() {
+	const ticketLists = await fetch(
+		'https://mon-entreprise.zammad.com/api/v1/ticket_overviews?view=tickets_repondus_le_mois_dernier',
+		{
+			headers: new Headers({
+				Authorization: `Token token=${process.env.ZAMMAD_API_SECRET_KEY}`,
+			}),
+		}
+	)
+	const answer = await ticketLists.json()
+	return answer.index.count
+}
+
 async function fetchUserFeedbackIssues() {
 	const tags = await fetch(
 		'https://mon-entreprise.zammad.com/api/v1/tag_list',
@@ -256,11 +269,13 @@ async function main() {
 			return satisfactionPage
 		})
 		const retoursUtilisateurs = await fetchUserFeedbackIssues()
+		const nbAnswersLast30days = await fetchUserAnswersStats()
 		writeInDataDir('stats.json', {
 			visitesJours,
 			visitesMois,
 			satisfaction,
 			retoursUtilisateurs,
+			nbAnswersLast30days,
 		})
 	} catch (e) {
 		console.error(e)
@@ -273,6 +288,7 @@ async function main() {
 			visitesMois: [],
 			satisfaction: [],
 			retoursUtilisateurs: [],
+			nbAnswersLast30days: 0,
 		})
 	}
 }

--- a/mon-entreprise/source/pages/Stats/DemandesUtilisateurs.tsx
+++ b/mon-entreprise/source/pages/Stats/DemandesUtilisateurs.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import stats from '../../data/stats.json'
 
 export default function DemandeUtilisateurs() {
-	const [extendedView, setExtendedView] = useState(false)
 	return (
 		<section>
 			<h2 id="demandes-utilisateurs">Demandes utilisateurs</h2>
@@ -14,24 +13,51 @@ export default function DemandeUtilisateurs() {
 				</small>
 			</p>
 			<h3>En attente d'implémentation</h3>
+			<Pagination
+				items={stats.retoursUtilisateurs.open}
+				itemComponent={Issue}
+			/>
+
+			<h3>Réalisées</h3>
+			<Pagination
+				items={stats.retoursUtilisateurs.closed}
+				itemComponent={Issue}
+			/>
+		</section>
+	)
+}
+
+type PaginationProps<ItemProps> = {
+	itemComponent: React.FC<ItemProps>
+	items: Array<ItemProps>
+}
+
+function Pagination<ItemProps>({
+	itemComponent,
+	items,
+}: PaginationProps<ItemProps>) {
+	const [currentPage, setCurrentPage] = useState(0)
+	return (
+		<>
 			<ul>
-				{stats.retoursUtilisateurs.open
-					.slice(0, !extendedView ? 10 : undefined)
-					.map(Issue)}
+				{items
+					.slice(currentPage * 10, (currentPage + 1) * 10)
+					.map(itemComponent)}
 			</ul>
 			<div css={{ textAlign: 'center' }}>
-				<button
-					className="ui__ small button"
-					onClick={() => setExtendedView(!extendedView)}
-				>
-					{extendedView ? 'Replier' : 'Voir plus'}
-				</button>
+				Page :
+				{[...Array(Math.ceil(items.length / 10)).keys()].map((i) => (
+					<button
+						className="ui__ small"
+						onClick={() => setCurrentPage(i)}
+						style={i === currentPage ? { fontWeight: 'bold' } : {}}
+						key={i}
+					>
+						{i + 1}
+					</button>
+				))}
 			</div>
-			<h3>Réalisées</h3>
-			<ul style={{ opacity: 0.8 }}>
-				{stats.retoursUtilisateurs.closed.map(Issue)}
-			</ul>
-		</section>
+		</>
 	)
 }
 

--- a/mon-entreprise/source/pages/Stats/GlobalStats.tsx
+++ b/mon-entreprise/source/pages/Stats/GlobalStats.tsx
@@ -1,5 +1,6 @@
 import Emoji from 'Components/utils/Emoji'
 import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import { SatisfactionStyle } from './SatisfactionChart'
 import { SatisfactionLevel, StatsStruct } from './types'
 import { Indicator, Indicators } from './utils'
@@ -138,7 +139,6 @@ export default function GlobalStats({ stats }: { stats: StatsStruct }) {
 
 	return (
 		<>
-			{' '}
 			<Indicators>
 				<BigIndicator
 					main={totalVisits}
@@ -150,8 +150,10 @@ export default function GlobalStats({ stats }: { stats: StatsStruct }) {
 					subTitle="Simulations lancées"
 					footnote="depuis le 1ᵉ janvier 2019"
 				/>
-			</Indicators>
-			<Indicators>
+				<BigIndicator
+					main={`${last30dConv} %`}
+					footnote="Taux de conversion vers une simulation"
+				/>
 				<BigIndicator
 					main={last30dVisits}
 					subTitle="Visites"
@@ -162,20 +164,19 @@ export default function GlobalStats({ stats }: { stats: StatsStruct }) {
 					subTitle="Simulations lancées"
 					footnote="sur les 30 derniers jours"
 				/>
+				<BigIndicator
+					main={stats.nbAnswersLast30days}
+					footnote={
+						<>
+							Réponses aux utilisateurs sur les 30 derniers jours
+							<br />
+							<Link to="#demandes-utilisateurs">
+								Voir les demandes populaires
+							</Link>
+						</>
+					}
+				/>
 			</Indicators>
-			<div
-				css={`
-					display: flex;
-					flex-direction: row;
-					justify-content: space-around;
-					margin: -1rem 0 0 0;
-				`}
-			>
-				<i>
-					<small>Taux de conversion vers une simulation&nbsp;:</small>{' '}
-					<b>{last30dConv}%</b>
-				</i>
-			</div>
 			<Indicators>
 				<Indicator
 					subTitle="Satisfaction utilisateurs"

--- a/mon-entreprise/source/pages/Stats/types.ts
+++ b/mon-entreprise/source/pages/Stats/types.ts
@@ -5,6 +5,7 @@ export interface StatsStruct {
 	visitesMois: Visites
 	satisfaction: PageSatisfaction[]
 	retoursUtilisateurs: RetoursUtilisateurs
+	nbAnswersLast30days: number
 }
 
 export interface RetoursUtilisateurs {

--- a/mon-entreprise/source/pages/Stats/utils.tsx
+++ b/mon-entreprise/source/pages/Stats/utils.tsx
@@ -5,12 +5,12 @@ export const Indicators = styled.div`
 	display: flex;
 	flex-direction: row;
 	justify-content: space-around;
-	margin: 2rem 0;
+	flex-wrap: wrap;
 `
 type IndicatorProps = {
 	main?: React.ReactNode
 	subTitle?: React.ReactNode
-	footnote?: string
+	footnote?: React.ReactNode
 	width?: string
 }
 export function Indicator({ main, subTitle, footnote, width }: IndicatorProps) {
@@ -20,6 +20,7 @@ export function Indicator({ main, subTitle, footnote, width }: IndicatorProps) {
 			css={`
 				text-align: center;
 				padding: 1rem;
+				margin: 1rem 0.5rem;
 				width: ${width || '210px'};
 				font-size: 110%;
 			`}

--- a/mon-entreprise/source/pages/Stats/utils.tsx
+++ b/mon-entreprise/source/pages/Stats/utils.tsx
@@ -23,6 +23,8 @@ export function Indicator({ main, subTitle, footnote, width }: IndicatorProps) {
 				margin: 1rem 0.5rem;
 				width: ${width || '210px'};
 				font-size: 110%;
+				display: flex;
+				flex-direction: column;
 			`}
 		>
 			<small
@@ -44,6 +46,7 @@ export function Indicator({ main, subTitle, footnote, width }: IndicatorProps) {
 					css={`
 						font-size: small;
 						display: block;
+						line-height: 1.6em;
 					`}
 				>
 					<i>{footnote}</i>


### PR DESCRIPTION
Fixes #1606

https://1758--mon-entreprise.netlify.app/stats

TODO : est-ce qu'on le garde vraiment comme un indicateur de premier niveau ou plus comme une info affichée un peu plus bas dans la section sur les retours utilisateurs ?