### PR TITLE
Ajoute une redirection pour tester le nouveau domaine en .urssaf.fr

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,12 @@ Content-Security-Policy = "default-src 'self' mon-entreprise.fr; style-src 'self
   to = "https://twemoji.maxcdn.com/:splat"
   status = 200
 
+## Temporary redirect requests to the upcoming new domain into the preview deployment
+[[redirects]]
+  from = "https://mon-entreprise.urssaf.fr/*"
+  to = "https://1788--mon-entreprise.netlify.app/:splat"
+  status = 200
+
 ############
 # Redirects following architectural changes
 


### PR DESCRIPTION
@johangirod Sur le côté “iso-prod” l'intérêt de cette approche est de tester le comportement du navigateur à réponse HTTP constante, même s'il faudra re-changer le `toml` lors de la mise en production du nouveau domaine.