### PR TITLE
Temporaire : déploiement Netlify de l'ancienne branche master

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,8 +36,8 @@ jobs:
   build:
     needs: deploy-context
     env:
-      FR_BASE_URL: ${{ needs.deploy-context.outputs.fr_url }}
-      EN_BASE_URL: ${{ needs.deploy-context.outputs.en_url }}
+      FR_BASE_URL: https://mon-entreprise.fr
+      EN_BASE_URL: https://mycompanyinfrance.fr
       PUBLICODES_BASE_URL: ${{ needs.deploy-context.outputs.publicodes_url }}
     runs-on: ubuntu-18.04
     steps:
@@ -62,8 +62,9 @@ jobs:
           ALGOLIA_SEARCH_KEY: ${{secrets.ALGOLIA_SEARCH_KEY}}
           ALGOLIA_INDEX_PREFIX: monentreprise-${{needs.deploy-context.outputs.env-name}}-
       - name: Replace site placeholders in netlify.toml redirection file
-        run: sed -i "s|:SITE_FR|$FR_BASE_URL|g" netlify.toml;
-          sed -i "s|:SITE_EN|$EN_BASE_URL|g" netlify.toml;
+        run:
+          sed -i "s|:SITE_FR|https://1832--mon-entreprise.netlify.app|g" netlify.toml;
+          sed -i "s|:SITE_EN|https://1832-en--mon-entreprise.netlify.app|g" netlify.toml;
           sed -i "s|:SITE_PUBLICODES|$PUBLICODES_BASE_URL|g" netlify.toml
       - name: Update Algolia index
         run: yarn workspace mon-entreprise algolia:update

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize]
   push:
-    branches: [master, demo, next]
+    branches: [master, demo, next, old-version-master]
 
   # We display the release notes in the "news" section of mon-entreprise.fr so
   # we want to re-deploy the site when a new release is published or edited on
@@ -134,8 +134,8 @@ jobs:
           github-deployment-environment: master
           deploy-message: Deploy production branch
         env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_OLD }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_OLD }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
 
   post-comment:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,9 +29,9 @@ jobs:
         run: echo "::set-output name=name::${{ github.event.number || '${GITHUB_REF#refs/*/}' }}"
       - id: base-urls
         run:
-          echo "::set-output name=fr::${{ steps.deploy-env.outputs.name == 'master' && 'https://mon-entreprise.fr' || format('https://{0}--mon-entreprise.netlify.app', steps.deploy-env.outputs.name) }}";
-          echo "::set-output name=en::${{ steps.deploy-env.outputs.name == 'master' && 'https://mycompanyinfrance.fr' || format('https://{0}-en--mon-entreprise.netlify.app', steps.deploy-env.outputs.name) }}";
-          echo "::set-output name=publicodes::${{ steps.deploy-env.outputs.name == 'master' && 'https://publi.codes' || format('https://{0}-publicodes--mon-entreprise.netlify.app', steps.deploy-env.outputs.name) }}";
+          echo "::set-output name=fr::${{ steps.deploy-env.outputs.name == 'old-version-master' && 'https://mon-entreprise.fr' || format('https://{0}--mon-entreprise.netlify.app', steps.deploy-env.outputs.name) }}";
+          echo "::set-output name=en::${{ steps.deploy-env.outputs.name == 'old-version-master' && 'https://mycompanyinfrance.fr' || format('https://{0}-en--mon-entreprise.netlify.app', steps.deploy-env.outputs.name) }}";
+          echo "::set-output name=publicodes::${{ steps.deploy-env.outputs.name == 'old-version-master' && 'https://publi.codes' || format('https://{0}-publicodes--mon-entreprise.netlify.app', steps.deploy-env.outputs.name) }}";
 
   build:
     needs: deploy-context
@@ -84,7 +84,7 @@ jobs:
   deploy-preview:
     needs: [build, deploy-context]
     runs-on: ubuntu-18.04
-    if: needs.deploy-context.outputs.env-name != 'master'
+    if: needs.deploy-context.outputs.env-name != 'old-version-master'
     strategy:
       matrix:
         site: ['', 'en', 'publicodes']
@@ -116,7 +116,7 @@ jobs:
   deploy-prod:
     needs: [build, deploy-context]
     runs-on: ubuntu-18.04
-    if: needs.deploy-context.outputs.env-name == 'master'
+    if: needs.deploy-context.outputs.env-name == 'old-version-master'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -134,8 +134,8 @@ jobs:
           github-deployment-environment: master
           deploy-message: Deploy production branch
         env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN_OLD }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_OLD }}
         timeout-minutes: 1
 
   post-comment:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Build app
         run: yarn workspace mon-entreprise build
         env:
-          AT_INTERNET_SITE_ID: ${{ needs.deploy-context.outputs.env-name == 'master' && 617190 || 617189 }}
+          AT_INTERNET_SITE_ID: 617190
           NODE_ENV: production
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_SEARCH_KEY: ${{secrets.ALGOLIA_SEARCH_KEY}}

--- a/mon-entreprise/source/pages/Simulateurs/metadata.tsx
+++ b/mon-entreprise/source/pages/Simulateurs/metadata.tsx
@@ -597,7 +597,6 @@ export function getSimulatorsData({
 				...pureSimulatorsData['demande-mobilité'].meta,
 			},
 			path: sitePaths.gérer.formulaireMobilité,
-			private: true,
 		},
 		pharmacien: {
 			...pureSimulatorsData['pharmacien'],


### PR DESCRIPTION
Suite au merge de #1788,  il nous faut un déploiement Netlify contenant l'ancienne branche master.

(Dans l'ancienne configuration Netlify gardait avant un déploiement de chaque commit, mais ce n'est plus le cas à ma connaissance depuis que l'on est passé aux Github actions. Il nous faut donc créer un nouveau déploiement de “preview” via une branche dédiée)