### PR TITLE
🐛 Corrige la fonction hexToHSL

### DIFF
--- a/site/source/hexToHSL.test.ts
+++ b/site/source/hexToHSL.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { hexToHSL } from './hexToHSL'
+
+describe('hexToHSL conversion', function () {
+	it('convert value', () => {
+		expect(hexToHSL('#CC0000')).to.be.deep.equal([360, 100, 40])
+	})
+})

--- a/site/source/hexToHSL.ts
+++ b/site/source/hexToHSL.ts
@@ -19,7 +19,7 @@ export function hexToHSL(hex: string): [number, number, number] {
 		s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
 		switch (max) {
 			case r:
-				h = (g - b) / d + (g < b ? 6 : 0)
+				h = (g - b) / d + (g <= b ? 6 : 0)
 				break
 			case g:
 				h = (b - r) / d + 2


### PR DESCRIPTION
J'ai copié collé cette fonction sur un autre projet, et rencontré un bug pour certaines valeurs RGB (quand G et B sont nulles). Comme je suis un bon citoyen je vous partage le correctif.