### PR TITLE
Améliore a11y de Progress, Questions et SimulationGoals

### DIFF
--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -27,14 +27,14 @@ export function Questions({
 }: {
 	customEndMessages?: ConversationProps['customEndMessages']
 }) {
-	const progress = useSimulationProgress()
+	const { numberCurrentStep, numberSteps } = useSimulationProgress()
 
 	return (
 		<>
-			<Progress progress={progress} />
+			<Progress progress={numberCurrentStep} maxValue={numberSteps} />
 			<QuestionsContainer>
 				<div className="print-hidden">
-					{progress < 1 && (
+					{numberCurrentStep < numberSteps && (
 						<Notice>
 							<Trans i18nKey="simulateurs.précision.défaut">
 								Améliorez votre simulation en répondant aux questions :

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -106,6 +106,7 @@ export function SimulationGoal({
 										  }
 										: undefined
 								}
+								aria-label={engine.getRule(dottedName)?.title || ''}
 								aria-labelledby={`${dottedName}-label`}
 								aria-describedby={`${dottedName}-description`}
 								displayedUnit="€"

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -60,6 +60,7 @@ export function SimulationGoal({
 	if (small && !editable && evaluation.nodeValue === undefined) {
 		return null
 	}
+	console.log(dottedName)
 
 	return (
 		<Appear unless={!appear || initialRender}>
@@ -106,7 +107,6 @@ export function SimulationGoal({
 										  }
 										: undefined
 								}
-								aria-label={engine.getRule(dottedName)?.title || ''}
 								aria-labelledby={`${dottedName}-label`}
 								aria-describedby={`${dottedName}-description`}
 								displayedUnit="€"

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -74,7 +74,7 @@ export function SimulationGoal({
 				>
 					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
 						<StyledGoalHeader>
-							<RuleLink id={dottedName} dottedName={dottedName}>
+							<RuleLink id={`${dottedName}-label`} dottedName={dottedName}>
 								{label}
 							</RuleLink>
 

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -74,7 +74,9 @@ export function SimulationGoal({
 				>
 					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
 						<StyledGoalHeader>
-							<RuleLink dottedName={dottedName}>{label}</RuleLink>
+							<RuleLink id={dottedName} dottedName={dottedName}>
+								{label}
+							</RuleLink>
 
 							<SmallBody
 								css={`

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -40,7 +40,7 @@ export function SimulationGoals({
 				publique={publique}
 				role="group"
 				aria-labelledby="simulator-legend"
-				aria-live="assertive"
+				aria-live="polite"
 			>
 				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
 					<div className="sr-only" id="simulator-legend">

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -40,6 +40,7 @@ export function SimulationGoals({
 				publique={publique}
 				role="group"
 				aria-labelledby="simulator-legend"
+				aria-live="polite"
 			>
 				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
 					<div className="sr-only" id="simulator-legend">

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -40,7 +40,7 @@ export function SimulationGoals({
 				publique={publique}
 				role="group"
 				aria-labelledby="simulator-legend"
-				aria-live="polite"
+				aria-live="assertive"
 			>
 				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
 					<div className="sr-only" id="simulator-legend">

--- a/site/source/components/conversation/TextInput.tsx
+++ b/site/source/components/conversation/TextInput.tsx
@@ -10,6 +10,7 @@ export default function TextInput({
 	description,
 	title,
 	missing,
+	autoFocus,
 }: InputProps & { value: Evaluation<string> }) {
 	const debouncedOnChange = useCallback(debounce(1000, onChange), [])
 
@@ -17,6 +18,8 @@ export default function TextInput({
 		<TextField
 			type="text"
 			label={title}
+			// eslint-disable-next-line jsx-a11y/no-autofocus
+			autoFocus={autoFocus}
 			onChange={(value) => {
 				debouncedOnChange(`'${value}'`)
 			}}

--- a/site/source/components/ui/Progress.tsx
+++ b/site/source/components/ui/Progress.tsx
@@ -3,28 +3,40 @@ import styled from 'styled-components'
 
 type ProgressProps = {
 	progress: number
+	minValue?: number
+	maxValue?: number
+	step?: number
 }
 
-export default function Progress({ progress }: ProgressProps) {
+export default function Progress({
+	progress,
+	minValue = 0,
+	maxValue = 1,
+	step = 1,
+}: ProgressProps) {
 	const propsBar = {
 		showValueLabel: false,
-		label: 'Précision de votre simulation',
-		minValue: 0,
-		maxValue: 1,
+		label: 'Précisions concernant votre simulation',
+		minValue,
+		maxValue,
 		value: progress,
 	}
+
+	const a11yPrefixLabel = `Étape ${progress + step} sur ${String(maxValue)}, `
 
 	const { progressBarProps, labelProps } = useProgressBar(propsBar)
 
 	return (
-		<>
-			<span {...labelProps} className="sr-only">
-				{propsBar.label}
+		<div aria-live="polite">
+			<span {...labelProps} className="sr-only" aria-hidden>
+				{`${a11yPrefixLabel} ${propsBar.label}`}
 			</span>
 			<ProgressContainer {...progressBarProps}>
-				<ProgressBar style={{ width: `${progress * 100}%` }} />
+				<ProgressBar
+					style={{ width: `${(progress * 100) / (maxValue || 1)}%` }}
+				/>
 			</ProgressContainer>
-		</>
+		</div>
 	)
 }
 

--- a/site/source/components/ui/Progress.tsx
+++ b/site/source/components/ui/Progress.tsx
@@ -16,7 +16,7 @@ export default function Progress({
 }: ProgressProps) {
 	const propsBar = {
 		showValueLabel: false,
-		label: 'Précisions concernant votre simulation',
+		label: 'Questions répondues pour améliorer la précision de la simulation',
 		minValue,
 		maxValue,
 		value: progress,

--- a/site/source/components/utils/useNextQuestion.tsx
+++ b/site/source/components/utils/useNextQuestion.tsx
@@ -173,9 +173,18 @@ export const useNextQuestions = function (): Array<DottedName> {
 	return nextQuestions
 }
 
-export function useSimulationProgress(): number {
+export function useSimulationProgress(): {
+	progressRatio: number
+	numberCurrentStep: number
+	numberSteps: number
+} {
 	const numberQuestionAnswered = useSelector(answeredQuestionsSelector).length
 	const numberQuestionLeft = useNextQuestions().length
 
-	return numberQuestionAnswered / (numberQuestionAnswered + numberQuestionLeft)
+	return {
+		progressRatio:
+			numberQuestionAnswered / (numberQuestionAnswered + numberQuestionLeft),
+		numberCurrentStep: numberQuestionAnswered,
+		numberSteps: numberQuestionAnswered + numberQuestionLeft,
+	}
 }

--- a/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
@@ -16,7 +16,7 @@ import { SimpleField } from '../_components/Fields'
 import { DéclarationRevenu } from './_components/DéclarationRevenu'
 
 export default function Cotisations() {
-	const progress = useSimulationProgress()
+	const { numberCurrentStep, numberSteps } = useSimulationProgress()
 	const engine = useEngine()
 
 	return (
@@ -100,7 +100,10 @@ export default function Cotisations() {
 													margin: 0 -1.5rem;
 												`}
 											>
-												<Progress progress={progress} />
+												<Progress
+													progress={numberCurrentStep}
+													maxValue={numberSteps}
+												/>
 											</div>
 										</div>
 									</Message>

--- a/site/source/pages/gerer/declaration-revenu-independants/index.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/index.tsx
@@ -88,7 +88,7 @@ function useSteps() {
 	const step1Progress = useProgress(Step1Objectifs)
 	const step2Progress = useProgress(Step2Objectifs)
 	const step3Progress = useProgress(useStep3Objectifs())
-	const step4Progress = useSimulationProgress()
+	const { progressRatio: step4Progress } = useSimulationProgress()
 	const casExcluStep1 = useEngine().evaluate('DRI . cas exclus ')
 		.nodeValue as boolean
 	const casExcluStep2 = useEngine().evaluate('DRI . imposition cas exclus')


### PR DESCRIPTION
* Améliore l'accessibilité de `Progress` et `Questions` : modification du label pour indiquer aux utilisateurs utilisant un lecteur d'écran l'étape en cours, combiné avec un aria-live pour annoncer le passage à l'étape suivante
* Améliore l'accessibilité de `SimulationGoals` : ajout d'un aria-live rend automatique la lecture des changements de valeurs
* refacto de `useSimulationProgress` afin de pouvoir utiliser les valeurs réelles d'étapes (actuelle et total), requis pour afficher un label pertinent dans `Progress`.

J'ai rajouté l'attribut `autoFocus` précédemment retiré, le temps de créer un nouveau système dans une prochaine PR : on va conserver le comportement de focus du premier champ à chaque changement d'étape du formulaire mais on va le faire à la mano afin de pouvoir éviter de le faire dans certaines circonstances.

J'ai fait pas mal de tests avec mon lecteur d'écran pour être certain d'avoir une bonne expérience utilisateur, je suis plutôt satisfait du résultat !