### PR TITLE
Crisp : Modifie l'envoyeur du message 

### DIFF
--- a/server/source/functions/send-crisp-message.ts
+++ b/server/source/functions/send-crisp-message.ts
@@ -82,8 +82,8 @@ export const sendCrispMessage = async (body: BodyType) => {
 				type: 'text',
 				content: message,
 				subject,
-				from: 'operator',
-				origin: 'chat',
+				from: 'user',
+				origin: 'email',
 			}
 		)
 	} catch (e) {


### PR DESCRIPTION
Corrige un problème : le message étant préalablement envoyé avec le paramètre `from` avec une valeur de `operator` c'était notre plugin Crisp qui envoyait les messages dans la conversation, ce qui faisait que le message était par défaut "lu" et que l'on ne recevait pas de notification par email. @wiinxt @johangirod je vous ping juste pour vous tenir au courant, je merge directement.