### PR TITLE
Supprime la dépendance à react-router pour la documentation

### DIFF
--- a/mon-entreprise/dev-server.js
+++ b/mon-entreprise/dev-server.js
@@ -17,7 +17,7 @@ const rewrite = (basename) => ({
 
 app.get('/', function (req, res) {
 	res.send(`<ul style="font-size: 200%;"><li><a href="/mon-entreprise">mon-entreprise [fr]</a></li>
-	<li><a href="/infrance">mycompaninfrance [en]</a></li>
+	<li><a href="/infrance">mycompanyinfrance [en]</a></li>
 	<li><a href="/mon-entreprise/dev/integration-test">intégration du simulateur sur site tiers [iframe fr]</a></li>
 	<li><a href="/publicodes">publicodes</a></li></ul>`)
 })

--- a/mon-entreprise/source/components/RuleLink.tsx
+++ b/mon-entreprise/source/components/RuleLink.tsx
@@ -16,6 +16,7 @@ export default function RuleLink(
 	return (
 		<EngineRuleLink
 			{...props}
+			linkComponent={Link}
 			engine={engine}
 			documentationPath={sitePaths.documentation.index}
 		/>

--- a/mon-entreprise/source/components/conversation/Aide.tsx
+++ b/mon-entreprise/source/components/conversation/Aide.tsx
@@ -1,13 +1,13 @@
 import { explainVariable } from 'Actions/actions'
 import Overlay from 'Components/Overlay'
+import { EngineContext } from 'Components/utils/EngineContext'
 import { Markdown } from 'Components/utils/markdown'
 import { useContext } from 'react'
+import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from 'Reducers/rootReducer'
-import { References } from 'publicodes-react'
-import { Trans } from 'react-i18next'
+import { References } from '../../pages/Documentation'
 import './Aide.css'
-import { EngineContext } from 'Components/utils/EngineContext'
 
 export default function Aide() {
 	const explained = useSelector((state: RootState) => state.explainedVariable)
@@ -36,7 +36,7 @@ export default function Aide() {
 						<h3>
 							<Trans>En savoir plus</Trans>
 						</h3>
-						<References refs={refs} />
+						<References references={refs} />
 					</>
 				)}
 			</div>

--- a/mon-entreprise/source/components/conversation/Question.tsx
+++ b/mon-entreprise/source/components/conversation/Question.tsx
@@ -4,7 +4,6 @@ import Emoji from 'Components/utils/Emoji'
 import { Markdown } from 'Components/utils/markdown'
 import { DottedName } from 'modele-social'
 import { EvaluatedNode, Rule, RuleNode, serializeEvaluation } from 'publicodes'
-import { References } from 'publicodes-react'
 import {
 	createContext,
 	useCallback,
@@ -13,6 +12,7 @@ import {
 	useState,
 } from 'react'
 import { Trans } from 'react-i18next'
+import { References } from '../../pages/Documentation'
 import { Explicable } from './Explicable'
 import { binaryQuestion, InputProps } from './RuleInput'
 
@@ -211,7 +211,7 @@ export const RadioLabel = (props: RadioLabelProps) => (
 						<h3>
 							<Trans>En savoir plus</Trans>
 						</h3>
-						<References refs={props.références} />
+						<References references={props.références} />
 					</>
 				)}
 			</Explicable>

--- a/mon-entreprise/source/pages/Documentation.tsx
+++ b/mon-entreprise/source/pages/Documentation.tsx
@@ -2,20 +2,27 @@ import SearchRules from 'Components/search/SearchRules'
 import { FromBottom } from 'Components/ui/animate'
 import { ThemeColorsProvider } from 'Components/utils/colors'
 import { useEngine } from 'Components/utils/EngineContext'
+import Meta from 'Components/utils/Meta'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
-import { RulePage, getDocumentationSiteMap } from 'publicodes-react'
+import rules, { DottedName } from 'modele-social'
+import { getDocumentationSiteMap, RulePage } from 'publicodes-react'
 import { useCallback, useContext, useMemo } from 'react'
+import { Helmet } from 'react-helmet-async'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { Redirect, useHistory, useLocation, Link } from 'react-router-dom'
+import {
+	Link,
+	Redirect,
+	Route,
+	useHistory,
+	useLocation,
+} from 'react-router-dom'
 import { RootState } from 'Reducers/rootReducer'
+import styled from 'styled-components'
 import { TrackPage } from '../ATInternetTracking'
-import rules, { DottedName } from 'modele-social'
 import RuleLink from '../components/RuleLink'
-import Meta from 'Components/utils/Meta'
-import { Route } from 'react-router-dom'
-import { Helmet } from 'react-helmet-async'
+import { capitalise0 } from '../utils'
 
 export default function MonEntrepriseRulePage() {
 	const currentSimulation = useSelector(
@@ -70,10 +77,10 @@ export default function MonEntrepriseRulePage() {
 							rulePath={match.params.name}
 							engine={engine}
 							documentationPath={documentationPath}
-							referenceImages={referencesImages}
 							renderers={{
 								Head: Helmet,
 								Link,
+								References,
 							}}
 						/>
 					)}
@@ -88,7 +95,7 @@ function BackToSimulation() {
 	const history = useHistory()
 	const handleClick = useCallback(() => {
 		url && history.push(url)
-	}, [])
+	}, [history, url])
 	return (
 		<button
 			className="ui__ simple small push-left button"
@@ -132,15 +139,86 @@ function DocumentationRulesList() {
 }
 
 const referencesImages = {
-	'service-public.fr': 'images/références/marianne.png',
-	'urssaf.fr': 'images/références/Urssaf.svg',
-	'secu-independants.fr': 'images/références/Urssaf.svg',
-	'gouv.fr': 'images/références/marianne.png',
-	'agirc-arrco.fr': 'images/références/agirc-arrco.png',
-	'pole-emploi.fr': 'images/références/pole-emploi.png',
+	'service-public.fr': '/images/références/marianne.png',
+	'legifrance.gouv.fr': '/images/références/marianne.png',
+	'urssaf.fr': '/images/références/Urssaf.svg',
+	'secu-independants.fr': '/images/références/Urssaf.svg',
+	'gouv.fr': '/images/références/marianne.png',
+	'agirc-arrco.fr': '/images/références/agirc-arrco.png',
+	'pole-emploi.fr': '/images/références/pole-emploi.png',
 	'ladocumentationfrançaise.fr':
-		'images/références/ladocumentationfrançaise.png',
-	'senat.fr': 'images/références/senat.png',
-	'ameli.fr': 'images/références/ameli.png',
-	'bpifrance-creation': 'images/références/bpi-création.png',
+		'/images/références/ladocumentationfrançaise.png',
+	'senat.fr': '/images/références/senat.png',
+	'ameli.fr': '/images/références/ameli.png',
+	'bpifrance-creation.fr': '/images/références/bpi-création.png',
 }
+
+type ReferencesProps = React.ComponentProps<
+	NonNullable<React.ComponentProps<typeof RulePage>['renderers']['References']>
+>
+
+export function References({ references }: ReferencesProps) {
+	const cleanDomain = (link: string) =>
+		(link.includes('://') ? link.split('/')[2] : link.split('/')[0]).replace(
+			'www.',
+			''
+		)
+
+	return (
+		<StyledReferences>
+			{Object.entries(references).map(([name, link]) => {
+				const domain = cleanDomain(link)
+				return (
+					<li key={name}>
+						<span className="imageWrapper">
+							{Object.keys(referencesImages).includes(domain) && (
+								<img
+									src={
+										referencesImages[domain as keyof typeof referencesImages]
+									}
+									alt={`logo de ${domain}`}
+								/>
+							)}
+						</span>
+						<a href={link} target="_blank">
+							{capitalise0(name)}
+						</a>
+						<span className="ui__ label">{domain}</span>
+					</li>
+				)
+			})}
+		</StyledReferences>
+	)
+}
+
+const StyledReferences = styled.ul`
+	list-style: none;
+	padding: 0;
+	a {
+		flex: 1;
+		min-width: 45%;
+		text-decoration: underline;
+		margin-right: 1rem;
+	}
+
+	li {
+		margin-bottom: 0.6em;
+		width: 100%;
+		display: flex;
+		align-items: center;
+	}
+	.imageWrapper {
+		width: 4.5rem;
+		height: 3rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin-right: 1rem;
+	}
+	img {
+		max-height: 3rem;
+		vertical-align: sub;
+		max-width: 100%;
+		border-radius: 0.3em;
+	}
+`

--- a/mon-entreprise/source/pages/Documentation.tsx
+++ b/mon-entreprise/source/pages/Documentation.tsx
@@ -4,19 +4,20 @@ import { ThemeColorsProvider } from 'Components/utils/colors'
 import { useEngine } from 'Components/utils/EngineContext'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
-import { RulePageWithContext, getDocumentationSiteMap } from 'publicodes-react'
+import { RulePage, getDocumentationSiteMap } from 'publicodes-react'
 import { useCallback, useContext, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { Redirect, useHistory, useLocation } from 'react-router-dom'
+import { Redirect, useHistory, useLocation, Link } from 'react-router-dom'
 import { RootState } from 'Reducers/rootReducer'
 import { TrackPage } from '../ATInternetTracking'
 import rules, { DottedName } from 'modele-social'
 import RuleLink from '../components/RuleLink'
 import Meta from 'Components/utils/Meta'
 import { Route } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 
-export default function RulePage() {
+export default function MonEntrepriseRulePage() {
 	const currentSimulation = useSelector(
 		(state: RootState) => !!state.simulation?.url
 	)
@@ -64,12 +65,16 @@ export default function RulePage() {
 				<Route
 					path={documentationPath + '/:name+'}
 					render={({ match }) => (
-						<RulePageWithContext
+						<RulePage
 							language={i18n.language as 'fr' | 'en'}
 							rulePath={match.params.name}
 							engine={engine}
 							documentationPath={documentationPath}
 							referenceImages={referencesImages}
+							renderers={{
+								Head: Helmet,
+								Link,
+							}}
 						/>
 					)}
 				/>

--- a/mon-entreprise/source/pages/Documentation.tsx
+++ b/mon-entreprise/source/pages/Documentation.tsx
@@ -4,7 +4,7 @@ import { ThemeColorsProvider } from 'Components/utils/colors'
 import { useEngine } from 'Components/utils/EngineContext'
 import { ScrollToTop } from 'Components/utils/Scroll'
 import { SitePathsContext } from 'Components/utils/SitePathsContext'
-import { Documentation, getDocumentationSiteMap } from 'publicodes-react'
+import { RulePageWithContext, getDocumentationSiteMap } from 'publicodes-react'
 import { useCallback, useContext, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
@@ -14,6 +14,7 @@ import { TrackPage } from '../ATInternetTracking'
 import rules, { DottedName } from 'modele-social'
 import RuleLink from '../components/RuleLink'
 import Meta from 'Components/utils/Meta'
+import { Route } from 'react-router-dom'
 
 export default function RulePage() {
 	const currentSimulation = useSelector(
@@ -60,11 +61,17 @@ export default function RulePage() {
 				>
 					{currentSimulation ? <BackToSimulation /> : <span />}
 				</div>
-				<Documentation
-					language={i18n.language as 'fr' | 'en'}
-					engine={engine}
-					documentationPath={documentationPath}
-					referenceImages={referencesImages}
+				<Route
+					path={documentationPath + '/:name+'}
+					render={({ match }) => (
+						<RulePageWithContext
+							language={i18n.language as 'fr' | 'en'}
+							rulePath={match.params.name}
+							engine={engine}
+							documentationPath={documentationPath}
+							referenceImages={referencesImages}
+						/>
+					)}
 				/>
 			</ThemeColorsProvider>
 		</FromBottom>

--- a/publicodes/core/source/AST/index.ts
+++ b/publicodes/core/source/AST/index.ts
@@ -325,6 +325,7 @@ const traverseProductNode: TraverseFunction<'produit'> = (fn, node) => ({
 const traverseRecalculNode: TraverseFunction<'recalcul'> = (fn, node) => ({
 	...node,
 	explanation: {
+		...node.explanation,
 		amendedSituation: node.explanation.amendedSituation.map(([name, value]) => [
 			fn(name),
 			fn(value),

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -90,6 +90,8 @@ export default class Engine<Name extends string = string> {
 	replacements: Record<string, Array<ReplacementRule>> = {}
 	cache: Cache = emptyCache()
 	options: Options
+	subEngines: Array<Engine<Name>> = []
+	subEngineId: number | undefined
 
 	constructor(
 		rules: string | Record<string, Rule> = {},
@@ -216,6 +218,8 @@ export default class Engine<Name extends string = string> {
 		newEngine.replacements = this.replacements
 		newEngine.parsedSituation = this.parsedSituation
 		newEngine.cache = this.cache
+		newEngine.subEngineId = this.subEngines.length
+		this.subEngines.push(newEngine)
 		return newEngine
 	}
 

--- a/publicodes/core/source/index.ts
+++ b/publicodes/core/source/index.ts
@@ -90,6 +90,16 @@ export default class Engine<Name extends string = string> {
 	replacements: Record<string, Array<ReplacementRule>> = {}
 	cache: Cache = emptyCache()
 	options: Options
+
+	// The subEngines attribute is used to get an outside reference to the
+	// recalcul intermediate calculations. The recalcul mechanism uses
+	// `shallowCopy` to instanciate a new engine, and we want to keep a reference
+	// to it for the documentation.
+	//
+	// TODO: A better implementation would to remove the "runtime" concept of
+	// "subEngines" and instead duplicate all rules names in the scope of the
+	// recalcul as described in
+	// https://github.com/betagouv/publicodes/discussions/92
 	subEngines: Array<Engine<Name>> = []
 	subEngineId: number | undefined
 

--- a/publicodes/core/source/mecanisms/recalcul.ts
+++ b/publicodes/core/source/mecanisms/recalcul.ts
@@ -60,7 +60,7 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 			recalcul: evaluatedNode,
 			amendedSituation,
 			parsedSituation: engine.parsedSituation,
-			subEngineId: engine.subEngineId,
+			subEngineId: engine.subEngineId as number,
 		},
 		missingVariables: evaluatedNode.missingVariables,
 		...('unit' in evaluatedNode && { unit: evaluatedNode.unit }),

--- a/publicodes/core/source/mecanisms/recalcul.ts
+++ b/publicodes/core/source/mecanisms/recalcul.ts
@@ -12,6 +12,7 @@ export type RecalculNode = {
 		recalcul: ASTNode
 		amendedSituation: Array<[ReferenceNode, ASTNode]>
 		parsedSituation?: Engine['parsedSituation']
+		subEngineId: number
 	}
 	nodeKind: 'recalcul'
 }
@@ -59,6 +60,7 @@ const evaluateRecalcul: EvaluationFunction<'recalcul'> = function (node) {
 			recalcul: evaluatedNode,
 			amendedSituation,
 			parsedSituation: engine.parsedSituation,
+			subEngineId: engine.subEngineId,
 		},
 		missingVariables: evaluatedNode.missingVariables,
 		...('unit' in evaluatedNode && { unit: evaluatedNode.unit }),

--- a/publicodes/core/source/replacement.tsx
+++ b/publicodes/core/source/replacement.tsx
@@ -117,6 +117,7 @@ export function inlineReplacements(
 			return {
 				...node,
 				explanation: {
+					...node.explanation,
 					recalcul: transform(node.explanation.recalcul),
 					amendedSituation: node.explanation.amendedSituation.map(
 						([name, value]) => [name, transform(value)]

--- a/publicodes/core/source/ruleUtils.ts
+++ b/publicodes/core/source/ruleUtils.ts
@@ -4,12 +4,12 @@ import { RuleNode } from './rule'
 const splitName = (str: string) => str.split(' . ')
 const joinName = (strs: Array<string>) => strs.join(' . ')
 export const nameLeaf = (name: string) => splitName(name).slice(-1)?.[0]
-export const encodeRuleName = (name) =>
+export const encodeRuleName = (name: string): string =>
 	name
 		?.replace(/\s\.\s/g, '/')
 		.replace(/-/g, '\u2011') // replace with a insecable tiret to differenciate from space
 		.replace(/\s/g, '-')
-export const decodeRuleName = (name) =>
+export const decodeRuleName = (name: string): string =>
 	name
 		.replace(/\//g, ' . ')
 		.replace(/-/g, ' ')

--- a/publicodes/docs/api.md
+++ b/publicodes/docs/api.md
@@ -101,11 +101,10 @@ intermédiaires qui permettent d'aboutir au résultat affiché.
 
 [Voir un exemple sur mon-entreprise.fr](https://mon-entreprise.fr/documentation/imp%C3%B4t/foyer-fiscal/imp%C3%B4t-sur-le-revenu/imp%C3%B4t-brut-par-part)
 
-## `<Documentation />`
+## `<RulePage />`
 
-Composant React permettant d'afficher une documentation explorable d'une base de
-règles publicodes. Se base sur react-router pour créer une arborescence de pages
-correspondant aux espaces de noms existants dans les règles.
+Composant React permettant d'afficher la page de documentation d’une règle
+donnée.
 
 Voir le [bac à sable](https://publi.codes/studio) pour voir le composant en
 action (il est affiché sur l'écran de droite).
@@ -115,8 +114,97 @@ action (il est affiché sur l'écran de droite).
 -   `engine`: l'objet moteur dont on veut afficher les calculs.
 -   `documentationPath` : (`string`) le chemin de base sur lequel la documentation sera
     montée. Par exemple, si c'est `/documentation` l'url de la règle `rémunération . primes` sera `/documentation/rémunération/primes`
+-   `rulePath`: (`string`) le chemin de la règle à afficher
 -   `language`: le language dans lequel afficher la documentation (pour l'instant,
     seuls `fr` et `en` sont supportés).
+-   `renderers`: `{ Head?: React.Component, Link: React.Component }` :
+    les composants React qui seront utilisés dans la page de documentation.
+    -   `Link`: pour afficher les liens. Le composant prend un argument `to`
+    -   `Head`: pour afficher les en-têtes de la page, balises `<meta>`, `<title>`, etc.
+    -   `References`: pour personnaliser l'affichage des références en pied de page. Le composant reçoit l'objet `références` brut définit dans le Yaml.
+
+En général, on voudra afficher la documentation pour l'ensemble des pages et non
+pour une page en particulier. Il faut donc associer le composant `<RulePage />`
+avec le routeur utilisé.
+
+Par exemple pour `react-router` :
+
+```jsx
+import { Route, Link } from 'react-router-dom'
+import { RulePage } from 'publicodes/react-ui'
+
+export function Documentation() {
+    return (
+        <Route
+            path="documentation/:name+"
+            render={({ match }) => (
+                <RulePage
+                    documentationPath="/documentation"
+                    rulePath={match.params.name}
+                    language="fr"
+                    renderers={{ Link }}
+                />
+            )}
+        />
+    )
+}
+```
+
+Autre exemple pour intégrer la documentation dans une application Next.js :
+
+```jsx
+// pages/documentation/[...slug].jsx
+import Head from 'next/head';
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export default Documentation() {
+  const { slug } = useRouter().query;
+  return <RulePage
+    documentationPath="/documentation"
+    rulePath={slug.join('/')}
+    language="fr"
+    renderers={{
+      Head,
+      Link: ({to, children}) => <Link href={to}><a>{children}</a></Link>
+    }}
+  />
+}
+```
+
+Vous pouvez même afficher cette documentation dans une application qui n'est pas développée en React, en “montant” React seulement pour la partie documentation. Par exemple dans une application Svelte :
+
+```html
+<script>
+    import { onMount } from 'svelte'
+    import { goto } from '$app/navigation'
+    import { createElement } from 'react'
+    import { render } from 'react-dom'
+    import { RulePage } from 'publicodes/react-ui'
+
+    let domElement
+
+    // A Link React component that calls SvelteKit `goto` on click
+    function Link({ to, children }) {
+        const onClick = (evt) => {
+            evt.preventDefault()
+            goto(to)
+        }
+        return createElement('a', { onClick }, children)
+    }
+
+    const props = {
+        renderers: { Link },
+        // other props left as an exercice to the reader
+    }
+
+    onMount(() => {
+        render(createElement(RulePage, props), domElement)
+    })
+</script>
+
+<div bind:this="{domElement}" />
+```
 
 ## `<RuleLink />`
 
@@ -127,8 +215,11 @@ Par défaut, le texte affiché est le nom de la règle.
 
 -   `engine`: l'objet moteur dont on veut afficher la règle.
 -   `documentationPath` : (`string`) le chemin de base sur lequel la documentation est
-    montée. Doit correspondre à celui précisé pour le composant `<Documentation />`
+    montée. Doit correspondre à celui précisé pour le composant `<RulePage />`
 -   `dottedName`: le nom de la règle à afficher
+-   `linkComponent`: le composant utilisé pour afficher le lien. C'est la même
+    interface que pour le composant `<RulePage />`. Il prend une unique prop `to`
+    qui est le chemin vers la règle.
 -   `displayIcon`: affiche l'icône de la règle dans le lien (par défaut à `false`)
 -   `children`: un noeud React quelconque. Par défaut, c'est le nom de la règle
     qui est utilisé.

--- a/publicodes/site/components/Studio.tsx
+++ b/publicodes/site/components/Studio.tsx
@@ -1,10 +1,15 @@
 import Engine from 'publicodes'
-import { Documentation, getDocumentationSiteMap } from 'publicodes-react'
+import { RulePage, getDocumentationSiteMap } from 'publicodes-react'
 import { invertObj, last } from 'ramda'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import emoji from 'react-easy-emoji'
 import MonacoEditor from 'react-monaco-editor'
-import { useHistory, useLocation } from 'react-router-dom'
+import {
+	Link,
+	MemoryRouter,
+	Route,
+	useHistory,
+	useLocation,
+} from 'react-router-dom'
 import styled from 'styled-components'
 
 const EXAMPLE_CODE = `
@@ -171,13 +176,22 @@ export const Results = ({ onClickShare, rules }: ResultsProps) => {
 				</div>
 			</div>
 
-			<ErrorBoundary>
-				<Documentation
-					engine={engine}
-					documentationPath={documentationPath}
-					language="fr"
-				/>
-			</ErrorBoundary>
+			<Route
+				path={'/studio/:name+'}
+				render={({ match }) => (
+					<ErrorBoundary>
+						<RulePage
+							language={'fr'}
+							rulePath={match.params.name}
+							engine={engine}
+							documentationPath={documentationPath}
+							renderers={{
+								Link,
+							}}
+						/>
+					</ErrorBoundary>
+				)}
+			/>
 		</>
 	)
 }

--- a/publicodes/ui-react/package.json
+++ b/publicodes/ui-react/package.json
@@ -19,22 +19,16 @@
 		"classnames": "^2.2.6",
 		"focus-trap-react": "^3.1.2",
 		"ramda": "^0.27.0",
-		"react-helmet-async": "^1.1.2",
 		"react-markdown": "^4.3.1",
-		"react-router-hash-link": "^2.4.3",
 		"styled-components": "^5.1.0",
 		"yaml": "^1.9.2"
 	},
 	"peerDependencies": {
 		"publicodes": "1.0.0-beta.16",
-		"react": "^17.0.2",
-		"react-router-dom": "^5.1.1",
-		"react-router-hash-link": "^1.2.2"
+		"react": "^17.0.2"
 	},
 	"devDependencies": {
 		"@types/react": "^17.0.0",
-		"@types/react-router-dom": "^5.1.7",
-		"@types/react-router-hash-link": "^2.4.0",
 		"@types/styled-components": "^5.1.10",
 		"js-yaml": "^4.1.0",
 		"typescript": "^4.3.2"

--- a/publicodes/ui-react/source/Markdown.tsx
+++ b/publicodes/ui-react/source/Markdown.tsx
@@ -1,8 +1,7 @@
 import React, { useContext } from 'react'
 import emoji from 'react-easy-emoji'
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown'
-import { HashLink as Link } from 'react-router-hash-link'
-import { EngineContext } from './contexts'
+import { EngineContext, RenderersContext } from './contexts'
 import { RuleLinkWithContext } from './RuleLink'
 import PublicodesBlock from './PublicodesBlock'
 
@@ -12,8 +11,12 @@ export function LinkRenderer({
 	...otherProps
 }: Omit<React.ComponentProps<'a'>, 'ref'>) {
 	const engine = useContext(EngineContext)
+	const { Link } = useContext(RenderersContext)
 	if (!engine) {
 		throw new Error('an engine should be provided in context')
+	}
+	if (!Link) {
+		throw new Error('a Link renderer must be provided')
 	}
 
 	if (href && href in engine.getParsedRules()) {
@@ -25,11 +28,7 @@ export function LinkRenderer({
 	}
 
 	if (href && !href.startsWith('http')) {
-		return (
-			<Link to={href} {...otherProps}>
-				{children}
-			</Link>
-		)
+		return <Link to={href}>{children}</Link>
 	}
 
 	return (

--- a/publicodes/ui-react/source/RuleLink.tsx
+++ b/publicodes/ui-react/source/RuleLink.tsx
@@ -1,14 +1,10 @@
 import Engine, { utils } from 'publicodes'
 import React, { useContext } from 'react'
-import { Link } from 'react-router-dom'
-import { BasepathContext, EngineContext } from './contexts'
+import { BasepathContext, EngineContext, RenderersContext } from './contexts'
 
 const { encodeRuleName } = utils
 
-type RuleLinkProps<Name extends string> = Omit<
-	React.ComponentProps<Link>,
-	'to'
-> & {
+type RuleLinkProps<Name extends string> = {
 	dottedName: Name
 	engine: Engine<Name>
 	documentationPath: string
@@ -16,6 +12,7 @@ type RuleLinkProps<Name extends string> = Omit<
 	currentEngineId?: number
 	situationName?: string
 	children?: React.ReactNode
+	linkComponent?: React.ComponentType<{ to: string }>
 }
 
 export function RuleLink<Name extends string>({
@@ -25,8 +22,14 @@ export function RuleLink<Name extends string>({
 	documentationPath,
 	displayIcon = false,
 	children,
+	linkComponent,
 	...props
 }: RuleLinkProps<Name>) {
+	const renderers = useContext(RenderersContext)
+	const Link = linkComponent || renderers.Link
+	if (!Link) {
+		throw new Error('You must provide a <Link /> component.')
+	}
 	const rule = engine.getRule(dottedName)
 	const newPath = documentationPath + '/' + encodeRuleName(dottedName)
 
@@ -49,10 +52,10 @@ export function RuleLink<Name extends string>({
 	}
 	return (
 		<Link
+			{...props}
 			to={
 				newPath + (currentEngineId ? `?currentEngineId=${currentEngineId}` : '')
 			}
-			{...props}
 		>
 			{children || rule.title}{' '}
 			{displayIcon && rule.rawNode.icônes && <span>{rule.rawNode.icônes}</span>}

--- a/publicodes/ui-react/source/contexts.tsx
+++ b/publicodes/ui-react/source/contexts.tsx
@@ -1,12 +1,15 @@
 import Engine from 'publicodes'
 import React, { createContext } from 'react'
+import References from './rule/References'
 
 export type SupportedRenderers = {
-	Head?: React.ComponentType
 	Link: React.ComponentType<{ to: string }>
+	Head?: React.ComponentType
+	References?: typeof References
 }
 
 export const BasepathContext = createContext<string>('/documentation')
 export const EngineContext = createContext<Engine<string> | null>(null)
-export const ReferencesImagesContext = createContext<Record<string, string>>({})
-export const RenderersContext = createContext<Partial<SupportedRenderers>>({})
+export const RenderersContext = createContext<Partial<SupportedRenderers>>({
+	References,
+})

--- a/publicodes/ui-react/source/contexts.tsx
+++ b/publicodes/ui-react/source/contexts.tsx
@@ -2,11 +2,5 @@ import Engine from 'publicodes'
 import { createContext } from 'react'
 
 export const BasepathContext = createContext<string>('/documentation')
-export const SituationMetaContext = createContext<{ name: string } | undefined>(
-	undefined
-)
 export const EngineContext = createContext<Engine<string> | null>(null)
-export const RegisterEngineContext = createContext<(engine: Engine) => void>(
-	() => {}
-)
 export const ReferencesImagesContext = createContext<Record<string, string>>({})

--- a/publicodes/ui-react/source/contexts.tsx
+++ b/publicodes/ui-react/source/contexts.tsx
@@ -1,6 +1,12 @@
 import Engine from 'publicodes'
-import { createContext } from 'react'
+import React, { createContext } from 'react'
+
+export type SupportedRenderers = {
+	Head?: React.ComponentType
+	Link: React.ComponentType<{ to: string }>
+}
 
 export const BasepathContext = createContext<string>('/documentation')
 export const EngineContext = createContext<Engine<string> | null>(null)
 export const ReferencesImagesContext = createContext<Record<string, string>>({})
+export const RenderersContext = createContext<Partial<SupportedRenderers>>({})

--- a/publicodes/ui-react/source/index.tsx
+++ b/publicodes/ui-react/source/index.tsx
@@ -1,9 +1,7 @@
 import { utils } from 'publicodes'
-import References from './rule/References'
 export { default as Explanation } from './Explanation'
 export { default as RulePage } from './rule/RulePage'
 export { RuleLink } from './RuleLink'
-export { References }
 
 export function getDocumentationSiteMap({ engine, documentationPath }) {
 	const parsedRules = engine.getParsedRules()

--- a/publicodes/ui-react/source/index.tsx
+++ b/publicodes/ui-react/source/index.tsx
@@ -1,54 +1,15 @@
-import Engine, { utils } from 'publicodes'
-import {
-	BasepathContext,
-	EngineContext,
-	ReferencesImagesContext,
-} from './contexts'
+import { utils } from 'publicodes'
 import References from './rule/References'
-import RulePage from './rule/RulePage'
-const { decodeRuleName, encodeRuleName } = utils
 export { default as Explanation } from './Explanation'
+export { default as RulePage } from './rule/RulePage'
 export { RuleLink } from './RuleLink'
 export { References }
-
-type DocumentationProps = {
-	documentationPath: string
-	rulePath: string
-	engine: Engine
-	language: 'fr' | 'en'
-	referenceImages?: Record<string, string>
-}
-
-export function RulePageWithContext({
-	documentationPath,
-	rulePath,
-	engine,
-	referenceImages = {},
-}: DocumentationProps) {
-	const currentEngineId = new URLSearchParams(window.location.search).get(
-		'currentEngineId'
-	)
-
-	return (
-		<EngineContext.Provider value={engine}>
-			<BasepathContext.Provider value={documentationPath}>
-				<ReferencesImagesContext.Provider value={referenceImages}>
-					<RulePage
-						dottedName={decodeRuleName(rulePath)}
-						subEngineId={currentEngineId}
-						language="fr"
-					/>
-				</ReferencesImagesContext.Provider>
-			</BasepathContext.Provider>
-		</EngineContext.Provider>
-	)
-}
 
 export function getDocumentationSiteMap({ engine, documentationPath }) {
 	const parsedRules = engine.getParsedRules()
 	return Object.fromEntries(
 		Object.keys(parsedRules).map((dottedName) => [
-			documentationPath + '/' + encodeRuleName(dottedName),
+			documentationPath + '/' + utils.encodeRuleName(dottedName),
 			dottedName,
 		])
 	)

--- a/publicodes/ui-react/source/mecanisms/Recalcul.tsx
+++ b/publicodes/ui-react/source/mecanisms/Recalcul.tsx
@@ -1,11 +1,7 @@
 import { EvaluatedNode } from 'publicodes'
 import { RecalculNode } from 'publicodes/dist/types/mecanisms/recalcul'
 import { useContext } from 'react'
-import {
-	EngineContext,
-	RegisterEngineContext,
-	SituationMetaContext,
-} from '../contexts'
+import { EngineContext } from '../contexts'
 import Explanation from '../Explanation'
 import { RuleLinkWithContext } from '../RuleLink'
 import { Mecanism } from './common'
@@ -19,24 +15,16 @@ export default function Recalcul({
 	if (!engine) {
 		throw new Error()
 	}
-	const recalculEngine = engine
-		.shallowCopy()
-		.setSituation(explanation.parsedSituation)
-	useContext(RegisterEngineContext)(recalculEngine)
+	const recalculEngine = explanation.subEngineId
+		? engine.subEngines[explanation.subEngineId]
+		: engine
 	return (
 		<Mecanism name="recalcul" value={nodeValue} unit={unit}>
 			<>
 				{explanation.recalcul && (
 					<EngineContext.Provider value={recalculEngine}>
-						<SituationMetaContext.Provider
-							value={{
-								name: 'Mécanisme recalcul',
-							}}
-						>
-							Recalcul de la valeur de{' '}
-							<Explanation node={explanation.recalcul} /> avec la situation
-							suivante :
-						</SituationMetaContext.Provider>
+						Recalcul de la valeur de <Explanation node={explanation.recalcul} />{' '}
+						avec la situation suivante :
 					</EngineContext.Provider>
 				)}
 				<ul>

--- a/publicodes/ui-react/source/mecanisms/ReplacementRule.tsx
+++ b/publicodes/ui-react/source/mecanisms/ReplacementRule.tsx
@@ -13,17 +13,19 @@ export default function ReplacementMecanism(node: ReplacementRule) {
 			{node.rawNode.dans && (
 				<>
 					dans{' '}
-					{node.whiteListedNames
-						.map((child, i) => <Explanation key={i} node={child} />)
-						.join(', ')}
+					{node.whiteListedNames.map((child, i) => [
+						i > 0 && ', ',
+						<Explanation key={i} node={child} />,
+					])}
 				</>
 			)}
 			{node.rawNode['sauf dans'] && (
 				<>
 					sauf dans{' '}
-					{node.blackListedNames
-						.map((child, i) => <Explanation key={i} node={child} />)
-						.join(', ')}
+					{node.blackListedNames.map((child, i) => [
+						i > 0 && ', ',
+						<Explanation key={i} node={child} />,
+					])}
 				</>
 			)}
 		</span>

--- a/publicodes/ui-react/source/rule/Header.tsx
+++ b/publicodes/ui-react/source/rule/Header.tsx
@@ -30,11 +30,7 @@ export default function RuleHeader({ dottedName }) {
 					))}
 			</ul>{' '}
 			<h1 className="rule-header__title">
-				<RuleLinkWithContext
-					dottedName={dottedName}
-					displayIcon
-					style={{ textDecoration: 'none' }}
-				/>
+				<RuleLinkWithContext dottedName={dottedName} displayIcon />
 			</h1>
 		</StyledHeader>
 	)
@@ -54,5 +50,9 @@ const StyledHeader = styled.header`
 
 	.rule-header__title {
 		margin: 0.6rem 0;
+	}
+
+	.rule-header__title > a {
+		text-decoration: none;
 	}
 `

--- a/publicodes/ui-react/source/rule/Meta.tsx
+++ b/publicodes/ui-react/source/rule/Meta.tsx
@@ -1,4 +1,5 @@
-import { Helmet } from 'react-helmet-async'
+import { useContext } from 'react'
+import { RenderersContext } from '../contexts'
 
 type PropType = {
 	title: string
@@ -6,13 +7,17 @@ type PropType = {
 }
 
 export default function Meta({ title, description }: PropType) {
+	const { Head } = useContext(RenderersContext)
+	if (!Head) {
+		return null
+	}
 	return (
-		<Helmet>
+		<Head>
 			<title>{title}</title>
 			<meta property="og:type" content="article" />
 			<meta property="og:title" content={title} />
 			{description && <meta property="og:description" content={description} />}
 			{description && <meta name="description" content={description} />}
-		</Helmet>
+		</Head>
 	)
 }

--- a/publicodes/ui-react/source/rule/References.tsx
+++ b/publicodes/ui-react/source/rule/References.tsx
@@ -1,97 +1,32 @@
-import { toPairs } from 'ramda'
 import { capitalise0 } from 'publicodes'
-import styled from 'styled-components'
-import { useContext } from 'react'
-import { ReferencesImagesContext } from '../contexts'
-
-const cleanDomain = (link: string) =>
-	(link.includes('://') ? link.split('/')[2] : link.split('/')[0]).replace(
-		'www.',
-		''
-	)
-
-type RefProps = {
-	name: string
-	link: string
-}
-
-// TODO: currently we only allow customizing the list of "references icons", but
-// this migth be limited for more advanced usages. For instance futur.eco uses a
-// different renderer for references:
-// https://futur.eco/documentation/transport/avion/impact We will probably want
-// to allow the user to provide its own components that can be inserted at
-// certains positions in the generated documentation ("hooks").
-function Ref({ name, link }: RefProps) {
-	const references = useContext(ReferencesImagesContext)
-	const refKey = Object.keys(references).find((r) => link.includes(r))
-	const domain = cleanDomain(link)
-	return (
-		<li
-			style={{
-				display: 'flex',
-				alignItems: 'center',
-			}}
-			key={name}
-		>
-			<span className="imageWrapper">
-				{refKey && <img src={references[refKey]} />}
-			</span>
-			<a
-				href={link}
-				target="_blank"
-				style={{
-					marginRight: '1rem',
-				}}
-			>
-				{capitalise0(name)}
-			</a>
-			<span className="ui__ label">{domain}</span>
-		</li>
-	)
-}
 
 type ReferencesProps = {
-	refs: { [name: string]: string }
+	references: Record<string, string>
 }
 
-export default function References({ refs }: ReferencesProps) {
-	const references = toPairs(refs)
+export default function References({ references }: ReferencesProps) {
 	return (
-		<StyledComponent>
-			{references.map(([name, link]) => (
-				<Ref key={link} name={name} link={link} />
+		<ul>
+			{Object.entries(references).map(([name, link]) => (
+				<li
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+					}}
+					key={name}
+				>
+					<a
+						href={link}
+						target="_blank"
+						style={{
+							marginRight: '1rem',
+						}}
+					>
+						{capitalise0(name)}
+					</a>
+					<span className="ui__ label">{link}</span>
+				</li>
 			))}
-		</StyledComponent>
+		</ul>
 	)
 }
-
-const StyledComponent = styled.ul`
-	list-style: none;
-	padding: 0;
-	a {
-		flex: 1;
-		min-width: 45%;
-		text-decoration: underline;
-	}
-
-	li {
-		margin-bottom: 0.6em;
-		width: 100%;
-		display: flex;
-		align-items: center;
-	}
-	.imageWrapper {
-		width: 4.5rem;
-		height: 3rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		margin-right: 1rem;
-	}
-	img {
-		max-height: 3rem;
-		vertical-align: sub;
-		max-width: 100%;
-		border-radius: 0.3em;
-	}
-`

--- a/publicodes/ui-react/source/rule/RulePage.tsx
+++ b/publicodes/ui-react/source/rule/RulePage.tsx
@@ -10,7 +10,6 @@ import { useContext } from 'react'
 import {
 	BasepathContext,
 	EngineContext,
-	ReferencesImagesContext,
 	RenderersContext,
 	SupportedRenderers,
 } from '../contexts'
@@ -18,7 +17,6 @@ import Explanation from '../Explanation'
 import { Markdown } from '../Markdown'
 import { RuleLinkWithContext } from '../RuleLink'
 import RuleHeader from './Header'
-import References from './References'
 import RuleSource from './RuleSource'
 
 type RulePageProps = {
@@ -26,7 +24,6 @@ type RulePageProps = {
 	rulePath: string
 	engine: Engine
 	language: 'fr' | 'en'
-	referenceImages?: Record<string, string>
 	renderers: SupportedRenderers
 }
 
@@ -36,7 +33,6 @@ export default function RulePage({
 	engine,
 	renderers,
 	language,
-	referenceImages = {},
 }: RulePageProps) {
 	const currentEngineId = new URLSearchParams(window.location.search).get(
 		'currentEngineId'
@@ -46,15 +42,13 @@ export default function RulePage({
 		<EngineContext.Provider value={engine}>
 			<BasepathContext.Provider value={documentationPath}>
 				<RenderersContext.Provider value={renderers}>
-					<ReferencesImagesContext.Provider value={referenceImages}>
-						<Rule
-							dottedName={decodeRuleName(rulePath)}
-							subEngineId={
-								currentEngineId ? parseInt(currentEngineId) : undefined
-							}
-							language={language}
-						/>
-					</ReferencesImagesContext.Provider>
+					<Rule
+						dottedName={decodeRuleName(rulePath)}
+						subEngineId={
+							currentEngineId ? parseInt(currentEngineId) : undefined
+						}
+						language={language}
+					/>
 				</RenderersContext.Provider>
 			</BasepathContext.Provider>
 		</EngineContext.Provider>
@@ -69,6 +63,7 @@ type RuleProps = {
 
 export function Rule({ dottedName, language, subEngineId }: RuleProps) {
 	const baseEngine = useContext(EngineContext)
+	const { References } = useContext(RenderersContext)
 	if (!baseEngine) {
 		throw new Error('Engine expected')
 	}
@@ -192,10 +187,10 @@ export function Rule({ dottedName, language, subEngineId }: RuleProps) {
 					</div>
 				</>
 			)}
-			{rule.rawNode.références && (
+			{rule.rawNode.références && References && (
 				<>
-					<h2>Références</h2>
-					<References refs={rule.rawNode.références} />
+					<h3>Références</h3>
+					<References references={rule.rawNode.références} />
 				</>
 			)}
 			{/* <Examples

--- a/publicodes/ui-react/source/rule/RulePage.tsx
+++ b/publicodes/ui-react/source/rule/RulePage.tsx
@@ -74,9 +74,6 @@ export function Rule({ dottedName, language, subEngineId }: RuleProps) {
 	const engine = useSubEngine
 		? baseEngine.subEngines[subEngineId as number]
 		: baseEngine
-	// HACK : currently we only use the subEngine feature in “recalcul”, we should
-	// attach this label to the subEngine
-	const situationName = useSubEngine ? 'recalcul' : null
 
 	if (!(dottedName in engine.getParsedRules())) {
 		return <p>Cette règle est introuvable dans la base</p>
@@ -86,7 +83,7 @@ export function Rule({ dottedName, language, subEngineId }: RuleProps) {
 	const { parent, valeur } = rule.explanation
 	return (
 		<div id="documentationRuleRoot">
-			{situationName && (
+			{useSubEngine && (
 				<div
 					className="ui__ card notice light-bg"
 					style={{
@@ -100,7 +97,7 @@ export function Rule({ dottedName, language, subEngineId }: RuleProps) {
 				>
 					<div>
 						Vous explorez la documentation avec le contexte{' '}
-						<strong className="ui__ label">{situationName}</strong>{' '}
+						<strong className="ui__ label">mécanisme recalcul</strong>
 					</div>
 					<div style={{ flex: 1 }} />
 					<div>

--- a/publicodes/ui-react/source/rule/RulePage.tsx
+++ b/publicodes/ui-react/source/rule/RulePage.tsx
@@ -6,7 +6,6 @@ import Engine, {
 } from 'publicodes'
 import { isEmpty } from 'ramda'
 import { useContext } from 'react'
-import { Link, useLocation } from 'react-router-dom'
 import { EngineContext } from '../contexts'
 import Explanation from '../Explanation'
 import { Markdown } from '../Markdown'
@@ -15,13 +14,19 @@ import RuleHeader from './Header'
 import References from './References'
 import RuleSource from './RuleSource'
 
-export default function Rule({ dottedName, language, situationName }) {
-	const engine = useContext(EngineContext)
-	const { pathname } = useLocation()
-
-	if (!engine) {
+export default function Rule({ dottedName, language, subEngineId }) {
+	const baseEngine = useContext(EngineContext)
+	if (!baseEngine) {
 		throw new Error('Engine expected')
 	}
+
+	const useSubEngine =
+		subEngineId && baseEngine.subEngines.length >= subEngineId
+
+	const engine = useSubEngine ? baseEngine.subEngines[subEngineId] : baseEngine
+	// HACK : currently we only use the subEngine feature in “recalcul”, we should attach this label to the subEngine
+	const situationName = useSubEngine ? 'recalcul' : null
+
 	if (!(dottedName in engine.getParsedRules())) {
 		return <p>Cette règle est introuvable dans la base</p>
 	}
@@ -48,7 +53,9 @@ export default function Rule({ dottedName, language, situationName }) {
 					</div>
 					<div style={{ flex: 1 }} />
 					<div>
-						<Link to={pathname}>Retourner à la version de base</Link>
+						<RuleLinkWithContext dottedName={dottedName} useSubEngine={false}>
+							Retourner à la version de base
+						</RuleLinkWithContext>
 					</div>
 				</div>
 			)}

--- a/publicodes/yarn.lock
+++ b/publicodes/yarn.lock
@@ -983,11 +983,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/history@*":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -1015,31 +1010,6 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
-"@types/react-router-dom@*", "@types/react-router-dom@^5.1.7":
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"
-  integrity sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-    "@types/react-router" "*"
-
-"@types/react-router-hash-link@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@types/react-router-hash-link/-/react-router-hash-link-2.4.0.tgz#8d028a841075f06a60b502eeea251eddf39fd985"
-  integrity sha512-4IB72mosjRshMmoli6ktb0ltzEFBPWgOT/GjZwPEmcehwuacGdsTytIboPfFT9O8hgL1pgdPZMWPfMwCywjO0Q==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-router-dom" "*"
-
-"@types/react-router@*":
-  version "5.1.15"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.15.tgz#c1069e0da4617fd315e381b56b18b89490e14e2a"
-  integrity sha512-z3UlMG/x91SFEVmmvykk9FLTliDvfdIUky4k2rCfXWQ0NKbrP8o9BTCaCTPuYsB8gDkUnUmkcA2vYlm2DR+HAA==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
 
 "@types/react@*", "@types/react@^17.0.0":
   version "17.0.11"
@@ -2812,21 +2782,6 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-fast-compare@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
-  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
-
-react-helmet@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
-  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.7.2"
-    react-fast-compare "^3.1.1"
-    react-side-effect "^2.1.0"
-
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -2845,18 +2800,6 @@ react-markdown@^4.3.1:
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
-
-react-router-hash-link@^2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz#570824d53d6c35ce94d73a46c8e98673a127bf08"
-  integrity sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==
-  dependencies:
-    prop-types "^15.7.2"
-
-react-side-effect@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
-  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 readable-stream@^2.0.1:
   version "2.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3616,27 +3616,10 @@
     "@types/react" "*"
     "@types/react-router" "*"
 
-"@types/react-router-dom@^5.1.7":
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"
-  integrity sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-    "@types/react-router" "*"
-
 "@types/react-router-hash-link@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/react-router-hash-link/-/react-router-hash-link-1.2.1.tgz#fba7dc351cef2985791023018b7a5dbd0653c843"
   integrity sha512-jdzPGE8jFGq7fHUpPaKrJvLW1Yhoe5MQCrmgeesC+eSLseMj3cGCTYMDA4BNWG8JQmwO8NTYt/oT3uBZ77pmBA==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-router-dom" "*"
-
-"@types/react-router-hash-link@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@types/react-router-hash-link/-/react-router-hash-link-2.4.0.tgz#8d028a841075f06a60b502eeea251eddf39fd985"
-  integrity sha512-4IB72mosjRshMmoli6ktb0ltzEFBPWgOT/GjZwPEmcehwuacGdsTytIboPfFT9O8hgL1pgdPZMWPfMwCywjO0Q==
   dependencies:
     "@types/react" "*"
     "@types/react-router-dom" "*"
@@ -13674,13 +13657,6 @@ react-router-hash-link@^1.2.2:
   integrity sha512-LBthLVHdqPeKDVt3+cFRhy15Z7veikOvdKRZRfyBR2vjqIE7rxn+tKLjb6DOmLm6JpoQVemVDnxQ35RVnEHdQA==
   dependencies:
     prop-types "^15.6.0"
-
-react-router-hash-link@^2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz#570824d53d6c35ce94d73a46c8e98673a127bf08"
-  integrity sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==
-  dependencies:
-    prop-types "^15.7.2"
 
 react-router@5.2.0:
   version "5.2.0"


### PR DESCRIPTION
fix https://github.com/betagouv/publicodes/issues/82

Supprime les dépendances à `react-router` et `react-helmet`, afin de permettre d'afficher les pages de documentation dans des applications qui utilisent un autre routeur (Next.js, Gatsby, etc.).

L'utilisateur doit maintenant fournir ses propres composants, par exemple pour `react-router` et `react-helmet` :

```js
import { Route, Link } from "react-router-dom";
import { RulePage } from "publicodes/react-ui";
import { Helmet } from "react-helmet";

export function Documentation() {
  return (
    <Route
      path="documentation/:name+"
      render={({ match }) => (
        <RulePage
          documentationPath="/documentation"
          rulePath={match.params.name}
          language="fr"
          renderers={{ Link, Head: Helmet, References }}
        />
      )}
    />
  );
}

function References({ references }) {
  return (
    <ul>
      {Object.entries(references).map(([name, link]) => 
        <li key={name}><a href={link}>{name}</a>
      )}
    </ul>
  );
}
```

➡ Plus de détails sur : https://1800-publicodes--mon-entreprise.netlify.app/documentation/api#%3Crulepage-/%3E

Modifie significativement l'implémentation pour la navigation dans les recalculs implémentée dans #1526, en intégrant la logique de “sous-moteurs” directement dans Publicodes, et en passant la valeur du sous-moteur actuel dans un paramètre d'URL plutôt que dans le “state” de react-router.

Le concept de `subEngineId` n'est pas incroyable, on pourrait s'en passer en changeant l'implémentation des recalculs, cf. https://github.com/betagouv/publicodes/discussions/92

