### PR TITLE
Mises à jour législatives

### DIFF
--- a/api/source/test-e2e/__snapshots__/index.test.ts.snap
+++ b/api/source/test-e2e/__snapshots__/index.test.ts.snap
@@ -24,7 +24,7 @@ exports[`e2e test mon-entreprise api > Test evaluate brut => net + super brut 2`
         "dirigeant . gérant minoritaire": 3691471.7408000007,
         "entreprise . catégorie juridique": 70128347.52400002,
         "situation personnelle . domiciliation fiscale à l'étranger": 60.00589999999998,
-        "établissement . localisation": 138.0059,
+        "établissement . localisation": 138.0089,
       },
       "nodeValue": 2744.60805,
       "traversedVariables": [

--- a/modele-social/règles/artiste-auteur.yaml
+++ b/modele-social/règles/artiste-auteur.yaml
@@ -55,7 +55,7 @@ artiste-auteur . cotisations:
       - formation professionnelle
     arrondi: oui
   références:
-    Urssaf.fr: https://www.urssaf.fr/portail/home/espaces-dedies/artistes-auteurs-diffuseurs-comm/vous-etes-artiste-auteur/taux-des-cotisations.html
+    Urssaf.fr: https://www.urssaf.fr/portail/home/espaces-dedies/artistes-auteurs-diffuseurs-comm/vous-etes-artiste-auteur/vos-cotisations-et-contributions.html
 
 artiste-auteur . cotisations . assiette:
   description: Les revenus des artistes-auteurs peuvent être catégorisés soit comme des traitements et salaires, soit comme des bénéfices non commerciaux. Les cotisations sociales sont payées sur la somme des revenus de ces deux catégories.

--- a/modele-social/règles/conventions-collectives/hôtels-cafés-restaurants.yaml
+++ b/modele-social/règles/conventions-collectives/hôtels-cafés-restaurants.yaml
@@ -30,10 +30,11 @@ contrat salarié . convention collective . HCR . prévoyance conventionnelle:
       - attributs:
           nom: employeur
           remplace: prévoyance . employeur
-        taux: 0.40%
+        taux: 0.90%
       - attributs:
           nom: salarié
           remplace: prévoyance . salarié
-        taux: 0.40%
+        taux: 0.47%
+  note: Taux spécifiques pour les salariés relevant du régime local Alsace-Moselle
   références:
-    Prévoyance HCR: https://www.hcrprevoyance.fr/contenu/documents/modalites_pratiques/HCR%20027_21%20Fiche%20Garantie%20Conventionnelle%20Prevoyance.pdf
+    Prévoyance HCR: https://www.hcrprevoyance.fr/Employeur/faq/employeur

--- a/modele-social/règles/conventions-collectives/hôtels-cafés-restaurants.yaml
+++ b/modele-social/règles/conventions-collectives/hôtels-cafés-restaurants.yaml
@@ -7,7 +7,7 @@ contrat salarié . convention collective . HCR:
 contrat salarié . convention collective . HCR . montant forfaitaire d'un repas:
   remplace:
     règle: rémunération . avantages en nature . nourriture . montant . repas forfaitaire
-  formule: 3.62 €/repas
+  formule: 3.94 €/repas
 
 contrat salarié . convention collective . HCR . majoration heures supplémentaires:
   remplace: temps de travail . heures supplémentaires . majoration

--- a/modele-social/règles/profession-libérale.yaml
+++ b/modele-social/règles/profession-libérale.yaml
@@ -1176,7 +1176,7 @@ dirigeant . indépendant . PL . CARMF . retraite complémentaire:
         produit:
           assiette: assiette des cotisations
           plafond: 3.5 * plafond sécurité sociale temps plein
-          taux: 9.80%
+          taux: 10%
   unité: €/an
   références:
     Site CARMF: http://www.carmf.fr/page.php?page=cdrom/coti/coti-chiffre.htm
@@ -1228,7 +1228,7 @@ dirigeant . indépendant . PL . CARMF . ASV:
     valeur:
       nom: assiette
       somme:
-        - 5325 €/an
+        - 5136 €/an
         - produit:
             assiette: PAMC . revenus activité conventionnée
             plafond: 5 * plafond sécurité sociale temps plein
@@ -1237,7 +1237,7 @@ dirigeant . indépendant . PL . CARMF . ASV:
     abattement: participation CPAM
     arrondi: oui
   références:
-    Taux 2021: http://www.carmf.fr/page.php?page=chiffrescles/stats/2021/taux2021.htm
+    Taux 2022: http://www.carmf.fr/page.php?page=chiffrescles/stats/2022/taux2022.htm
 
 dirigeant . indépendant . PL . CARMF . ASV . participation CPAM:
   titre: Participation CPAM aux allocations supplémentaires de vieillesse

--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -336,7 +336,6 @@ protection sociale . retraite . complémentaire indépendants:
         - si: date >= 01/01/2019
           alors: 1.191 €/an/point
   références:
-    secu-independants.fr: https://www.secu-independants.fr/retraite/calcul-retraite/retraite-complementaire/
     cnav.fr: https://www.lassuranceretraite.fr/portail-info/home/actif/travailleur-independant/calcul-retraite/retraite-complementaire.html
     barèmes cnav.fr: https://www.legislation.cnav.fr/Pages/bareme.aspx?Nom=rci_valeur_point_bar
 

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -1705,7 +1705,7 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
     produit:
       assiette:
         nom: repas forfaitaire
-        valeur: 4.85 €/repas
+        valeur: 5 €/repas
       facteur: repas par mois
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/taux-et-baremes/avantages-en-nature/nourriture.html

--- a/modele-social/règles/salarié.yaml
+++ b/modele-social/règles/salarié.yaml
@@ -3119,11 +3119,16 @@ contrat salarié . maladie . taux employeur . taux réduit:
   formule: cotisations . assiette < plafond de réduction employeur
 
 contrat salarié . maladie . taux salarié:
-  formule:
-    variations:
-      - si: régime alsace moselle
-        alors: 1.5%
-      - sinon: 0%
+  description: |
+    Les salariés exerçant leur activité en Alsace Moselle sont redevable d’une cotisation supplémentaire pour financer le régime local d’assurance maladie.
+  applicable si: régime alsace moselle
+  variations:
+    - si: date >= 01/04/2022
+      alors: 1.3%
+    - sinon: 1.5%
+  références:
+    Urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-maladie---maternit/cas-particuliers.html
+    Régime local: https://regime-local.fr
 
 contrat salarié . maladie . plafond de réduction employeur:
   formule: 2.5 * SMIC

--- a/scripts/check-links-validity.js
+++ b/scripts/check-links-validity.js
@@ -35,9 +35,11 @@ async function processNextQueueItem() {
 async function fetchAndReport(link) {
 	let status = await getHTTPStatus(link)
 
-	// Retry one time in case of timeout
-	if (status === 499) {
-		await sleep(10_000)
+	// Retries in case of timeout
+	let remainingRetries = 3
+	while (status === 499 && remainingRetries > 0) {
+		remainingRetries--
+		await sleep(20_000)
 		status = await getHTTPStatus(link)
 	}
 	report({ status, link })
@@ -58,7 +60,7 @@ async function getHTTPStatus(link) {
 
 async function report({ status, link }) {
 	console.log(status >= 404 ? '❌' : status >= 400 ? '⬛' : '✅', status, link)
-	if (status >= 404) {
+	if (status >= 404 && status !== 499) {
 		detectedErrors.push({ status, link })
 	}
 }

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -3249,6 +3249,12 @@ contrat salarié . maladie . taux employeur . taux réduit:
   titre.en: reduced rate
   titre.fr: taux réduit
 contrat salarié . maladie . taux salarié:
+  description.en: >
+    [automatic] Employees working in Alsace Moselle are liable for an additional
+    contribution to finance the local health insurance scheme.
+  description.fr: >
+    Les salariés exerçant leur activité en Alsace Moselle sont redevable d’une
+    cotisation supplémentaire pour financer le régime local d’assurance maladie.
   titre.en: employee rate
   titre.fr: taux salarié
 contrat salarié . maladie . taux solidarité autonomie:
@@ -8744,13 +8750,9 @@ impôt . taux neutre d'impôt sur le revenu:
   titre.en: neutral income tax rate
   titre.fr: taux neutre d'impôt sur le revenu
 impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique:
-  note.en: '[automatic] This scale was not upgraded in 2021.'
-  note.fr: Ce barème n'a pas été revalorisé en 2021.
   titre.en: Guadeloupe Reunion Island Martinique scale
   titre.fr: barème Guadeloupe Réunion Martinique
 impôt . taux neutre d'impôt sur le revenu . barème Guyane Mayotte:
-  note.en: '[automatic] This scale was not upgraded in 2021.'
-  note.fr: Ce barème n'a pas été revalorisé en 2021.
   titre.en: Guyana Mayotte scale
   titre.fr: barème Guyane Mayotte
 impôt . taux personnalisé:

--- a/site/source/pages/Simulateurs/NextSteps.tsx
+++ b/site/source/pages/Simulateurs/NextSteps.tsx
@@ -83,11 +83,6 @@ const guidesUrssaf = [
 		title: 'Guide Urssaf pour les auto-entrepreneurs',
 	},
 	{
-		url: 'http://www.secu-artistes-auteurs.fr/sites/default/files/pdf/Guide%20pratique%20de%20d%C3%A9but%20d%27activit%C3%A9.pdf',
-		associatedRule: "dirigeant = 'artiste-auteur'",
-		title: 'Guide Urssaf pour les artistes-auteurs',
-	},
-	{
 		url: 'https://www.urssaf.fr/portail/files/live/sites/urssaf/files/documents/Diaporama_TI_statuts_hors_AE.pdf',
 		associatedRule: 'dirigeant',
 		title: 'Guide Urssaf pour les indépendants',

--- a/site/test/regressions/__snapshots__/simulations-professions-libérales.test.ts.snap
+++ b/site/test/regressions/__snapshots__/simulations-professions-libérales.test.ts.snap
@@ -103,20 +103,20 @@ exports[`calculate simulations-professions-libérales > expert-comptable 2`] = `
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
-exports[`calculate simulations-professions-libérales > médecin 1`] = `"[50000,0,14385,35615,5011,30604,0,4,476]"`;
+exports[`calculate simulations-professions-libérales > médecin 1`] = `"[50000,0,14395,35605,5008,30597,0,4,476]"`;
 
-exports[`calculate simulations-professions-libérales > médecin 2`] = `"[50000,0,22059,27941,2710,25231,0,4,378]"`;
+exports[`calculate simulations-professions-libérales > médecin 2`] = `"[50000,0,21965,28035,2738,25297,0,4,379]"`;
 
-exports[`calculate simulations-professions-libérales > médecin 3`] = `"[300000,0,87915,212085,78409,133676,0,4,550]"`;
+exports[`calculate simulations-professions-libérales > médecin 3`] = `"[300000,0,88005,211995,78368,133627,0,4,550]"`;
 
-exports[`calculate simulations-professions-libérales > médecin 4`] = `"[400000,0,108031,291969,117164,174805,0,4,550]"`;
+exports[`calculate simulations-professions-libérales > médecin 4`] = `"[400000,0,108116,291884,117122,174762,0,4,550]"`;
 
 exports[`calculate simulations-professions-libérales > médecin 5`] = `
-"[120000,0,36415,83585,21327,62258,0,4,536]
+"[120000,0,36559,83441,21268,62173,0,4,536]
 Notifications affichées : entreprise . chiffre d'affaires . franchise de TVA . dépassement"
 `;
 
-exports[`calculate simulations-professions-libérales > médecin 6`] = `"[50000,0,14385,35615,5011,30604,0,4,476]"`;
+exports[`calculate simulations-professions-libérales > médecin 6`] = `"[50000,0,14395,35605,5008,30597,0,4,476]"`;
 
 exports[`calculate simulations-professions-libérales > sage-femme 1`] = `"[50000,0,12479,37521,5584,31937,0,4,501]"`;
 

--- a/site/test/regressions/__snapshots__/simulations-salarié.test.ts.snap
+++ b/site/test/regressions/__snapshots__/simulations-salarié.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1
 
 exports[`calculate simulations-salarié > CCN HCR 1`] = `
-"[3470,0,2500,2005,1894]
+"[3500,0,2500,2013,1902]
 Notifications affichées : contrat salarié . convention collective . contrôle décharge"
 `;
 
@@ -102,7 +102,7 @@ exports[`calculate simulations-salarié > avantages 1`] = `"[2543,0,2000,1540,14
 
 exports[`calculate simulations-salarié > avantages 2`] = `"[2553,0,2000,1539,1489]"`;
 
-exports[`calculate simulations-salarié > avantages 3`] = `"[2462,0,2000,1549,1514]"`;
+exports[`calculate simulations-salarié > avantages 3`] = `"[2465,0,2000,1549,1514]"`;
 
 exports[`calculate simulations-salarié > cadre 1`] = `"[4116,0,3000,2348,2160]"`;
 
@@ -196,12 +196,12 @@ exports[`calculate simulations-salarié > heures supplémentaires et complément
 exports[`calculate simulations-salarié > heures supplémentaires et complémentaires 3`] = `"[2524,0,2000,1636,1601]"`;
 
 exports[`calculate simulations-salarié > heures supplémentaires et complémentaires 4`] = `
-"[2451,0,2000,1632,1598]
+"[2470,0,2000,1639,1605]
 Notifications affichées : contrat salarié . convention collective . contrôle décharge"
 `;
 
 exports[`calculate simulations-salarié > heures supplémentaires et complémentaires 5`] = `
-"[2419,0,2000,1606,1572]
+"[2437,0,2000,1613,1579]
 Notifications affichées : contrat salarié . convention collective . contrôle décharge"
 `;
 

--- a/site/test/useSearchParamsSimulationSharing.test.js
+++ b/site/test/useSearchParamsSimulationSharing.test.js
@@ -48,7 +48,7 @@ rule without:
 				).toString()
 			)
 		})
-		it.skip('builds search params with object', () => {
+		it('builds search params with object', () => {
 			expect(
 				getSearchParamsFromSituation(
 					engine,


### PR DESCRIPTION
- Baisse du taux maladie Alsace-Moselle au 1er avril; fixes #1958 
- Mise à jour barèmes CARMF 2022, fixes #1927
- Mise à jour avantage forfaitaire repas 2022, fixes #1960
- Supprime les liens morts, closes #2165
