### PR TITLE
Retouche le texte du simulateur dividendes

### DIFF
--- a/mon-entreprise/source/locales/ui-en.yaml
+++ b/mon-entreprise/source/locales/ui-en.yaml
@@ -463,9 +463,8 @@ d'aides: of aid
 dividendes:
   warning: <0>This simulation is only given as an indication. It only concerns
     French companies subject to corporation tax (IS), and does not concern
-    managers affiliated to the self-employed workers' regime.</0><1>The amount
-    of tax on dividends is calculated in addition to the tax on other taxable
-    income. </1>
+    self-employed workers.</0><1>The amount of tax on dividends is calculated in
+    addition to the tax on other taxable income.</1>
 domiciliation inconnue: unknown address
 domiciliée à: domiciled in
 déductible: deductible
@@ -847,7 +846,6 @@ mensuel: monthly
 mois: month
 montant à atteindre: minimum value
 multiplicateur: multiplier
-
 nextSteps:
   integration-iframe: <0><0></0> Integrate the web module</0><1>Add this simulator
     to your website in one click with a simple script.</1>
@@ -1276,11 +1274,11 @@ pages:
         chosen. This simulator can be used to compare the two systems.</4><5>An
         advance payment of the amount of tax (12.8%) is deducted at the time of
         payment of the dividends, unless the beneficiary meets <2>certain
-        criteria</2>.</5><6>Particular case of the manager under the
-        self-employed worker regime</6><7> Under the self-employed worker's
-        regime, the portion of dividends exceeding 10% of the share capital will
-        be subject to contributions and levies in the same way as the manager's
-        income.</7><8>This case is not yet taken into account by this
+        criteria</2>.</5><6>Special case of the self-employed manager</6><7>For
+        the self-employed worker, the portion of the dividends exceeding 10% of
+        the share capital will be subject to contributions and fees according to
+        the same terms and conditions as his remuneration as a
+        manager.</7><8>This case is not yet taken into account by this
         simulator.</8>
       title: Dividend Payment Simulator
     ei:

--- a/mon-entreprise/source/locales/ui-fr.yaml
+++ b/mon-entreprise/source/locales/ui-fr.yaml
@@ -260,10 +260,10 @@ créer:
 d'aides: d'aides
 dividendes:
   warning: <0>Cette simulation est uniquement donnée à titre indicatif. Elle ne
-    concerne que les sociétés françaises à l'impôt sur les sociétés (IS), et ne
-    concerne pas les dirigeants affiliés au régime des travailleurs
-    indépendants.</0><1>Le montant de l'impôt sur les dividendes est calculé en
-    sus de l'impôt sur les autres revenus imposables. </1>
+    concerne que les sociétés françaises à l’impôt sur les sociétés (IS), et ne
+    concerne pas les travailleurs indépendants non salariés.</0><1>Le montant de
+    l'impôt sur les dividendes est calculé en sus de l’impôt sur les autres
+    revenus imposables.</1>
 domiciliation inconnue: domiciliation inconnue
 domiciliée à: domiciliée à
 embauche:
@@ -576,7 +576,6 @@ listeformejuridique:
   page:
     titre: Liste des statuts juridiques pour la création de votre entreprise
 mensuel: mensuel
-
 nextSteps:
   integration-iframe: <0><0></0> Intégrer le module web</0><1>Ajouter ce
     simulateur sur votre site internet en un clic via un script clé en main.</1>
@@ -913,11 +912,11 @@ pages:
         description: Calculez le montant de l'impôt et des cotisations sur les
           dividendes versés par votre entreprise.
         title: Dividendes
-      seo: <0>Les dividendes et distributions</0><1>A la fin de l'exercice d'une
+      seo: <0>Les dividendes et distributions</0><1>À la fin de l'exercice d'une
         société, le résultat de l'exercice précédent peut être conservé en
         réserve (pour de futurs investissements) ou bien être versé en
         dividendes. Du point de vue des bénéficiaires, ce sont des revenus de
