### PR TITLE
Répare le test E2E Navigation

### DIFF
--- a/site/cypress/integration/mon-entreprise/english/navigation.ts
+++ b/site/cypress/integration/mon-entreprise/english/navigation.ts
@@ -66,7 +66,10 @@ describe(`Navigation to income simulator using company name (${
 			fr ? 'Rechercher votre entreprise ' : 'Search for your company '
 		).click()
 
-		cy.get('input').first().type('menoz').wait('@search')
+		cy.get('input[data-test-id="company-search-input"]')
+			.first()
+			.type('menoz')
+			.wait('@search')
 
 		cy.contains('834364291').click()
 		cy.contains('SAS(U)').click()
@@ -86,7 +89,9 @@ describe(`Navigation to income simulator using company name (${
 			fr ? 'Rechercher votre entreprise ' : 'Search for your company '
 		).click()
 
-		cy.get('input').first().type('johan girod').wait('@search')
+		cy.get('input[data-test-id="company-search-input"]')
+			.type('johan girod')
+			.wait('@search')
 
 		cy.contains('834825614').click()
 		// ask if auto-entrepreneur


### PR DESCRIPTION
Test cassé depuis l'ajout du darkMode, nous ciblons désormais le `data-test-id` de l'input ce qui est plus robuste.