### PR TITLE
MAJ indemnités journalières

### DIFF
--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -1121,6 +1121,7 @@ dirigeant . indépendant . cotisations et contributions . indemnités journaliè
     versé.
   produit:
     assiette:
+      nom: assiette sociale
       valeur: assiette des cotisations
       plancher: assiette minimale . maladie
       plafond: 5 * plafond sécurité sociale

--- a/modele-social/règles/dirigeant.yaml
+++ b/modele-social/règles/dirigeant.yaml
@@ -1121,7 +1121,7 @@ dirigeant . indépendant . cotisations et contributions . indemnités journaliè
     versé.
   produit:
     assiette:
-      nom: assiette sociale
+      nom: assiette
       valeur: assiette des cotisations
       plancher: assiette minimale . maladie
       plafond: 5 * plafond sécurité sociale

--- a/modele-social/règles/profession-libérale.yaml
+++ b/modele-social/règles/profession-libérale.yaml
@@ -515,12 +515,18 @@ dirigeant . indépendant . PL . CNAVPL . indemnités journalières maladie:
     maladie.
 
     En conséquence une nouvelle cotisation est créée.
-  remplace: cotisations et contributions . indemnités journalières maladie
+  remplace:
+    - cotisations et contributions . indemnités journalières maladie
+    - règle: protection sociale . santé . indemnités journalières . TNS . raam . plafond
+      par: assiette . plafond
   non applicable si: PL . CNBF
   produit:
     assiette:
+      nom: assiette
       valeur: assiette des cotisations
-      plafond: 3 * plafond sécurité sociale
+      plafond:
+        nom: plafond
+        valeur: 3 * plafond sécurité sociale
       plancher: 40% * plafond sécurité sociale
     taux:
       variations:

--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -412,37 +412,40 @@ protection sociale . santé . indemnités journalières:
     site](https://www.coover.fr/prevoyance/tns/arret-maladie-profession-liberale)
   formule:
     somme:
-      - indemnités journalières . auto-entrepreneur
-      - indemnités journalières . indépendant
+      - indemnités journalières . TNS
       - indemnités journalières . salarié
 
-protection sociale . santé . indemnités journalières . auto-entrepreneur:
-  applicable si: dirigeant . auto-entrepreneur
-  unité: €/jour
+protection sociale . santé . indemnités journalières . raam:
+  titre: Revenu d’activité annuel moyen
+  formule: dirigeant . indépendant . cotisations et contributions . indemnités journalières maladie . assiette sociale
 
-  formule:
+protection sociale . santé . indemnités journalières . TNS:
+  unité: €/jour
+  valeur:
     variations:
-      - si: revenu moyen < 3919.20 €/an
-        alors: 0 €/jour
-      - sinon:
-          produit:
-            assiette: revenu moyen
-            taux: 50%
-          plafond: 55.51 €/jour
+      - si: dirigeant . indépendant . PL
+        alors: raam * 1 / 730
+      - si:
+          une de ces conditions:
+            - dirigeant . indépendant
+            - dirigeant . auto-entrepreneur
+        alors:
+          condition:
+            si: raam < 10 % * plafond sécurité sociale temps plein
+            alors: 0 €/jour
+            sinon: raam * 1 / 730
+  plafond:
+    variations:
+      - si: dirigeant . indépendant . PL
+        alors: 3 * plafond sécurité sociale temps plein
+      - si:
+          une de ces conditions:
+            - dirigeant . indépendant
+            - dirigeant . auto-entrepreneur
+        alors: plafond sécurité sociale temps plein
   reférences:
-    - secu-independants.fr: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-artisans-commercants#text_124972
-
-protection sociale . santé . indemnités journalières . indépendant:
-  applicable si: dirigeant . indépendant
-  unité: €/jour
-  formule:
-    produit:
-      assiette: revenu moyen
-      taux: 50%
-    plancher: 21 €/jour
-    plafond: 55.51 €/jour
-  reférences:
-    - secu-independants.fr: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-artisans-commercants#text_124972
+    - ameli.fr: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-profession-liberale#text_170670
+    - ameli.fr: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-artisans-commercants#text_124972
 
 protection sociale . santé . indemnités journalières . salarié:
   unité: €/jour

--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -415,37 +415,31 @@ protection sociale . santé . indemnités journalières:
       - indemnités journalières . TNS
       - indemnités journalières . salarié
 
-protection sociale . santé . indemnités journalières . raam:
-  titre: Revenu d’activité annuel moyen
-  formule: dirigeant . indépendant . cotisations et contributions . indemnités journalières maladie . assiette sociale
-
 protection sociale . santé . indemnités journalières . TNS:
+  applicable si:
+    une de ces conditions:
+      - dirigeant . indépendant
+      - dirigeant . auto-entrepreneur
   unité: €/jour
-  valeur:
-    variations:
-      - si: dirigeant . indépendant . PL
-        alors: raam * 1 / 730
-      - si:
-          une de ces conditions:
-            - dirigeant . indépendant
-            - dirigeant . auto-entrepreneur
-        alors:
-          condition:
-            si: raam < 10 % * plafond sécurité sociale temps plein
-            alors: 0 €/jour
-            sinon: raam * 1 / 730
-  plafond:
-    variations:
-      - si: dirigeant . indépendant . PL
-        alors: 3 * plafond sécurité sociale temps plein
-      - si:
-          une de ces conditions:
-            - dirigeant . indépendant
-            - dirigeant . auto-entrepreneur
-        alors: plafond sécurité sociale temps plein
+  produit:
+    assiette: raam
+    facteur: 1 an / 730 jour
+  avec:
+    raam:
+      titre: Revenu d’activité annuel moyen
+      valeur:
+        variations:
+          - si: dirigeant . indépendant
+            alors: dirigeant . indépendant . cotisations et contributions . indemnités journalières maladie . assiette
+          - si: dirigeant . auto-entrepreneur
+            alors: dirigeant . auto-entrepreneur . impôt . revenu imposable
+      plafond:
+        nom: plafond
+        valeur: plafond sécurité sociale
+
   reférences:
-    - ameli.fr: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-profession-liberale#text_170670
-    - ameli.fr: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-artisans-commercants#text_124972
+    Quelles indemnités journalières pour les artisans/commerçants: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-artisans-commercants#text_124972
+    Quelles indemnités journalières pour les professions libérales: https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-profession-liberale#text_170670
 
 protection sociale . santé . indemnités journalières . salarié:
   unité: €/jour


### PR DESCRIPTION
fix #2169

TODO : 
- [ ] Seuil de revenu en dessous duquel il n'y a pas d'IJ


> Le montant de votre indemnité journalière est égal à 0 € quand votre revenu d'activité annuel moyen (Raam) des 3 années civiles d'activité précédant votre arrêt de travail est inférieur à 10 % de la moyenne des valeurs annuelles du plafond de la Sécurité sociale (Pass) en vigueur au cours des 3 années considérées (4 093,20 € en 2022). En savoir plus sur [le Pass et son montant](https://www.ameli.fr/entreprise/vos-salaries/montants-reference/plafond-securite-sociale) (espace entreprise).
Source : https://www.ameli.fr/assure/remboursements/indemnites-journalieres/arret-maladie-artisans-commercants#text_124972