### PR TITLE
Ajout d'une commande i18n:translate

### DIFF
--- a/mon-entreprise/package.json
+++ b/mon-entreprise/package.json
@@ -12,7 +12,10 @@
 	"engines": {
 		"node": ">=12.16.1"
 	},
-	"browserslist": ["> 1% in FR", "not ie < 11"],
+	"browserslist": [
+		"> 1% in FR",
+		"not ie < 11"
+	],
 	"devDependencies": {
 		"@babel/core": "^7.9.0",
 		"@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -123,6 +126,7 @@
 		"test:dev-e2e:mycompanyinfrance": "cypress open --browser chromium --config baseUrl=http://localhost:8080/infrance,integrationFolder=cypress/integration/mon-entreprise/english --env language=en",
 		"test:record-http-calls:mon-entreprise": "cypress run --env record_http=",
 		"i18n:check": "yarn run i18n:rules:check && yarn run i18n:ui:check",
+		"i18n:translate": "yarn run i18n:rules:translate && yarn run i18n:ui:translate",
 		"i18n:rules:check": "node scripts/i18n/check-missing-rule-translation.js",
 		"i18n:rules:translate": "node scripts/i18n/translate-rules.js",
 		"i18n:ui:check": "yarn run i18next -c scripts/i18n/parser.config.js && node scripts/i18n/check-missing-UI-translation",


### PR DESCRIPTION
J'ai toujours besoin de me concentrer un peu pour choisir entre `i18n:rules:translate` et `i18n:ui:translate`, ce commit ajoute une commande qui fait les deux d'un coup