### PR TITLE
:alien: ajoute une traduction manquante

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,4 +50,4 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-v2
       - run: yarn install --frozen-lockfile
-      - run: yarn run i18n:check
+      - run: yarn workspace site run i18n:check

--- a/package.json
+++ b/package.json
@@ -26,13 +26,7 @@
 		"test:type": "yarn workspaces run tsc --skipLibCheck --noEmit",
 		"clean": "yarn workspaces run clean && rimraf node_modules",
 		"start": "yarn workspace site start",
-		"moso:up": "yarn workspace modele-social run up && yarn workspace site upgrade modele-social",
-		"i18n:check": "yarn run i18n:rules:check && yarn run i18n:ui:check",
-		"i18n:translate": "yarn run i18n:rules:translate && yarn run i18n:ui:translate",
-		"i18n:rules:check": "node site/scripts/i18n/check-missing-rule-translation.js",
-		"i18n:rules:translate": "node site/scripts/i18n/translate-rules.js",
-		"i18n:ui:check": "yarn workspace site run i18next -c scripts/i18n/parser.config.cjs && node site/scripts/i18n/check-missing-UI-translation",
-		"i18n:ui:translate": "rm -rf site/source/locales/static-analysis-fr.json && yarn workspace site run i18next -c scripts/i18n/parser.config.cjs && node site/scripts/i18n/translate-ui.js"
+		"moso:up": "yarn workspace modele-social run up && yarn workspace site upgrade modele-social"
 	},
 	"resolutions": {
 		"@mui/styled-engine": "npm:@mui/styled-engine-sc@latest"

--- a/site/package.json
+++ b/site/package.json
@@ -33,7 +33,14 @@
 		"test:dev-e2e:mycompanyinfrance": "cypress open --browser chromium --config baseUrl=http://localhost:8080/infrance,integrationFolder=cypress/integration/mon-entreprise/english --env language=en",
 		"test:record-http-calls:mon-entreprise": "cypress run --env record_http=",
 		"algolia:update": "node scripts/search/update-data.js",
-		"algolia:clean": "node scripts/search/clean.js"
+		"algolia:clean": "node scripts/search/clean.js",
+		"i18n:check": "yarn run i18n:rules:check && yarn run i18n:ui:check",
+		"i18n:translate": "yarn run i18n:rules:translate && yarn run i18n:ui:translate",
+		"i18n:rules:check": "node scripts/i18n/check-missing-rule-translation.js",
+		"i18n:rules:translate": "node scripts/i18n/translate-rules.js",
+		"i18n:ui:check": "i18next -c scripts/i18n/parser.config.cjs && node scripts/i18n/check-missing-UI-translation",
+		"i18n:ui:translate": "rm -rf source/locales/static-analysis-fr.json && i18next -c scripts/i18n/parser.config.cjs && node scripts/i18n/translate-ui.js"
+
 	},
 	"resolutions": {
 		"@mui/styled-engine": "npm:@mui/styled-engine-sc@latest"

--- a/site/source/components/SchemeComparaison.tsx
+++ b/site/source/components/SchemeComparaison.tsx
@@ -124,7 +124,7 @@ export default function SchemeComparaison({
 				<div className="AS">
 					<div>
 						<Trans i18nKey="comparaisonRégimes.status.AS">
-							SAS, SASU ou SARL avec gérant minoritaire
+							SAS, SASU ou SARL avec gérant minoritaire ou égalitaire
 						</Trans>
 					</div>
 				</div>
@@ -825,5 +825,4 @@ const StyledGrid = styled.div`
 		font-size: 1rem;
 	}
 }
-
 `

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -435,7 +435,7 @@ comparaisonRégimes:
     <1/>
     <2>Start simulation</2>
   status:
-    AS: SAS, SASU or SARL with minority director
+    AS: SAS, SASU or SARL with a minority or equal manager
     auto: Auto-entreprise
     indep:
       "1": EI, EIRL, EURL or SARL with majority director

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -253,7 +253,7 @@ comparaisonRégimes:
   simulationText: <0>Comparer mes revenus, pension de retraite et indemnité
     maladie</0><1></1><2>Lancer la simulation</2>
   status:
-    AS: SAS, SASU ou SARL avec gérant minoritaire
+    AS: SAS, SASU ou SARL avec gérant minoritaire ou égalitaire
     auto: Auto-entreprise
     indep:
       "1": EI, EIRL, EURL ou SARL avec gérant majoritaire


### PR DESCRIPTION
Déplace les scripts de traduction au même niveau que le .env.template qui définie les variables
d'environement qu'ils utilisent.