### PR TITLE
Ajout fonctionnalité d'activation d'autofocus manuel

### DIFF
--- a/site/source/actions/actions.ts
+++ b/site/source/actions/actions.ts
@@ -20,6 +20,7 @@ export type Action =
 			| typeof deleteFromSituation
 			| typeof updateUnit
 			| typeof batchUpdateSituation
+			| typeof updateShouldFocusField
 	  >
 	| CompanyCreationAction
 	| CompanyStatusAction
@@ -102,4 +103,10 @@ export const explainVariable = (variableName: DottedName | null = null) =>
 	({
 		type: 'EXPLAIN_VARIABLE',
 		variableName,
+	} as const)
+
+export const updateShouldFocusField = (shouldFocusField: boolean) =>
+	({
+		type: 'UPDATE_SHOULDFOCUSFIELD',
+		shouldFocusField,
 	} as const)

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -43,7 +43,7 @@ export function SimulationGoals({
 				aria-live="polite"
 			>
 				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
-					<div className="sr-only" id="simulator-legend">
+					<div className="sr-only" aria-hidden="true" id="simulator-legend">
 						{legend}
 					</div>
 					{children}

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -103,6 +103,7 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 				{choice.children.map((node) => (
 					<Fragment key={node.dottedName}>
 						<RadioCard
+							// eslint-disable-next-line jsx-a11y/no-autofocus
 							autoFocus={
 								defaultValue ===
 								`'${relativeDottedName(props.dottedName, node.dottedName)}'`
@@ -130,6 +131,7 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 			aria-labelledby={props['aria-labelledby'] || undefined}
 		>
 			<RadioChoice
+				// eslint-disable-next-line jsx-a11y/no-autofocus
 				autoFocus={props.autoFocus ? defaultValue : undefined}
 				choice={choice}
 				rootDottedName={props.dottedName}
@@ -181,6 +183,7 @@ function RadioChoice<Names extends string = DottedName>({
 					) : (
 						<span>
 							<Radio
+								// eslint-disable-next-line jsx-a11y/no-autofocus
 								autoFocus={
 									autoFocus ===
 									`'${relativeDottedName(rootDottedName, node.dottedName)}'`
@@ -239,9 +242,11 @@ export function OuiNonInput<Names extends string = DottedName>(
 			value={currentSelection ?? undefined}
 			aria-labelledby={props['aria-labelledby'] || undefined}
 		>
+			{/* eslint-disable-next-line jsx-a11y/no-autofocus */}
 			<Radio value="oui" autoFocus={props.autoFocus && defaultValue === 'oui'}>
 				<Trans>Oui</Trans>
 			</Radio>
+			{/* eslint-disable-next-line jsx-a11y/no-autofocus */}
 			<Radio value="non" autoFocus={props.autoFocus && defaultValue === 'non'}>
 				<Trans>Non</Trans>
 			</Radio>

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -76,6 +76,7 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 	if (type === 'select') {
 		return (
 			<Select
+				aria-labelledby={props['aria-labelledby'] || undefined}
 				label={props.title}
 				onSelectionChange={handleChange}
 				defaultSelectedKey={defaultValue}
@@ -97,6 +98,7 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 			<RadioCardGroup
 				onChange={handleChange}
 				value={currentSelection ?? undefined}
+				aria-labelledby={props['aria-labelledby'] || undefined}
 			>
 				{choice.children.map((node) => (
 					<Fragment key={node.dottedName}>
@@ -122,7 +124,11 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 	const Component = type === 'radio' ? RadioGroup : ToggleGroup
 
 	return (
-		<Component onChange={handleChange} value={currentSelection ?? undefined}>
+		<Component
+			onChange={handleChange}
+			value={currentSelection ?? undefined}
+			aria-labelledby={props['aria-labelledby'] || undefined}
+		>
 			<RadioChoice
 				autoFocus={props.autoFocus ? defaultValue : undefined}
 				choice={choice}
@@ -228,7 +234,11 @@ export function OuiNonInput<Names extends string = DottedName>(
 	const { handleChange, defaultValue, currentSelection } = useSelection(props)
 
 	return (
-		<ToggleGroup onChange={handleChange} value={currentSelection ?? undefined}>
+		<ToggleGroup
+			onChange={handleChange}
+			value={currentSelection ?? undefined}
+			aria-labelledby={props['aria-labelledby'] || undefined}
+		>
 			<Radio value="oui" autoFocus={props.autoFocus && defaultValue === 'oui'}>
 				<Trans>Oui</Trans>
 			</Radio>

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -53,13 +53,16 @@ export default function Conversation({
 			dispatch(goToQuestion(currentQuestion))
 		}
 	}, [dispatch, currentQuestion])
+
 	const goToNextQuestion = () => {
 		dispatch(updateShouldFocusField(true))
 		dispatch(stepAction(currentQuestion))
 	}
 
-	const goToPrevious = () =>
+	const goToPrevious = () => {
+		dispatch(updateShouldFocusField(true))
 		dispatch(goToQuestion(previousAnswers.slice(-1)[0]))
+	}
 
 	const onChange = (value: PublicodesExpression | undefined) => {
 		dispatch(

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -99,7 +99,7 @@ export default function Conversation({
 									align-items: baseline;
 								`}
 							>
-								<H3>
+								<H3 id="questionHeader">
 									{evaluateQuestion(engine, engine.getRule(currentQuestion))}
 									<ExplicableRule light dottedName={currentQuestion} />
 								</H3>
@@ -110,6 +110,7 @@ export default function Conversation({
 									onChange={onChange}
 									key={currentQuestion}
 									onSubmit={goToNextQuestion}
+									aria-labelledby="questionHeader"
 								/>
 							</fieldset>
 							<Spacing md />

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -127,7 +127,7 @@ export default function Conversation({
 								{previousAnswers.length > 0 && (
 									<Grid item xs={6} sm="auto">
 										<Button light onPress={goToPrevious} size="XS">
-											← <Trans>Précédent</Trans>
+											<span aria-hidden="true">←</span> <Trans>Précédent</Trans>
 										</Button>
 									</Grid>
 								)}
@@ -142,7 +142,7 @@ export default function Conversation({
 										) : (
 											<Trans>Passer</Trans>
 										)}{' '}
-										→
+										<span aria-hidden="true">→</span>
 									</Button>
 								</Grid>
 								<Grid

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -2,6 +2,7 @@ import {
 	deleteFromSituation,
 	goToQuestion,
 	stepAction,
+	updateShouldFocusField,
 	updateSituation,
 } from '@/actions/actions'
 import RuleInput from '@/components/conversation/RuleInput'
@@ -52,7 +53,10 @@ export default function Conversation({
 			dispatch(goToQuestion(currentQuestion))
 		}
 	}, [dispatch, currentQuestion])
-	const goToNextQuestion = () => dispatch(stepAction(currentQuestion))
+	const goToNextQuestion = () => {
+		dispatch(updateShouldFocusField(true))
+		dispatch(stepAction(currentQuestion))
+	}
 
 	const goToPrevious = () =>
 		dispatch(goToQuestion(previousAnswers.slice(-1)[0]))
@@ -104,7 +108,6 @@ export default function Conversation({
 								<RuleInput
 									dottedName={currentQuestion}
 									onChange={onChange}
-									autoFocus
 									key={currentQuestion}
 									onSubmit={goToNextQuestion}
 								/>

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -52,7 +52,7 @@ export type InputProps<Name extends string = string> = Omit<
 	Props<Name>,
 	'onChange'
 > &
-	Pick<RuleNode, 'title' | 'suggestions'> & {
+	Pick<RuleNode, 'suggestions'> & {
 		question: RuleNode['rawNode']['question']
 		description: RuleNode['rawNode']['description']
 		value: EvaluatedNode['nodeValue']
@@ -102,7 +102,6 @@ export default function RuleInput<Names extends string = DottedName>({
 			(!showDefaultDateValue && dottedName in evaluation.missingVariables),
 		onChange: (value: PublicodesExpression | undefined) =>
 			onChange(value, dottedName),
-		title: rule.title,
 		onSubmit,
 		description: rule.rawNode.description,
 		id: props.id ?? dottedName,
@@ -172,6 +171,7 @@ export default function RuleInput<Names extends string = DottedName>({
 	return (
 		<NumberInput
 			{...commonProps}
+			title=""
 			unit={evaluation.unit}
 			value={value as Evaluation<number>}
 		/>

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -1,6 +1,8 @@
+import { updateShouldFocusField } from '@/actions/actions'
 import NumberInput from '@/components/conversation/NumberInput'
 import SelectCommune from '@/components/conversation/select/SelectCommune'
 import { EngineContext } from '@/components/utils/EngineContext'
+import { shouldFocusFieldSelector } from '@/selectors/simulationSelectors'
 import { getMeta } from '@/utils'
 import { DottedName } from 'modele-social'
 import Engine, {
@@ -11,7 +13,8 @@ import Engine, {
 	reduceAST,
 	RuleNode,
 } from 'publicodes'
-import React, { useContext } from 'react'
+import React, { useContext, useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { Choice, MultipleAnswerInput, OuiNonInput } from './ChoicesInput'
 import DateInput from './DateInput'
 import ParagrapheInput from './ParagrapheInput'
@@ -80,6 +83,17 @@ export default function RuleInput<Names extends string = DottedName>({
 	const rule = engine.getRule(dottedName)
 	const evaluation = engine.evaluate({ valeur: dottedName, ...modifiers })
 	const value = evaluation.nodeValue
+	const dispatch = useDispatch()
+	const shouldFocusField = useSelector(shouldFocusFieldSelector)
+
+	useEffect(() => {
+		setTimeout(() => {
+			dispatch(updateShouldFocusField(false))
+		}, 0)
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
+
 	const commonProps: InputProps<Names> = {
 		dottedName,
 		value,
@@ -94,9 +108,11 @@ export default function RuleInput<Names extends string = DottedName>({
 		id: props.id ?? dottedName,
 		question: rule.rawNode.question,
 		suggestions: showSuggestions ? rule.suggestions : {},
+		autoFocus: shouldFocusField,
 		...props,
 	}
 	const meta = getMeta<{ affichage?: string }>(rule.rawNode, {})
+
 	if (getVariant(engine.getRule(dottedName))) {
 		const type =
 			inputType ??

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -90,7 +90,6 @@ export default function RuleInput<Names extends string = DottedName>({
 		setTimeout(() => {
 			dispatch(updateShouldFocusField(false))
 		}, 0)
-
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
 

--- a/site/source/components/ui/AnimatedTargetValue.tsx
+++ b/site/source/components/ui/AnimatedTargetValue.tsx
@@ -53,6 +53,7 @@ export default function AnimatedTargetValue({
 	return (
 		<div
 			className="print-hidden"
+			aria-hidden="true"
 			key={difference}
 			css={`
 				position: relative;

--- a/site/source/reducers/rootReducer.ts
+++ b/site/source/reducers/rootReducer.ts
@@ -73,6 +73,7 @@ export type Simulation = {
 	targetUnit: string
 	foldedSteps: Array<DottedName>
 	unfoldedStep?: DottedName | null
+	shouldFocusField: boolean
 }
 
 function simulation(
@@ -90,6 +91,7 @@ function simulation(
 			targetUnit: config['unité par défaut'] || '€/mois',
 			foldedSteps: [],
 			unfoldedStep: null,
+			shouldFocusField: false,
 		}
 	}
 
@@ -169,6 +171,12 @@ function simulation(
 			return {
 				...state,
 				targetUnit: action.targetUnit,
+			}
+
+		case 'UPDATE_SHOULDFOCUSFIELD':
+			return {
+				...state,
+				shouldFocusField: action.shouldFocusField,
 			}
 	}
 

--- a/site/source/selectors/simulationSelectors.ts
+++ b/site/source/selectors/simulationSelectors.ts
@@ -47,3 +47,6 @@ export const currentQuestionSelector = (state: RootState) =>
 
 export const answeredQuestionsSelector = (state: RootState) =>
 	state.simulation?.foldedSteps ?? []
+
+export const shouldFocusFieldSelector = (state: RootState) =>
+	state.simulation?.shouldFocusField ?? false


### PR DESCRIPTION
Les recommandations d'accessibilité sont de retirer tous les `autoFocus`. Néanmoins ils peuvent rester pertinents dans le cas d'un formulaire à étape, mais il est nécessaire d'avoir la main sur l'activation de cet autoFocus pour pouvoir de désactiver quand cela est nécessaire. Par exemple dans la simulation salaire, au clic sur le bouton "SMIC" il ne faut pas que le focus soit déplacer automatiquement sur le formulaire de questions additionnelles, sous peine de perdre l'utilisateur faisant usage d'un lecteur d'écran.

* Stockage de la valeur `shouldFocusField` dans le store redux simulation (et ajout de la logique redux qui va bien)