### PR TITLE
🐛 Fix les iframe avec une mauvaise couleur

### DIFF
--- a/site/source/components/utils/colors.tsx
+++ b/site/source/components/utils/colors.tsx
@@ -1,5 +1,5 @@
 import { hexToHSL } from '@/hexToHSL'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { ThemeProvider } from 'styled-components'
 import { useIsEmbedded } from './embeddedContext'
 
@@ -25,9 +25,18 @@ const PALETTE = {
 const rawIframeColor = new URLSearchParams(
 	import.meta.env.SSR ? '' : document.location.search.substring(1)
 ).get('couleur')
-const IFRAME_COLOR = rawIframeColor
-	? (JSON.parse(decodeURIComponent(rawIframeColor)) as number[])
-	: DEFAULT_COLOR_HS
+
+let iframeColor = DEFAULT_COLOR_HS
+try {
+	if (rawIframeColor) {
+		iframeColor = JSON.parse(decodeURIComponent(rawIframeColor)) as number[]
+	}
+} catch (error) {
+	// eslint-disable-next-line no-console
+	console.error(error)
+}
+const IFRAME_COLOR = iframeColor
+
 // Note that the iframeColor is first set in the index.html file, but without
 // the full palette generation that happen here. This is to prevent a UI
 // flash, cf. #1786.

--- a/site/source/template.html
+++ b/site/source/template.html
@@ -196,11 +196,20 @@
 		<script>
 			// Set the main colors from the provided customization in the URL We do it
 			// before loading the whole JS bundle to avoid a UI flash. cf. #1786
+			const parseColor = (rawColor) => {
+				try {
+					return JSON.parse(decodeURIComponent(rawColor))
+				} catch (error) {
+					console.error(error)
+
+					return null
+				}
+			}
 			try {
 				let rawColor = new URLSearchParams(
 					document.location.search.substring(1)
 				).get('couleur')
-				let iframeColor = rawColor && JSON.parse(decodeURIComponent(rawColor))
+				let iframeColor = rawColor && parseColor(rawColor)
 				;[
 					document.documentElement,
 					...document.querySelectorAll('[data-js-color-element]'),


### PR DESCRIPTION
fix #2344 

exemple [avant](https://mon-entreprise.urssaf.fr/iframes/simulateur-embauche?couleur=%230c3b65&iframe=&integratorUrl=http%3A%2F%2Fwww.aides-entreprises.fr%2Foutil%2Fsimulateur-du-cout-d-embauche)/[après](https://2345--mon-entreprise.netlify.app/iframes/simulateur-embauche?couleur=%230c3b65&iframe=&integratorUrl=http%3A%2F%2Fwww.aides-entreprises.fr%2Foutil%2Fsimulateur-du-cout-d-embauche)