### PR TITLE
Passe l'email du formulaire Crisp en non requis

### DIFF
--- a/server/source/utils.ts
+++ b/server/source/utils.ts
@@ -47,7 +47,7 @@ export const validateCrispBody = (body: BodyType): BodyType => {
 		isStringAndNotEmpty(subject) &&
 		subject.length <= SHORT_MAX_LENGTH &&
 		isStringAndNotEmpty(message) &&
-		isStringAndNotEmpty(email) &&
+		typeof email === 'string' &&
 		email.length <= SHORT_MAX_LENGTH
 	) {
 		return body


### PR DESCRIPTION
Incohérence entre la fonction de validation des données du formulaire de feedback côté serveur et les règles de validation côté front : email requis côté backend et non requis côté front > erreur si l'on ne renseigne pas d'adresse email.