### PR TITLE
Cache les symboles flèche unicode

### DIFF
--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -194,7 +194,7 @@ export default function Conversation({
 							{previousAnswers.length > 0 && (
 								<Grid item xs={6} sm="auto">
 									<Button light onPress={goToPrevious} size="XS">
-										← <Trans>Précédent</Trans>
+										<span aria-hidden="true">←</span> <Trans>Précédent</Trans>
 									</Button>
 								</Grid>
 							)}

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -491,7 +491,7 @@ entreprise:
           business plan.
         cta: Simuler les cotisations
         title: Simulateur de cotisations indépendant
-  retour: ← Choisir un autre statut
+  retour: Choisir un autre statut
   tâches:
     adresse:
       description: <0><0>L'adresse</0> est l'espace physique où votre entreprise sera

--- a/site/source/pages/Creer/AfterRegistration.tsx
+++ b/site/source/pages/Creer/AfterRegistration.tsx
@@ -23,7 +23,7 @@ export default function AfterRegistration() {
 			<ScrollToTop />
 			<TrackPage name="apres_la_creation" />
 			<Link to={absoluteSitePaths.créer.index}>
-				← <Trans>Retour à la création</Trans>
+				<span aria-hidden="true">←</span> <Trans>Retour à la création</Trans>
 			</Link>
 			<H1>
 				<Trans i18nKey="après.titre">Après la création</Trans>

--- a/site/source/pages/Creer/CreationChecklist.tsx
+++ b/site/source/pages/Creer/CreationChecklist.tsx
@@ -87,7 +87,8 @@ export default function CreateCompany({ statut }: CreateCompanyProps) {
 					dispatch(resetCompanyStatusChoice())
 				}}
 			>
-				<Trans i18nKey="entreprise.retour">← Choisir un autre statut</Trans>
+				<span aria-hidden="true">←</span>
+				<Trans i18nKey="entreprise.retour">Choisir un autre statut</Trans>
 			</Link>
 
 			<H1>{titre}</H1>

--- a/site/source/pages/Creer/GuideStatut/index.tsx
+++ b/site/source/pages/Creer/GuideStatut/index.tsx
@@ -57,7 +57,7 @@ export default function Créer() {
 	return (
 		<>
 			<Link to={absoluteSitePaths.créer.index}>
-				← <Trans>Retour</Trans>
+				<span aria-hidden="true">←</span> <Trans>Retour</Trans>
 			</Link>
 			<TrackChapter chapter2="guide">
 				<H1>

--- a/site/source/pages/Documentation.tsx
+++ b/site/source/pages/Documentation.tsx
@@ -137,7 +137,8 @@ function BackToSimulation() {
 		<>
 			<Spacing lg />
 			<Button to={url}>
-				← <Trans i18nKey="back">Retourner à la simulation</Trans>
+				<span aria-hidden="true">←</span>{' '}
+				<Trans i18nKey="back">Retourner à la simulation</Trans>
 			</Button>
 		</>
 	)

--- a/site/source/pages/Nouveautes/Nouveautes.tsx
+++ b/site/source/pages/Nouveautes/Nouveautes.tsx
@@ -21,11 +21,6 @@ import { TrackPage } from '../../ATInternetTracking'
 
 const slugify = (name: string) => name.toLowerCase().replace(' ', '-')
 
-type ReleasesData = Array<{
-	name: string
-	description: string
-}>
-
 type Releases = typeof import('@/public/data/releases.json')
 
 export default function Nouveautés() {
@@ -119,14 +114,16 @@ export default function Nouveautés() {
 							<NavigationButtons>
 								{selectedRelease + 1 < data.length ? (
 									<Link to={getPath(selectedRelease + 1)}>
-										← {data[selectedRelease + 1].name}
+										<span aria-hidden="true">←</span>{' '}
+										{data[selectedRelease + 1].name}
 									</Link>
 								) : (
 									<span /> // For spacing
 								)}
 								{selectedRelease > 0 && (
 									<Link to={getPath(selectedRelease - 1)}>
-										{data[selectedRelease - 1].name} →
+										{data[selectedRelease - 1].name}{' '}
+										<span aria-hidden="true">→</span>
 									</Link>
 								)}
 							</NavigationButtons>

--- a/site/source/pages/Simulateurs/EconomieCollaborative/index.tsx
+++ b/site/source/pages/Simulateurs/EconomieCollaborative/index.tsx
@@ -27,7 +27,7 @@ export default function ÉconomieCollaborative() {
 					end
 					style={({ isActive }) => (isActive ? { display: 'none' } : {})}
 				>
-					←{' '}
+					<span aria-hidden="true">←</span>{' '}
 					<Trans i18nKey="économieCollaborative.retourAccueil">
 						Retour à la selection d'activités
 					</Trans>

--- a/site/source/pages/Simulateurs/ExonerationCovid/ExonérationCovid.tsx
+++ b/site/source/pages/Simulateurs/ExonerationCovid/ExonérationCovid.tsx
@@ -129,7 +129,7 @@ export const ExonérationCovid = () => {
 							}}
 							onClick={setStep1Situation}
 						>
-							← <Trans>Précédent</Trans>
+							<span aria-hidden="true">←</span> <Trans>Précédent</Trans>
 						</Button>
 					) : (
 						<Button
@@ -153,7 +153,7 @@ export const ExonérationCovid = () => {
 								  }
 								: null)}
 						>
-							<Trans>Suivant</Trans> →
+							<Trans>Suivant</Trans> <span aria-hidden="true">→</span>
 						</Button>
 					)}
 				</Grid>

--- a/site/source/pages/Simulateurs/index.tsx
+++ b/site/source/pages/Simulateurs/index.tsx
@@ -55,11 +55,13 @@ export default function Simulateurs() {
 			{pathname !== absoluteSitePaths.simulateurs.index &&
 				(lastState?.fromGérer ? (
 					<Link to={absoluteSitePaths.gérer.index}>
-						← <Trans>Retour à mon activité</Trans>
+						<span aria-hidden="true">←</span>{' '}
+						<Trans>Retour à mon activité</Trans>
 					</Link>
 				) : lastState?.fromCréer ? (
 					<Link to={absoluteSitePaths.créer.index}>
-						← <Trans>Retour à la création</Trans>
+						<span aria-hidden="true">←</span>{' '}
+						<Trans>Retour à la création</Trans>
 					</Link>
 				) : !isEmbedded ? (
 					(!lastState || lastState?.fromSimulateurs) && (
@@ -67,7 +69,8 @@ export default function Simulateurs() {
 							className="print-hidden"
 							to={absoluteSitePaths.simulateurs.index}
 						>
-							← <Trans>Voir les autres simulateurs</Trans>
+							<span aria-hidden="true">←</span>{' '}
+							<Trans>Voir les autres simulateurs</Trans>
 						</Link>
 					)
 				) : null)}

--- a/site/source/pages/gerer/index.tsx
+++ b/site/source/pages/gerer/index.tsx
@@ -66,7 +66,7 @@ export default function Gérer() {
 
 	const back = (
 		<Link to={absoluteSitePaths.gérer.index}>
-			← <Trans>Retour à mon activité</Trans>
+			<span aria-hidden="true">←</span> <Trans>Retour à mon activité</Trans>
 		</Link>
 	)
 

--- a/site/source/pages/integration/index.tsx
+++ b/site/source/pages/integration/index.tsx
@@ -34,7 +34,8 @@ export default function Integration() {
 					className="ui__ simple small push-left button"
 					to={absoluteSitePaths.développeur.index}
 				>
-					← <Trans>Outils pour les développeurs</Trans> <Emoji emoji="👨‍💻" />
+					<span aria-hidden="true">←</span>{' '}
+					<Trans>Outils pour les développeurs</Trans> <Emoji emoji="👨‍💻" />
 				</Link>
 			)}
 			{openJobOffer && (


### PR DESCRIPTION
On ajoute un `aria-hidden` sur les symboles unicode "flèche" afin d'éviter qu'ils soient lus par les lecteurs d'écran.