### PR TITLE
:chart_with_upwards_trend: Référencement & Accessibilité

### DIFF
--- a/mon-entreprise/source/Provider.tsx
+++ b/mon-entreprise/source/Provider.tsx
@@ -128,6 +128,7 @@ export default function Provider({
 					<div className="ui__ container">
 						<img
 							src={logo}
+							alt="logo"
 							style={{ maxWidth: '200px', width: '100%', marginTop: '1rem' }}
 						></img>
 						<h1>Une erreur est survenue</h1>

--- a/mon-entreprise/source/components/PageHeader.tsx
+++ b/mon-entreprise/source/components/PageHeader.tsx
@@ -20,6 +20,7 @@ export default function PageHeader({
 				<img
 					className="ui__ hide-mobile"
 					src={picture}
+					alt={`${titre}`}
 					css={`
 						margin-left: 3rem;
 						z-index: -1;

--- a/mon-entreprise/source/components/layout/Footer/Footer.tsx
+++ b/mon-entreprise/source/components/layout/Footer/Footer.tsx
@@ -152,13 +152,19 @@ export default function Footer() {
 				</StyledFooter>
 
 				<div style={{ display: 'flex', justifyContent: 'center' }}>
-					<a href="https://twitter.com/monentreprisefr">
+					<a href="https://twitter.com/monentreprisefr" aria-label="twitter">
 						<SocialIcon media="twitter" />
 					</a>
-					<a href="https://www.linkedin.com/company/mon-entreprise-fr/">
+					<a
+						href="https://www.linkedin.com/company/mon-entreprise-fr/"
+						aria-label="linkedin"
+					>
 						<SocialIcon media="linkedin" />
 					</a>
-					<a href="https://github.com/betagouv/mon-entreprise/">
+					<a
+						href="https://github.com/betagouv/mon-entreprise/"
+						aria-label="github"
+					>
 						<SocialIcon media="github" />
 					</a>
 				</div>

--- a/mon-entreprise/source/components/utils/Meta.tsx
+++ b/mon-entreprise/source/components/utils/Meta.tsx
@@ -1,7 +1,9 @@
 import { Helmet } from 'react-helmet'
+import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router'
 
 type PropType = {
+	page: string,
 	title: string
 	description: string
 	ogDescription?: string
@@ -10,6 +12,7 @@ type PropType = {
 }
 
 export default function Meta({
+	page,
 	title,
 	description,
 	ogDescription,
@@ -17,20 +20,28 @@ export default function Meta({
 	ogImage,
 }: PropType) {
 	const { pathname } = useLocation()
+	const { t } = useTranslation()
+	const meta = {
+		title: t(`${page}.titre`, title) || title,
+		description: t(`${page}.description`, description) || description,
+		ogDescription: ogDescription ? t(`${page}.ogDescription`, ogDescription) || ogDescription : description,
+		ogTitle: ogTitle ? t(`${page}.ogTitle`, ogTitle) || ogTitle : title,
+		ogImage: ogImage ? t(`${page}.ogImage`, ogImage) || ogImage : null,
+	}
 	return (
 		<Helmet>
-			<title>{title}</title>
-			<meta name="description" content={description} />
+			<title>{meta.title}</title>
+			<meta name="description" content={meta.description} />
 			<meta property="og:type" content="website" />
-			<meta property="og:title" content={ogTitle ?? title} />
-			<meta property="og:description" content={ogDescription ?? description} />
-			{ogImage && (
+			<meta property="og:title" content={meta.ogTitle ?? meta.title} />
+			<meta property="og:description" content={meta.ogDescription ?? meta.description} />
+			{meta.ogImage && (
 				<meta
 					property="og:image"
 					content={
-						ogImage.startsWith('http')
-							? ogImage
-							: window.location.host + pathname + '/' + ogImage
+						meta.ogImage.startsWith('http')
+							? meta.ogImage
+							: window.location.host + pathname + '/' + meta.ogImage
 					}
 				/>
 			)}

--- a/mon-entreprise/source/components/utils/Meta.tsx
+++ b/mon-entreprise/source/components/utils/Meta.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router'
 
 type PropType = {
-	page: string,
+	page: string
 	title: string
 	description: string
 	ogDescription?: string
@@ -20,21 +20,26 @@ export default function Meta({
 	ogImage,
 }: PropType) {
 	const { pathname } = useLocation()
-	const { t } = useTranslation()
+	const { t, i18n } = useTranslation()
 	const meta = {
 		title: t(`${page}.titre`, title) || title,
 		description: t(`${page}.description`, description) || description,
-		ogDescription: ogDescription ? t(`${page}.ogDescription`, ogDescription) || ogDescription : description,
+		ogDescription: ogDescription
+			? t(`${page}.ogDescription`, ogDescription) || ogDescription
+			: description,
 		ogTitle: ogTitle ? t(`${page}.ogTitle`, ogTitle) || ogTitle : title,
 		ogImage: ogImage ? t(`${page}.ogImage`, ogImage) || ogImage : null,
 	}
 	return (
-		<Helmet>
+		<Helmet htmlAttributes={{ lang: i18n.language }}>
 			<title>{meta.title}</title>
 			<meta name="description" content={meta.description} />
 			<meta property="og:type" content="website" />
 			<meta property="og:title" content={meta.ogTitle ?? meta.title} />
-			<meta property="og:description" content={meta.ogDescription ?? meta.description} />
+			<meta
+				property="og:description"
+				content={meta.ogDescription ?? meta.description}
+			/>
 			{meta.ogImage && (
 				<meta
 					property="og:image"

--- a/mon-entreprise/source/pages/Accessibilité.tsx
+++ b/mon-entreprise/source/pages/Accessibilité.tsx
@@ -1,9 +1,15 @@
 import { Trans } from 'react-i18next'
 import { TrackPage } from '../ATInternetTracking'
+import Meta from '../components/utils/Meta'
 
 export default function Accessibilité() {
 	return (
 		<Trans i18nKey="pages.accessibilité">
+			<Meta
+				page="accessibilité"
+				title="Accessibilité"
+				description="Référentiel Général d’Amélioration de l’Accessibilité"
+			/>
 			<h1>Accessibilité</h1>
 			<TrackPage chapter1="informations" name="accessibilite" />
 

--- a/mon-entreprise/source/pages/Budget/Budget.tsx
+++ b/mon-entreprise/source/pages/Budget/Budget.tsx
@@ -9,6 +9,7 @@ import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { TrackPage } from '../../ATInternetTracking'
+import Meta from '../../components/utils/Meta'
 import prose from './budget.md'
 import budget from './budget.yaml'
 
@@ -42,9 +43,11 @@ export default function Budget() {
 	return (
 		<>
 			<TrackPage chapter1="informations" name="budget" />
-			<Helmet>
-				<title>Le budget de mon-entreprise.fr</title>
-			</Helmet>
+			<Meta
+				page="budget"
+				title="Budget"
+				description="Le budget de mon-entreprise.fr"
+			/>
 			<ScrollToTop />
 			<h1>
 				Budget <Emoji emoji="💶" />

--- a/mon-entreprise/source/pages/Créer/Home.tsx
+++ b/mon-entreprise/source/pages/Créer/Home.tsx
@@ -1,8 +1,8 @@
 import PageHeader from 'Components/PageHeader'
 import { FromBottom } from 'Components/ui/animate'
+import Meta from 'Components/utils/Meta'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import { useContext } from 'react'
-import { Helmet } from 'react-helmet'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -22,10 +22,12 @@ export default function Créer() {
 	return (
 		<FromBottom>
 			<TrackPage name="accueil" />
-
-			<Helmet>
-				<title>{t('créer.titre', 'Créer une entreprise')}</title>
-			</Helmet>
+			<Meta
+				page="créer"
+				title="Créer"
+				description="Créer une entreprise"
+				ogImage={créerSvg}
+			/>
 			<PageHeader
 				titre={<Trans i18nKey="créer.titre">Créer une entreprise</Trans>}
 				picture={créerSvg}

--- a/mon-entreprise/source/pages/Documentation.tsx
+++ b/mon-entreprise/source/pages/Documentation.tsx
@@ -13,6 +13,7 @@ import { RootState } from 'Reducers/rootReducer'
 import { TrackPage } from '../ATInternetTracking'
 import rules, { DottedName } from 'modele-social'
 import RuleLink from '../components/RuleLink'
+import Meta from 'Components/utils/Meta'
 
 export default function RulePage() {
 	const currentSimulation = useSelector(
@@ -90,6 +91,11 @@ function DocumentationLanding() {
 	return (
 		<>
 			<TrackPage chapter1="documentation" name="accueil" />
+			<Meta
+				page="documentation"
+				title="Documentation"
+				description="Explorez toutes les règles de la documentation"
+			/>
 			<h1>
 				<Trans i18nKey="page.documentation.title">Documentation</Trans>
 			</h1>

--- a/mon-entreprise/source/pages/Gérer/Home.tsx
+++ b/mon-entreprise/source/pages/Gérer/Home.tsx
@@ -12,13 +12,13 @@ import Emoji from 'Components/utils/Emoji'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePaths, SitePathsContext } from 'Components/utils/SitePathsContext'
 import { useContext, useEffect, useRef, useState } from 'react'
-import { Helmet } from 'react-helmet'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { Company } from 'Reducers/inFranceAppReducer'
 import { RootState } from 'Reducers/rootReducer'
 import { TrackPage } from '../../ATInternetTracking'
+import Meta from '../../components/utils/Meta'
 import AideOrganismeLocal from './AideOrganismeLocal'
 import businessPlan from './businessPlan.svg'
 
@@ -64,9 +64,12 @@ export default function Gérer() {
 
 	return (
 		<>
-			<Helmet>
-				<title>{t('gérer.titre', 'Gérer mon activité')}</title>
-			</Helmet>
+			<Meta
+				page="gérer"
+				title="Gérer"
+				description="Gérer mon activité"
+				ogImage={businessPlan}
+			/>
 			<TrackPage name="accueil" />
 			<ScrollToTop />
 			<FromBottom>

--- a/mon-entreprise/source/pages/Landing/Landing.tsx
+++ b/mon-entreprise/source/pages/Landing/Landing.tsx
@@ -1,6 +1,7 @@
 import Footer from 'Components/layout/Footer/Footer'
 import Header from 'Components/layout/Header'
 import Emoji from 'Components/utils/Emoji'
+import Meta from 'Components/utils/Meta'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import logoSvg from 'Images/logo.svg'
 import { useContext } from 'react'
@@ -22,6 +23,12 @@ export default function Landing() {
 	return (
 		<>
 			<TrackPage chapter1="informations" name="accueil" />
+			<Meta
+				page="landing"
+				title="Mon-entreprise"
+				description="L'assistant officiel de l'entrepreneur"
+				ogImage={logoSvg}
+			/>
 			<Header />
 			<div className="app-content ui__ container">
 				{language === 'en' && (

--- a/mon-entreprise/source/pages/Landing/Landing.tsx
+++ b/mon-entreprise/source/pages/Landing/Landing.tsx
@@ -58,7 +58,11 @@ export default function Landing() {
 							</Trans>
 						</p>
 					</header>
-					<img src={illustrationSvg} className="landing-title__img" />
+					<img
+						src={illustrationSvg}
+						alt="landing image"
+						className="landing-title__img"
+					/>
 				</section>
 
 				<section className="ui__ full-width box-container">

--- a/mon-entreprise/source/pages/Nouveautés/Nouveautés.tsx
+++ b/mon-entreprise/source/pages/Nouveautés/Nouveautés.tsx
@@ -2,6 +2,7 @@ import { determinant, hideNewsBanner } from 'Components/layout/NewsBanner'
 import MoreInfosOnUs from 'Components/MoreInfosOnUs'
 import Emoji from 'Components/utils/Emoji'
 import { MarkdownWithAnchorLinks } from 'Components/utils/markdown'
+import Meta from 'Components/utils/Meta'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import { useContext, useEffect } from 'react'
@@ -53,6 +54,11 @@ export default function Nouveautés() {
 	return (
 		<>
 			<TrackPage chapter1="informations" name="nouveautes" />
+			<Meta
+				page="nouveautés"
+				title="Nouveautés"
+				description="Nous améliorons le site en continu à partir de vos retours. Découvrez les dernières nouveautés"
+			/>
 			<ScrollToTop key={selectedRelease} />
 			<h1>
 				Les nouveautés <Emoji emoji="✨" />

--- a/mon-entreprise/source/pages/Simulateurs/Home.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Home.tsx
@@ -10,6 +10,7 @@ import { Helmet } from 'react-helmet'
 import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { TrackPage } from '../../ATInternetTracking'
+import Meta from '../../components/utils/Meta'
 import simulatorSvg from './images/illustration-simulateur.svg'
 import useSimulatorsData, { SimulatorData } from './metadata'
 
@@ -22,6 +23,12 @@ export default function Simulateurs() {
 	return (
 		<>
 			<TrackPage chapter1="simulateurs" name="accueil" />
+			<Meta
+				page="simulateurs"
+				title="simulateurs"
+				description="Tous les simulateurs sur ce site sont maintenus à jour avec les dernières évolutions législatives."
+				ogImage={simulatorSvg}
+			/>
 			<Helmet>
 				<title>{titre}</title>
 			</Helmet>

--- a/mon-entreprise/source/pages/Stats/Stats.tsx
+++ b/mon-entreprise/source/pages/Stats/Stats.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Trans } from 'react-i18next'
 import { useHistory, useLocation } from 'react-router-dom'
 import { toAtString, TrackPage } from '../../ATInternetTracking'
+import Meta from '../../components/utils/Meta'
 import statsJson from '../../data/stats.json'
 import { debounce } from '../../utils'
 import { SimulateurCard } from '../Simulateurs/Home'
@@ -306,6 +307,11 @@ export default function Stats() {
 	return (
 		<>
 			<TrackPage chapter1="informations" name="stats" />
+			<Meta
+				page="stats"
+				title="Statistiques"
+				description="	Découvrez nos statistiques d'utilisation mises à jour quotidiennement."
+			/>
 			<ScrollToTop />
 
 			<h1>

--- a/mon-entreprise/source/pages/integration/Options.tsx
+++ b/mon-entreprise/source/pages/integration/Options.tsx
@@ -4,12 +4,19 @@ import { SitePathsContext } from 'Components/utils/SitePathsContext'
 import { useContext } from 'react'
 import { Trans } from 'react-i18next'
 import { Link } from 'react-router-dom'
+import Meta from '../../components/utils/Meta'
 import illustration from './illustration.png'
 
 export default function Options() {
 	const sitePaths = useContext(SitePathsContext)
 	return (
 		<>
+			<Meta
+				page="intégration"
+				title="Intégration"
+				description="Outils pour les développeurs"
+				ogImage={illustration}
+			/>
 			<h1 css="margin-bottom: 0">
 				<Trans>Outils pour les développeurs</Trans> <Emoji emoji="👨‍💻" />
 			</h1>


### PR DESCRIPTION
En lien avec #972 et #1411 j'ai remarqué que la meta description était absente sur plusieurs pages et que le component Meta n'étais plus utilisé, je l'ai modifier de façon à ce qu'il puisse gérer la traduction et ajouter aux pages: 

- landing
- créer
- gérer
- simulateurs
- nouveautés
- stats
- accessibilité
- budget
- intégration
- documentation

L'attribut alt sur certaine images sur la landing page et les component HeaderPage et Provider était manquant. 