-        capitaux mobiliers, soumis à des cotisations et une imposition
+        capitaux mobiliers, soumis à cotisations et à une imposition
         spécifiques.</1><2>Ne sont pris en compte dans ce simulateur que les cas
         de figure du bénéficiaire personne physique et des dividendes décidés
         par la société.</2><3>Comment sont calculés les prélèvements sur les
@@ -927,10 +926,10 @@ pages:
         être choisi. Ce simulateur peut être utilisé pour comparer les deux
         régimes.</4><5>Un acompte du montant de l'impôt (12,8%) est prélevé au
         moment du versement des dividendes, sauf si le bénéficiaire remplit
-        <2>certains critères</2>.</5><6>Cas particulier du dirigeant au régime
-        du travailleur indépendant</6><7> Au régime du travailleur indépendant,
-        la part des dividendes dépassant 10% du capital social sera soumise au
-        cotisations et contributions au même titre que les revenus du
+        <2>certains critères</2>.</5><6>Cas particulier du dirigeant non
+        salarié</6><7>Pour le travailleur indépendant non salarié, la part des
+        dividendes dépassant 10% du capital social sera soumise au cotisations
+        et contributions suivant les mêmes modalités que sa rémunération de
         dirigeant.</7><8>Ce cas de figure n'est pas encore pris en compte par ce
         simulateur.</8>
       title: Simulateur de versement de dividendes

--- a/mon-entreprise/source/pages/Simulateurs/Dividendes.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/Dividendes.tsx
@@ -22,13 +22,12 @@ export default function DividendesSimulation() {
 				<Trans i18nKey="dividendes.warning">
 					<p>
 						Cette simulation est uniquement donnée à titre indicatif. Elle ne
-						concerne que les sociétés françaises à l'impôt sur les sociétés
-						(IS), et ne concerne pas les dirigeants affiliés au régime des
-						travailleurs indépendants.
+						concerne que les sociétés françaises à l’impôt sur les sociétés
+						(IS), et ne concerne pas les travailleurs indépendants non salariés.
 					</p>
 					<p>
 						Le montant de l'impôt sur les dividendes est calculé en sus de
-						l'impôt sur les autres revenus imposables.{' '}
+						l’impôt sur les autres revenus imposables.
 					</p>
 				</Trans>
 			</Warning>

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -794,11 +794,11 @@ export function getSimulatorsData({
 				<Trans i18nKey="pages.simulateurs.dividendes.seo">
 					<h2>Les dividendes et distributions</h2>
 					<p>
-						A la fin de l'exercice d'une société, le résultat de l'exercice
+						À la fin de l'exercice d'une société, le résultat de l'exercice
 						précédent peut être conservé en réserve (pour de futurs
 						investissements) ou bien être versé en dividendes. Du point de vue
 						des bénéficiaires, ce sont des revenus de capitaux mobiliers, soumis
-						à des cotisations et une imposition spécifiques.
+						à cotisations et à une imposition spécifiques.
 					</p>
 					<p>
 						Ne sont pris en compte dans ce simulateur que les cas de figure du
@@ -825,14 +825,12 @@ export function getSimulatorsData({
 						</a>
 						.
 					</p>
-					<h2>
-						Cas particulier du dirigeant au régime du travailleur indépendant
-					</h2>
+					<h2>Cas particulier du dirigeant non salarié</h2>
 					<p>
-						{' '}
-						Au régime du travailleur indépendant, la part des dividendes
+						Pour le travailleur indépendant non salarié, la part des dividendes
 						dépassant 10% du capital social sera soumise au cotisations et
-						contributions au même titre que les revenus du dirigeant.
+						contributions suivant les mêmes modalités que sa rémunération de
+						dirigeant.
 					</p>
 					<p>
 						Ce cas de figure n'est pas encore pris en compte par ce simulateur.


### PR DESCRIPTION
Suite au retour d’Agnès

le point le plus important est qu'il faut bien distinguer les « travailleurs non salariés » des « travailleurs indépendants » (catégorie la plus large qui inclue tout le monde y compris les dirigeants de SAS/SASU)