### PR TITLE
Nouveautés : corrige la date de la dernière release

### DIFF
--- a/site/scripts/fetch-releases.js
+++ b/site/scripts/fetch-releases.js
@@ -75,7 +75,7 @@ async function fetchReleases() {
 				},
 			},
 		} = await response.json()
-		return releases.filter(Boolean).reverse()
+		return releases.filter(Boolean)
 	} catch (e) {
 		return fakeData
 	}


### PR DESCRIPTION
L'API Github semble avoir changé ! En local, avec le `reverse()`, je récupère l'objet avec le label "Février 2021" en premier dans l'array de résultat et c'est donc lui qui est affiché. En le retirant on récupère bien Septembre 2022. ✌️ 