### PR TITLE
Supprime l'autofocus sur la page d'accueil

### DIFF
--- a/site/source/components/CompanySearchField.tsx
+++ b/site/source/components/CompanySearchField.tsx
@@ -23,7 +23,6 @@ export function CompanySearchField(props: {
 	onValue?: () => void
 	onClear?: () => void
 	onSubmit?: (établissement: FabriqueSocialEntreprise) => void
-	autoFocus?: boolean
 }) {
 	const { t } = useTranslation()
 

--- a/site/source/pages/Landing/SearchOrCreate.tsx
+++ b/site/source/pages/Landing/SearchOrCreate.tsx
@@ -26,7 +26,7 @@ export default function SearchOrCreate() {
 				<H3 as="h2">
 					<Trans>Rechercher une entreprise</Trans>{' '}
 				</H3>
-				<CompanySearchField autoFocus onSubmit={handleCompanySubmit} />
+				<CompanySearchField onSubmit={handleCompanySubmit} />
 			</Grid>
 			<Grid item lg md={12}>
 				<ButtonContainer>


### PR DESCRIPTION
À l'usage je trouve que le saut du curseur sur le champ de recherche d'entreprise est perturbant. Je pense que ça pose aussi des problèmes d'accessibilité (navigation au clavier, lecteur d'écran), en particulier pour la page d'accueil.
https://developer.mozilla.org/fr/docs/Web/HTML/Global_attributes/autofocus#remarques_sur_laccessibilit%C3%A9_de_la_fonctionnalit%C3%A9

Google met bien de l'autofocus sur sa page d'accueil mais le champ de recherche est vraiment ce que la personne va utiliser à 99%, ce qui n'est pas le cas pour nous.

Qu'en pensez-vous ?
