### PR TITLE
Petite simplification de l'intégration iframe

### DIFF
--- a/site/source/iframe-integration-script.js
+++ b/site/source/iframe-integration-script.js
@@ -1,8 +1,6 @@
 import { hexToHSL } from './hexToHSL'
 
-let script =
-		document.getElementById('script-monentreprise') ||
-		document.getElementById('script-simulateur-embauche'),
+let script = document.currentScript,
 	moduleName = script.dataset.module || 'simulateur-embauche',
 	couleur =
 		script.dataset.couleur &&
@@ -65,8 +63,8 @@ links.innerHTML = `
 	</div>
 `
 
-script.parentNode.insertBefore(iframe, script)
-script.parentNode.insertBefore(links, script)
+script.before(iframe)
+script.before(links)
 
 window.addEventListener('message', function (evt) {
 	if (evt.data.kind === 'resize-height') {

--- a/site/source/pages/integration/Iframe.tsx
+++ b/site/source/pages/integration/Iframe.tsx
@@ -333,12 +333,7 @@ function IntegrationCode({
 			`}
 		>
 			<span>{'<'}</span>
-			<em>
-				script
-				<br />
-				id
-			</em>
-			="script-simulateur-embauche"
+			<em>script</em>
 			<br />
 			<em>data-module</em>="
 			<span>{module}</span>"


### PR DESCRIPTION
L'insertion de l'iframe par le script ne dépend plus d'un identifiant présent dans le DOM. Permet également l'insertion de plusieurs iframes sur la même page, ce qui était impossible avant.

(Inspiré par https://github.com/sveltejs/kit/issues/2221)
