### PR TITLE
Correction crash page stats

### DIFF
--- a/site/scripts/fetch-stats.js
+++ b/site/scripts/fetch-stats.js
@@ -275,11 +275,6 @@ async function main() {
 	// token isn't valid) we fallback to some fake data -- it would be better to
 	// have a static ressource accessible without authentification.
 	writeInDataDir('stats.json', {
-		visitesJours: [],
-		visitesMois: {
-			pages: [],
-		},
-		satisfaction: [],
 		retoursUtilisateurs: {
 			open: [],
 			closed: [],

--- a/site/source/components/search/SearchRulesAndSimulators.tsx
+++ b/site/source/components/search/SearchRulesAndSimulators.tsx
@@ -2,11 +2,11 @@ import algoliasearch from 'algoliasearch/lite'
 import { Spacing } from '@/design-system/layout'
 import { useEffect } from 'react'
 import { Configure, Index } from 'react-instantsearch-dom'
-import { useHistory } from 'react-router'
 import { RulesInfiniteHits } from './RulesInfiniteHits'
 import { SearchBox } from './SearchBox'
 import { SearchRoot } from './SearchRoot'
 import { SimulatorHits } from './SimulatorHits'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 const ALGOLIA_APP_ID = import.meta.env.VITE_ALGOLIA_APP_ID || ''
 const ALGOLIA_SEARCH_KEY = import.meta.env.VITE_ALGOLIA_SEARCH_KEY || ''
@@ -19,13 +19,8 @@ interface Props {
 }
 
 export default function SearchRulesAndSimulators({ closePopover }: Props) {
-	const history = useHistory()
-
-	useEffect(() => {
-		const unlisten = history.listen(closePopover)
-
-		return unlisten
-	}, [closePopover, history])
+	const location = useLocation()
+	useEffect(() => closePopover(), [location])
 
 	return (
 		<SearchRoot

--- a/site/source/pages/Stats/GlobalStats.tsx
+++ b/site/source/pages/Stats/GlobalStats.tsx
@@ -162,19 +162,21 @@ export default function GlobalStats({ stats }: { stats: StatsStruct }) {
 					}
 				/>
 
-				<Grid item lg={12}>
-					<Indicator
-						subTitle="Satisfaction utilisateurs"
-						main={
-							<>
-								<RetoursAsProgress
-									percentages={currentMonthSatisfaction.percentages}
-								/>{' '}
-							</>
-						}
-						footnote={`${currentMonthSatisfaction.total} avis ce mois ci`}
-					/>
-				</Grid>
+				{currentMonthSatisfaction.total > 0 && (
+					<Grid item lg={12}>
+						<Indicator
+							subTitle="Satisfaction utilisateurs"
+							main={
+								<>
+									<RetoursAsProgress
+										percentages={currentMonthSatisfaction.percentages}
+									/>{' '}
+								</>
+							}
+							footnote={`${currentMonthSatisfaction.total} avis ce mois ci`}
+						/>
+					</Grid>
+				)}
 			</Grid>
 			<Spacing md />
 			<Grid container spacing={2}>

--- a/site/source/pages/Stats/Stats.tsx
+++ b/site/source/pages/Stats/Stats.tsx
@@ -29,7 +29,7 @@ type Period = 'mois' | 'jours'
 type Chapter2 = PageChapter2 | 'PAM'
 
 const chapters2: Chapter2[] = [
-	...new Set(stats.visitesMois.pages.map((p) => p.page_chapter2)),
+	...new Set(stats.visitesMois?.pages.map((p) => p.page_chapter2)),
 	'PAM',
 ]
 
@@ -301,10 +301,18 @@ const Indicators = styled.div`
 `
 
 export default function Stats() {
+	const statsAvailable = stats.visitesMois !== undefined
+
 	return (
 		<>
-			<GlobalStats stats={stats} />
-			<StatsDetail />
+			{statsAvailable ? (
+				<>
+					<StatsDetail />
+					<GlobalStats stats={stats} />
+				</>
+			) : (
+				<p>Statistiques indisponibles.</p>
+			)}
 
 			<DemandeUtilisateurs />
 		</>

--- a/site/source/pages/integration/Iframe.tsx
+++ b/site/source/pages/integration/Iframe.tsx
@@ -14,7 +14,7 @@ import urssafLogo from '@/images/Urssaf.svg'
 import { lazy, Suspense, useContext, useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Route } from 'react-router'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useSearchParams } from 'react-router-dom-v5-compat'
 import styled from 'styled-components'
 import { TrackingContext, TrackPage } from '../../ATInternetTracking'
 import { hexToHSL } from '../../hexToHSL'
@@ -28,7 +28,6 @@ import './iframe.css'
 import cciLogo from './images/cci.png'
 import minTraLogo from './images/min-tra.jpg'
 import poleEmploiLogo from './images/pole-emploi.png'
-import { useSearchParams } from 'react-router-dom-v5-compat'
 
 const LazyColorPicker = lazy(() => import('../Dev/ColorPicker'))
 


### PR DESCRIPTION
Pas réussi à reproduire le problème du crash le 1er du mois, mais a minima cette PR mets un message « Statistiques indisponibles » plutôt que de crasher le site complet.