### PR TITLE
Corrige le fonctionnement des liens d'évitement sur les pages autres que Landing

### DIFF
--- a/site/source/App.tsx
+++ b/site/source/App.tsx
@@ -20,7 +20,9 @@ import { useIsEmbedded } from '@/components/utils/useIsEmbedded'
 import { Container, Spacing } from '@/design-system/layout'
 
 import Provider, { ProviderProps } from './Provider'
+import { Link } from './design-system/typography/link'
 import { useAxeCoreAnalysis } from './hooks/useAxeCoreAnalysis'
+import { useGetFullPath } from './hooks/useGetFullPath'
 import { useSaveAndRestoreScrollPosition } from './hooks/useSaveAndRestoreScrollPosition'
 import Accessibilité from './pages/Accessibilité'
 import Budget from './pages/Budget/Budget'
@@ -97,6 +99,8 @@ const App = () => {
 
 	const { t } = useTranslation()
 
+	const fullPath = useGetFullPath()
+
 	useSaveAndRestoreScrollPosition()
 	const isEmbedded = useIsEmbedded()
 	if (!import.meta.env.PROD && import.meta.env.VITE_AXE_CORE_ENABLED) {
@@ -109,9 +113,9 @@ const App = () => {
 	return (
 		<StyledLayout isEmbedded={isEmbedded}>
 			{!isEmbedded && <Header />}
-			<a href="#footer" className="skip-link print-hidden">
+			<Link href={`${fullPath}#footer`} className="skip-link print-hidden">
 				{t('Passer le contenu')}
-			</a>
+			</Link>
 			<main role="main" id="main">
 				<Container>
 					<ErrorBoundary fallback={CatchOffline}>

--- a/site/source/App.tsx
+++ b/site/source/App.tsx
@@ -20,9 +20,8 @@ import { useIsEmbedded } from '@/components/utils/useIsEmbedded'
 import { Container, Spacing } from '@/design-system/layout'
 
 import Provider, { ProviderProps } from './Provider'
-import { Link } from './design-system/typography/link'
 import { useAxeCoreAnalysis } from './hooks/useAxeCoreAnalysis'
-import { useGetFullPath } from './hooks/useGetFullPath'
+import { useGetFullURL } from './hooks/useGetFullURL'
 import { useSaveAndRestoreScrollPosition } from './hooks/useSaveAndRestoreScrollPosition'
 import Accessibilité from './pages/Accessibilité'
 import Budget from './pages/Budget/Budget'
@@ -99,7 +98,7 @@ const App = () => {
 
 	const { t } = useTranslation()
 
-	const fullPath = useGetFullPath()
+	const fullURL = useGetFullURL()
 
 	useSaveAndRestoreScrollPosition()
 	const isEmbedded = useIsEmbedded()
@@ -113,9 +112,9 @@ const App = () => {
 	return (
 		<StyledLayout isEmbedded={isEmbedded}>
 			{!isEmbedded && <Header />}
-			<Link href={`${fullPath}#footer`} className="skip-link print-hidden">
+			<a href={`${fullURL}#footer`} className="skip-link print-hidden">
 				{t('Passer le contenu')}
-			</Link>
+			</a>
 			<main role="main" id="main">
 				<Container>
 					<ErrorBoundary fallback={CatchOffline}>

--- a/site/source/App.tsx
+++ b/site/source/App.tsx
@@ -20,9 +20,7 @@ import { useIsEmbedded } from '@/components/utils/useIsEmbedded'
 import { Container, Spacing } from '@/design-system/layout'
 
 import Provider, { ProviderProps } from './Provider'
-import { Link } from './design-system/typography/link'
 import { useAxeCoreAnalysis } from './hooks/useAxeCoreAnalysis'
-import { useGetFullPath } from './hooks/useGetFullPath'
 import { useSaveAndRestoreScrollPosition } from './hooks/useSaveAndRestoreScrollPosition'
 import Accessibilité from './pages/Accessibilité'
 import Budget from './pages/Budget/Budget'
@@ -99,8 +97,6 @@ const App = () => {
 
 	const { t } = useTranslation()
 
-	const fullPath = useGetFullPath()
-
 	useSaveAndRestoreScrollPosition()
 	const isEmbedded = useIsEmbedded()
 	if (!import.meta.env.PROD && import.meta.env.VITE_AXE_CORE_ENABLED) {
@@ -113,9 +109,9 @@ const App = () => {
 	return (
 		<StyledLayout isEmbedded={isEmbedded}>
 			{!isEmbedded && <Header />}
-			<Link href={`${fullPath}#footer`} className="skip-link print-hidden">
+			<a href="#footer" className="skip-link print-hidden">
 				{t('Passer le contenu')}
-			</Link>
+			</a>
 			<main role="main" id="main">
 				<Container>
 					<ErrorBoundary fallback={CatchOffline}>

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -9,15 +9,12 @@ import { Container } from '@/design-system/layout'
 import { Switch } from '@/design-system/switch'
 import { Link } from '@/design-system/typography/link'
 import { useDarkMode } from '@/hooks/useDarkMode'
-import { useGetFullPath } from '@/hooks/useGetFullPath'
 import { useSitePaths } from '@/sitePaths'
 
 import NewsBanner from './NewsBanner'
 
 export default function Header() {
 	const { absoluteSitePaths } = useSitePaths()
-
-	const fullPath = useGetFullPath()
 
 	const {
 		i18n: { language },
@@ -28,9 +25,9 @@ export default function Header() {
 
 	return (
 		<header role="banner">
-			<Link href={`${fullPath}#main`} className="skip-link">
+			<a href="#main" className="skip-link print-hidden">
 				{t('Aller au contenu')}
-			</Link>
+			</a>
 			<Container>
 				<StyledHeader role="banner">
 					<Link

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -9,12 +9,15 @@ import { Container } from '@/design-system/layout'
 import { Switch } from '@/design-system/switch'
 import { Link } from '@/design-system/typography/link'
 import { useDarkMode } from '@/hooks/useDarkMode'
+import { useGetFullPath } from '@/hooks/useGetFullPath'
 import { useSitePaths } from '@/sitePaths'
 
 import NewsBanner from './NewsBanner'
 
 export default function Header() {
 	const { absoluteSitePaths } = useSitePaths()
+
+	const fullPath = useGetFullPath()
 
 	const {
 		i18n: { language },
@@ -25,9 +28,9 @@ export default function Header() {
 
 	return (
 		<header role="banner">
-			<a href="#main" className="skip-link print-hidden">
+			<Link href={`${fullPath}#main`} className="skip-link">
 				{t('Aller au contenu')}
-			</a>
+			</Link>
 			<Container>
 				<StyledHeader role="banner">
 					<Link

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -9,7 +9,7 @@ import { Container } from '@/design-system/layout'
 import { Switch } from '@/design-system/switch'
 import { Link } from '@/design-system/typography/link'
 import { useDarkMode } from '@/hooks/useDarkMode'
-import { useGetFullPath } from '@/hooks/useGetFullPath'
+import { useGetFullURL } from '@/hooks/useGetFullURL'
 import { useSitePaths } from '@/sitePaths'
 
 import NewsBanner from './NewsBanner'
@@ -17,7 +17,7 @@ import NewsBanner from './NewsBanner'
 export default function Header() {
 	const { absoluteSitePaths } = useSitePaths()
 
-	const fullPath = useGetFullPath()
+	const fullURL = useGetFullURL()
 
 	const {
 		i18n: { language },
@@ -28,9 +28,9 @@ export default function Header() {
 
 	return (
 		<header role="banner">
-			<Link href={`${fullPath}#main`} className="skip-link">
+			<a href={`${fullURL}#main`} className="skip-link print-hidden">
 				{t('Aller au contenu')}
-			</Link>
+			</a>
 			<Container>
 				<StyledHeader role="banner">
 					<Link

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -146,6 +146,8 @@ button:enabled {
 	margin: 0;
 	overflow: hidden;
 	clip: rect(1px, 1px, 1px, 1px);
+	font-family: 'Roboto';
+	font-weight: bold;
 }
 
 .skip-link:focus {

--- a/site/source/hooks/useGetFullPath.ts
+++ b/site/source/hooks/useGetFullPath.ts
@@ -14,7 +14,7 @@ export const useGetFullPath = () => {
 
 	const language = i18n.language as 'fr' | 'en'
 
-	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : '/'
+	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : ''
 
 	return `${pathStart}${pathname !== '/' ? pathname : ''}`
 }

--- a/site/source/hooks/useGetFullPath.ts
+++ b/site/source/hooks/useGetFullPath.ts
@@ -14,7 +14,7 @@ export const useGetFullPath = () => {
 
 	const language = i18n.language as 'fr' | 'en'
 
-	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : ''
+	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : '/'
 
 	return `${pathStart}${pathname !== '/' ? pathname : ''}`
 }

--- a/site/source/hooks/useGetFullURL.ts
+++ b/site/source/hooks/useGetFullURL.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 
@@ -16,7 +17,11 @@ export const useGetFullURL = () => {
 
 	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : ''
 
-	return `${window.location.origin}${pathStart}${
-		pathname !== '/' ? pathname : ''
-	}`
+	const originRef = useRef('')
+
+	useEffect(() => {
+		originRef.current = window?.location?.origin || ''
+	}, [])
+
+	return `${originRef.current}${pathStart}${pathname !== '/' ? pathname : ''}`
 }

--- a/site/source/hooks/useGetFullURL.ts
+++ b/site/source/hooks/useGetFullURL.ts
@@ -17,8 +17,8 @@ export const useGetFullURL = () => {
 
 	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : ''
 
+	// Rustine : permet d'utiliser window en SSR
 	const originRef = useRef('')
-
 	useEffect(() => {
 		originRef.current = window?.location?.origin || ''
 	}, [])

--- a/site/source/hooks/useGetFullURL.ts
+++ b/site/source/hooks/useGetFullURL.ts
@@ -1,20 +1,22 @@
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 
-import { isDevelopment } from './../utils'
+import { isDevelopment } from '../utils'
 
 const DEVELOPMENT_BASE_PATHS = {
 	fr: '/mon-entreprise',
 	en: '/infrance',
 }
 
-export const useGetFullPath = () => {
+export const useGetFullURL = () => {
 	const { i18n } = useTranslation()
 	const { pathname } = useLocation()
 
 	const language = i18n.language as 'fr' | 'en'
 
-	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : '/'
+	const pathStart = isDevelopment() ? DEVELOPMENT_BASE_PATHS[language] : ''
 
-	return `${pathStart}${pathname !== '/' ? pathname : ''}`
+	return `${window.location.origin}${pathStart}${
+		pathname !== '/' ? pathname : ''
+	}`
 }

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -10,7 +10,6 @@ import { Container, Grid, Spacing } from '@/design-system/layout'
 import { H2 } from '@/design-system/typography/heading'
 import { Link } from '@/design-system/typography/link'
 import { Body, Intro } from '@/design-system/typography/paragraphs'
-import { useGetFullPath } from '@/hooks/useGetFullPath'
 import { useSitePaths } from '@/sitePaths'
 
 import { TrackPage } from '../../ATInternetTracking'
@@ -25,8 +24,6 @@ export default function Landing() {
 	const { absoluteSitePaths } = useSitePaths()
 	const { t } = useTranslation()
 
-	const fullPath = useGetFullPath()
-
 	return (
 		<>
 			<TrackPage chapter1="informations" name="accueil" />
@@ -37,9 +34,9 @@ export default function Landing() {
 				ogImage="/logo-share.png"
 			/>
 			<Header />
-			<Link href={`${fullPath}#footer`} className="skip-link print-hidden">
+			<a href="#footer" className="skip-link print-hidden">
 				{t('Passer le contenu')}
-			</Link>
+			</a>
 			<main role="main" id="main">
 				<Container>
 					<PageHeader

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -10,6 +10,7 @@ import { Container, Grid, Spacing } from '@/design-system/layout'
 import { H2 } from '@/design-system/typography/heading'
 import { Link } from '@/design-system/typography/link'
 import { Body, Intro } from '@/design-system/typography/paragraphs'
+import { useGetFullPath } from '@/hooks/useGetFullPath'
 import { useSitePaths } from '@/sitePaths'
 
 import { TrackPage } from '../../ATInternetTracking'
@@ -24,6 +25,8 @@ export default function Landing() {
 	const { absoluteSitePaths } = useSitePaths()
 	const { t } = useTranslation()
 
+	const fullPath = useGetFullPath()
+
 	return (
 		<>
 			<TrackPage chapter1="informations" name="accueil" />
@@ -34,9 +37,9 @@ export default function Landing() {
 				ogImage="/logo-share.png"
 			/>
 			<Header />
-			<a href="#footer" className="skip-link print-hidden">
+			<Link href={`${fullPath}#footer`} className="skip-link print-hidden">
 				{t('Passer le contenu')}
-			</a>
+			</Link>
 			<main role="main" id="main">
 				<Container>
 					<PageHeader

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -10,7 +10,7 @@ import { Container, Grid, Spacing } from '@/design-system/layout'
 import { H2 } from '@/design-system/typography/heading'
 import { Link } from '@/design-system/typography/link'
 import { Body, Intro } from '@/design-system/typography/paragraphs'
-import { useGetFullPath } from '@/hooks/useGetFullPath'
+import { useGetFullURL } from '@/hooks/useGetFullURL'
 import { useSitePaths } from '@/sitePaths'
 
 import { TrackPage } from '../../ATInternetTracking'
@@ -25,7 +25,7 @@ export default function Landing() {
 	const { absoluteSitePaths } = useSitePaths()
 	const { t } = useTranslation()
 
-	const fullPath = useGetFullPath()
+	const fullURL = useGetFullURL()
 
 	return (
 		<>
@@ -37,9 +37,9 @@ export default function Landing() {
 				ogImage="/logo-share.png"
 			/>
 			<Header />
-			<Link href={`${fullPath}#footer`} className="skip-link print-hidden">
+			<a href={`${fullURL}#footer`} className="skip-link print-hidden">
 				{t('Passer le contenu')}
-			</Link>
+			</a>
 			<main role="main" id="main">
 				<Container>
 					<PageHeader


### PR DESCRIPTION
Le lien d'évitement est cassé sur les pages autres que la landing ; comportement différent en SSR qu'en local. Solution : utiliser une balise `<a>` avec le lien complet.