### PR TITLE
:hammer: Correction de l'abattement sur les dividendes

### DIFF
--- a/modele-social/règles/bénéficiaire.yaml
+++ b/modele-social/règles/bénéficiaire.yaml
@@ -94,9 +94,9 @@ bénéficiaire . dividendes . cotisations et contributions:
 
 bénéficiaire . dividendes . imposables:
   somme:
-    - bruts
+    - valeur: bruts
+      abattement: 40%
     - (- cotisations et contributions . CSG déductible)
-  abattement: 40%
   titre: Net imposable des dividendes auxquels s'applique le barème de l'impôt
     sur le revenu
   description: |
@@ -108,6 +108,7 @@ bénéficiaire . dividendes . imposables:
     - les dividendes sont décidés en assemblée générale.
   références:
     Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32963
+    Article 158 du Code général des impôts: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038836594/
 
 # [TODO] [dividendes-indep]
 bénéficiaire . dividendes . cotisations et contributions . assiette forfaitaire:


### PR DESCRIPTION
Je me suis aperçu d'une erreur sur l'abattement appliqué aux dividendes lorsqu'ils sont soumis au barème standard. L'abattement doit se faire sur le montant brut des dividendes, avant déduction de la CSG déductible.

https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043662629

> 2° Les revenus mentionnés au 1° distribués par les sociétés passibles de l'impôt sur les sociétés ou d'un impôt équivalent ou soumises sur option à cet impôt, ayant leur siège dans un Etat de l'Union européenne ou dans un Etat ou territoire ayant conclu avec la France une convention fiscale en vue d'éviter les doubles impositions en matière d'impôt sur les revenus qui contient une clause d'assistance administrative en vue de lutter contre la fraude et l'évasion fiscales et résultant d'une décision régulière des organes compétents, sont réduits, pour le calcul de l'impôt sur le revenu, d'un abattement égal à 40 % de leur montant brut perçu ;

