### PR TITLE
Refacto darkmode 🌚

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -129,7 +129,7 @@
 		"@types/serve-static": "^1.15.0",
 		"@types/styled-components": "^5.1.26",
 		"@vitejs/plugin-legacy": "^2.3.1",
-		"@vitejs/plugin-react": "^2.2.0",
+		"@vitejs/plugin-react": "^3.0.0",
 		"cypress": "https://cdn.cypress.io/beta/npm/12.0.0/linux-arm64/release/12.0.0-e8898d2f6b65a11f36ceb2dd32ce7f1d87b103bc/cypress.tgz",
 		"cypress-axe": "^1.1.0",
 		"cypress-plugin-tab": "^1.0.5",

--- a/site/package.json
+++ b/site/package.json
@@ -128,7 +128,7 @@
 		"@types/recharts": "^1.8.24",
 		"@types/serve-static": "^1.15.0",
 		"@types/styled-components": "^5.1.26",
-		"@vitejs/plugin-legacy": "^2.3.1",
+		"@vitejs/plugin-legacy": "^3.0.1",
 		"@vitejs/plugin-react": "^3.0.0",
 		"cypress": "https://cdn.cypress.io/beta/npm/12.0.0/linux-arm64/release/12.0.0-e8898d2f6b65a11f36ceb2dd32ce7f1d87b103bc/cypress.tgz",
 		"cypress-axe": "^1.1.0",

--- a/site/package.json
+++ b/site/package.json
@@ -143,7 +143,7 @@
 		"ts-morph": "^17.0.1",
 		"ts-node": "^10.9.1",
 		"typescript": "^4.9.3",
-		"vite": "^3.2.4",
+		"vite": "^3.2.5",
 		"vite-plugin-pwa": "^0.13.3",
 		"vitest": "^0.25.3",
 		"workbox-expiration": "^6.5.4",

--- a/site/source/Provider.tsx
+++ b/site/source/Provider.tsx
@@ -22,6 +22,7 @@ import logo from '@/images/logo-monentreprise.svg'
 import { TrackingContext } from './ATInternetTracking'
 import { createTracker } from './ATInternetTracking/Tracker'
 import { ServiceWorker } from './ServiceWorker'
+import { DarkModeProvider } from './contexts/DarkModeContext'
 import { Message } from './design-system'
 import * as safeLocalStorage from './storage/safeLocalStorage'
 import { store } from './store'
@@ -45,77 +46,79 @@ export default function Provider({
 	const { t } = useTranslation()
 
 	return (
-		<DesignSystemThemeProvider>
-			<GlobalStyle />
-			<ErrorBoundary
-				showDialog
-				fallback={(errorData) => (
-					<main style={{ height: '100vh' }}>
-						<Container>
-							<Link href="/" aria-label={t("Retourner à la page d'accueil")}>
-								<img
-									src={logo}
-									alt="Logo mon-entreprise"
-									style={{
-										maxWidth: '200px',
-										width: '100%',
-										marginTop: '1rem',
-									}}
-								></img>
-							</Link>
-							<H1>Une erreur est survenue</H1>
-							<Intro>
-								L'équipe technique mon-entreprise a été automatiquement
-								prévenue.
-							</Intro>
-							<Body>
-								Vous pouvez également nous contacter directement à l'adresse{' '}
-								<Link
-									href="mailto:contact@mon-entreprise.beta.gouv.fr"
-									aria-label={t(
-										'Envoyer un courriel à contact@mon-entreprise.beta.gouv.fr, nouvelle fenêtre'
-									)}
-								>
-									contact@mon-entreprise.beta.gouv.fr
-								</Link>{' '}
-								si vous souhaitez partager une remarque. Veuillez nous excuser
-								pour la gêne occasionnée.
-							</Body>
-							<Grid container>
-								<Grid item xs={12} lg={6}>
-									<Message type="info">
-										<H4>Cause de l'erreur :</H4>
-										<Body>
-											{errorData.error.name} : {errorData.error.message}
-										</Body>
-									</Message>
+		<DarkModeProvider>
+			<DesignSystemThemeProvider>
+				<GlobalStyle />
+				<ErrorBoundary
+					showDialog
+					fallback={(errorData) => (
+						<main style={{ height: '100vh' }}>
+							<Container>
+								<Link href="/" aria-label={t("Retourner à la page d'accueil")}>
+									<img
+										src={logo}
+										alt="Logo mon-entreprise"
+										style={{
+											maxWidth: '200px',
+											width: '100%',
+											marginTop: '1rem',
+										}}
+									></img>
+								</Link>
+								<H1>Une erreur est survenue</H1>
+								<Intro>
+									L'équipe technique mon-entreprise a été automatiquement
+									prévenue.
+								</Intro>
+								<Body>
+									Vous pouvez également nous contacter directement à l'adresse{' '}
+									<Link
+										href="mailto:contact@mon-entreprise.beta.gouv.fr"
+										aria-label={t(
+											'Envoyer un courriel à contact@mon-entreprise.beta.gouv.fr, nouvelle fenêtre'
+										)}
+									>
+										contact@mon-entreprise.beta.gouv.fr
+									</Link>{' '}
+									si vous souhaitez partager une remarque. Veuillez nous excuser
+									pour la gêne occasionnée.
+								</Body>
+								<Grid container>
+									<Grid item xs={12} lg={6}>
+										<Message type="info">
+											<H4>Cause de l'erreur :</H4>
+											<Body>
+												{errorData.error.name} : {errorData.error.message}
+											</Body>
+										</Message>
+									</Grid>
 								</Grid>
-							</Grid>
-						</Container>
-					</main>
-				)}
-			>
-				{!import.meta.env.SSR &&
-					import.meta.env.MODE === 'production' &&
-					'serviceWorker' in navigator &&
-					!inIframe() && <ServiceWorker />}
-				<OverlayProvider>
-					<ReduxProvider store={store}>
-						<ThemeColorsProvider>
-							<DisableAnimationOnPrintProvider>
-								<SiteNameContext.Provider value={basename}>
-									<I18nextProvider i18n={i18next}>
-										<BrowserRouterProvider basename={basename}>
-											{children}
-										</BrowserRouterProvider>
-									</I18nextProvider>
-								</SiteNameContext.Provider>
-							</DisableAnimationOnPrintProvider>
-						</ThemeColorsProvider>
-					</ReduxProvider>
-				</OverlayProvider>
-			</ErrorBoundary>
-		</DesignSystemThemeProvider>
+							</Container>
+						</main>
+					)}
+				>
+					{!import.meta.env.SSR &&
+						import.meta.env.MODE === 'production' &&
+						'serviceWorker' in navigator &&
+						!inIframe() && <ServiceWorker />}
+					<OverlayProvider>
+						<ReduxProvider store={store}>
+							<ThemeColorsProvider>
+								<DisableAnimationOnPrintProvider>
+									<SiteNameContext.Provider value={basename}>
+										<I18nextProvider i18n={i18next}>
+											<BrowserRouterProvider basename={basename}>
+												{children}
+											</BrowserRouterProvider>
+										</I18nextProvider>
+									</SiteNameContext.Provider>
+								</DisableAnimationOnPrintProvider>
+							</ThemeColorsProvider>
+						</ReduxProvider>
+					</OverlayProvider>
+				</ErrorBoundary>
+			</DesignSystemThemeProvider>
+		</DarkModeProvider>
 	)
 }
 

--- a/site/source/components/BetaBanner/index.tsx
+++ b/site/source/components/BetaBanner/index.tsx
@@ -15,7 +15,7 @@ export default function BetaBanner({
 }) {
 	return (
 		<Container
-			backgroundColor={(theme) =>
+			$backgroundColor={(theme) =>
 				theme.darkMode
 					? theme.colors.bases.tertiary[700]
 					: theme.colors.bases.tertiary[100]

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -164,7 +164,7 @@ function ActivitéMixte() {
 						defaultSelected={defaultChecked}
 						onChange={onMixteChecked}
 						light
-						textColor={(theme) => theme.colors.extended.grey[100]}
+						$textColor={(theme) => theme.colors.extended.grey[100]}
 					>
 						Activité mixte
 					</Switch>

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -164,6 +164,7 @@ function ActivitéMixte() {
 						defaultSelected={defaultChecked}
 						onChange={onMixteChecked}
 						light
+						textColor={(theme) => theme.colors.extended.grey[100]}
 					>
 						Activité mixte
 					</Switch>

--- a/site/source/components/LegalNotice.tsx
+++ b/site/source/components/LegalNotice.tsx
@@ -2,13 +2,11 @@ import { Trans, useTranslation } from 'react-i18next'
 
 import { PopoverWithTrigger } from '@/design-system'
 import { H2 } from '@/design-system/typography/heading'
-import { Link } from '@/design-system/typography/link'
+import { Link, StyledLink } from '@/design-system/typography/link'
 import { Body } from '@/design-system/typography/paragraphs'
-import { useDarkMode } from '@/hooks/useDarkMode'
 
 export default function LegalNotice() {
 	const { t } = useTranslation()
-	const [darkMode] = useDarkMode()
 
 	return (
 		<PopoverWithTrigger
@@ -56,15 +54,15 @@ export default function LegalNotice() {
 					<br />
 					San Francisco, CA 94107 <br />
 					Site web :&nbsp;
-					<a
+					<StyledLink
 						href="https://www.netlify.com"
 						aria-label="https://www.netlify.com, nouvelle fenêtre"
 						target="_blank"
 						rel="noreferrer"
-						style={darkMode ? { color: '#9EBBF1' } : { color: '#2E5FB6' }}
+						textColor={(theme) => theme.colors.theme.linkColor}
 					>
 						https://www.netlify.com
-					</a>
+					</StyledLink>
 				</Trans>
 			</Body>
 			<H2>
@@ -72,14 +70,14 @@ export default function LegalNotice() {
 			</H2>
 			<Body>
 				<Trans i18nKey="legalNotice.contact.content">
-					<a
+					<StyledLink
 						href="mailto:contact@mon-entreprise.beta.gouv.fr"
 						target="_blank"
 						rel="noreferrer"
-						style={darkMode ? { color: '#9EBBF1' } : { color: '#2E5FB6' }}
+						textColor={(theme) => theme.colors.theme.linkColor}
 					>
 						contact@mon-entreprise.beta.gouv.fr
-					</a>
+					</StyledLink>
 				</Trans>
 			</Body>{' '}
 		</PopoverWithTrigger>

--- a/site/source/components/LegalNotice.tsx
+++ b/site/source/components/LegalNotice.tsx
@@ -15,7 +15,7 @@ export default function LegalNotice() {
 					{...buttonProps}
 					aria-haspopup="dialog"
 					noUnderline
-					textColor={(theme) => theme.colors.extended.grey[100]}
+					$textColor={(theme) => theme.colors.extended.grey[100]}
 				>
 					<Trans i18nKey="legalNotice.title">Mentions légales</Trans>
 				</Link>
@@ -59,7 +59,7 @@ export default function LegalNotice() {
 						aria-label="https://www.netlify.com, nouvelle fenêtre"
 						target="_blank"
 						rel="noreferrer"
-						textColor={(theme) => theme.colors.theme.linkColor}
+						$textColor={(theme) => theme.colors.theme.linkColor}
 					>
 						https://www.netlify.com
 					</StyledLink>
@@ -74,7 +74,7 @@ export default function LegalNotice() {
 						href="mailto:contact@mon-entreprise.beta.gouv.fr"
 						target="_blank"
 						rel="noreferrer"
-						textColor={(theme) => theme.colors.theme.linkColor}
+						$textColor={(theme) => theme.colors.theme.linkColor}
 					>
 						contact@mon-entreprise.beta.gouv.fr
 					</StyledLink>

--- a/site/source/components/LegalNotice.tsx
+++ b/site/source/components/LegalNotice.tsx
@@ -13,7 +13,12 @@ export default function LegalNotice() {
 	return (
 		<PopoverWithTrigger
 			trigger={(buttonProps) => (
-				<Link {...buttonProps} aria-haspopup="dialog" noUnderline>
+				<Link
+					{...buttonProps}
+					aria-haspopup="dialog"
+					noUnderline
+					textColor={(theme) => theme.colors.extended.grey[100]}
+				>
 					<Trans i18nKey="legalNotice.title">Mentions légales</Trans>
 				</Link>
 			)}

--- a/site/source/components/PaySlip.css
+++ b/site/source/components/PaySlip.css
@@ -19,7 +19,6 @@
 }
 .payslip__container h3 {
 	border-bottom: 1px solid rgba(0, 0, 0, 0.85);
-	color: #1D458C;
 	background-color: inherit;
 	print-color-adjust: exact !important;
 	margin: 0;
@@ -43,7 +42,6 @@
 
 .payslip__container h5 {
 	margin: 0;
-	color: #1D458C;
 	background-color: inherit;
 	margin-bottom: 0.5rem;
 	margin-top: 0.5rem;

--- a/site/source/components/PaySlipSections.tsx
+++ b/site/source/components/PaySlipSections.tsx
@@ -13,7 +13,11 @@ import { H4 } from '@/design-system/typography/heading'
 export const SalaireBrutSection = () => {
 	return (
 		<div className="payslip__salarySection">
-			<H4 className="payslip__salaryTitle" as="h3">
+			<H4
+				className="payslip__salaryTitle"
+				as="h3"
+				$textColor={(theme) => theme.colors.theme.headingColor}
+			>
 				<Trans>Salaire</Trans>
 			</H4>
 			<Line rule="salarié . contrat . salaire brut" />

--- a/site/source/components/PreviousSimulationBanner.tsx
+++ b/site/source/components/PreviousSimulationBanner.tsx
@@ -32,6 +32,7 @@ export default function PreviousSimulationBanner() {
 					'Retrouver ma simulation, charger les données de ma précédente simulation.'
 				)}
 				role="button"
+				$textColor={(theme) => theme.colors.theme.linkColor}
 			>
 				<Trans i18nKey="previousSimulationBanner.retrieveButton">
 					Retrouver ma simulation

--- a/site/source/components/QuickLinks.tsx
+++ b/site/source/components/QuickLinks.tsx
@@ -1,6 +1,6 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import styled from 'styled-components'
+import styled, { DefaultTheme, ThemeProvider } from 'styled-components'
 
 import { goToQuestion } from '@/actions/actions'
 import { Spacing } from '@/design-system/layout'
@@ -62,6 +62,8 @@ const StyledLinks = styled(SmallBody)`
 	gap: ${({ theme }) => theme.spacings.sm};
 `
 
-const StyledLink = styled(Link)<{ underline: boolean }>`
+const StyledLink = styled(Link)<{
+	underline: boolean
+}>`
 	text-decoration: ${({ underline }) => (underline ? 'underline' : '')};
 `

--- a/site/source/components/QuickLinks.tsx
+++ b/site/source/components/QuickLinks.tsx
@@ -1,6 +1,6 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import styled, { DefaultTheme, ThemeProvider } from 'styled-components'
+import styled from 'styled-components'
 
 import { goToQuestion } from '@/actions/actions'
 import { Spacing } from '@/design-system/layout'

--- a/site/source/components/SearchButton.tsx
+++ b/site/source/components/SearchButton.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 
 import { PopoverWithTrigger } from '@/design-system'
 import { Button } from '@/design-system/buttons'
-import { FocusStyle } from '@/design-system/global-style'
 
 import SearchRulesAndSimulators from './search/SearchRulesAndSimulators'
 

--- a/site/source/components/SearchButton.tsx
+++ b/site/source/components/SearchButton.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { PopoverWithTrigger } from '@/design-system'
 import { Button } from '@/design-system/buttons'
+import { FocusStyle } from '@/design-system/global-style'
 
 import SearchRulesAndSimulators from './search/SearchRulesAndSimulators'
 

--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -15,10 +15,15 @@ const QuestionsContainer = styled.div`
 	padding: ${({ theme }) => ` ${theme.spacings.xs} ${theme.spacings.lg}`};
 	border-radius: ${({ theme }) =>
 		`0 0 ${theme.box.borderRadius} ${theme.box.borderRadius}`};
-	background: ${({ theme }) =>
-		theme.darkMode
-			? theme.colors.extended.grey[800]
-			: theme.colors.bases.primary[100]};
+
+	background: ${({ theme }) => {
+		const palettePrimary = theme.colors.bases.primary
+		const paletteGrey = theme.colors.extended.grey
+
+		return theme.darkMode
+			? `linear-gradient(60deg, ${paletteGrey[800]} 0%, ${paletteGrey[700]} 100%);`
+			: `linear-gradient(60deg, ${palettePrimary[200]} 0%, ${palettePrimary[100]} 100%);`
+	}};
 `
 
 const Notice = styled(Body)`

--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -15,13 +15,10 @@ const QuestionsContainer = styled.div`
 	padding: ${({ theme }) => ` ${theme.spacings.xs} ${theme.spacings.lg}`};
 	border-radius: ${({ theme }) =>
 		`0 0 ${theme.box.borderRadius} ${theme.box.borderRadius}`};
-	background: ${({ theme }) => {
-		const colorPalette = theme.colors.bases.primary
-
-		return theme.darkMode
-			? `linear-gradient(60deg, ${colorPalette[800]} 0%, ${colorPalette[700]} 100%);`
-			: `linear-gradient(60deg, ${colorPalette[200]} 0%, ${colorPalette[100]} 100%);`
-	}};
+	background: ${({ theme }) =>
+		theme.darkMode
+			? theme.colors.extended.grey[800]
+			: theme.colors.bases.primary[100]};
 `
 
 const Notice = styled(Body)`

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -125,11 +125,14 @@ export function SimulationGoal({
 								formatOptions={{
 									maximumFractionDigits: 0,
 								}}
+								hasDarkBackground
 							/>
 						</Grid>
 					) : (
 						<Grid item>
-							<Body>{formatValue(evaluation, { displayedUnit: '€' })}</Body>
+							<Body textColor={(theme) => theme.colors.extended.grey[100]}>
+								{formatValue(evaluation, { displayedUnit: '€' })}
+							</Body>
 						</Grid>
 					)}
 				</Grid>

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -125,7 +125,7 @@ export function SimulationGoal({
 								formatOptions={{
 									maximumFractionDigits: 0,
 								}}
-								hasDarkBackground
+								isLight
 							/>
 						</Grid>
 					) : (

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -76,23 +76,20 @@ export function SimulationGoal({
 				>
 					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
 						<StyledGoalHeader>
-							<RuleLink
+							<StyledRuleLink
 								id={`${dottedName.replace(/\s|\./g, '')}-label`}
 								dottedName={dottedName}
 							>
 								{label}
-							</RuleLink>
+							</StyledRuleLink>
 
 							{rule.rawNode.résumé && (
-								<SmallBody
-									css={`
-										margin-bottom: 0;
-									`}
+								<StyledSmallBody
 									className={small ? 'sr-only' : ''}
 									id={`${dottedName.replace(/\s|\./g, '')}-description`}
 								>
 									{rule.rawNode.résumé}
-								</SmallBody>
+								</StyledSmallBody>
 							)}
 						</StyledGoalHeader>
 					</Grid>
@@ -166,8 +163,16 @@ const StyledGoal = styled.div`
 	position: relative;
 	z-index: 1;
 	padding: ${({ theme }) => theme.spacings.sm} 0;
-
 	@media print {
 		padding: 0;
 	}
+`
+
+const StyledRuleLink = styled(RuleLink)`
+	color: ${({ theme }) => theme.colors.bases.primary[100]};
+`
+
+const StyledSmallBody = styled(SmallBody)`
+	margin-bottom: 0;
+	color: ${({ theme }) => theme.colors.bases.primary[100]};
 `

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -130,7 +130,7 @@ export function SimulationGoal({
 						</Grid>
 					) : (
 						<Grid item>
-							<Body textColor={(theme) => theme.colors.extended.grey[100]}>
+							<Body $textColor={(theme) => theme.colors.extended.grey[100]}>
 								{formatValue(evaluation, { displayedUnit: '€' })}
 							</Body>
 						</Grid>

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -36,22 +36,23 @@ export function SimulationGoals({
 	return (
 		<WatchInitialRender>
 			<TopSection toggles={toggles} />
-			<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
-				<StyledSimulationGoals
-					isEmbeded={isEmbeded}
-					isFirstStepCompleted={isFirstStepCompleted}
-					publique={publique}
-					role="group"
-					id="simulator-legend"
-					aria-labelledby="simulator-legend-label"
-					aria-live="polite"
-				>
+
+			<StyledSimulationGoals
+				isEmbeded={isEmbeded}
+				isFirstStepCompleted={isFirstStepCompleted}
+				publique={publique}
+				role="group"
+				id="simulator-legend"
+				aria-labelledby="simulator-legend-label"
+				aria-live="polite"
+			>
+				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
 					<div className="sr-only" aria-hidden id="simulator-legend-label">
 						{legend}
 					</div>
 					{children}
-				</StyledSimulationGoals>
-			</ThemeProvider>
+				</ThemeProvider>
+			</StyledSimulationGoals>
 		</WatchInitialRender>
 	)
 }

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import styled, { ThemeProvider, css } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Grid } from '@/design-system/layout'
 import { Link } from '@/design-system/typography/link'
@@ -46,12 +46,10 @@ export function SimulationGoals({
 				aria-labelledby="simulator-legend-label"
 				aria-live="polite"
 			>
-				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
-					<div className="sr-only" aria-hidden id="simulator-legend-label">
-						{legend}
-					</div>
-					{children}
-				</ThemeProvider>
+				<div className="sr-only" aria-hidden id="simulator-legend-label">
+					{legend}
+				</div>
+				{children}
 			</StyledSimulationGoals>
 		</WatchInitialRender>
 	)

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -36,7 +36,7 @@ export function SimulationGoals({
 	return (
 		<WatchInitialRender>
 			<TopSection toggles={toggles} />
-			<ThemeProvider theme={(theme) => ({ ...theme, darkMode: false })}>
+			<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
 				<StyledSimulationGoals
 					isEmbeded={isEmbeded}
 					isFirstStepCompleted={isFirstStepCompleted}

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import styled, { css } from 'styled-components'
+import styled, { ThemeProvider, css } from 'styled-components'
 
 import { Grid } from '@/design-system/layout'
 import { Link } from '@/design-system/typography/link'
@@ -35,22 +35,24 @@ export function SimulationGoals({
 
 	return (
 		<WatchInitialRender>
-			<TopSection toggles={toggles} />
+			<ThemeProvider theme={(theme) => ({ ...theme, darkMode: false })}>
+				<TopSection toggles={toggles} />
 
-			<StyledSimulationGoals
-				isEmbeded={isEmbeded}
-				isFirstStepCompleted={isFirstStepCompleted}
-				publique={publique}
-				role="group"
-				id="simulator-legend"
-				aria-labelledby="simulator-legend-label"
-				aria-live="polite"
-			>
-				<div className="sr-only" aria-hidden id="simulator-legend-label">
-					{legend}
-				</div>
-				{children}
-			</StyledSimulationGoals>
+				<StyledSimulationGoals
+					isEmbeded={isEmbeded}
+					isFirstStepCompleted={isFirstStepCompleted}
+					publique={publique}
+					role="group"
+					id="simulator-legend"
+					aria-labelledby="simulator-legend-label"
+					aria-live="polite"
+				>
+					<div className="sr-only" aria-hidden id="simulator-legend-label">
+						{legend}
+					</div>
+					{children}
+				</StyledSimulationGoals>
+			</ThemeProvider>
 		</WatchInitialRender>
 	)
 }

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -35,9 +35,8 @@ export function SimulationGoals({
 
 	return (
 		<WatchInitialRender>
+			<TopSection toggles={toggles} />
 			<ThemeProvider theme={(theme) => ({ ...theme, darkMode: false })}>
-				<TopSection toggles={toggles} />
-
 				<StyledSimulationGoals
 					isEmbeded={isEmbeded}
 					isFirstStepCompleted={isFirstStepCompleted}

--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -121,6 +121,7 @@ export default function Simulation({
 												aria-label={t(
 													'Voir ma situation, accéder à la page de gestion de mon entreprise'
 												)}
+												$textColor={(theme) => theme.colors.theme.linkColor}
 											>
 												<Trans>Voir ma situation</Trans>
 											</Link>

--- a/site/source/components/company/Details.tsx
+++ b/site/source/components/company/Details.tsx
@@ -32,7 +32,9 @@ export function CompanyDetails({
 					<H4
 						data-test-id="currently-selected-company"
 						as={headingTag}
-						textColor={(theme: DefaultTheme) => theme.colors.bases.primary[700]}
+						$textColor={(theme: DefaultTheme) =>
+							theme.colors.bases.primary[700]
+						}
 					>
 						<Value expression="entreprise . nom" linkToRule={false} />{' '}
 						<Value expression="entreprise . SIREN" linkToRule={false} />

--- a/site/source/components/company/Details.tsx
+++ b/site/source/components/company/Details.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react'
 import { Trans } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { DefaultTheme } from 'styled-components'
 
 import { Message } from '@/design-system'
 import { Grid, Spacing } from '@/design-system/layout'
@@ -32,7 +32,7 @@ export function CompanyDetails({
 					<H4
 						data-test-id="currently-selected-company"
 						as={headingTag}
-						textColor={(theme) => theme.colors.bases.primary[700]}
+						textColor={(theme: DefaultTheme) => theme.colors.bases.primary[700]}
 					>
 						<Value expression="entreprise . nom" linkToRule={false} />{' '}
 						<Value expression="entreprise . SIREN" linkToRule={false} />

--- a/site/source/components/company/Details.tsx
+++ b/site/source/components/company/Details.tsx
@@ -29,16 +29,10 @@ export function CompanyDetails({
 				spacing={3}
 			>
 				<Grid item xs={12} lg>
-					<H4
-						data-test-id="currently-selected-company"
-						as={headingTag}
-						$textColor={(theme: DefaultTheme) =>
-							theme.colors.bases.primary[700]
-						}
-					>
+					<StyledH4 data-test-id="currently-selected-company" as={headingTag}>
 						<Value expression="entreprise . nom" linkToRule={false} />{' '}
 						<Value expression="entreprise . SIREN" linkToRule={false} />
-					</H4>
+					</StyledH4>
 					<Body>
 						<Trans>
 							Entreprise créée le{' '}
@@ -70,3 +64,9 @@ export function CompanyDetails({
 }
 
 const StyledCompanyContainer = styled(Message).attrs({ border: false })``
+
+const StyledH4 = styled(H4)`
+	& span {
+		color: ${({ theme }) => theme.colors.bases.primary[700]};
+	}
+`

--- a/site/source/components/company/Details.tsx
+++ b/site/source/components/company/Details.tsx
@@ -29,7 +29,11 @@ export function CompanyDetails({
 				spacing={3}
 			>
 				<Grid item xs={12} lg>
-					<H4 data-test-id="currently-selected-company" as={headingTag}>
+					<H4
+						data-test-id="currently-selected-company"
+						as={headingTag}
+						textColor={(theme) => theme.colors.bases.primary[700]}
+					>
 						<Value expression="entreprise . nom" linkToRule={false} />{' '}
 						<Value expression="entreprise . SIREN" linkToRule={false} />
 					</H4>

--- a/site/source/components/company/SearchField.tsx
+++ b/site/source/components/company/SearchField.tsx
@@ -24,6 +24,7 @@ export function CompanySearchField(props: {
 	onValue?: () => void
 	onClear?: () => void
 	onSubmit?: (search: FabriqueSocialEntreprise | null) => void
+	isDark?: boolean
 }) {
 	const { t } = useTranslation()
 	const refResults = useRef<FabriqueSocialEntreprise[] | null>(null)
@@ -62,7 +63,12 @@ export function CompanySearchField(props: {
 	return (
 		<Grid container>
 			<Grid item xs={12}>
-				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
+				<ThemeProvider
+					theme={(theme) => ({
+						...theme,
+						darkMode: props?.isDark ?? theme.darkMode,
+					})}
+				>
 					<SearchField
 						data-test-id="company-search-input"
 						state={state}

--- a/site/source/components/company/SearchField.tsx
+++ b/site/source/components/company/SearchField.tsx
@@ -1,7 +1,7 @@
 import { useSearchFieldState } from '@react-stately/searchfield'
 import { ReactNode, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { ThemeProvider } from 'styled-components'
 
 import { FabriqueSocialEntreprise } from '@/api/fabrique-social'
 import { Message } from '@/design-system'
@@ -62,13 +62,15 @@ export function CompanySearchField(props: {
 	return (
 		<Grid container>
 			<Grid item xs={12}>
-				<SearchField
-					data-test-id="company-search-input"
-					state={state}
-					isSearchStalled={searchPending}
-					onClear={onClear}
-					{...searchFieldProps}
-				/>
+				<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
+					<SearchField
+						data-test-id="company-search-input"
+						state={state}
+						isSearchStalled={searchPending}
+						onClear={onClear}
+						{...searchFieldProps}
+					/>
+				</ThemeProvider>
 			</Grid>
 			<Grid item xs={12}>
 				{state.value && !searchPending && (

--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -305,7 +305,7 @@ const StyledAnswerList = styled(Grid)`
 			theme.darkMode
 				? theme.colors.extended.dark[500]
 				: theme.colors.bases.primary[100]};
-		color: inherit;
+		color: ${({ theme }) => theme.colors.theme.textColor};
 		color-adjust: exact !important;
 		outline: solid
 			${({ theme }) =>

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -216,10 +216,7 @@ function RadioChoice<Names extends string = DottedName>({
 									rootDottedName,
 									node.dottedName
 								)}'`}
-								id={`radio-input-${relativeDottedName(
-									rootDottedName,
-									node.dottedName
-								).replace(/\s|\./g, '')}`}
+								id={`radio-input-${node.dottedName.replace(/\s|\./g, '')}`}
 							>
 								{node.title}{' '}
 								{node.rawNode.icônes && <Emoji emoji={node.rawNode.icônes} />}

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -105,11 +105,7 @@ export default function Conversation({
 									align-items: baseline;
 								`}
 							>
-								<H3
-									id="questionHeader"
-									as="h2"
-									textColor={(theme) => theme.colors.bases.primary[700]}
-								>
+								<H3 id="questionHeader" as="h2">
 									{evaluateQuestion(engine, engine.getRule(currentQuestion))}
 									<ExplicableRule
 										aria-label={t('En savoir plus')}
@@ -135,6 +131,7 @@ export default function Conversation({
 							<Spacing md />
 							<button
 								aria-hidden
+								aria-label={t('Valider')}
 								className="sr-only"
 								aria-label={t('Valider')}
 								type="submit"

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -105,7 +105,11 @@ export default function Conversation({
 									align-items: baseline;
 								`}
 							>
-								<H3 id="questionHeader" as="h2">
+								<H3
+									id="questionHeader"
+									as="h2"
+									textColor={(theme) => theme.colors.bases.primary[700]}
+								>
 									{evaluateQuestion(engine, engine.getRule(currentQuestion))}
 									<ExplicableRule
 										aria-label={t('En savoir plus')}

--- a/site/source/components/conversation/Conversation.tsx
+++ b/site/source/components/conversation/Conversation.tsx
@@ -133,7 +133,6 @@ export default function Conversation({
 								aria-hidden
 								aria-label={t('Valider')}
 								className="sr-only"
-								aria-label={t('Valider')}
 								type="submit"
 								tabIndex={-1}
 							/>

--- a/site/source/components/conversation/DateInput.tsx
+++ b/site/source/components/conversation/DateInput.tsx
@@ -14,7 +14,8 @@ export default function DateInput({
 	required,
 	autoFocus,
 	value,
-}: InputProps) {
+	isLight,
+}: InputProps & { isLight?: boolean }) {
 	const dateValue = useMemo(() => {
 		if (!value || typeof value !== 'string') {
 			return undefined
@@ -54,6 +55,7 @@ export default function DateInput({
 							onChange(value)
 						}}
 						onSecondClick={() => onSubmit?.('suggestion')}
+						isLight={isLight}
 					/>
 				)}
 				<DateField
@@ -63,6 +65,7 @@ export default function DateInput({
 					onChange={handleDateChange}
 					aria-label={title}
 					label={title}
+					isLight={isLight}
 				/>
 			</div>
 		</div>

--- a/site/source/components/conversation/InputSuggestions.tsx
+++ b/site/source/components/conversation/InputSuggestions.tsx
@@ -11,6 +11,7 @@ type InputSuggestionsProps = {
 	onFirstClick: (val: ASTNode) => void
 	onSecondClick?: (val: ASTNode) => void
 	className?: string
+	isLight?: boolean
 }
 
 export default function InputSuggestions({
@@ -18,6 +19,7 @@ export default function InputSuggestions({
 	onSecondClick = (x) => x,
 	onFirstClick,
 	className,
+	isLight,
 }: InputSuggestionsProps) {
 	const [suggestion, setSuggestion] = useState<ASTNode>()
 	const { t } = useTranslation()
@@ -41,7 +43,11 @@ export default function InputSuggestions({
 						}}
 						role="button"
 						aria-label={t('Insérer dans le champ la valeur du {{text}}', text)}
-						$textColor={(theme) => theme.colors.theme.linkColor}
+						$textColor={(theme) =>
+							isLight
+								? theme.colors.extended.grey[100]
+								: theme.colors.theme.linkColor
+						}
 					>
 						{text}
 					</Link>

--- a/site/source/components/conversation/InputSuggestions.tsx
+++ b/site/source/components/conversation/InputSuggestions.tsx
@@ -41,7 +41,7 @@ export default function InputSuggestions({
 						}}
 						role="button"
 						aria-label={t('Insérer dans le champ la valeur du {{text}}', text)}
-						$textColor={(theme) => theme.colors.extended.grey[100]}
+						$textColor={(theme) => theme.colors.theme.linkColor}
 					>
 						{text}
 					</Link>

--- a/site/source/components/conversation/InputSuggestions.tsx
+++ b/site/source/components/conversation/InputSuggestions.tsx
@@ -41,7 +41,7 @@ export default function InputSuggestions({
 						}}
 						role="button"
 						aria-label={t('Insérer dans le champ la valeur du {{text}}', text)}
-						textColor={(theme) => theme.colors.extended.grey[100]}
+						$textColor={(theme) => theme.colors.extended.grey[100]}
 					>
 						{text}
 					</Link>

--- a/site/source/components/conversation/InputSuggestions.tsx
+++ b/site/source/components/conversation/InputSuggestions.tsx
@@ -41,6 +41,7 @@ export default function InputSuggestions({
 						}}
 						role="button"
 						aria-label={t('Insérer dans le champ la valeur du {{text}}', text)}
+						textColor={(theme) => theme.colors.extended.grey[100]}
 					>
 						{text}
 					</Link>

--- a/site/source/components/conversation/NumberInput.tsx
+++ b/site/source/components/conversation/NumberInput.tsx
@@ -23,6 +23,7 @@ export default function NumberInput({
 	...fieldProps
 }: InputProps & {
 	unit?: Unit
+	isLight?: boolean
 }) {
 	const unité = serializeUnit(unit)
 	const [currentValue, setCurrentValue] = useState<number | undefined>(
@@ -102,6 +103,7 @@ export default function NumberInput({
 					onChange(node)
 				}}
 				onSecondClick={() => onSubmit?.('suggestion')}
+				isLight={fieldProps?.isLight}
 			/>
 		</StyledNumberInput>
 	)

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -46,7 +46,7 @@ type Props<Names extends string = DottedName> = Omit<
 	formatOptions?: Intl.NumberFormatOptions
 	displayedUnit?: string
 	modifiers?: Record<string, string>
-	hasDarkBackground?: boolean
+	isLight?: boolean
 }
 
 export type InputProps<Name extends string = string> = Omit<

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -46,6 +46,7 @@ type Props<Names extends string = DottedName> = Omit<
 	formatOptions?: Intl.NumberFormatOptions
 	displayedUnit?: string
 	modifiers?: Record<string, string>
+	hasDarkBackground?: boolean
 }
 
 export type InputProps<Name extends string = string> = Omit<

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -192,7 +192,7 @@ export default function Footer() {
 											<LegalNotice />
 										</li>
 										<li>
-											<Privacy />
+											<Privacy isDark />
 										</li>
 										{language === 'fr' && (
 											<li>

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -90,22 +90,38 @@ export default function Footer() {
 									<nav title="firstColumnNav">
 										<ul>
 											<li>
-												<Link to={absoluteSitePaths.plan} noUnderline>
+												<Link
+													to={absoluteSitePaths.plan}
+													noUnderline
+													textColor={(theme) => theme.colors.extended.grey[100]}
+												>
 													<Trans>Plan du site</Trans>
 												</Link>
 											</li>
 											<li>
-												<Link to={absoluteSitePaths.nouveautés} noUnderline>
+												<Link
+													to={absoluteSitePaths.nouveautés}
+													noUnderline
+													textColor={(theme) => theme.colors.extended.grey[100]}
+												>
 													Nouveautés <Emoji emoji="✨" />
 												</Link>
 											</li>
 											<li>
-												<Link to={absoluteSitePaths.stats} noUnderline>
+												<Link
+													to={absoluteSitePaths.stats}
+													noUnderline
+													textColor={(theme) => theme.colors.extended.grey[100]}
+												>
 													Stats <Emoji emoji="📊" />
 												</Link>
 											</li>
 											<li>
-												<Link to={absoluteSitePaths.budget} noUnderline>
+												<Link
+													to={absoluteSitePaths.budget}
+													noUnderline
+													textColor={(theme) => theme.colors.extended.grey[100]}
+												>
 													Budget <Emoji emoji="💶" />
 												</Link>
 											</li>
@@ -120,6 +136,7 @@ export default function Footer() {
 											<Link
 												to={absoluteSitePaths.développeur.index}
 												noUnderline
+												textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												<Trans>Intégrer nos simulateurs</Trans>
 											</Link>
@@ -136,6 +153,7 @@ export default function Footer() {
 													openInSameWindow
 													lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
 													noUnderline
+													textColor={(theme) => theme.colors.extended.grey[100]}
 												>
 													{hrefLink.hrefLang === 'fr' ? (
 														<>
@@ -173,6 +191,7 @@ export default function Footer() {
 														'Accessibilité : non conforme, en savoir plus'
 													)}
 													noUnderline
+													textColor={(theme) => theme.colors.extended.grey[100]}
 												>
 													<Trans i18nKey="footer.accessibilité">
 														Accessibilité : non conforme

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -1,6 +1,5 @@
 import { Helmet } from 'react-helmet-async'
 import { Trans, useTranslation } from 'react-i18next'
-import { ThemeProvider } from 'styled-components'
 
 import PageFeedback from '@/components/Feedback'
 import LegalNotice from '@/components/LegalNotice'
@@ -79,131 +78,129 @@ export default function Footer() {
 				</Container>
 
 				<Container backgroundColor={(theme) => theme.colors.bases.primary[700]}>
-					<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
-						<FooterContainer
-							className="print-hidden"
-							role="navigation"
-							aria-label={t('Menu de navigation')}
-						>
-							<FooterColumn>
-								{language === 'fr' && (
-									<nav title="firstColumnNav">
-										<ul>
-											<li>
-												<Link
-													to={absoluteSitePaths.plan}
-													noUnderline
-													textColor={(theme) => theme.colors.extended.grey[100]}
-												>
-													<Trans>Plan du site</Trans>
-												</Link>
-											</li>
-											<li>
-												<Link
-													to={absoluteSitePaths.nouveautés}
-													noUnderline
-													textColor={(theme) => theme.colors.extended.grey[100]}
-												>
-													Nouveautés <Emoji emoji="✨" />
-												</Link>
-											</li>
-											<li>
-												<Link
-													to={absoluteSitePaths.stats}
-													noUnderline
-													textColor={(theme) => theme.colors.extended.grey[100]}
-												>
-													Stats <Emoji emoji="📊" />
-												</Link>
-											</li>
-											<li>
-												<Link
-													to={absoluteSitePaths.budget}
-													noUnderline
-													textColor={(theme) => theme.colors.extended.grey[100]}
-												>
-													Budget <Emoji emoji="💶" />
-												</Link>
-											</li>
-										</ul>
-									</nav>
-								)}
-							</FooterColumn>
-							<FooterColumn>
-								<nav title="secondColumnNav">
+					<FooterContainer
+						className="print-hidden"
+						role="navigation"
+						aria-label={t('Menu de navigation')}
+					>
+						<FooterColumn>
+							{language === 'fr' && (
+								<nav title="firstColumnNav">
 									<ul>
 										<li>
 											<Link
-												to={absoluteSitePaths.développeur.index}
+												to={absoluteSitePaths.plan}
 												noUnderline
 												textColor={(theme) => theme.colors.extended.grey[100]}
 											>
-												<Trans>Intégrer nos simulateurs</Trans>
+												<Trans>Plan du site</Trans>
 											</Link>
 										</li>
-										{language === 'fr' && (
-											<li>
-												<InscriptionBetaTesteur />
-											</li>
-										)}
-										{hrefLink && (
-											<li key={hrefLink.hrefLang}>
-												<Link
-													href={hrefLink.href}
-													openInSameWindow
-													lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
-													noUnderline
-													textColor={(theme) => theme.colors.extended.grey[100]}
-												>
-													{hrefLink.hrefLang === 'fr' ? (
-														<>
-															Passer en français <Emoji emoji="🇫🇷" />
-														</>
-													) : hrefLink.hrefLang === 'en' ? (
-														<>
-															Switch to English <Emoji emoji="🇬🇧" />
-														</>
-													) : (
-														hrefLink.hrefLang
-													)}
-												</Link>
-											</li>
-										)}
+										<li>
+											<Link
+												to={absoluteSitePaths.nouveautés}
+												noUnderline
+												textColor={(theme) => theme.colors.extended.grey[100]}
+											>
+												Nouveautés <Emoji emoji="✨" />
+											</Link>
+										</li>
+										<li>
+											<Link
+												to={absoluteSitePaths.stats}
+												noUnderline
+												textColor={(theme) => theme.colors.extended.grey[100]}
+											>
+												Stats <Emoji emoji="📊" />
+											</Link>
+										</li>
+										<li>
+											<Link
+												to={absoluteSitePaths.budget}
+												noUnderline
+												textColor={(theme) => theme.colors.extended.grey[100]}
+											>
+												Budget <Emoji emoji="💶" />
+											</Link>
+										</li>
 									</ul>
 								</nav>
-							</FooterColumn>
+							)}
+						</FooterColumn>
+						<FooterColumn>
+							<nav title="secondColumnNav">
+								<ul>
+									<li>
+										<Link
+											to={absoluteSitePaths.développeur.index}
+											noUnderline
+											textColor={(theme) => theme.colors.extended.grey[100]}
+										>
+											<Trans>Intégrer nos simulateurs</Trans>
+										</Link>
+									</li>
+									{language === 'fr' && (
+										<li>
+											<InscriptionBetaTesteur />
+										</li>
+									)}
+									{hrefLink && (
+										<li key={hrefLink.hrefLang}>
+											<Link
+												href={hrefLink.href}
+												openInSameWindow
+												lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
+												noUnderline
+												textColor={(theme) => theme.colors.extended.grey[100]}
+											>
+												{hrefLink.hrefLang === 'fr' ? (
+													<>
+														Passer en français <Emoji emoji="🇫🇷" />
+													</>
+												) : hrefLink.hrefLang === 'en' ? (
+													<>
+														Switch to English <Emoji emoji="🇬🇧" />
+													</>
+												) : (
+													hrefLink.hrefLang
+												)}
+											</Link>
+										</li>
+									)}
+								</ul>
+							</nav>
+						</FooterColumn>
 
-							<FooterColumn>
-								<nav title="thirdColumnNav">
-									<ul>
+						<FooterColumn>
+							<nav title="thirdColumnNav">
+								<ul>
+									<li>
+										<LegalNotice />
+									</li>
+									<li>
+										<Privacy />
+									</li>
+									{language === 'fr' && (
 										<li>
-											<LegalNotice />
+											<Link
+												to={absoluteSitePaths.accessibilité}
+												aria-label={t(
+													'footer.accessibilitéAriaLabel',
+													'Accessibilité : non conforme, en savoir plus'
+												)}
+												noUnderline
+												textColor={(theme) => theme.colors.extended.grey[100]}
+											>
+												<Trans i18nKey="footer.accessibilité">
+													Accessibilité : non conforme
+												</Trans>
+											</Link>
 										</li>
-										<li>
-											<Privacy />
-										</li>
-										{language === 'fr' && (
-											<li>
-												<Link
-													to={absoluteSitePaths.accessibilité}
-													aria-label={t(
-														'footer.accessibilitéAriaLabel',
-														'Accessibilité : non conforme, en savoir plus'
-													)}
-													noUnderline
-													textColor={(theme) => theme.colors.extended.grey[100]}
-												>
-													<Trans i18nKey="footer.accessibilité">
-														Accessibilité : non conforme
-													</Trans>
-												</Link>
-											</li>
-										)}
-									</ul>
-								</nav>
-							</FooterColumn>
-						</FooterContainer>
-					</ThemeProvider>
+									)}
+								</ul>
+							</nav>
+						</FooterColumn>
+					</FooterContainer>
 				</Container>
 			</footer>
 		</>

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -54,7 +54,7 @@ export default function Footer() {
 			/>
 			<footer role="contentinfo" id="footer">
 				<Container
-					backgroundColor={(theme) =>
+					$backgroundColor={(theme) =>
 						theme.darkMode
 							? theme.colors.extended.dark[600]
 							: theme.colors.bases.tertiary[100]
@@ -77,7 +77,9 @@ export default function Footer() {
 					)}
 				</Container>
 
-				<Container backgroundColor={(theme) => theme.colors.bases.primary[700]}>
+				<Container
+					$backgroundColor={(theme) => theme.colors.bases.primary[700]}
+				>
 					<FooterContainer
 						className="print-hidden"
 						role="navigation"
@@ -91,7 +93,7 @@ export default function Footer() {
 											<Link
 												to={absoluteSitePaths.plan}
 												noUnderline
-												textColor={(theme) => theme.colors.extended.grey[100]}
+												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												<Trans>Plan du site</Trans>
 											</Link>
@@ -100,7 +102,7 @@ export default function Footer() {
 											<Link
 												to={absoluteSitePaths.nouveautés}
 												noUnderline
-												textColor={(theme) => theme.colors.extended.grey[100]}
+												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												Nouveautés <Emoji emoji="✨" />
 											</Link>
@@ -109,7 +111,7 @@ export default function Footer() {
 											<Link
 												to={absoluteSitePaths.stats}
 												noUnderline
-												textColor={(theme) => theme.colors.extended.grey[100]}
+												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												Stats <Emoji emoji="📊" />
 											</Link>
@@ -118,7 +120,7 @@ export default function Footer() {
 											<Link
 												to={absoluteSitePaths.budget}
 												noUnderline
-												textColor={(theme) => theme.colors.extended.grey[100]}
+												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												Budget <Emoji emoji="💶" />
 											</Link>
@@ -134,7 +136,7 @@ export default function Footer() {
 										<Link
 											to={absoluteSitePaths.développeur.index}
 											noUnderline
-											textColor={(theme) => theme.colors.extended.grey[100]}
+											$textColor={(theme) => theme.colors.extended.grey[100]}
 										>
 											<Trans>Intégrer nos simulateurs</Trans>
 										</Link>
@@ -151,7 +153,7 @@ export default function Footer() {
 												openInSameWindow
 												lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
 												noUnderline
-												textColor={(theme) => theme.colors.extended.grey[100]}
+												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												{hrefLink.hrefLang === 'fr' ? (
 													<>
@@ -189,7 +191,7 @@ export default function Footer() {
 													'Accessibilité : non conforme, en savoir plus'
 												)}
 												noUnderline
-												textColor={(theme) => theme.colors.extended.grey[100]}
+												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
 												<Trans i18nKey="footer.accessibilité">
 													Accessibilité : non conforme

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from 'react-helmet-async'
 import { Trans, useTranslation } from 'react-i18next'
+import { ThemeProvider } from 'styled-components'
 
 import PageFeedback from '@/components/Feedback'
 import LegalNotice from '@/components/LegalNotice'
@@ -80,129 +81,143 @@ export default function Footer() {
 				<Container
 					$backgroundColor={(theme) => theme.colors.bases.primary[700]}
 				>
-					<FooterContainer
-						className="print-hidden"
-						role="navigation"
-						aria-label={t('Menu de navigation')}
-					>
-						<FooterColumn>
-							{language === 'fr' && (
-								<nav title="firstColumnNav">
+					<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
+						<FooterContainer
+							className="print-hidden"
+							role="navigation"
+							aria-label={t('Menu de navigation')}
+						>
+							<FooterColumn>
+								{language === 'fr' && (
+									<nav title="firstColumnNav">
+										<ul>
+											<li>
+												<Link
+													to={absoluteSitePaths.plan}
+													noUnderline
+													$textColor={(theme) =>
+														theme.colors.extended.grey[100]
+													}
+												>
+													<Trans>Plan du site</Trans>
+												</Link>
+											</li>
+											<li>
+												<Link
+													to={absoluteSitePaths.nouveautés}
+													noUnderline
+													$textColor={(theme) =>
+														theme.colors.extended.grey[100]
+													}
+												>
+													Nouveautés <Emoji emoji="✨" />
+												</Link>
+											</li>
+											<li>
+												<Link
+													to={absoluteSitePaths.stats}
+													noUnderline
+													$textColor={(theme) =>
+														theme.colors.extended.grey[100]
+													}
+												>
+													Stats <Emoji emoji="📊" />
+												</Link>
+											</li>
+											<li>
+												<Link
+													to={absoluteSitePaths.budget}
+													noUnderline
+													$textColor={(theme) =>
+														theme.colors.extended.grey[100]
+													}
+												>
+													Budget <Emoji emoji="💶" />
+												</Link>
+											</li>
+										</ul>
+									</nav>
+								)}
+							</FooterColumn>
+							<FooterColumn>
+								<nav title="secondColumnNav">
 									<ul>
 										<li>
 											<Link
-												to={absoluteSitePaths.plan}
+												to={absoluteSitePaths.développeur.index}
 												noUnderline
 												$textColor={(theme) => theme.colors.extended.grey[100]}
 											>
-												<Trans>Plan du site</Trans>
+												<Trans>Intégrer nos simulateurs</Trans>
 											</Link>
 										</li>
-										<li>
-											<Link
-												to={absoluteSitePaths.nouveautés}
-												noUnderline
-												$textColor={(theme) => theme.colors.extended.grey[100]}
-											>
-												Nouveautés <Emoji emoji="✨" />
-											</Link>
-										</li>
-										<li>
-											<Link
-												to={absoluteSitePaths.stats}
-												noUnderline
-												$textColor={(theme) => theme.colors.extended.grey[100]}
-											>
-												Stats <Emoji emoji="📊" />
-											</Link>
-										</li>
-										<li>
-											<Link
-												to={absoluteSitePaths.budget}
-												noUnderline
-												$textColor={(theme) => theme.colors.extended.grey[100]}
-											>
-												Budget <Emoji emoji="💶" />
-											</Link>
-										</li>
+										{language === 'fr' && (
+											<li>
+												<InscriptionBetaTesteur />
+											</li>
+										)}
+										{hrefLink && (
+											<li key={hrefLink.hrefLang}>
+												<Link
+													href={hrefLink.href}
+													openInSameWindow
+													lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
+													noUnderline
+													$textColor={(theme) =>
+														theme.colors.extended.grey[100]
+													}
+												>
+													{hrefLink.hrefLang === 'fr' ? (
+														<>
+															Passer en français <Emoji emoji="🇫🇷" />
+														</>
+													) : hrefLink.hrefLang === 'en' ? (
+														<>
+															Switch to English <Emoji emoji="🇬🇧" />
+														</>
+													) : (
+														hrefLink.hrefLang
+													)}
+												</Link>
+											</li>
+										)}
 									</ul>
 								</nav>
-							)}
-						</FooterColumn>
-						<FooterColumn>
-							<nav title="secondColumnNav">
-								<ul>
-									<li>
-										<Link
-											to={absoluteSitePaths.développeur.index}
-											noUnderline
-											$textColor={(theme) => theme.colors.extended.grey[100]}
-										>
-											<Trans>Intégrer nos simulateurs</Trans>
-										</Link>
-									</li>
-									{language === 'fr' && (
-										<li>
-											<InscriptionBetaTesteur />
-										</li>
-									)}
-									{hrefLink && (
-										<li key={hrefLink.hrefLang}>
-											<Link
-												href={hrefLink.href}
-												openInSameWindow
-												lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
-												noUnderline
-												$textColor={(theme) => theme.colors.extended.grey[100]}
-											>
-												{hrefLink.hrefLang === 'fr' ? (
-													<>
-														Passer en français <Emoji emoji="🇫🇷" />
-													</>
-												) : hrefLink.hrefLang === 'en' ? (
-													<>
-														Switch to English <Emoji emoji="🇬🇧" />
-													</>
-												) : (
-													hrefLink.hrefLang
-												)}
-											</Link>
-										</li>
-									)}
-								</ul>
-							</nav>
-						</FooterColumn>
+							</FooterColumn>
 
-						<FooterColumn>
-							<nav title="thirdColumnNav">
-								<ul>
-									<li>
-										<LegalNotice />
-									</li>
-									<li>
-										<Privacy />
-									</li>
-									{language === 'fr' && (
+							<FooterColumn>
+								<nav title="thirdColumnNav">
+									<ul>
 										<li>
-											<Link
-												to={absoluteSitePaths.accessibilité}
-												aria-label={t(
-													'footer.accessibilitéAriaLabel',
-													'Accessibilité : non conforme, en savoir plus'
-												)}
-												noUnderline
-												$textColor={(theme) => theme.colors.extended.grey[100]}
-											>
-												<Trans i18nKey="footer.accessibilité">
-													Accessibilité : non conforme
-												</Trans>
-											</Link>
+											<LegalNotice />
 										</li>
-									)}
-								</ul>
-							</nav>
-						</FooterColumn>
-					</FooterContainer>
+										<li>
+											<Privacy />
+										</li>
+										{language === 'fr' && (
+											<li>
+												<Link
+													to={absoluteSitePaths.accessibilité}
+													aria-label={t(
+														'footer.accessibilitéAriaLabel',
+														'Accessibilité : non conforme, en savoir plus'
+													)}
+													noUnderline
+													$textColor={(theme) =>
+														theme.colors.extended.grey[100]
+													}
+												>
+													<Trans i18nKey="footer.accessibilité">
+														Accessibilité : non conforme
+													</Trans>
+												</Link>
+											</li>
+										)}
+									</ul>
+								</nav>
+							</FooterColumn>
+						</FooterContainer>
+					</ThemeProvider>
 				</Container>
 			</footer>
 		</>

--- a/site/source/components/layout/Footer/InscriptionBetaTesteur/index.tsx
+++ b/site/source/components/layout/Footer/InscriptionBetaTesteur/index.tsx
@@ -16,7 +16,7 @@ export default function InscriptionBetaTesteur() {
 					{...buttonProps}
 					aria-haspopup="dialog"
 					noUnderline
-					textColor={(theme) => theme.colors.extended.grey[100]}
+					$textColor={(theme) => theme.colors.extended.grey[100]}
 				>
 					Devenir beta-testeur
 				</Link>

--- a/site/source/components/layout/Footer/InscriptionBetaTesteur/index.tsx
+++ b/site/source/components/layout/Footer/InscriptionBetaTesteur/index.tsx
@@ -12,7 +12,12 @@ export default function InscriptionBetaTesteur() {
 	return (
 		<PopoverWithTrigger
 			trigger={(buttonProps) => (
-				<Link {...buttonProps} aria-haspopup="dialog" noUnderline>
+				<Link
+					{...buttonProps}
+					aria-haspopup="dialog"
+					noUnderline
+					textColor={(theme) => theme.colors.extended.grey[100]}
+				>
 					Devenir beta-testeur
 				</Link>
 			)}

--- a/site/source/components/layout/Footer/Privacy.tsx
+++ b/site/source/components/layout/Footer/Privacy.tsx
@@ -31,7 +31,12 @@ export default function Privacy({ label }: { label?: string }) {
 	return (
 		<PopoverWithTrigger
 			trigger={(buttonProps) => (
-				<Link {...buttonProps} aria-haspopup="dialog" noUnderline>
+				<Link
+					{...buttonProps}
+					aria-haspopup="dialog"
+					noUnderline
+					textColor={(theme) => theme.colors.extended.grey[100]}
+				>
 					{label ?? <Trans>Gestion des données personnelles</Trans>}
 				</Link>
 			)}

--- a/site/source/components/layout/Footer/Privacy.tsx
+++ b/site/source/components/layout/Footer/Privacy.tsx
@@ -12,9 +12,11 @@ import * as safeLocalStorage from '../../../storage/safeLocalStorage'
 export default function Privacy({
 	label,
 	noUnderline = true,
+	isDark,
 }: {
 	label?: string
 	noUnderline?: boolean
+	isDark?: boolean
 }) {
 	const tracker = useContext(TrackingContext)
 	const [valueChanged, setValueChanged] = useState(false)
@@ -41,7 +43,11 @@ export default function Privacy({
 					{...buttonProps}
 					aria-haspopup="dialog"
 					noUnderline={noUnderline}
-					$textColor={(theme) => theme.colors.extended.grey[100]}
+					$textColor={(theme) =>
+						isDark
+							? theme.colors.extended.grey[100]
+							: theme.colors.theme.linkColor
+					}
 				>
 					{label ?? <Trans>Gestion des données personnelles</Trans>}
 				</Link>

--- a/site/source/components/layout/Footer/Privacy.tsx
+++ b/site/source/components/layout/Footer/Privacy.tsx
@@ -35,7 +35,7 @@ export default function Privacy({ label }: { label?: string }) {
 					{...buttonProps}
 					aria-haspopup="dialog"
 					noUnderline
-					textColor={(theme) => theme.colors.extended.grey[100]}
+					$textColor={(theme) => theme.colors.extended.grey[100]}
 				>
 					{label ?? <Trans>Gestion des données personnelles</Trans>}
 				</Link>

--- a/site/source/components/layout/Footer/Privacy.tsx
+++ b/site/source/components/layout/Footer/Privacy.tsx
@@ -9,7 +9,13 @@ import { Body, SmallBody } from '@/design-system/typography/paragraphs'
 import { TrackPage, TrackingContext } from '../../../ATInternetTracking'
 import * as safeLocalStorage from '../../../storage/safeLocalStorage'
 
-export default function Privacy({ label }: { label?: string }) {
+export default function Privacy({
+	label,
+	noUnderline = true,
+}: {
+	label?: string
+	noUnderline?: boolean
+}) {
 	const tracker = useContext(TrackingContext)
 	const [valueChanged, setValueChanged] = useState(false)
 	const { t } = useTranslation()
@@ -34,7 +40,7 @@ export default function Privacy({ label }: { label?: string }) {
 				<Link
 					{...buttonProps}
 					aria-haspopup="dialog"
-					noUnderline
+					noUnderline={noUnderline}
 					$textColor={(theme) => theme.colors.extended.grey[100]}
 				>
 					{label ?? <Trans>Gestion des données personnelles</Trans>}

--- a/site/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/site/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -37,7 +37,7 @@ export default function SalaryExplanation() {
 			<DistributionSection />
 
 			<Container
-				backgroundColor={(theme) =>
+				$backgroundColor={(theme) =>
 					theme.darkMode
 						? theme.colors.extended.dark[700]
 						: theme.colors.bases.primary[100]

--- a/site/source/components/simulationExplanation/SalaryExplanation.tsx
+++ b/site/source/components/simulationExplanation/SalaryExplanation.tsx
@@ -16,8 +16,6 @@ import { SmallBody } from '@/design-system/typography/paragraphs'
 export default function SalaryExplanation() {
 	const payslipRef = useRef<HTMLDivElement>(null)
 
-	const { t } = useTranslation()
-
 	if (useInversionFail()) {
 		return null
 	}

--- a/site/source/components/ui/AnimatedTargetValue.tsx
+++ b/site/source/components/ui/AnimatedTargetValue.tsx
@@ -1,5 +1,5 @@
 import { formatValue } from 'publicodes'
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import styled, { keyframes } from 'styled-components'

--- a/site/source/components/ui/WarningBlock.tsx
+++ b/site/source/components/ui/WarningBlock.tsx
@@ -36,7 +36,7 @@ export default function Warning({ localStorageKey, children }: WarningProps) {
 								aria-label={t(
 									'Lire les précisions, ouvrir le message condensé.'
 								)}
-								textColor={(theme) => theme.colors.bases.tertiary[700]}
+								$textColor={(theme) => theme.colors.bases.tertiary[700]}
 							>
 								<Trans i18nKey="simulateurs.warning.plus">
 									Lire les précisions

--- a/site/source/components/ui/WarningBlock.tsx
+++ b/site/source/components/ui/WarningBlock.tsx
@@ -36,6 +36,7 @@ export default function Warning({ localStorageKey, children }: WarningProps) {
 								aria-label={t(
 									'Lire les précisions, ouvrir le message condensé.'
 								)}
+								textColor={(theme) => theme.colors.bases.tertiary[700]}
 							>
 								<Trans i18nKey="simulateurs.warning.plus">
 									Lire les précisions

--- a/site/source/components/utils/colors.tsx
+++ b/site/source/components/utils/colors.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { ThemeProvider } from 'styled-components'
 
 import { hexToHSL } from '@/hexToHSL'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 import { useIsEmbedded } from './useIsEmbedded'
 
@@ -63,6 +64,9 @@ export function ThemeColorsProvider({ children }: ProviderProps) {
 		)
 	}, [hue, saturation])
 	const isEmbeded = useIsEmbedded()
+
+	const [isDarkMode] = useDarkMode()
+
 	if (!themeColor && !isEmbeded) {
 		return <>{children}</>
 	}
@@ -74,6 +78,21 @@ export function ThemeColorsProvider({ children }: ProviderProps) {
 				colors: {
 					...theme.colors,
 					bases: { ...theme.colors.bases, primary: PALETTE },
+					...(IFRAME_COLOR
+						? {
+								theme: {
+									...theme.colors.theme,
+									headingColor: isDarkMode
+										? theme.colors.extended.grey[100]
+										: PALETTE[700],
+									$textColor: theme.colors.extended.grey[800],
+									linkColor: isDarkMode
+										? theme.colors.extended.grey[100]
+										: PALETTE[700],
+									linkDarkColor: PALETTE[100],
+								},
+						  }
+						: {}),
 				},
 			})}
 		>

--- a/site/source/contexts/DarkModeContext.tsx
+++ b/site/source/contexts/DarkModeContext.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useEffect, useState } from 'react'
+import { ReactNode, createContext, useState } from 'react'
 
 import { useIsEmbedded } from '@/components/utils/useIsEmbedded'
 import { getItem, setItem } from '@/storage/safeLocalStorage'
@@ -37,34 +37,11 @@ export const DarkModeProvider = ({ children }: { children: ReactNode }) => {
 		console.log(darkMode ? 'Nuit' : 'Jour')
 	}
 
-	useEffect(() => {
-		if (!window.matchMedia) {
-			return
-		}
-		const onDarkModeChange = (e: MediaQueryListEvent) => {
-			setDarkMode(e.matches)
-		}
-		const matchDarkMode = window.matchMedia('(prefers-color-scheme: dark)')
-
-		// safari 13 doesn't have addEventListener
-		matchDarkMode.addEventListener
-			? matchDarkMode.addEventListener('change', onDarkModeChange)
-			: matchDarkMode.addListener(onDarkModeChange)
-
-		return () => {
-			// safari 13 doesn't have removeEventListener
-			matchDarkMode.removeEventListener
-				? matchDarkMode.removeEventListener('change', onDarkModeChange)
-				: matchDarkMode.removeListener(onDarkModeChange)
-		}
-	})
 	const finalDarkMode = !useIsEmbedded() && darkMode
 
 	return (
 		<DarkModeContext.Provider value={[finalDarkMode, setDarkMode]}>
-			{/* <ThemeProvider theme={(theme) => ({ ...theme, darkMode: finalDarkMode })}> */}
 			{children}
-			{/* </ThemeProvider> */}
 		</DarkModeContext.Provider>
 	)
 }

--- a/site/source/design-system/InfoBulle/index.tsx
+++ b/site/source/design-system/InfoBulle/index.tsx
@@ -33,7 +33,7 @@ const InfoBulleText = styled.span`
 	border-radius: 3px;
 	font-family: 'Roboto';
 	background-color: white;
-	color: inherit;
+	color: ${({ theme }) => theme.colors.extended.grey[800]};
 	transition: opacity 0.2s, transform 0.2s;
 	opacity: 0;
 	box-shadow: 0px 2px 4px -1px rgba(41, 117, 209, 0.2),

--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -50,7 +50,7 @@ function AccordionItem<T>(props: AccordionItemProps<T>) {
 	const animatedStyle = useSpring({
 		reset: false,
 		to: isOpen
-			? { opacity: 1, height: height + 48, display: 'block' } // We add 48px that corresponds to the margin
+			? { opacity: 1, height: height + 48 } // We add 48px that corresponds to the margin
 			: { opacity: 0, height: 0 },
 	})
 
@@ -66,7 +66,7 @@ function AccordionItem<T>(props: AccordionItemProps<T>) {
 				</StyledButton>
 			</StyledTitle>
 			{/* @ts-ignore: https://github.com/pmndrs/react-spring/issues/1515 */}
-			<StyledContent {...regionProps} style={animatedStyle} isOpen>
+			<StyledContent {...regionProps} style={animatedStyle}>
 				<div ref={regionRef}>{item.props.children}</div>
 			</StyledContent>
 		</StyledAccordionItem>
@@ -82,6 +82,8 @@ const StyledAccordionItem = styled.div<{ isOpen?: boolean }>`
 		border-top: 1px solid ${({ theme }) => theme.colors.bases.primary[400]};
 	}
 
+	// Empêche le focus sur les éléments enfants de StyledContent
+	// en état fermé
 	${({ isOpen }) =>
 		!isOpen &&
 		`

--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -102,9 +102,13 @@ const StyledButton = styled.button`
 	${({ theme }) => css`
 		font-family: ${theme.fonts.main};
 		font-size: ${theme.baseFontSize};
-		color: ${theme.colors.bases.primary[700]};
+		color: ${theme.darkMode
+			? theme.colors.extended.grey[100]
+			: theme.colors.bases.primary[700]};
 		padding: ${theme.spacings.lg};
-		background-color: ${theme.colors.bases.primary[100]};
+		background-color: ${theme.darkMode
+			? theme.colors.extended.grey[700]
+			: theme.colors.bases.primary[100]};
 		> span {
 			border-radius: ${theme.box.borderRadius};
 		}
@@ -124,7 +128,7 @@ const ChevronRightMedium = styled.img.attrs({ src: chevronImg })<Chevron>`
 		!$isOpen &&
 		css`
 			transform: rotate(180deg);
-		`}
+		`};
 `
 
 const StyledContent = styled(animated.div)`

--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -45,18 +45,20 @@ function AccordionItem<T>(props: AccordionItemProps<T>) {
 	const { buttonProps, regionProps } = useAccordionItem<T>(props, state, ref)
 
 	const isOpen = state.expandedKeys.has(item.key)
-	// const isDisabled = state.disabledKeys.has(item.key)
 
 	const [regionRef, { height }] = useMeasure()
 	const animatedStyle = useSpring({
 		reset: false,
 		to: isOpen
-			? { opacity: 1, height: height + 48 } // We add 48px that corresponds to the margin
+			? { opacity: 1, height: height + 48, display: 'block' } // We add 48px that corresponds to the margin
 			: { opacity: 0, height: 0 },
 	})
 
 	return (
-		<StyledAccordionItem onMouseDown={(x) => x.stopPropagation()}>
+		<StyledAccordionItem
+			onMouseDown={(x) => x.stopPropagation()}
+			isOpen={isOpen}
+		>
 			<StyledTitle>
 				<StyledButton {...buttonProps} ref={ref}>
 					<span>{item.props.title}</span>
@@ -64,7 +66,7 @@ function AccordionItem<T>(props: AccordionItemProps<T>) {
 				</StyledButton>
 			</StyledTitle>
 			{/* @ts-ignore: https://github.com/pmndrs/react-spring/issues/1515 */}
-			<StyledContent {...regionProps} style={animatedStyle}>
+			<StyledContent {...regionProps} style={animatedStyle} isOpen>
 				<div ref={regionRef}>{item.props.children}</div>
 			</StyledContent>
 		</StyledAccordionItem>
@@ -75,10 +77,18 @@ const StyledTitle = styled.h3`
 	margin: 0;
 `
 
-const StyledAccordionItem = styled.div`
+const StyledAccordionItem = styled.div<{ isOpen?: boolean }>`
 	:not(:first-child) {
 		border-top: 1px solid ${({ theme }) => theme.colors.bases.primary[400]};
 	}
+
+	${({ isOpen }) =>
+		!isOpen &&
+		`
+		& ${StyledContent} > div {
+			visibility: hidden;
+		}
+	`}
 `
 
 const StyledButton = styled.button`
@@ -99,9 +109,6 @@ const StyledButton = styled.button`
 	`}
 	:hover {
 		text-decoration: underline;
-	}
-	:focus {
-		outline: none;
 	}
 `
 

--- a/site/source/design-system/buttons/Button.tsx
+++ b/site/source/design-system/buttons/Button.tsx
@@ -122,7 +122,9 @@ export const StyledButton = styled.button<StyledButtonProps>`
 			background-color: ${theme.colors.bases[$color][
 				$color === 'primary' ? 700 : 300
 			]};
-			color: ${theme.colors.extended.grey[$color === 'primary' ? 100 : 800]};
+			color: ${theme.colors.extended.grey[
+				$color === 'primary' ? 100 : 800
+			]} !important;
 		`}
 
 	/* Primary, secondary & tertiary light colors */
@@ -130,7 +132,9 @@ export const StyledButton = styled.button<StyledButtonProps>`
 		$light &&
 		!theme.darkMode &&
 		css`
-			color: ${theme.colors.bases[$color][$color === 'primary' ? 700 : 700]};
+			color: ${theme.colors.bases[$color][
+				$color === 'primary' ? 700 : 700
+			]} !important;
 			background-color: ${theme.colors.extended.grey[100]};
 			${$color === 'secondary' &&
 			css`
@@ -154,7 +158,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
 			css`
 				background-color: transparent;
 				border-color: ${theme.colors.extended.grey[100]};
-				color: ${theme.colors.extended.grey[100]};
+				color: ${theme.colors.extended.grey[100]}!important;
 			`}
 	}
 	/* HOVER STYLE */

--- a/site/source/design-system/buttons/Button.tsx
+++ b/site/source/design-system/buttons/Button.tsx
@@ -7,6 +7,8 @@ import {
 } from '@/design-system/typography/link'
 import { wrapperDebounceEvents } from '@/utils'
 
+import { FocusStyle } from '../global-style'
+
 type Size = 'XL' | 'MD' | 'XS' | 'XXS'
 type Color = 'primary' | 'secondary' | 'tertiary'
 
@@ -176,6 +178,10 @@ export const StyledButton = styled.button<StyledButtonProps>`
 							$color === 'primary' ? 800 : 400
 						]};
 				  `}
+	}
+
+	:focus {
+		${FocusStyle}
 	}
 
 	/* Dark mode */

--- a/site/source/design-system/card/Article.tsx
+++ b/site/source/design-system/card/Article.tsx
@@ -53,6 +53,7 @@ export function Article({
 					display: flex;
 					align-items: center;
 				`}
+				$textColor={(theme) => theme.colors.theme.linkColor}
 			>
 				{ctaLabel}
 				{linkProps.external && <NewWindowLinkIcon />}
@@ -98,7 +99,7 @@ const StyledBody = styled(Body)`
 	background-color: transparent;
 	&,
 	& * {
-		color: ${({ theme }) => theme.colors.bases.primary[700]};
+		color: ${({ theme }) => theme.colors.theme.linkColor};
 		font-weight: 700;
 	}
 

--- a/site/source/design-system/card/Article.tsx
+++ b/site/source/design-system/card/Article.tsx
@@ -47,7 +47,7 @@ export function Article({
 			<StyledHeader as={titleProps.as}>
 				{titleProps.children} {icon}
 			</StyledHeader>
-			<Body>{children}</Body>
+			<Content>{children}</Content>
 			<StyledBody
 				css={`
 					display: flex;
@@ -83,14 +83,19 @@ const StyledHeader = styled(H4)`
 		theme.darkMode
 			? theme.colors.bases.primary[200]
 			: theme.colors.bases.primary[600]};
-	background-color: inherit;
+	background-color: transparent;
 `
 
 const StyledChevron = styled(Chevron)`
 	margin-left: ${({ theme }) => theme.spacings.xxs};
 `
 
+const Content = styled(Body)`
+	background-color: transparent;
+`
+
 const StyledBody = styled(Body)`
+	background-color: transparent;
 	&,
 	& * {
 		color: ${({ theme }) => theme.colors.bases.primary[700]};

--- a/site/source/design-system/card/Card.tsx
+++ b/site/source/design-system/card/Card.tsx
@@ -157,7 +157,4 @@ export const CardContainer = styled.div<{ $compact?: boolean }>`
 					${spacings.md} ${spacings.lg}
 			  `};
 	transition: box-shadow 0.15s, background-color 0.15s;
-	& h2 {
-		background-color: transparent;
-	}
 `

--- a/site/source/design-system/card/Card.tsx
+++ b/site/source/design-system/card/Card.tsx
@@ -157,4 +157,7 @@ export const CardContainer = styled.div<{ $compact?: boolean }>`
 					${spacings.md} ${spacings.lg}
 			  `};
 	transition: box-shadow 0.15s, background-color 0.15s;
+	& h2 {
+		background-color: transparent;
+	}
 `

--- a/site/source/design-system/field/Checkbox.tsx
+++ b/site/source/design-system/field/Checkbox.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components'
 
 import { Body } from '@/design-system/typography/paragraphs'
 
+import { FocusStyle } from '../global-style'
+
 export default function Checkbox(
 	props: AriaCheckboxProps &
 		(
@@ -153,5 +155,9 @@ const CheckboxContainer = styled.label`
 			theme.darkMode
 				? theme.colors.extended.grey[100]
 				: theme.colors.bases.primary[700]};
+	}
+
+	&:focus-within {
+		${FocusStyle}
 	}
 `

--- a/site/source/design-system/field/DateField.tsx
+++ b/site/source/design-system/field/DateField.tsx
@@ -2,7 +2,9 @@ import { AriaTextFieldOptions } from '@react-aria/textfield'
 
 import TextField from './TextField'
 
-export default function DateField(props: AriaTextFieldOptions<'input'>) {
+export default function DateField(
+	props: AriaTextFieldOptions<'input'> & { isLight?: boolean }
+) {
 	return (
 		<TextField
 			{...props}

--- a/site/source/design-system/field/NumberField.tsx
+++ b/site/source/design-system/field/NumberField.tsx
@@ -35,6 +35,7 @@ type NumberFieldProps = Omit<AriaNumberFieldProps, 'placeholder'> & {
 	small?: boolean
 	placeholder?: number
 	onChange?: (n?: number) => void
+	hasDarkBackground?: boolean
 }
 
 export default function NumberField(props: NumberFieldProps) {
@@ -103,6 +104,7 @@ export default function NumberField(props: NumberFieldProps) {
 				hasError={!!props.errorMessage || props.validationState === 'invalid'}
 				hasLabel={!!props.label}
 				small={props.small}
+				hasDarkBackground={props?.hasDarkBackground}
 			>
 				<StyledNumberInput
 					{...(omit(props, 'label') as HTMLAttributes<HTMLInputElement>)}
@@ -152,7 +154,10 @@ const StyledUnit = styled(StyledSuffix)`
 	white-space: nowrap;
 `
 
-const StyledNumberInput = styled(StyledInput)<{ withUnit: boolean }>`
+const StyledNumberInput = styled(StyledInput)<{
+	withUnit: boolean
+	hasDarkBackground?: boolean
+}>`
 	${({ withUnit }) =>
 		withUnit &&
 		css`

--- a/site/source/design-system/field/NumberField.tsx
+++ b/site/source/design-system/field/NumberField.tsx
@@ -35,7 +35,7 @@ type NumberFieldProps = Omit<AriaNumberFieldProps, 'placeholder'> & {
 	small?: boolean
 	placeholder?: number
 	onChange?: (n?: number) => void
-	hasDarkBackground?: boolean
+	isLight?: boolean
 }
 
 export default function NumberField(props: NumberFieldProps) {
@@ -104,7 +104,7 @@ export default function NumberField(props: NumberFieldProps) {
 				hasError={!!props.errorMessage || props.validationState === 'invalid'}
 				hasLabel={!!props.label}
 				small={props.small}
-				hasDarkBackground={props?.hasDarkBackground}
+				isLight={props?.isLight}
 			>
 				<StyledNumberInput
 					{...(omit(props, 'label') as HTMLAttributes<HTMLInputElement>)}
@@ -159,7 +159,7 @@ const StyledUnit = styled(StyledSuffix)`
 
 const StyledNumberInput = styled(StyledInput)<{
 	withUnit: boolean
-	hasDarkBackground?: boolean
+	isLight?: boolean
 }>`
 	${({ withUnit }) =>
 		withUnit &&

--- a/site/source/design-system/field/NumberField.tsx
+++ b/site/source/design-system/field/NumberField.tsx
@@ -148,8 +148,11 @@ const StyledNumberFieldContainer = styled(StyledContainer)`
 `
 
 const StyledUnit = styled(StyledSuffix)`
-	color: ${({ theme }) => theme.colors.extended.grey[600]};
-	background-color: inherit;
+	color: ${({ theme }) =>
+		theme.darkMode
+			? theme.colors.extended.grey[200]
+			: theme.colors.extended.grey[600]};
+	background-color: transparent;
 	padding-left: 0 !important;
 	white-space: nowrap;
 `

--- a/site/source/design-system/field/Radio/Radio.tsx
+++ b/site/source/design-system/field/Radio/Radio.tsx
@@ -123,9 +123,6 @@ export const VisibleRadio = styled.span`
 				? theme.colors.bases.primary[500]
 				: theme.colors.bases.primary[700]};
 	}
-	& > span {
-		background-color: transparent;
-	}
 `
 
 export const LabelBody = styled(Body)<{ $hideRadio?: boolean; for?: string }>`

--- a/site/source/design-system/field/Radio/Radio.tsx
+++ b/site/source/design-system/field/Radio/Radio.tsx
@@ -118,7 +118,13 @@ export const VisibleRadio = styled.span`
 	}
 
 	:hover ${OutsideCircle} {
-		border-color: ${({ theme }) => theme.colors.bases.primary[700]};
+		border-color: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.bases.primary[200]
+				: theme.colors.bases.primary[700]};
+	}
+	& span {
+		background-color: transparent;
 	}
 `
 
@@ -139,7 +145,10 @@ export const InputRadio = styled.input`
 		:checked
 		+ ${VisibleRadio}
 		${OutsideCircle} {
-		border-color: ${({ theme }) => theme.colors.bases.primary[700]};
+		border-color: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.bases.primary[200]
+				: theme.colors.bases.primary[700]};
 	}
 
 	:checked + ${VisibleRadio} ${InsideCircle} {

--- a/site/source/design-system/field/Radio/Radio.tsx
+++ b/site/source/design-system/field/Radio/Radio.tsx
@@ -123,7 +123,7 @@ export const VisibleRadio = styled.span`
 				? theme.colors.bases.primary[200]
 				: theme.colors.bases.primary[700]};
 	}
-	& span {
+	& > span {
 		background-color: transparent;
 	}
 `

--- a/site/source/design-system/field/Radio/Radio.tsx
+++ b/site/source/design-system/field/Radio/Radio.tsx
@@ -120,7 +120,7 @@ export const VisibleRadio = styled.span`
 	:hover ${OutsideCircle} {
 		border-color: ${({ theme }) =>
 			theme.darkMode
-				? theme.colors.bases.primary[200]
+				? theme.colors.bases.primary[500]
 				: theme.colors.bases.primary[700]};
 	}
 	& > span {
@@ -145,10 +145,7 @@ export const InputRadio = styled.input`
 		:checked
 		+ ${VisibleRadio}
 		${OutsideCircle} {
-		border-color: ${({ theme }) =>
-			theme.darkMode
-				? theme.colors.bases.primary[200]
-				: theme.colors.bases.primary[700]};
+		border-color: ${({ theme }) => theme.colors.bases.primary[700]};
 	}
 
 	:checked + ${VisibleRadio} ${InsideCircle} {

--- a/site/source/design-system/field/Radio/Radio.tsx
+++ b/site/source/design-system/field/Radio/Radio.tsx
@@ -4,6 +4,7 @@ import { AriaRadioProps } from '@react-types/radio'
 import { createContext, useContext, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
+import { FocusStyle } from '@/design-system/global-style'
 import { Body } from '@/design-system/typography/paragraphs'
 
 export const RadioContext = createContext<RadioGroupState | null>(null)
@@ -52,14 +53,6 @@ export const RadioPoint = ({ className }: { className?: string }) => (
 		<InsideCircle />
 	</RadioButton>
 )
-
-const Label = styled.label<{ $hideRadio?: boolean; for?: string }>`
-	${({ $hideRadio }) =>
-		$hideRadio &&
-		css`
-			margin-top: -1px;
-		`}
-`
 
 const OutsideCircle = styled.span`
 	position: absolute;
@@ -151,5 +144,16 @@ export const InputRadio = styled.input`
 
 	:checked + ${VisibleRadio} ${InsideCircle} {
 		transform: scale(1);
+	}
+`
+
+const Label = styled.label<{ $hideRadio?: boolean; for?: string }>`
+	${({ $hideRadio }) =>
+		$hideRadio &&
+		css`
+			margin-top: -1px;
+		`}
+	:focus-within ${VisibleRadio} {
+		${FocusStyle}
 	}
 `

--- a/site/source/design-system/field/SearchField.tsx
+++ b/site/source/design-system/field/SearchField.tsx
@@ -11,6 +11,7 @@ import styled, { css } from 'styled-components'
 import { Loader } from '@/design-system/icons/Loader'
 import { SearchIcon } from '@/design-system/icons/SearchIcon'
 
+import { FocusStyle } from '../global-style'
 import {
 	StyledContainer,
 	StyledDescription,
@@ -32,6 +33,9 @@ const SearchInput = styled(StyledInput)`
 
 const SearchInputContainer = styled(StyledInputContainer)`
 	padding-left: 0.5rem;
+	:focus-within {
+		outline-color: ${({ theme }) => theme.colors.extended.grey[100]};
+	}
 `
 
 const IconContainer = styled.div<{ hasLabel?: boolean }>`

--- a/site/source/design-system/field/SearchField.tsx
+++ b/site/source/design-system/field/SearchField.tsx
@@ -11,7 +11,6 @@ import styled, { css } from 'styled-components'
 import { Loader } from '@/design-system/icons/Loader'
 import { SearchIcon } from '@/design-system/icons/SearchIcon'
 
-import { FocusStyle } from '../global-style'
 import {
 	StyledContainer,
 	StyledDescription,
@@ -106,7 +105,7 @@ export default function SearchField(
 const StyledClearButton = styled.button`
 	position: absolute;
 	right: 0;
-	background: none;
+	background: transparent;
 	border: none;
 	font-size: 2rem;
 	line-height: 2rem;
@@ -116,6 +115,5 @@ const StyledClearButton = styled.button`
 		darkMode &&
 		css`
 			color: white !important;
-			background-color: inherit;
 		`}
 `

--- a/site/source/design-system/field/Select/index.tsx
+++ b/site/source/design-system/field/Select/index.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
+import { FocusStyle } from '@/design-system/global-style'
 import { CarretDown } from '@/design-system/icons/carret-down'
 import { omit } from '@/utils'
 
@@ -69,6 +70,10 @@ const Button = styled.button<ButtonProps>`
 				background-color: inherit;
 			}
 		`}
+
+	&:focus {
+		${FocusStyle}
+	}
 `
 
 const Value = styled.span`

--- a/site/source/design-system/field/Select/index.tsx
+++ b/site/source/design-system/field/Select/index.tsx
@@ -36,7 +36,7 @@ export const Label = styled.label`
 		css`
 			@media not print {
 				color: ${theme.colors.extended.grey[100]} !important;
-				background-color: inherit;
+				background-color: transparent;
 			}
 		`}
 `
@@ -67,7 +67,7 @@ const Button = styled.button<ButtonProps>`
 		css`
 			@media not print {
 				color: ${theme.colors.extended.grey[100]} !important;
-				background-color: inherit;
+				background-color: transparent;
 			}
 		`}
 

--- a/site/source/design-system/field/TextAreaField.tsx
+++ b/site/source/design-system/field/TextAreaField.tsx
@@ -85,7 +85,7 @@ export const StyledTextArea = styled.textarea`
 		css`
 			@media not print {
 				color: ${theme.colors.extended.grey[100]} !important;
-				background-color: inherit;
+				background-color: transparent;
 			}
 		`}
 `
@@ -107,7 +107,7 @@ export const StyledLabel = styled.label`
 		css`
 			@media not print {
 				color: ${theme.colors.extended.grey[100]} !important;
-				background-color: inherit;
+				background-color: transparent;
 			}
 		`}
 `

--- a/site/source/design-system/field/TextField.tsx
+++ b/site/source/design-system/field/TextField.tsx
@@ -12,8 +12,8 @@ const LABEL_HEIGHT = '1rem'
 type TextFieldProps = AriaTextFieldOptions<'input'> & {
 	inputRef?: RefObject<HTMLInputElement>
 	small?: boolean
-	hasDarkBackground?: boolean
-	hasLightBackground?: boolean
+	isDark?: boolean
+	isLight?: boolean
 }
 
 export default function TextField(props: TextFieldProps) {
@@ -27,8 +27,8 @@ export default function TextField(props: TextFieldProps) {
 			<StyledInputContainer
 				hasError={!!props.errorMessage || props.validationState === 'invalid'}
 				hasLabel={!!props.label && !props.small}
-				hasDarkBackground={props?.hasDarkBackground}
-				hasLightBackground={props?.hasLightBackground}
+				isLight={props?.isLight}
+				isDark={props?.isDark}
 			>
 				<StyledInput
 					{...(omit(props, 'label') as HTMLAttributes<HTMLInputElement>)}
@@ -136,28 +136,28 @@ export const StyledInputContainer = styled.div<{
 	hasError: boolean
 	hasLabel: boolean
 	small?: boolean
-	hasLightBackground?: boolean
-	hasDarkBackground?: boolean
+	isDark?: boolean
+	isLight?: boolean
 }>`
 	border-radius: ${({ theme }) => theme.box.borderRadius};
-	border: ${({ theme, hasLightBackground, hasDarkBackground }) =>
+	border: ${({ theme, isDark, isLight }) =>
 		`${theme.box.borderWidth} solid 
 		${
-			hasLightBackground
+			isDark
 				? `${theme.colors.extended.grey[800]}`
-				: hasDarkBackground
+				: isLight
 				? `${theme.colors.extended.grey[100]}`
 				: theme.darkMode
-				? theme.colors.extended.grey[100]
+				? theme.colors.extended.grey[300]
 				: theme.colors.extended.grey[700]
 		}`};
 	outline: transparent solid 1px;
 	position: relative;
 	display: flex;
-	background-color: ${({ theme, hasLightBackground, hasDarkBackground }) =>
-		hasLightBackground
+	background-color: ${({ theme, isDark, isLight }) =>
+		isDark
 			? 'rgba(255, 255, 255, 20%)'
-			: hasDarkBackground
+			: isLight
 			? 'rgba(255, 255, 255, 20%)'
 			: theme.darkMode
 			? 'rgba(255, 255, 255, 20%)'
@@ -165,19 +165,13 @@ export const StyledInputContainer = styled.div<{
 	align-items: center;
 	transition: all 0.2s;
 	:focus-within {
-		${({ theme, hasDarkBackground }) =>
-			hasDarkBackground &&
-			css`
-				outline-color: ${theme.colors.bases.primary[200]}!important;
-			`}
-		${({ theme, hasLightBackground }) =>
-			hasLightBackground &&
-			css`
-				outline-color: ${theme.colors.bases.primary[700]}!important;
-			`}
-		outline-color: ${({ theme, hasError }) =>
+		outline-color: ${({ theme, hasError, isLight, isDark }) =>
 			hasError
 				? theme.colors.extended.error[400]
+				: isLight
+				? theme.colors.extended.grey[100]
+				: isDark
+				? theme.colors.bases.primary[700]
 				: theme.darkMode
 				? theme.colors.bases.primary[300]
 				: theme.colors.bases.primary[800]};
@@ -239,10 +233,10 @@ export const StyledInputContainer = styled.div<{
 				: css`calc(${hasLabel ? LABEL_HEIGHT : '0rem'} + ${
 						theme.spacings.xs
 				  }) ${theme.spacings.sm} ${theme.spacings.xs}`};
-		color: ${({ theme, hasDarkBackground, hasLightBackground }) =>
-			hasDarkBackground
+		color: ${({ theme, isLight, isDark }) =>
+			isLight
 				? theme.colors.extended.grey[100]
-				: hasLightBackground
+				: isDark
 				? theme.colors.extended.grey[800]
 				: theme.darkMode
 				? theme.colors.extended.grey[100]

--- a/site/source/design-system/field/TextField.tsx
+++ b/site/source/design-system/field/TextField.tsx
@@ -5,11 +5,15 @@ import styled, { css } from 'styled-components'
 import { ExtraSmallBody } from '@/design-system/typography/paragraphs'
 import { omit } from '@/utils'
 
+import { CustomizeBlockStyle } from '../global-style'
+
 const LABEL_HEIGHT = '1rem'
 
 type TextFieldProps = AriaTextFieldOptions<'input'> & {
 	inputRef?: RefObject<HTMLInputElement>
 	small?: boolean
+	hasDarkBackground?: boolean
+	hasLightBackground?: boolean
 }
 
 export default function TextField(props: TextFieldProps) {
@@ -23,6 +27,8 @@ export default function TextField(props: TextFieldProps) {
 			<StyledInputContainer
 				hasError={!!props.errorMessage || props.validationState === 'invalid'}
 				hasLabel={!!props.label && !props.small}
+				hasDarkBackground={props?.hasDarkBackground}
+				hasLightBackground={props?.hasLightBackground}
 			>
 				<StyledInput
 					{...(omit(props, 'label') as HTMLAttributes<HTMLInputElement>)}
@@ -66,10 +72,6 @@ export const StyledInput = styled.input`
 	height: 100%;
 	outline: none;
 	transition: color 0.2s;
-	color: ${({ theme }) =>
-		theme.darkMode
-			? theme.colors.extended.grey[100]
-			: theme.colors.extended.grey[800]};
 	::placeholder {
 		${({ theme }) =>
 			theme.darkMode &&
@@ -105,8 +107,10 @@ export const StyledLabel = styled.label`
 	${({ theme }) =>
 		theme.darkMode &&
 		css`
-			color: ${theme.colors.extended.grey[100]} !important;
-			background-color: transparent;
+			@media not print {
+				color: ${theme.colors.extended.grey[100]} !important;
+				background-color: transparent;
+			}
 		`}
 `
 
@@ -140,9 +144,9 @@ export const StyledInputContainer = styled.div<{
 		`${theme.box.borderWidth} solid 
 		${
 			hasLightBackground
-				? `${theme.box.borderWidth} solid ${theme.colors.extended.grey[800]}`
+				? `${theme.colors.extended.grey[800]}`
 				: hasDarkBackground
-				? `${theme.box.borderWidth} solid ${theme.colors.extended.grey[100]}`
+				? `${theme.colors.extended.grey[100]}`
 				: theme.darkMode
 				? theme.colors.extended.grey[100]
 				: theme.colors.extended.grey[700]
@@ -150,7 +154,14 @@ export const StyledInputContainer = styled.div<{
 	outline: transparent solid 1px;
 	position: relative;
 	display: flex;
-	background-color: rgba(255, 255, 255, 20%);
+	background-color: ${({ theme, hasLightBackground, hasDarkBackground }) =>
+		hasLightBackground
+			? 'rgba(255, 255, 255, 20%)'
+			: hasDarkBackground
+			? 'rgba(255, 255, 255, 20%)'
+			: theme.darkMode
+			? 'rgba(255, 255, 255, 20%)'
+			: theme.colors.extended.grey[100]};
 	align-items: center;
 	transition: all 0.2s;
 	:focus-within {
@@ -228,6 +239,14 @@ export const StyledInputContainer = styled.div<{
 				: css`calc(${hasLabel ? LABEL_HEIGHT : '0rem'} + ${
 						theme.spacings.xs
 				  }) ${theme.spacings.sm} ${theme.spacings.xs}`};
+		color: ${({ theme, hasDarkBackground, hasLightBackground }) =>
+			hasDarkBackground
+				? theme.colors.extended.grey[100]
+				: hasLightBackground
+				? theme.colors.extended.grey[800]
+				: theme.darkMode
+				? theme.colors.extended.grey[100]
+				: theme.colors.extended.grey[800]};
 	}
 
 	${({ small }) =>
@@ -238,4 +257,6 @@ export const StyledInputContainer = styled.div<{
 				line-height: 1.25rem;
 			}
 		`}
+
+	${CustomizeBlockStyle}
 `

--- a/site/source/design-system/field/TextField.tsx
+++ b/site/source/design-system/field/TextField.tsx
@@ -66,6 +66,7 @@ export const StyledInput = styled.input`
 	height: 100%;
 	outline: none;
 	transition: color 0.2s;
+	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	::placeholder {
 		${({ theme }) =>
 			theme.darkMode &&
@@ -101,10 +102,8 @@ export const StyledLabel = styled.label`
 	${({ theme }) =>
 		theme.darkMode &&
 		css`
-			@media not print {
-				color: ${theme.colors.extended.grey[100]} !important;
-				background-color: transparent;
-			}
+			color: ${theme.colors.extended.grey[100]} !important;
+			background-color: transparent;
 		`}
 `
 
@@ -130,31 +129,35 @@ export const StyledInputContainer = styled.div<{
 	hasError: boolean
 	hasLabel: boolean
 	small?: boolean
+	hasLightBackground?: boolean
+	hasDarkBackground?: boolean
 }>`
 	border-radius: ${({ theme }) => theme.box.borderRadius};
 	border: ${({ theme }) =>
-		`${theme.box.borderWidth} solid ${
-			theme.darkMode
-				? theme.colors.extended.grey[100]
-				: theme.colors.extended.grey[700]
-		}`};
+		`${theme.box.borderWidth} solid ${theme.colors.extended.grey[100]}`};
 	outline: transparent solid 1px;
 	position: relative;
 	display: flex;
-	background-color: ${({ theme }) =>
-		theme.darkMode
-			? 'rgba(255, 255, 255, 20%)'
-			: theme.colors.extended.grey[100]};
+	background-color: rgba(255, 255, 255, 20%);
 	align-items: center;
 	transition: all 0.2s;
-
 	:focus-within {
+		${({ theme, hasDarkBackground }) =>
+			hasDarkBackground &&
+			css`
+				outline-color: ${theme.colors.bases.primary[200]}!important;
+			`}
+		${({ theme, hasLightBackground }) =>
+			hasLightBackground &&
+			css`
+				outline-color: ${theme.colors.bases.primary[700]}!important;
+			`}
 		outline-color: ${({ theme, hasError }) =>
 			hasError
 				? theme.colors.extended.error[400]
 				: theme.darkMode
-				? theme.colors.bases.primary[400]
-				: theme.colors.bases.primary[700]};
+				? theme.colors.bases.primary[300]
+				: theme.colors.bases.primary[800]};
 		outline-offset: ${({ theme }) => theme.spacings.xxs};
 		outline-width: ${({ theme }) => theme.spacings.xxs};
 	}

--- a/site/source/design-system/field/TextField.tsx
+++ b/site/source/design-system/field/TextField.tsx
@@ -66,7 +66,10 @@ export const StyledInput = styled.input`
 	height: 100%;
 	outline: none;
 	transition: color 0.2s;
-	color: ${({ theme }) => theme.colors.extended.grey[100]};
+	color: ${({ theme }) =>
+		theme.darkMode
+			? theme.colors.extended.grey[100]
+			: theme.colors.extended.grey[800]};
 	::placeholder {
 		${({ theme }) =>
 			theme.darkMode &&
@@ -133,8 +136,17 @@ export const StyledInputContainer = styled.div<{
 	hasDarkBackground?: boolean
 }>`
 	border-radius: ${({ theme }) => theme.box.borderRadius};
-	border: ${({ theme }) =>
-		`${theme.box.borderWidth} solid ${theme.colors.extended.grey[100]}`};
+	border: ${({ theme, hasLightBackground, hasDarkBackground }) =>
+		`${theme.box.borderWidth} solid 
+		${
+			hasLightBackground
+				? `${theme.box.borderWidth} solid ${theme.colors.extended.grey[800]}`
+				: hasDarkBackground
+				? `${theme.box.borderWidth} solid ${theme.colors.extended.grey[100]}`
+				: theme.darkMode
+				? theme.colors.extended.grey[100]
+				: theme.colors.extended.grey[700]
+		}`};
 	outline: transparent solid 1px;
 	position: relative;
 	display: flex;

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -1,4 +1,4 @@
-import { createGlobalStyle, css } from 'styled-components'
+import { DefaultTheme, createGlobalStyle, css } from 'styled-components'
 
 export const SROnly = css`
 	position: absolute !important;
@@ -216,4 +216,20 @@ figure {
 		display: none;
 	}
 }
+`
+
+export const CustomizeBlockStyle = css`
+	${({
+		theme,
+		backgroundColor,
+		color,
+	}: {
+		theme: DefaultTheme
+		backgroundColor?: (theme: DefaultTheme) => string
+		color?: (theme: DefaultTheme) => string
+	}) =>
+		`
+		${backgroundColor ? `background-color: ${backgroundColor(theme)};` : ''}
+		${color ? `color: ${color(theme)};` : ''}
+		`}
 `

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -235,7 +235,7 @@ export const CustomizeBlockStyle = css`
 `
 
 export const FocusStyle = css`
-	outline: 2px solid -webkit-focus-ring-color;
-	outline-offset: 1px;
+	outline: 3px solid ${({ theme }) => theme.colors.bases.primary[700]};
+	outline-offset: 2px;
 	box-shadow: 0 0 0 2px #ffffff;
 `

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -221,16 +221,16 @@ figure {
 export const CustomizeBlockStyle = css`
 	${({
 		theme,
-		backgroundColor,
-		textColor,
+		$backgroundColor,
+		$textColor,
 	}: {
 		theme: DefaultTheme
-		backgroundColor?: (theme: DefaultTheme) => string
-		textColor?: (theme: DefaultTheme) => string
+		$backgroundColor?: (theme: DefaultTheme) => string
+		$textColor?: (theme: DefaultTheme) => string
 	}) =>
 		`
-		${backgroundColor ? `background-color: ${backgroundColor(theme)};` : ''}
-		${textColor ? `color: ${textColor(theme)};` : ''}
+		${$backgroundColor ? `background-color: ${$backgroundColor(theme)};` : ''}
+		${$textColor ? `color: ${$textColor(theme)};` : ''}
 		`}
 `
 

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -109,7 +109,6 @@ html, body, #js, #js > * {
 *:before,
 *:after {
 	box-sizing: inherit;
-	transition: color 0.15s, background-color 0.15s;
 }
 
 body {

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -222,14 +222,14 @@ export const CustomizeBlockStyle = css`
 	${({
 		theme,
 		backgroundColor,
-		color,
+		textColor,
 	}: {
 		theme: DefaultTheme
 		backgroundColor?: (theme: DefaultTheme) => string
-		color?: (theme: DefaultTheme) => string
+		textColor?: (theme: DefaultTheme) => string
 	}) =>
 		`
 		${backgroundColor ? `background-color: ${backgroundColor(theme)};` : ''}
-		${color ? `color: ${color(theme)};` : ''}
+		${textColor ? `color: ${textColor(theme)};` : ''}
 		`}
 `

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -215,6 +215,10 @@ figure {
 		display: none;
 	}
 }
+
+body #mobile-menu-portal-id nav {
+	background: ${({ theme }) => theme.colors.theme.backgroundColorLight}
+}
 `
 
 export const CustomizeBlockStyle = css`

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -233,3 +233,9 @@ export const CustomizeBlockStyle = css`
 		${textColor ? `color: ${textColor(theme)};` : ''}
 		`}
 `
+
+export const FocusStyle = css`
+	outline: 2px solid -webkit-focus-ring-color;
+	outline-offset: 1px;
+	box-shadow: 0 0 0 2px #ffffff;
+`

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -109,6 +109,7 @@ html, body, #js, #js > * {
 *:before,
 *:after {
 	box-sizing: inherit;
+	transition: color 0.15s, background-color 0.15s;
 }
 
 body {

--- a/site/source/design-system/layout/Container.tsx
+++ b/site/source/design-system/layout/Container.tsx
@@ -47,7 +47,6 @@ const InnerContainer = styled.div`
 
 type OuterContainerProps = {
 	backgroundColor?: (theme: DefaultTheme) => string
-	color?: (theme: DefaultTheme) => string
 }
 
 type ContainerProps = {

--- a/site/source/design-system/layout/Container.tsx
+++ b/site/source/design-system/layout/Container.tsx
@@ -3,6 +3,8 @@ import styled, { DefaultTheme, ThemeProvider } from 'styled-components'
 
 import { useDarkMode } from '@/hooks/useDarkMode'
 
+import { CustomizeBlockStyle } from '../global-style'
+
 const InnerContainer = styled.div`
 	margin-right: auto;
 	margin-left: auto;
@@ -45,6 +47,7 @@ const InnerContainer = styled.div`
 
 type OuterContainerProps = {
 	backgroundColor?: (theme: DefaultTheme) => string
+	color?: (theme: DefaultTheme) => string
 }
 
 type ContainerProps = {
@@ -79,8 +82,7 @@ export default function Container({
 const OuterContainer = styled.div<OuterContainerProps>`
 	flex: 1;
 	min-width: 100vw;
-	background-color: ${({ theme, backgroundColor }) =>
-		backgroundColor ? backgroundColor(theme) : theme.colors};
+	background-color: ${({ theme }) => theme.colors.theme.backgroundColorLight};
 	@media print {
 		min-width: initial;
 	}
@@ -91,6 +93,7 @@ const OuterContainer = styled.div<OuterContainerProps>`
 			padding: 0.5em;
 		}
 	}
+	${CustomizeBlockStyle}
 `
 
 const OuterOuterContainer = styled.div`

--- a/site/source/design-system/layout/Container.tsx
+++ b/site/source/design-system/layout/Container.tsx
@@ -70,7 +70,7 @@ export default function Container({
 			})}
 		>
 			<OuterOuterContainer>
-				<OuterContainer backgroundColor={backgroundColor}>
+				<OuterContainer $backgroundColor={backgroundColor}>
 					<InnerContainer>{children}</InnerContainer>
 				</OuterContainer>
 			</OuterOuterContainer>

--- a/site/source/design-system/layout/Container.tsx
+++ b/site/source/design-system/layout/Container.tsx
@@ -46,17 +46,17 @@ const InnerContainer = styled.div`
 `
 
 type OuterContainerProps = {
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 }
 
 type ContainerProps = {
 	children: ReactNode
 	darkMode?: boolean
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 }
 
 export default function Container({
-	backgroundColor,
+	$backgroundColor,
 	darkMode,
 	children,
 }: ContainerProps) {
@@ -70,7 +70,7 @@ export default function Container({
 			})}
 		>
 			<OuterOuterContainer>
-				<OuterContainer $backgroundColor={backgroundColor}>
+				<OuterContainer $backgroundColor={$backgroundColor}>
 					<InnerContainer>{children}</InnerContainer>
 				</OuterContainer>
 			</OuterOuterContainer>

--- a/site/source/design-system/layout/Grid.tsx
+++ b/site/source/design-system/layout/Grid.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
 import styled, { css } from 'styled-components'
 
+import { CustomizeBlockStyle } from '../global-style'
 import { SpacingKey } from '../theme'
 
 const breakPoints = ['sm', 'md', 'lg', 'xl'] as Array<SpacingKey>
@@ -70,6 +71,7 @@ const StyledGridContainer = styled.div<GridContainerProps>`
 	width: calc(
 		100% + ${({ theme, rowSpacing }) => theme.spacing[rowSpacing ?? 0]}
 	);
+	${CustomizeBlockStyle}
 `
 
 const StyledGridItem = styled.div<GridItemProps & ContainerContext>`
@@ -88,6 +90,8 @@ const StyledGridItem = styled.div<GridItemProps & ContainerContext>`
 					}
 				`
 			)}
+
+	${CustomizeBlockStyle}
 `
 type GridContainerProps = {
 	columns?: number

--- a/site/source/design-system/message/index.tsx
+++ b/site/source/design-system/message/index.tsx
@@ -90,7 +90,7 @@ const StyledMessage = styled.div<StyledMessageProps>`
 			& p,
 			& span,
 			& li {
-				color: ${({ theme }) => theme.colors.extended.grey[800]}!important;
+				color: ${({ theme }) => theme.colors.extended.grey[800]};
 			}
 			& a {
 				color: ${(colorSpace as Palette)[700] ?? colorSpace[600]};

--- a/site/source/design-system/message/index.tsx
+++ b/site/source/design-system/message/index.tsx
@@ -3,7 +3,6 @@ import styled, { ThemeProvider, css } from 'styled-components'
 
 import { Palette, SmallPalette } from '@/types/styled'
 
-import { Button } from '../buttons'
 import { Body } from '../typography/paragraphs'
 import baseIcon from './baseIcon.svg'
 import errorIcon from './errorIcon.svg'

--- a/site/source/design-system/message/index.tsx
+++ b/site/source/design-system/message/index.tsx
@@ -92,7 +92,8 @@ const StyledMessage = styled.div<StyledMessageProps>`
 			& li {
 				color: ${({ theme }) => theme.colors.extended.grey[800]};
 			}
-			& a {
+			& a,
+			& button {
 				color: ${(colorSpace as Palette)[700] ?? colorSpace[600]};
 			}
 		`

--- a/site/source/design-system/message/index.tsx
+++ b/site/source/design-system/message/index.tsx
@@ -87,11 +87,17 @@ const StyledMessage = styled.div<StyledMessageProps>`
 				color: ${(colorSpace as Palette)[700] ?? colorSpace[600]};
 				background-color: inherit;
 			}
+			& p,
+			& span,
+			& li {
+				color: ${({ theme }) => theme.colors.extended.grey[800]}!important;
+			}
 			& a {
 				color: ${(colorSpace as Palette)[700] ?? colorSpace[600]};
 			}
 		`
 	}}
+	color: red;
 `
 
 const StyledIcon = styled.img`

--- a/site/source/design-system/message/index.tsx
+++ b/site/source/design-system/message/index.tsx
@@ -3,6 +3,7 @@ import styled, { ThemeProvider, css } from 'styled-components'
 
 import { Palette, SmallPalette } from '@/types/styled'
 
+import { Button } from '../buttons'
 import { Body } from '../typography/paragraphs'
 import baseIcon from './baseIcon.svg'
 import errorIcon from './errorIcon.svg'
@@ -85,6 +86,9 @@ const StyledMessage = styled.div<StyledMessageProps>`
 			&& h6 {
 				color: ${(colorSpace as Palette)[700] ?? colorSpace[600]};
 				background-color: inherit;
+			}
+			& a {
+				color: ${(colorSpace as Palette)[700] ?? colorSpace[600]};
 			}
 		`
 	}}

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -77,7 +77,7 @@ export default function Popover(
 		<ThemeProvider theme={(theme) => ({ ...theme, darkMode: false })}>
 			<OverlayContainer>
 				<Underlay {...underlayProps} $offsetTop={offsetTop}>
-					<Container backgroundColor={() => 'transparent'}>
+					<Container $backgroundColor={() => 'transparent'}>
 						<Grid
 							container
 							css={`

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -77,7 +77,7 @@ export default function Popover(
 		<ThemeProvider theme={(theme) => ({ ...theme, darkMode: false })}>
 			<OverlayContainer>
 				<Underlay {...underlayProps} $offsetTop={offsetTop}>
-					<Container>
+					<Container backgroundColor={() => 'transparent'}>
 						<Grid
 							container
 							css={`

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -109,7 +109,7 @@ export default function Popover(
 														role="img"
 														aria-hidden
 														viewBox="0 0 24 24"
-														fill="none"
+														fill="red"
 														xmlns="http://www.w3.org/2000/svg"
 													>
 														<path
@@ -224,7 +224,7 @@ const CloseButton = styled.button`
 
 	color: ${({ theme }) =>
 		theme.darkMode
-			? theme.colors.bases.primary[400]
+			? theme.colors.bases.primary[100]
 			: theme.colors.bases.primary[700]};
 	font-family: ${({ theme }) => theme.fonts.main};
 	font-weight: 700;
@@ -232,7 +232,7 @@ const CloseButton = styled.button`
 	line-height: 24px;
 	padding: ${({ theme }) => theme.spacings.sm};
 	path {
-		fill: ${({ theme }) => theme.colors.bases.primary[700]};
+		fill: ${({ theme }) => theme.colors.theme.linkColor};
 	}
 	svg {
 		width: ${({ theme }) => theme.spacings.lg};

--- a/site/source/design-system/root.tsx
+++ b/site/source/design-system/root.tsx
@@ -6,7 +6,6 @@ import styled, {
 	css,
 } from 'styled-components'
 
-import { DarkModeProvider } from '@/contexts/DarkModeContext'
 import urssafTheme, { getThemeColorsValues } from '@/design-system/theme'
 import { useDarkMode } from '@/hooks/useDarkMode'
 

--- a/site/source/design-system/root.tsx
+++ b/site/source/design-system/root.tsx
@@ -7,7 +7,7 @@ import styled, {
 } from 'styled-components'
 
 import { DarkModeProvider } from '@/contexts/DarkModeContext'
-import urssafTheme from '@/design-system/theme'
+import urssafTheme, { getThemeColorsValues } from '@/design-system/theme'
 import { useDarkMode } from '@/hooks/useDarkMode'
 
 type SystemRootProps = {
@@ -17,12 +17,22 @@ type SystemRootProps = {
 const SystemRoot = ({ children }: SystemRootProps) => {
 	const userAgent = typeof navigator !== 'undefined' && navigator.userAgent
 
+	const [isDarkMode] = useDarkMode()
+
+	const darkModeColorValues = getThemeColorsValues(isDarkMode)
+
 	return (
 		<StyleSheetManager disableCSSOMInjection={isbot(userAgent)}>
-			<ThemeProvider theme={urssafTheme}>
-				<DarkModeProvider>
-					<Background>{children}</Background>
-				</DarkModeProvider>
+			<ThemeProvider
+				theme={{
+					...urssafTheme,
+					colors: {
+						...urssafTheme.colors,
+						...darkModeColorValues,
+					},
+				}}
+			>
+				<Background>{children}</Background>
 			</ThemeProvider>
 		</StyleSheetManager>
 	)

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -90,7 +90,7 @@ const LabelBody = styled(Body)`
 	cursor: pointer;
 `
 
-const Text = styled.span<{ textColor?: (theme: DefaultTheme) => string }>`
+const Text = styled.span<{ $textColor?: (theme: DefaultTheme) => string }>`
 	margin-right: ${({ theme }) => theme.spacings.xxs};
 	${CustomizeBlockStyle}
 `
@@ -103,7 +103,7 @@ export type SwitchProps = AriaSwitchProps & {
 	children?: ReactNode
 	className?: string
 	role?: string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }
 
 export const Switch = (props: SwitchProps) => {
@@ -123,7 +123,7 @@ export const Switch = (props: SwitchProps) => {
 
 	return (
 		<LabelBody as="label" className={className}>
-			{children && <Text textColor={props?.textColor}>{children}</Text>}
+			{children && <Text $textColor={props?.$textColor}>{children}</Text>}
 			<StyledSwitch
 				light={light}
 				size={size}

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -1,9 +1,13 @@
 import { useSwitch } from '@react-aria/switch'
 import { useToggleState } from '@react-stately/toggle'
 import { ReactNode, useRef } from 'react'
-import styled, { css } from 'styled-components'
+import styled, { DefaultTheme, css } from 'styled-components'
 
-import { SROnly } from '@/design-system/global-style'
+import {
+	CustomizeBlockStyle,
+	FocusStyle,
+	SROnly,
+} from '@/design-system/global-style'
 
 import { Body } from '../typography/paragraphs'
 
@@ -75,6 +79,9 @@ const StyledSwitch = styled.span<StyledProps>`
 					color: ${theme.colors.extended.grey[500]};
 			  `
 			: ''}
+	:focus-within {
+		${FocusStyle}
+	}
 `
 
 const LabelBody = styled(Body)`
@@ -83,8 +90,9 @@ const LabelBody = styled(Body)`
 	cursor: pointer;
 `
 
-const Text = styled.span`
+const Text = styled.span<{ textColor?: (theme: DefaultTheme) => string }>`
 	margin-right: ${({ theme }) => theme.spacings.xxs};
+	${CustomizeBlockStyle}
 `
 
 type AriaSwitchProps = Parameters<typeof useSwitch>[0]
@@ -95,6 +103,7 @@ export type SwitchProps = AriaSwitchProps & {
 	children?: ReactNode
 	className?: string
 	role?: string
+	textColor?: (theme: DefaultTheme) => string
 }
 
 export const Switch = (props: SwitchProps) => {
@@ -114,7 +123,7 @@ export const Switch = (props: SwitchProps) => {
 
 	return (
 		<LabelBody as="label" className={className}>
-			{children && <Text>{children}</Text>}
+			{children && <Text textColor={props?.textColor}>{children}</Text>}
 			<StyledSwitch
 				light={light}
 				size={size}

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -186,6 +186,7 @@ const baseTheme = {
 const themeColorsDefaultValues = {
 	theme: {
 		headingColor: baseTheme.colors.bases.primary[700],
+		headingDarkColor: baseTheme.colors.extended.grey[100],
 		textColor: baseTheme.colors.extended.grey[800],
 		linkColor: baseTheme.colors.bases.primary[700],
 		linkDarkColor: baseTheme.colors.bases.primary[100],
@@ -199,7 +200,7 @@ export const getThemeColorsValues = (isDarkMode: boolean) => {
 		return {
 			theme: {
 				headingColor: baseTheme.colors.extended.grey[100],
-				headingDarkColor: baseTheme.colors.extended.grey[100],
+				headingDarkColor: baseTheme.colors.extended.grey[700],
 				textColor: baseTheme.colors.extended.grey[100],
 				linkColor: baseTheme.colors.bases.primary[100],
 				linkDarkColor: baseTheme.colors.bases.primary[700],

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -185,7 +185,7 @@ const baseTheme = {
 
 const themeColorsDefaultValues = {
 	theme: {
-		headingColor: baseTheme.colors.bases.primary[800],
+		headingColor: baseTheme.colors.bases.primary[700],
 		textColor: baseTheme.colors.extended.grey[800],
 		backgroundColorLight: baseTheme.colors.extended.grey[100],
 		backgroundColorDark: baseTheme.colors.bases.primary[800],
@@ -198,7 +198,7 @@ export const getThemeColorsValues = (isDarkMode: boolean) => {
 			theme: {
 				headingColor: baseTheme.colors.extended.grey[100],
 				textColor: baseTheme.colors.extended.grey[100],
-				backgroundColorLight: baseTheme.colors.bases.primary[800],
+				backgroundColorLight: baseTheme.colors.extended.dark[800],
 				backgroundColorDark: baseTheme.colors.extended.grey[100],
 			},
 		}

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -183,6 +183,30 @@ const baseTheme = {
 	},
 }
 
+const themeColorsDefaultValues = {
+	theme: {
+		headingColor: baseTheme.colors.bases.primary[800],
+		textColor: baseTheme.colors.extended.grey[800],
+		backgroundColorLight: baseTheme.colors.extended.grey[100],
+		backgroundColorDark: baseTheme.colors.bases.primary[800],
+	},
+}
+
+export const getThemeColorsValues = (isDarkMode: boolean) => {
+	if (isDarkMode) {
+		return {
+			theme: {
+				headingColor: baseTheme.colors.extended.grey[100],
+				textColor: baseTheme.colors.extended.grey[100],
+				backgroundColorLight: baseTheme.colors.bases.primary[800],
+				backgroundColorDark: baseTheme.colors.extended.grey[100],
+			},
+		}
+	}
+
+	return themeColorsDefaultValues
+}
+
 // We use the Grid from material-ui, we need to uniformise
 // breakpoints and spacing with the Urssaf design system
 export type SpacingKey = keyof typeof baseTheme.breakpointsWidth
@@ -193,6 +217,14 @@ const breakpoints = Object.fromEntries(
 	])
 ) as Record<SpacingKey, number>
 
+const baseThemeWithThemeColors = {
+	...baseTheme,
+	colors: {
+		...baseTheme.colors,
+		...themeColorsDefaultValues,
+	},
+}
+
 const theme = {
 	breakpoints: {
 		values: {
@@ -202,7 +234,7 @@ const theme = {
 	},
 	spacing: Object.values(baseTheme.spacings),
 
-	...baseTheme,
+	...baseThemeWithThemeColors,
 } satisfies Theme
 
 export default theme

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -186,7 +186,7 @@ const baseTheme = {
 const themeColorsDefaultValues = {
 	theme: {
 		headingColor: baseTheme.colors.bases.primary[700],
-		$textColor: baseTheme.colors.extended.grey[800],
+		textColor: baseTheme.colors.extended.grey[800],
 		linkColor: baseTheme.colors.bases.primary[700],
 		linkDarkColor: baseTheme.colors.bases.primary[100],
 		backgroundColorLight: baseTheme.colors.extended.grey[100],
@@ -199,7 +199,8 @@ export const getThemeColorsValues = (isDarkMode: boolean) => {
 		return {
 			theme: {
 				headingColor: baseTheme.colors.extended.grey[100],
-				$textColor: baseTheme.colors.extended.grey[100],
+				headingDarkColor: baseTheme.colors.extended.grey[100],
+				textColor: baseTheme.colors.extended.grey[100],
 				linkColor: baseTheme.colors.bases.primary[100],
 				linkDarkColor: baseTheme.colors.bases.primary[700],
 				backgroundColorLight: baseTheme.colors.extended.dark[800],

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -187,6 +187,8 @@ const themeColorsDefaultValues = {
 	theme: {
 		headingColor: baseTheme.colors.bases.primary[700],
 		textColor: baseTheme.colors.extended.grey[800],
+		linkColor: baseTheme.colors.bases.primary[700],
+		linkDarkColor: baseTheme.colors.bases.primary[100],
 		backgroundColorLight: baseTheme.colors.extended.grey[100],
 		backgroundColorDark: baseTheme.colors.bases.primary[800],
 	},
@@ -198,6 +200,8 @@ export const getThemeColorsValues = (isDarkMode: boolean) => {
 			theme: {
 				headingColor: baseTheme.colors.extended.grey[100],
 				textColor: baseTheme.colors.extended.grey[100],
+				linkColor: baseTheme.colors.bases.primary[100],
+				linkDarkColor: baseTheme.colors.bases.primary[700],
 				backgroundColorLight: baseTheme.colors.extended.dark[800],
 				backgroundColorDark: baseTheme.colors.extended.grey[100],
 			},

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -186,7 +186,7 @@ const baseTheme = {
 const themeColorsDefaultValues = {
 	theme: {
 		headingColor: baseTheme.colors.bases.primary[700],
-		textColor: baseTheme.colors.extended.grey[800],
+		$textColor: baseTheme.colors.extended.grey[800],
 		linkColor: baseTheme.colors.bases.primary[700],
 		linkDarkColor: baseTheme.colors.bases.primary[100],
 		backgroundColorLight: baseTheme.colors.extended.grey[100],
@@ -199,7 +199,7 @@ export const getThemeColorsValues = (isDarkMode: boolean) => {
 		return {
 			theme: {
 				headingColor: baseTheme.colors.extended.grey[100],
-				textColor: baseTheme.colors.extended.grey[100],
+				$textColor: baseTheme.colors.extended.grey[100],
 				linkColor: baseTheme.colors.bases.primary[100],
 				linkDarkColor: baseTheme.colors.bases.primary[700],
 				backgroundColorLight: baseTheme.colors.extended.dark[800],

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -11,8 +11,8 @@ const baseHeading = css`
 			? theme.colors.extended.grey[100]
 			: theme.colors.bases.primary[700]};
 	background-color: inherit;
-	color: ${({ theme }) => theme.colors.theme.headingColor};
-
+	color: ${({ theme }: { theme: DefaultTheme }) =>
+		theme.colors.theme.headingColor};
 	${CustomizeBlockStyle}// TODO: Fix ts issue
 `
 
@@ -29,7 +29,7 @@ export const HeadingUnderline = css`
 export const H1 = styled.h1<{
 	noUnderline?: boolean
 	backgroundColor?: (theme: DefaultTheme) => string
-	color?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	font-size: 2rem;
@@ -48,7 +48,7 @@ export const H1 = styled.h1<{
 export const H2 = styled.h2<{
 	noUnderline?: boolean
 	backgroundColor?: (theme: DefaultTheme) => string
-	color?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	font-size: 1.625rem;
@@ -75,7 +75,7 @@ export const H3 = styled.h3<{
 
 export const H4 = styled.h4<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	color?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	margin: ${({ theme }) =>
@@ -88,7 +88,7 @@ export const H4 = styled.h4<{
 
 export const H5 = styled.h5<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	color?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	font-size: 1rem;
@@ -101,7 +101,7 @@ export const H5 = styled.h5<{
 
 export const H6 = styled.h6<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	color?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	margin: ${({ theme }) =>

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -29,7 +29,7 @@ export const HeadingUnderline = css`
 export const H1 = styled.h1<{
 	noUnderline?: boolean
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	font-size: 2rem;
@@ -48,7 +48,7 @@ export const H1 = styled.h1<{
 export const H2 = styled.h2<{
 	noUnderline?: boolean
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	font-size: 1.625rem;
@@ -62,7 +62,7 @@ export const H2 = styled.h2<{
 
 export const H3 = styled.h3<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	margin: ${({ theme }) =>
@@ -75,7 +75,7 @@ export const H3 = styled.h3<{
 
 export const H4 = styled.h4<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	margin: ${({ theme }) =>
@@ -88,7 +88,7 @@ export const H4 = styled.h4<{
 
 export const H5 = styled.h5<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	font-size: 1rem;
@@ -101,7 +101,7 @@ export const H5 = styled.h5<{
 
 export const H6 = styled.h6<{
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
 	margin: ${({ theme }) =>

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import styled, { DefaultTheme, css } from 'styled-components'
 
 import { CustomizeBlockStyle } from '../global-style'
 
@@ -12,10 +12,8 @@ const baseHeading = css`
 			: theme.colors.bases.primary[700]};
 	background-color: inherit;
 	color: ${({ theme }) => theme.colors.theme.headingColor};
-	${({ theme, isDarkMode }) => {
-		console.log(isDarkMode, theme)
-	}}
-	${CustomizeBlockStyle as any} // TODO: Fix ts issue
+
+	${CustomizeBlockStyle}// TODO: Fix ts issue
 `
 
 export const HeadingUnderline = css`
@@ -28,7 +26,11 @@ export const HeadingUnderline = css`
 	}
 `
 
-export const H1 = styled.h1<{ noUnderline?: boolean }>`
+export const H1 = styled.h1<{
+	noUnderline?: boolean
+	backgroundColor?: (theme: DefaultTheme) => string
+	color?: (theme: DefaultTheme) => string
+}>`
 	${baseHeading}
 	font-size: 2rem;
 	margin: ${({ theme }) =>
@@ -43,7 +45,11 @@ export const H1 = styled.h1<{ noUnderline?: boolean }>`
 	}
 `
 
-export const H2 = styled.h2<{ noUnderline?: boolean }>`
+export const H2 = styled.h2<{
+	noUnderline?: boolean
+	backgroundColor?: (theme: DefaultTheme) => string
+	color?: (theme: DefaultTheme) => string
+}>`
 	${baseHeading}
 	font-size: 1.625rem;
 	line-height: 2rem;
@@ -54,7 +60,10 @@ export const H2 = styled.h2<{ noUnderline?: boolean }>`
 	${({ noUnderline }) => (!noUnderline ? HeadingUnderline : '')}
 `
 
-export const H3 = styled.h3`
+export const H3 = styled.h3<{
+	backgroundColor?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
+}>`
 	${baseHeading}
 	margin: ${({ theme }) =>
 		css`
@@ -64,7 +73,10 @@ export const H3 = styled.h3`
 	line-height: 1.75rem;
 `
 
-export const H4 = styled.h4`
+export const H4 = styled.h4<{
+	backgroundColor?: (theme: DefaultTheme) => string
+	color?: (theme: DefaultTheme) => string
+}>`
 	${baseHeading}
 	margin: ${({ theme }) =>
 		css`
@@ -74,7 +86,10 @@ export const H4 = styled.h4`
 	line-height: 1.5rem;
 `
 
-export const H5 = styled.h5`
+export const H5 = styled.h5<{
+	backgroundColor?: (theme: DefaultTheme) => string
+	color?: (theme: DefaultTheme) => string
+}>`
 	${baseHeading}
 	font-size: 1rem;
 	margin: ${({ theme }) =>
@@ -84,7 +99,10 @@ export const H5 = styled.h5`
 	line-height: 1.5rem;
 `
 
-export const H6 = styled.h6`
+export const H6 = styled.h6<{
+	backgroundColor?: (theme: DefaultTheme) => string
+	color?: (theme: DefaultTheme) => string
+}>`
 	${baseHeading}
 	margin: ${({ theme }) =>
 		css`

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components'
 
+import { CustomizeBlockStyle } from '../global-style'
+
 const baseHeading = css`
 	font-family: 'Montserrat', sans-serif;
 	font-weight: 700;
@@ -9,6 +11,11 @@ const baseHeading = css`
 			? theme.colors.extended.grey[100]
 			: theme.colors.bases.primary[700]};
 	background-color: inherit;
+	color: ${({ theme }) => theme.colors.theme.headingColor};
+	${({ theme, isDarkMode }) => {
+		console.log(isDarkMode, theme)
+	}}
+	${CustomizeBlockStyle as any} // TODO: Fix ts issue
 `
 
 export const HeadingUnderline = css`

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -13,7 +13,7 @@ const baseHeading = css`
 	background-color: inherit;
 	color: ${({ theme }: { theme: DefaultTheme }) =>
 		theme.colors.theme.headingColor};
-	${CustomizeBlockStyle}// TODO: Fix ts issue
+	${CustomizeBlockStyle}
 `
 
 export const HeadingUnderline = css`

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -10,7 +10,7 @@ const baseHeading = css`
 		theme.darkMode
 			? theme.colors.extended.grey[100]
 			: theme.colors.bases.primary[700]};
-	background-color: inherit;
+	background-color: transparent;
 	color: ${({ theme }: { theme: DefaultTheme }) =>
 		theme.colors.theme.headingColor};
 	${CustomizeBlockStyle}

--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -28,7 +28,7 @@ export const HeadingUnderline = css`
 
 export const H1 = styled.h1<{
 	noUnderline?: boolean
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
@@ -47,7 +47,7 @@ export const H1 = styled.h1<{
 
 export const H2 = styled.h2<{
 	noUnderline?: boolean
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
@@ -61,7 +61,7 @@ export const H2 = styled.h2<{
 `
 
 export const H3 = styled.h3<{
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
@@ -74,7 +74,7 @@ export const H3 = styled.h3<{
 `
 
 export const H4 = styled.h4<{
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
@@ -87,7 +87,7 @@ export const H4 = styled.h4<{
 `
 
 export const H5 = styled.h5<{
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}
@@ -100,7 +100,7 @@ export const H5 = styled.h5<{
 `
 
 export const H6 = styled.h6<{
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }>`
 	${baseHeading}

--- a/site/source/design-system/typography/index.ts
+++ b/site/source/design-system/typography/index.ts
@@ -12,7 +12,8 @@ export const U = styled.u`
 	text-decoration: underline;
 `
 export const Code = styled.code`
-	background-color: #eee;
+	background-color: ${({ theme }) =>
+		theme.darkMode ? theme.colors.extended.grey[600] : '#eee'};
 	color: inherit;
 	padding: 0.25rem;
 	border-radius: 0.25rem;

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -8,7 +8,9 @@ import React, {
 	useRef,
 } from 'react'
 import { NavLink } from 'react-router-dom'
-import styled, { css } from 'styled-components'
+import styled, { DefaultTheme, css } from 'styled-components'
+
+import { CustomizeBlockStyle } from '../global-style'
 
 export const StyledLinkHover = css`
 	text-decoration: underline;
@@ -21,6 +23,8 @@ export const StyledLinkHover = css`
 interface StyledLinkProps {
 	$isDisabled?: boolean
 	$noUnderline?: boolean
+	backgroundColor?: (theme: DefaultTheme) => string
+	textColor?: (theme: DefaultTheme) => string
 }
 
 export const StyledLink = styled.a<StyledLinkProps>`
@@ -29,13 +33,6 @@ export const StyledLink = styled.a<StyledLinkProps>`
 			? theme.colors.extended.grey[600]
 			: theme.colors.bases.primary[700]};
 	background-color: inherit;
-	${({ theme }) =>
-		theme.darkMode &&
-		css`
-			@media not print {
-				color: ${theme.colors.extended.grey[100]};
-			}
-		`}
 	${({ $isDisabled }) =>
 		$isDisabled &&
 		css`
@@ -61,6 +58,7 @@ export const StyledLink = styled.a<StyledLinkProps>`
 				  `
 				: ''}
 	}
+	${CustomizeBlockStyle}
 `
 
 export const Link = React.forwardRef<
@@ -69,9 +67,18 @@ export const Link = React.forwardRef<
 		children: React.ReactNode
 		isDisabled?: boolean
 		noUnderline?: boolean
+		backgroundColor?: (theme: DefaultTheme) => string
+		textColor?: (theme: DefaultTheme) => string
 	}
 >(function Link(props, forwardedRef) {
-	const { isDisabled, role, noUnderline, ...ariaButtonProps } = props
+	const {
+		isDisabled,
+		role,
+		noUnderline,
+		backgroundColor,
+		textColor,
+		...ariaButtonProps
+	} = props
 	const buttonOrLinkProps = useButtonOrLink(ariaButtonProps, forwardedRef)
 
 	return (
@@ -83,6 +90,8 @@ export const Link = React.forwardRef<
 			$noUnderline={noUnderline}
 			tabIndex={isDisabled ? -1 : buttonOrLinkProps.tabIndex}
 			as={isDisabled ? 'span' : buttonOrLinkProps.as}
+			backgroundColor={backgroundColor}
+			textColor={textColor}
 		/>
 	)
 })

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -24,7 +24,7 @@ interface StyledLinkProps {
 	$isDisabled?: boolean
 	$noUnderline?: boolean
 	backgroundColor?: (theme: DefaultTheme) => string
-	textColor?: (theme: DefaultTheme) => string
+	$textColor?: (theme: DefaultTheme) => string
 }
 
 export const StyledLink = styled.a<StyledLinkProps>`
@@ -68,7 +68,7 @@ export const Link = React.forwardRef<
 		isDisabled?: boolean
 		noUnderline?: boolean
 		backgroundColor?: (theme: DefaultTheme) => string
-		textColor?: (theme: DefaultTheme) => string
+		$textColor?: (theme: DefaultTheme) => string
 	}
 >(function Link(props, forwardedRef) {
 	const {
@@ -76,7 +76,7 @@ export const Link = React.forwardRef<
 		role,
 		noUnderline,
 		backgroundColor,
-		textColor,
+		$textColor,
 		...ariaButtonProps
 	} = props
 	const buttonOrLinkProps = useButtonOrLink(ariaButtonProps, forwardedRef)
@@ -90,8 +90,8 @@ export const Link = React.forwardRef<
 			$noUnderline={noUnderline}
 			tabIndex={isDisabled ? -1 : buttonOrLinkProps.tabIndex}
 			as={isDisabled ? 'span' : buttonOrLinkProps.as}
-			backgroundColor={backgroundColor}
-			textColor={textColor}
+			$backgroundColor={backgroundColor}
+			$textColor={$textColor}
 		/>
 	)
 })

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -31,7 +31,7 @@ export const StyledLink = styled.a<StyledLinkProps>`
 	color: ${({ theme, $isDisabled }) =>
 		$isDisabled
 			? theme.colors.extended.grey[600]
-			: theme.colors.bases.primary[700]};
+			: theme.colors.theme.linkColor};
 	background-color: inherit;
 	${({ $isDisabled }) =>
 		$isDisabled &&

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -16,7 +16,7 @@ export const StyledLinkHover = css`
 	text-decoration: underline;
 	color: ${({ theme }) =>
 		theme.darkMode
-			? theme.colors.bases.primary[100]
+			? theme.colors.bases.primary[300]
 			: theme.colors.bases.primary[800]};
 `
 

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -23,7 +23,7 @@ export const StyledLinkHover = css`
 interface StyledLinkProps {
 	$isDisabled?: boolean
 	$noUnderline?: boolean
-	backgroundColor?: (theme: DefaultTheme) => string
+	$backgroundColor?: (theme: DefaultTheme) => string
 	$textColor?: (theme: DefaultTheme) => string
 }
 
@@ -67,7 +67,7 @@ export const Link = React.forwardRef<
 		children: React.ReactNode
 		isDisabled?: boolean
 		noUnderline?: boolean
-		backgroundColor?: (theme: DefaultTheme) => string
+		$backgroundColor?: (theme: DefaultTheme) => string
 		$textColor?: (theme: DefaultTheme) => string
 	}
 >(function Link(props, forwardedRef) {
@@ -75,7 +75,7 @@ export const Link = React.forwardRef<
 		isDisabled,
 		role,
 		noUnderline,
-		backgroundColor,
+		$backgroundColor,
 		$textColor,
 		...ariaButtonProps
 	} = props
@@ -90,7 +90,7 @@ export const Link = React.forwardRef<
 			$noUnderline={noUnderline}
 			tabIndex={isDisabled ? -1 : buttonOrLinkProps.tabIndex}
 			as={isDisabled ? 'span' : buttonOrLinkProps.as}
-			$backgroundColor={backgroundColor}
+			$backgroundColor={$backgroundColor}
 			$textColor={$textColor}
 		/>
 	)

--- a/site/source/design-system/typography/paragraphs.tsx
+++ b/site/source/design-system/typography/paragraphs.tsx
@@ -9,18 +9,8 @@ export const baseParagraphStyle = css`
 	background-color: inherit;
 
 	@media not print {
-		${({ theme }) =>
-			theme.darkMode &&
-			css`
-				color: ${theme.colors.extended.grey[100]};
-			`}
-		/* Hack for text color in Message component in documentation */
-		&& {
-			color: ${({ theme }) =>
-				theme.darkMode
-					? theme.colors.extended.grey[100]
-					: theme.colors.extended.grey[800]};
-		}
+		color: ${({ theme }) =>
+			theme.darkMode ? `${theme.colors.extended.grey[100]}` : ''};
 	}
 
 	${CustomizeBlockStyle}

--- a/site/source/design-system/typography/paragraphs.tsx
+++ b/site/source/design-system/typography/paragraphs.tsx
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components'
 
+import { CustomizeBlockStyle } from '../global-style'
+
 export const baseParagraphStyle = css`
 	font-family: ${({ theme }) => theme.fonts.main};
 	font-weight: normal;
@@ -20,6 +22,8 @@ export const baseParagraphStyle = css`
 					: theme.colors.extended.grey[800]};
 		}
 	}
+
+	${CustomizeBlockStyle}
 `
 
 export const Intro = styled.p`

--- a/site/source/pages/Budget/Budget.tsx
+++ b/site/source/pages/Budget/Budget.tsx
@@ -1,6 +1,6 @@
 import { formatValue } from 'publicodes'
 import { useState } from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import MoreInfosOnUs from '@/components/MoreInfosOnUs'

--- a/site/source/pages/Creer/Home.tsx
+++ b/site/source/pages/Creer/Home.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 
 import PageHeader from '@/components/PageHeader'
 import { FromBottom } from '@/components/ui/animate'
-import DefaultHelmet from '@/components/utils/DefaultHelmet'
 import Meta from '@/components/utils/Meta'
 import { Button } from '@/design-system/buttons'
 import { Card } from '@/design-system/card'

--- a/site/source/pages/Iframes/IframeFooter.tsx
+++ b/site/source/pages/Iframes/IframeFooter.tsx
@@ -10,7 +10,7 @@ export default function IframeFooter() {
 				}}
 			>
 				<Spacing xl />
-				<Privacy />
+				<Privacy noUnderline={false} />
 				<Spacing lg />
 			</div>
 		</>

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -146,6 +146,7 @@ export default function Landing() {
 									<Link
 										aria-label="équipe, accéder à notre page de présentation d'équipe, nouvelle fenêtre"
 										href="https://beta.gouv.fr/startups/mon-entreprise.html#equipe"
+										textColor={(theme) => theme.colors.bases.primary[400]}
 									>
 										équipe
 									</Link>{' '}
@@ -153,6 +154,7 @@ export default function Landing() {
 									<Link
 										href="https://www.urssaf.fr"
 										aria-label="l'URSSAF, accéder au site urssaf.fr, nouvelle fenêtre"
+										textColor={(theme) => theme.colors.bases.primary[400]}
 									>
 										l’Urssaf
 									</Link>
@@ -161,6 +163,7 @@ export default function Landing() {
 									<Link
 										href="https://beta.gouv.fr/manifeste"
 										aria-label="beta.gouv.fr, accéder au site beta.gouv.fr, nouvelle fenêtre"
+										textColor={(theme) => theme.colors.bases.primary[400]}
 									>
 										beta.gouv.fr
 									</Link>

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -60,7 +60,6 @@ export default function Landing() {
 					</PageHeader>
 				</Container>
 				<Container
-					darkMode
 					$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 				>
 					<SearchOrCreate />

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -61,7 +61,7 @@ export default function Landing() {
 				</Container>
 				<Container
 					darkMode
-					backgroundColor={(theme) => theme.colors.bases.primary[600]}
+					$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 				>
 					<SearchOrCreate />
 					<Spacing xl />
@@ -112,7 +112,7 @@ export default function Landing() {
 					<Spacing xl />
 				</Container>
 				<Container
-					backgroundColor={(theme) =>
+					$backgroundColor={(theme) =>
 						theme.darkMode
 							? theme.colors.extended.dark[700]
 							: theme.colors.bases.primary[100]

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -146,6 +146,7 @@ export default function Landing() {
 									<Link
 										aria-label="équipe, accéder à notre page de présentation d'équipe, nouvelle fenêtre"
 										href="https://beta.gouv.fr/startups/mon-entreprise.html#equipe"
+										$textColor={(theme) => theme.colors.theme.linkColor}
 									>
 										équipe
 									</Link>{' '}
@@ -153,6 +154,7 @@ export default function Landing() {
 									<Link
 										href="https://www.urssaf.fr"
 										aria-label="l'URSSAF, accéder au site urssaf.fr, nouvelle fenêtre"
+										$textColor={(theme) => theme.colors.theme.linkColor}
 									>
 										l’Urssaf
 									</Link>
@@ -161,6 +163,7 @@ export default function Landing() {
 									<Link
 										href="https://beta.gouv.fr/manifeste"
 										aria-label="beta.gouv.fr, accéder au site beta.gouv.fr, nouvelle fenêtre"
+										$textColor={(theme) => theme.colors.theme.linkColor}
 									>
 										beta.gouv.fr
 									</Link>

--- a/site/source/pages/Landing/Landing.tsx
+++ b/site/source/pages/Landing/Landing.tsx
@@ -146,7 +146,6 @@ export default function Landing() {
 									<Link
 										aria-label="équipe, accéder à notre page de présentation d'équipe, nouvelle fenêtre"
 										href="https://beta.gouv.fr/startups/mon-entreprise.html#equipe"
-										textColor={(theme) => theme.colors.bases.primary[400]}
 									>
 										équipe
 									</Link>{' '}
@@ -154,7 +153,6 @@ export default function Landing() {
 									<Link
 										href="https://www.urssaf.fr"
 										aria-label="l'URSSAF, accéder au site urssaf.fr, nouvelle fenêtre"
-										textColor={(theme) => theme.colors.bases.primary[400]}
 									>
 										l’Urssaf
 									</Link>
@@ -163,7 +161,6 @@ export default function Landing() {
 									<Link
 										href="https://beta.gouv.fr/manifeste"
 										aria-label="beta.gouv.fr, accéder au site beta.gouv.fr, nouvelle fenêtre"
-										textColor={(theme) => theme.colors.bases.primary[400]}
 									>
 										beta.gouv.fr
 									</Link>

--- a/site/source/pages/Landing/SearchOrCreate.tsx
+++ b/site/source/pages/Landing/SearchOrCreate.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { generatePath, useNavigate } from 'react-router-dom'
-import { ThemeProvider } from 'styled-components'
 
 import { resetCompany } from '@/actions/companyActions'
 import {
@@ -36,73 +35,73 @@ export default function SearchOrCreate() {
 	const { t } = useTranslation()
 
 	return (
-		<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
-			<Grid container spacing={3}>
-				<Grid item xl={8} lg={10} md={12}>
-					{companySIREN ? (
-						<>
-							<H3 as="h2">Votre entreprise</H3>
-							<CompanyDetails headingTag="h3" />
-							<Spacing md />
-							<AnswerGroup role="list">
-								<Button
-									role="link"
-									to={generatePath(absoluteSitePaths.gérer.entreprise, {
-										entreprise: companySIREN as string,
-									})}
-									aria-label="Voir ma situation, accéder à la page de gestion de mon entreprise"
-								>
-									Voir ma situation
-								</Button>
-								<PopoverConfirm
-									trigger={(buttonProps) => (
-										<Button
-											light
-											aria-label={t('Réinitialiser la situation enregistrée')}
-											{...buttonProps}
-										>
-											Réinitialiser
-										</Button>
-									)}
-									onConfirm={() => dispatch(resetCompany())}
-									small
-									title={t(
-										'Êtes-vous sûr de vouloir réinitialiser la situation enregistrée ?'
-									)}
-								/>
-							</AnswerGroup>
-						</>
-					) : (
-						<>
-							<H3 as="h2">
-								<Trans>Rechercher votre entreprise</Trans>{' '}
-							</H3>
-							<CompanySearchField onSubmit={handleCompanySubmit} />
-							<Spacing md />
-
+		<Grid container spacing={3}>
+			<Grid item xl={8} lg={10} md={12}>
+				{companySIREN ? (
+					<>
+						<H3 as="h2" textColor={(theme) => theme.colors.extended.grey[100]}>
+							Votre entreprise
+						</H3>
+						<CompanyDetails headingTag="h3" />
+						<Spacing md />
+						<AnswerGroup role="list">
 							<Button
-								size="XL"
 								role="link"
-								to={
-									statutChoisi
-										? absoluteSitePaths.créer[statutChoisi]
-										: absoluteSitePaths.créer.index
-								}
-								aria-label={t(
-									'landing.choice.create.aria-label',
-									"Je n'ai pas encore d'entreprise, accéder au guide de création d'entreprise."
-								)}
+								to={generatePath(absoluteSitePaths.gérer.entreprise, {
+									entreprise: companySIREN as string,
+								})}
+								aria-label="Voir ma situation, accéder à la page de gestion de mon entreprise"
 							>
-								<Emoji emoji="💡" />{' '}
-								<Trans i18nKey="landing.choice.create.title">
-									Je n'ai pas encore d'entreprise
-								</Trans>
+								Voir ma situation
 							</Button>
-						</>
-					)}
-				</Grid>
+							<PopoverConfirm
+								trigger={(buttonProps) => (
+									<Button
+										light
+										aria-label={t('Réinitialiser la situation enregistrée')}
+										{...buttonProps}
+									>
+										Réinitialiser
+									</Button>
+								)}
+								onConfirm={() => dispatch(resetCompany())}
+								small
+								title={t(
+									'Êtes-vous sûr de vouloir réinitialiser la situation enregistrée ?'
+								)}
+							/>
+						</AnswerGroup>
+					</>
+				) : (
+					<>
+						<H3 as="h2" textColor={(theme) => theme.colors.extended.grey[100]}>
+							<Trans>Rechercher votre entreprise</Trans>{' '}
+						</H3>
+						<CompanySearchField onSubmit={handleCompanySubmit} />
+						<Spacing md />
+
+						<Button
+							size="XL"
+							role="link"
+							to={
+								statutChoisi
+									? absoluteSitePaths.créer[statutChoisi]
+									: absoluteSitePaths.créer.index
+							}
+							aria-label={t(
+								'landing.choice.create.aria-label',
+								"Je n'ai pas encore d'entreprise, accéder au guide de création d'entreprise."
+							)}
+						>
+							<Emoji emoji="💡" />{' '}
+							<Trans i18nKey="landing.choice.create.title">
+								Je n'ai pas encore d'entreprise
+							</Trans>
+						</Button>
+					</>
+				)}
 			</Grid>
-		</ThemeProvider>
+		</Grid>
 	)
 }
 

--- a/site/source/pages/Landing/SearchOrCreate.tsx
+++ b/site/source/pages/Landing/SearchOrCreate.tsx
@@ -39,7 +39,7 @@ export default function SearchOrCreate() {
 			<Grid item xl={8} lg={10} md={12}>
 				{companySIREN ? (
 					<>
-						<H3 as="h2" textColor={(theme) => theme.colors.extended.grey[100]}>
+						<H3 as="h2" $textColor={(theme) => theme.colors.extended.grey[100]}>
 							Votre entreprise
 						</H3>
 						<CompanyDetails headingTag="h3" />
@@ -74,7 +74,7 @@ export default function SearchOrCreate() {
 					</>
 				) : (
 					<>
-						<H3 as="h2" textColor={(theme) => theme.colors.extended.grey[100]}>
+						<H3 as="h2" $textColor={(theme) => theme.colors.extended.grey[100]}>
 							<Trans>Rechercher votre entreprise</Trans>{' '}
 						</H3>
 						<CompanySearchField onSubmit={handleCompanySubmit} />

--- a/site/source/pages/Landing/SearchOrCreate.tsx
+++ b/site/source/pages/Landing/SearchOrCreate.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { generatePath, useNavigate } from 'react-router-dom'
+import { ThemeProvider } from 'styled-components'
 
 import { resetCompany } from '@/actions/companyActions'
 import {
@@ -44,60 +45,63 @@ export default function SearchOrCreate() {
 						</H3>
 						<CompanyDetails headingTag="h3" />
 						<Spacing md />
-						<AnswerGroup role="list">
-							<Button
-								role="link"
-								to={generatePath(absoluteSitePaths.gérer.entreprise, {
-									entreprise: companySIREN as string,
-								})}
-								aria-label="Voir ma situation, accéder à la page de gestion de mon entreprise"
-							>
-								Voir ma situation
-							</Button>
-							<PopoverConfirm
-								trigger={(buttonProps) => (
-									<Button
-										light
-										aria-label={t('Réinitialiser la situation enregistrée')}
-										{...buttonProps}
-									>
-										Réinitialiser
-									</Button>
-								)}
-								onConfirm={() => dispatch(resetCompany())}
-								small
-								title={t(
-									'Êtes-vous sûr de vouloir réinitialiser la situation enregistrée ?'
-								)}
-							/>
-						</AnswerGroup>
+						<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
+							<AnswerGroup role="list">
+								<Button
+									role="link"
+									to={generatePath(absoluteSitePaths.gérer.entreprise, {
+										entreprise: companySIREN as string,
+									})}
+									aria-label="Voir ma situation, accéder à la page de gestion de mon entreprise"
+								>
+									Voir ma situation
+								</Button>
+								<PopoverConfirm
+									trigger={(buttonProps) => (
+										<Button
+											light
+											aria-label={t('Réinitialiser la situation enregistrée')}
+											{...buttonProps}
+										>
+											Réinitialiser
+										</Button>
+									)}
+									onConfirm={() => dispatch(resetCompany())}
+									small
+									title={t(
+										'Êtes-vous sûr de vouloir réinitialiser la situation enregistrée ?'
+									)}
+								/>
+							</AnswerGroup>
+						</ThemeProvider>
 					</>
 				) : (
 					<>
 						<H3 as="h2" $textColor={(theme) => theme.colors.extended.grey[100]}>
 							<Trans>Rechercher votre entreprise</Trans>{' '}
 						</H3>
-						<CompanySearchField onSubmit={handleCompanySubmit} />
+						<CompanySearchField onSubmit={handleCompanySubmit} isDark />
 						<Spacing md />
-
-						<Button
-							size="XL"
-							role="link"
-							to={
-								statutChoisi
-									? absoluteSitePaths.créer[statutChoisi]
-									: absoluteSitePaths.créer.index
-							}
-							aria-label={t(
-								'landing.choice.create.aria-label',
-								"Je n'ai pas encore d'entreprise, accéder au guide de création d'entreprise."
-							)}
-						>
-							<Emoji emoji="💡" />{' '}
-							<Trans i18nKey="landing.choice.create.title">
-								Je n'ai pas encore d'entreprise
-							</Trans>
-						</Button>
+						<ThemeProvider theme={(theme) => ({ ...theme, darkMode: true })}>
+							<Button
+								size="XL"
+								role="link"
+								to={
+									statutChoisi
+										? absoluteSitePaths.créer[statutChoisi]
+										: absoluteSitePaths.créer.index
+								}
+								aria-label={t(
+									'landing.choice.create.aria-label',
+									"Je n'ai pas encore d'entreprise, accéder au guide de création d'entreprise."
+								)}
+							>
+								<Emoji emoji="💡" />{' '}
+								<Trans i18nKey="landing.choice.create.title">
+									Je n'ai pas encore d'entreprise
+								</Trans>
+							</Button>
+						</ThemeProvider>
 					</>
 				)}
 			</Grid>

--- a/site/source/pages/Plan.tsx
+++ b/site/source/pages/Plan.tsx
@@ -32,7 +32,7 @@ export default function Plan() {
 					<h2>
 						<Link
 							to={absoluteSitePaths.index}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Page d'accueil</Trans>
 						</Link>
@@ -42,7 +42,7 @@ export default function Plan() {
 					<h2>
 						<HeaderLink
 							to={absoluteSitePaths.créer.index}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Créer une entreprise</Trans>
 						</HeaderLink>
@@ -53,7 +53,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.créer.après}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Après la création</Trans>
 								</Link>
@@ -63,7 +63,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.créer.guideStatut.index}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Choix du statut juridique</Trans>
 								</Link>
@@ -75,7 +75,7 @@ export default function Plan() {
 					<h2>
 						<HeaderLink
 							to={absoluteSitePaths.gérer.index}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Gérer mon activité</Trans>
 						</HeaderLink>
@@ -86,7 +86,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.gérer.embaucher}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Embaucher</Trans>
 								</Link>
@@ -96,7 +96,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.gérer.sécuritéSociale}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Protection sociale</Trans>
 								</Link>
@@ -106,7 +106,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.gérer.déclarationIndépendant.index}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>
 										Assistant à la détermination des charges sociales
@@ -119,7 +119,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.gérer.formulaireMobilité}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Simulateur de demande de mobilité</Trans>
 								</Link>
@@ -131,7 +131,7 @@ export default function Plan() {
 					<h2>
 						<HeaderLink
 							to={absoluteSitePaths.simulateurs.index}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Simulateurs disponibles</Trans>
 						</HeaderLink>
@@ -151,7 +151,7 @@ export default function Plan() {
 										<h3>
 											<Link
 												to={simulateurPath}
-												textColor={(theme) => theme.colors.theme.headingColor}
+												$textColor={(theme) => theme.colors.theme.headingColor}
 											>
 												{
 													metadata[
@@ -168,7 +168,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.simulateurs.comparaison}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Assistant au choix du statut juridique</Trans>
 								</Link>
@@ -178,7 +178,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.simulateurs.économieCollaborative.index}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>
 										Assistant à la déclaration des revenus des plateformes en
@@ -193,7 +193,7 @@ export default function Plan() {
 					<h2>
 						<Link
 							to={absoluteSitePaths.nouveautés}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Nouveautés</Trans>
 						</Link>
@@ -204,7 +204,7 @@ export default function Plan() {
 					<h2>
 						<Link
 							to={absoluteSitePaths.budget}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Budget</Trans>
 						</Link>
@@ -214,7 +214,7 @@ export default function Plan() {
 					<h2>
 						<Link
 							to={absoluteSitePaths.accessibilité}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Accessibilité</Trans>
 						</Link>
@@ -224,7 +224,7 @@ export default function Plan() {
 					<h2>
 						<Link
 							to={absoluteSitePaths.stats}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Statistiques</Trans>
 						</Link>
@@ -234,7 +234,7 @@ export default function Plan() {
 					<h2>
 						<HeaderLink
 							to={absoluteSitePaths.développeur.index}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Outils pour les développeurs</Trans>
 						</HeaderLink>
@@ -245,7 +245,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.développeur.api}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>API REST de simulation</Trans>
 								</Link>
@@ -255,7 +255,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.développeur.iframe}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Intégrer le module Web</Trans>
 								</Link>
@@ -265,7 +265,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.développeur.library}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>
 										Utiliser les calculs des simulateurs dans votre application
@@ -277,7 +277,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.développeur.spreadsheet}
-									textColor={(theme) => theme.colors.theme.headingColor}
+									$textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>Utiliser avec un tableur</Trans>
 								</Link>
@@ -290,7 +290,7 @@ export default function Plan() {
 					<h2>
 						<Link
 							to={absoluteSitePaths.documentation.index}
-							textColor={(theme) => theme.colors.theme.headingColor}
+							$textColor={(theme) => theme.colors.theme.headingColor}
 						>
 							<Trans>Documentation</Trans>
 						</Link>

--- a/site/source/pages/Plan.tsx
+++ b/site/source/pages/Plan.tsx
@@ -30,14 +30,20 @@ export default function Plan() {
 			<StyledUl>
 				<Li>
 					<h2>
-						<Link to={absoluteSitePaths.index}>
+						<Link
+							to={absoluteSitePaths.index}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Page d'accueil</Trans>
 						</Link>
 					</h2>
 				</Li>
 				<Li>
 					<h2>
-						<HeaderLink to={absoluteSitePaths.créer.index}>
+						<HeaderLink
+							to={absoluteSitePaths.créer.index}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Créer une entreprise</Trans>
 						</HeaderLink>
 					</h2>
@@ -45,14 +51,20 @@ export default function Plan() {
 					<Ul>
 						<Li>
 							<h3>
-								<Link to={absoluteSitePaths.créer.après}>
+								<Link
+									to={absoluteSitePaths.créer.après}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Après la création</Trans>
 								</Link>
 							</h3>
 						</Li>
 						<Li>
 							<h3>
-								<Link to={absoluteSitePaths.créer.guideStatut.index}>
+								<Link
+									to={absoluteSitePaths.créer.guideStatut.index}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Choix du statut juridique</Trans>
 								</Link>
 							</h3>
@@ -61,7 +73,10 @@ export default function Plan() {
 				</Li>
 				<Li>
 					<h2>
-						<HeaderLink to={absoluteSitePaths.gérer.index}>
+						<HeaderLink
+							to={absoluteSitePaths.gérer.index}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Gérer mon activité</Trans>
 						</HeaderLink>
 					</h2>
@@ -69,21 +84,30 @@ export default function Plan() {
 					<Ul>
 						<Li>
 							<h3>
-								<Link to={absoluteSitePaths.gérer.embaucher}>
+								<Link
+									to={absoluteSitePaths.gérer.embaucher}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Embaucher</Trans>
 								</Link>
 							</h3>
 						</Li>
 						<Li>
 							<h3>
-								<Link to={absoluteSitePaths.gérer.sécuritéSociale}>
+								<Link
+									to={absoluteSitePaths.gérer.sécuritéSociale}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Protection sociale</Trans>
 								</Link>
 							</h3>
 						</Li>
 						<Li>
 							<h3>
-								<Link to={absoluteSitePaths.gérer.déclarationIndépendant.index}>
+								<Link
+									to={absoluteSitePaths.gérer.déclarationIndépendant.index}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>
 										Assistant à la détermination des charges sociales
 										déductibles
@@ -93,7 +117,10 @@ export default function Plan() {
 						</Li>
 						<Li>
 							<h3>
-								<Link to={absoluteSitePaths.gérer.formulaireMobilité}>
+								<Link
+									to={absoluteSitePaths.gérer.formulaireMobilité}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Simulateur de demande de mobilité</Trans>
 								</Link>
 							</h3>
@@ -102,7 +129,10 @@ export default function Plan() {
 				</Li>
 				<Li>
 					<h2>
-						<HeaderLink to={absoluteSitePaths.simulateurs.index}>
+						<HeaderLink
+							to={absoluteSitePaths.simulateurs.index}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Simulateurs disponibles</Trans>
 						</HeaderLink>
 					</h2>
@@ -119,7 +149,10 @@ export default function Plan() {
 								return (
 									<Li key={`list-item-${simulateurKey}`}>
 										<h3>
-											<Link to={simulateurPath}>
+											<Link
+												to={simulateurPath}
+												textColor={(theme) => theme.colors.theme.headingColor}
+											>
 												{
 													metadata[
 														simulateurKey as keyof typeof absoluteSitePaths.simulateurs &
@@ -133,7 +166,10 @@ export default function Plan() {
 							})}
 						<Li key="list-item-comparaison">
 							<h3>
-								<Link to={absoluteSitePaths.simulateurs.comparaison}>
+								<Link
+									to={absoluteSitePaths.simulateurs.comparaison}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Assistant au choix du statut juridique</Trans>
 								</Link>
 							</h3>
@@ -142,6 +178,7 @@ export default function Plan() {
 							<h3>
 								<Link
 									to={absoluteSitePaths.simulateurs.économieCollaborative.index}
+									textColor={(theme) => theme.colors.theme.headingColor}
 								>
 									<Trans>
 										Assistant à la déclaration des revenus des plateformes en
@@ -154,7 +191,10 @@ export default function Plan() {
 				</Li>
 				<Li>
 					<h2>
-						<Link to={absoluteSitePaths.nouveautés}>
+						<Link
+							to={absoluteSitePaths.nouveautés}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Nouveautés</Trans>
 						</Link>
 					</h2>
@@ -162,28 +202,40 @@ export default function Plan() {
 
 				<Li>
 					<h2>
-						<Link to={absoluteSitePaths.budget}>
+						<Link
+							to={absoluteSitePaths.budget}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Budget</Trans>
 						</Link>
 					</h2>
 				</Li>
 				<Li>
 					<h2>
-						<Link to={absoluteSitePaths.accessibilité}>
+						<Link
+							to={absoluteSitePaths.accessibilité}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Accessibilité</Trans>
 						</Link>
 					</h2>
 				</Li>
 				<Li>
 					<h2>
-						<Link to={absoluteSitePaths.stats}>
+						<Link
+							to={absoluteSitePaths.stats}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Statistiques</Trans>
 						</Link>
 					</h2>
 				</Li>
 				<Li>
 					<h2>
-						<HeaderLink to={absoluteSitePaths.développeur.index}>
+						<HeaderLink
+							to={absoluteSitePaths.développeur.index}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Outils pour les développeurs</Trans>
 						</HeaderLink>
 					</h2>
@@ -191,21 +243,30 @@ export default function Plan() {
 					<Ul>
 						<Li key="list-item-développeur-api">
 							<h3>
-								<Link to={absoluteSitePaths.développeur.api}>
+								<Link
+									to={absoluteSitePaths.développeur.api}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>API REST de simulation</Trans>
 								</Link>
 							</h3>
 						</Li>
 						<Li key="list-item-développeur-iframe">
 							<h3>
-								<Link to={absoluteSitePaths.développeur.iframe}>
+								<Link
+									to={absoluteSitePaths.développeur.iframe}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Intégrer le module Web</Trans>
 								</Link>
 							</h3>
 						</Li>
 						<Li key="list-item-développeur-library">
 							<h3>
-								<Link to={absoluteSitePaths.développeur.library}>
+								<Link
+									to={absoluteSitePaths.développeur.library}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>
 										Utiliser les calculs des simulateurs dans votre application
 									</Trans>
@@ -214,7 +275,10 @@ export default function Plan() {
 						</Li>
 						<Li key="list-item-développeur-spreadsheet">
 							<h3>
-								<Link to={absoluteSitePaths.développeur.spreadsheet}>
+								<Link
+									to={absoluteSitePaths.développeur.spreadsheet}
+									textColor={(theme) => theme.colors.theme.headingColor}
+								>
 									<Trans>Utiliser avec un tableur</Trans>
 								</Link>
 							</h3>
@@ -224,7 +288,10 @@ export default function Plan() {
 
 				<Li>
 					<h2>
-						<Link to={absoluteSitePaths.documentation.index}>
+						<Link
+							to={absoluteSitePaths.documentation.index}
+							textColor={(theme) => theme.colors.theme.headingColor}
+						>
 							<Trans>Documentation</Trans>
 						</Link>
 					</h2>

--- a/site/source/pages/Simulateurs/ExonerationCovid/FormulaireS2.tsx
+++ b/site/source/pages/Simulateurs/ExonerationCovid/FormulaireS2.tsx
@@ -18,6 +18,7 @@ const Info = styled(Body)`
 	padding: 1rem;
 	border: 2px solid ${({ theme }) => theme.colors.extended.info['300']};
 	border-radius: 0.35rem;
+	color: ${({ theme }) => theme.colors.bases.tertiary[700]};
 `
 
 export const FormulaireS2 = ({

--- a/site/source/pages/Simulateurs/ExonerationCovid/Table.tsx
+++ b/site/source/pages/Simulateurs/ExonerationCovid/Table.tsx
@@ -82,7 +82,8 @@ export const Thead = styled.thead`
 
 export const Tbody = styled.tbody`
 	${Tr}:nth-child(odd) {
-		background: ${({ theme }) => theme.colors.extended.grey[200]};
+		background: ${({ theme }) =>
+			theme.darkMode ? '' : theme.colors.extended.grey[200]};
 	}
 `
 

--- a/site/source/pages/Simulateurs/Home.tsx
+++ b/site/source/pages/Simulateurs/Home.tsx
@@ -1,8 +1,7 @@
 import { Trans, useTranslation } from 'react-i18next'
-import styled, { ThemeProvider } from 'styled-components'
+import styled from 'styled-components'
 
 import PageHeader from '@/components/PageHeader'
-import DefaultHelmet from '@/components/utils/DefaultHelmet'
 import Emoji from '@/components/utils/Emoji'
 import { useIsEmbedded } from '@/components/utils/useIsEmbedded'
 import InfoBulle from '@/design-system/InfoBulle'

--- a/site/source/pages/Simulateurs/Home.tsx
+++ b/site/source/pages/Simulateurs/Home.tsx
@@ -227,7 +227,7 @@ export function SimulateurCard({
 	const { t } = useTranslation()
 
 	return (
-		<ThemeProvider theme={(theme) => ({ ...theme, darkMode: false })}>
+		<>
 			{small ? (
 				<Grid item xs={12} sm={6} md={6} lg={4} {...props}>
 					<SmallCard
@@ -275,7 +275,7 @@ export function SimulateurCard({
 					</Card>
 				</Grid>
 			)}
-		</ThemeProvider>
+		</>
 	)
 }
 

--- a/site/source/pages/gerer/declaration-charges-sociales-independant/_components/RésultatSimple.tsx
+++ b/site/source/pages/gerer/declaration-charges-sociales-independant/_components/RésultatSimple.tsx
@@ -1,5 +1,6 @@
 import { utils } from 'publicodes'
 import { Trans, useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 import Value, { Condition } from '@/components/EngineValue'
 import { FromTop } from '@/components/ui/animate'
@@ -25,7 +26,7 @@ export default function ResultatsSimples() {
 				$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 			>
 				{' '}
-				<H2>
+				<H2 $textColor={(theme) => theme.colors.extended.grey[100]}>
 					<Emoji emoji="📄" />{' '}
 					<Trans i18nKey="aide-déclaration-indépendant.results.title">
 						Montants à reporter dans votre déclaration de revenus
@@ -43,6 +44,7 @@ export default function ResultatsSimples() {
 						aria-label={t(
 							'En savoir plus sur impots.gouv.fr, nouvelle fenêtre'
 						)}
+						$textColor={(theme) => theme.colors.extended.grey[100]}
 					>
 						En savoir plus
 					</Link>
@@ -64,7 +66,7 @@ export default function ResultatsSimples() {
 
 					return (
 						<FromTop key={dottedName}>
-							<H3>
+							<H3 $textColor={(theme) => theme.colors.extended.grey[100]}>
 								{r.title}
 								<Condition
 									expression={{
@@ -78,14 +80,14 @@ export default function ResultatsSimples() {
 									<small>{r.rawNode.résumé}</small>
 								</Condition>{' '}
 							</H3>
-							<Intro>
+							<StyledIntro>
 								<Value
 									expression={r.dottedName}
 									displayedUnit="€"
 									unit="€/an"
 									precision={0}
 								/>
-							</Intro>
+							</StyledIntro>
 
 							{r.rawNode.description && (
 								<Markdown>{r.rawNode.description}</Markdown>
@@ -156,3 +158,9 @@ export default function ResultatsSimples() {
 		</>
 	)
 }
+
+const StyledIntro = styled(Intro)`
+	& a {
+		color: ${({ theme }) => theme.colors.extended.grey[100]};
+	}
+`

--- a/site/source/pages/gerer/declaration-charges-sociales-independant/_components/RésultatSimple.tsx
+++ b/site/source/pages/gerer/declaration-charges-sociales-independant/_components/RésultatSimple.tsx
@@ -22,7 +22,7 @@ export default function ResultatsSimples() {
 
 			<Container
 				darkMode
-				backgroundColor={(theme) => theme.colors.bases.primary[600]}
+				$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 			>
 				{' '}
 				<H2>

--- a/site/source/pages/gerer/declaration-revenu-independants/_components/DéclarationRevenu.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/_components/DéclarationRevenu.tsx
@@ -127,7 +127,9 @@ export function DéclarationRevenuSection({ progress }: { progress: number }) {
 						éléments de votre déclaration de revenu.
 					</Body>
 				)}
-				<H2>Votre déclaration de revenu</H2>
+				<H2 $textColor={(theme) => theme.colors.extended.grey[100]}>
+					Votre déclaration de revenu
+				</H2>
 				<Grid
 					container
 					spacing={3}

--- a/site/source/pages/gerer/declaration-revenu-independants/_components/DéclarationRevenu.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/_components/DéclarationRevenu.tsx
@@ -113,7 +113,7 @@ export function DéclarationRevenuSection({ progress }: { progress: number }) {
 	return (
 		<Container
 			darkMode={!déclarationRevenusManuel}
-			backgroundColor={
+			$backgroundColor={
 				!déclarationRevenusManuel
 					? (theme) => theme.colors.bases.primary[600]
 					: undefined

--- a/site/source/pages/gerer/declaration-revenu-independants/_components/Exceptions.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/_components/Exceptions.tsx
@@ -7,7 +7,11 @@ export default function Exceptions() {
 		<PopoverWithTrigger
 			title="Liste des cas non pris en compte"
 			trigger={(props) => (
-				<Link {...props} aria-haspopup="dialog">
+				<Link
+					{...props}
+					aria-haspopup="dialog"
+					textColor={(theme) => theme.colors.bases.primary[700]}
+				>
 					Voir les cas non pris en compte.
 				</Link>
 			)}

--- a/site/source/pages/gerer/declaration-revenu-independants/_components/Exceptions.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/_components/Exceptions.tsx
@@ -10,7 +10,7 @@ export default function Exceptions() {
 				<Link
 					{...props}
 					aria-haspopup="dialog"
-					textColor={(theme) => theme.colors.bases.primary[700]}
+					$textColor={(theme) => theme.colors.bases.primary[700]}
 				>
 					Voir les cas non pris en compte.
 				</Link>

--- a/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
@@ -46,7 +46,9 @@ export default function Cotisations() {
 						<Grid container columnSpacing={4} rowSpacing={2}>
 							<Grid item lg={10} xl={8}>
 								<FromTop>
-									<H2>Estimation des cotisations à payer</H2>
+									<H2 $textColor={(theme) => theme.colors.extended.grey[100]}>
+										Estimation des cotisations à payer
+									</H2>
 
 									<Message icon border={false}>
 										<Intro>
@@ -113,11 +115,11 @@ export default function Cotisations() {
 								</FromTop>
 							</Grid>
 
-							<Grid item md={6} sm={12}>
-								<H3>
+							<StyledGrid item md={6} sm={12}>
+								<H3 $textColor={(theme) => theme.colors.extended.grey[100]}>
 									{engine.getRule('DRI . cotisations . provisionnelles').title}
 								</H3>
-								<Intro>
+								<Intro $textColor={(theme) => theme.colors.extended.grey[100]}>
 									<Value
 										expression="dirigeant . indépendant . cotisations et contributions"
 										displayedUnit="€"
@@ -127,9 +129,9 @@ export default function Cotisations() {
 									{engine.getRule('DRI . cotisations . provisionnelles').rawNode
 										.description ?? ''}
 								</Markdown>{' '}
-							</Grid>
-							<Grid item md={6} sm={12}>
-								<H3>
+							</StyledGrid>
+							<StyledGrid item md={6} sm={12}>
+								<H3 $textColor={(theme) => theme.colors.extended.grey[100]}>
 									{engine.getRule('DRI . cotisations . régularisation').title}
 								</H3>
 								<Intro>
@@ -139,7 +141,7 @@ export default function Cotisations() {
 									{engine.getRule('DRI . cotisations . régularisation').rawNode
 										.description ?? ''}
 								</Markdown>{' '}
-							</Grid>
+							</StyledGrid>
 						</Grid>
 						<ShareOrSaveSimulationBanner share print />
 						<Spacing xl />
@@ -163,5 +165,11 @@ export default function Cotisations() {
 const StyledMessage = styled(Message)`
 	& h2 {
 		color: ${({ theme }) => theme.colors.bases.primary[700]};
+	}
+`
+
+const StyledGrid = styled(Grid)`
+	& a {
+		color: ${({ theme }) => theme.colors.extended.grey[100]} !important;
 	}
 `

--- a/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
@@ -40,7 +40,7 @@ export default function Cotisations() {
 			<WhenAlreadyDefined dottedName="DRI . cotisations . appelées en 2021">
 				<Container
 					darkMode
-					backgroundColor={(theme) => theme.colors.bases.primary[600]}
+					$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 				>
 					<FromTop>
 						<Grid container columnSpacing={4} rowSpacing={2}>
@@ -147,7 +147,7 @@ export default function Cotisations() {
 				</Container>
 
 				<Container
-					backgroundColor={(theme) =>
+					$backgroundColor={(theme) =>
 						theme.darkMode
 							? theme.colors.extended.dark[600]
 							: theme.colors.bases.tertiary[100]

--- a/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/cotisations.tsx
@@ -1,3 +1,5 @@
+import styled from 'styled-components'
+
 import Value, { Condition, WhenAlreadyDefined } from '@/components/EngineValue'
 import PageFeedback from '@/components/Feedback'
 import ShareOrSaveSimulationBanner from '@/components/ShareSimulationBanner'
@@ -79,7 +81,7 @@ export default function Cotisations() {
 											<Strong>l'année 2021</Strong> :
 										</Body>
 									</div>
-									<Message border={false}>
+									<StyledMessage border={false}>
 										<div
 											css={`
 												margin: -0.75rem 0;
@@ -107,7 +109,7 @@ export default function Cotisations() {
 												/>
 											</div>
 										</div>
-									</Message>
+									</StyledMessage>
 								</FromTop>
 							</Grid>
 
@@ -157,3 +159,9 @@ export default function Cotisations() {
 		</FromTop>
 	)
 }
+
+const StyledMessage = styled(Message)`
+	& h2 {
+		color: ${({ theme }) => theme.colors.bases.primary[700]};
+	}
+`

--- a/site/source/pages/gerer/declaration-revenu-independants/imposition.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/imposition.tsx
@@ -304,7 +304,7 @@ function ResultSection() {
 		<FromTop>
 			<Container
 				darkMode
-				backgroundColor={(theme) => theme.colors.bases.primary[600]}
+				$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 			>
 				<H2>Vos déclarations fiscales</H2>
 

--- a/site/source/pages/gerer/declaration-revenu-independants/imposition.tsx
+++ b/site/source/pages/gerer/declaration-revenu-independants/imposition.tsx
@@ -306,11 +306,15 @@ function ResultSection() {
 				darkMode
 				$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 			>
-				<H2>Vos déclarations fiscales</H2>
+				<H2 $textColor={(theme) => theme.colors.extended.grey[100]}>
+					Vos déclarations fiscales
+				</H2>
 
 				<Grid container spacing={4}>
 					<Grid item lg={6}>
-						<H3>Pour vous</H3>
+						<H3 $textColor={(theme) => theme.colors.extended.grey[100]}>
+							Pour vous
+						</H3>
 
 						<Message border={false}>
 							<FormulaireTitle formulaire="Formulaire 2042">
@@ -440,7 +444,9 @@ function ResultSection() {
 						</WhenNotApplicable>
 					</Grid>
 					<Grid item lg={6}>
-						<H3>Pour votre entreprise</H3>
+						<H3 $textColor={(theme) => theme.colors.extended.grey[100]}>
+							Pour votre entreprise
+						</H3>
 						<WhenApplicable dottedName="DRI . liasse">
 							<Message border={false}>
 								<LiasseFiscaleTitle />

--- a/site/source/pages/gerer/demande-mobilité/EndBlock.tsx
+++ b/site/source/pages/gerer/demande-mobilité/EndBlock.tsx
@@ -221,6 +221,7 @@ export default function EndBlock({ fields, missingValues }: EndBlockProps) {
 												})
 											}}
 											download="demande-mobilité-internationale.pdf"
+											id="button-download"
 										>
 											Télécharger le fichier
 										</Button>

--- a/site/source/pages/gerer/demande-mobilité/FieldsPDF.tsx
+++ b/site/source/pages/gerer/demande-mobilité/FieldsPDF.tsx
@@ -15,7 +15,7 @@ export default function FieldsPDF({ fields }: FieldsPDFProps) {
 	return (
 		<>
 			{fields.map(
-				({ rawNode: { type, question, note, API }, title, dottedName }) => (
+				({ rawNode: { type, question, note }, title, dottedName }) => (
 					<View style={styles.field} key={dottedName} wrap={false}>
 						{type === 'groupe' ? (
 							<>

--- a/site/source/pages/gerer/index.tsx
+++ b/site/source/pages/gerer/index.tsx
@@ -271,7 +271,7 @@ function Home() {
 			</PageHeader>
 
 			<Container
-				backgroundColor={(theme) => theme.colors.bases.primary[600]}
+				$backgroundColor={(theme) => theme.colors.bases.primary[600]}
 				darkMode
 			>
 				<FromTop>

--- a/site/source/pages/gerer/index.tsx
+++ b/site/source/pages/gerer/index.tsx
@@ -270,14 +270,13 @@ function Home() {
 				<Spacing xl />
 			</PageHeader>
 
-			<Container
-				$backgroundColor={(theme) => theme.colors.bases.primary[600]}
-				darkMode
-			>
+			<Container $backgroundColor={(theme) => theme.colors.bases.primary[600]}>
 				<FromTop>
 					<FormsImage src={forms} alt="" />
 					<Spacing xs />
-					<H2>Simulateurs pour votre entreprise</H2>
+					<H2 $textColor={(theme) => theme.colors.extended.grey[100]}>
+						Simulateurs pour votre entreprise
+					</H2>
 					<Grid
 						container
 						spacing={3}

--- a/site/source/types/styled.d.ts
+++ b/site/source/types/styled.d.ts
@@ -58,11 +58,11 @@ export interface Theme {
 		}
 
 		theme: {
-			headingColor: string
-			textColor: string
-			linkColor: string
-			backgroundColorLight: string
-			backgroundColorDark: string
+			headingColor: Color
+			textColor: Color
+			linkColor: Color
+			backgroundColorLight: Color
+			backgroundColorDark: Color
 		}
 	}
 

--- a/site/source/types/styled.d.ts
+++ b/site/source/types/styled.d.ts
@@ -59,7 +59,7 @@ export interface Theme {
 
 		theme: {
 			headingColor: Color
-			$textColor: Color
+			textColor: Color
 			linkColor: Color
 			backgroundColorLight: Color
 			backgroundColorDark: Color

--- a/site/source/types/styled.d.ts
+++ b/site/source/types/styled.d.ts
@@ -1,6 +1,6 @@
 import 'styled-components'
 
-import theme from '@/design-system/theme'
+import theme, { SpacingKey } from '@/design-system/theme'
 
 type Color = string
 
@@ -55,6 +55,13 @@ export interface Theme {
 			success: SmallPalette
 			info: SmallPalette
 			dark: Palette
+		}
+
+		theme: {
+			headingColor: string
+			textColor: string
+			backgroundColorLight: string
+			backgroundColorDark: string
 		}
 	}
 

--- a/site/source/types/styled.d.ts
+++ b/site/source/types/styled.d.ts
@@ -60,6 +60,7 @@ export interface Theme {
 		theme: {
 			headingColor: string
 			textColor: string
+			linkColor: string
 			backgroundColorLight: string
 			backgroundColorDark: string
 		}

--- a/site/source/types/styled.d.ts
+++ b/site/source/types/styled.d.ts
@@ -59,8 +59,10 @@ export interface Theme {
 
 		theme: {
 			headingColor: Color
+			headingDarkColor: Color
 			textColor: Color
 			linkColor: Color
+			linkDarkColor: Color
 			backgroundColorLight: Color
 			backgroundColorDark: Color
 		}

--- a/site/source/types/styled.d.ts
+++ b/site/source/types/styled.d.ts
@@ -59,7 +59,7 @@ export interface Theme {
 
 		theme: {
 			headingColor: Color
-			textColor: Color
+			$textColor: Color
 			linkColor: Color
 			backgroundColorLight: Color
 			backgroundColorDark: Color

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,10 +2877,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/standalone@npm:^7.20.0":
-  version: 7.20.4
-  resolution: "@babel/standalone@npm:7.20.4"
-  checksum: cfc549333b0e779b7b33e3fe491912562818d4b2fab82e475fd51c92302a03265bb845e8a9c95c765bb5f33625e4d3c24d33075694221241c5555060102721e8
+"@babel/standalone@npm:^7.20.6":
+  version: 7.20.6
+  resolution: "@babel/standalone@npm:7.20.6"
+  checksum: 92f9d23e8ecfff74f659cdddcb2568e0b7f01272809ae5d350181310fda7cb98df5a2d5e1dbedecec3efd4f8488a199b9474a9125f285c3dd988db14ef9b4637
   languageName: node
   linkType: hard
 
@@ -8997,19 +8997,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-legacy@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "@vitejs/plugin-legacy@npm:2.3.1"
+"@vitejs/plugin-legacy@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@vitejs/plugin-legacy@npm:3.0.1"
   dependencies:
-    "@babel/standalone": ^7.20.0
-    core-js: ^3.26.0
-    magic-string: ^0.26.7
-    regenerator-runtime: ^0.13.10
+    "@babel/standalone": ^7.20.6
+    core-js: ^3.26.1
+    magic-string: ^0.27.0
+    regenerator-runtime: ^0.13.11
     systemjs: ^6.13.0
   peerDependencies:
     terser: ^5.4.0
-    vite: ^3.0.0
-  checksum: ade1495ac289ab15a87c788e11d6c043d60ddc834ad04e6976b81932e4a85d448d2c9fb6eec9e835ca4ae8c585ca1bb0b064ca898571d6dcc821cdf26fde70aa
+    vite: ^4.0.0
+  checksum: e02785e84f66e62b5710aa28069bf43199eb464f0bd19ff72b58808735ba85f6b947ad8a33d562edaa651f89275310a69409dc199b66ebbd807b5861188d8240
   languageName: node
   linkType: hard
 
@@ -12579,7 +12579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.0.4, core-js@npm:^3.26.0, core-js@npm:^3.6.5, core-js@npm:^3.8.2":
+"core-js@npm:^3.0.4, core-js@npm:^3.26.1, core-js@npm:^3.6.5, core-js@npm:^3.8.2":
   version: 3.26.1
   resolution: "core-js@npm:3.26.1"
   checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
@@ -24799,7 +24799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.10, regenerator-runtime@npm:^0.13.2, regenerator-runtime@npm:^0.13.4, regenerator-runtime@npm:^0.13.7":
+"regenerator-runtime@npm:^0.13.10, regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.2, regenerator-runtime@npm:^0.13.4, regenerator-runtime@npm:^0.13.7":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -26056,7 +26056,7 @@ __metadata:
     "@types/recharts": ^1.8.24
     "@types/serve-static": ^1.15.0
     "@types/styled-components": ^5.1.26
-    "@vitejs/plugin-legacy": ^2.3.1
+    "@vitejs/plugin-legacy": ^3.0.1
     "@vitejs/plugin-react": ^3.0.0
     algoliasearch: ^4.14.2
     cypress: "https://cdn.cypress.io/beta/npm/12.0.0/linux-arm64/release/12.0.0-e8898d2f6b65a11f36ceb2dd32ce7f1d87b103bc/cypress.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.20.5":
+  version: 7.20.5
+  resolution: "@babel/core@npm:7.20.5"
+  dependencies:
+    "@ampproject/remapping": ^2.1.0
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.20.5
+    "@babel/helper-compilation-targets": ^7.20.0
+    "@babel/helper-module-transforms": ^7.20.2
+    "@babel/helpers": ^7.20.5
+    "@babel/parser": ^7.20.5
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.20.5
+    "@babel/types": ^7.20.5
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.1
+    semver: ^6.3.0
+  checksum: 9547f1e6364bc58c3621e3b17ec17f0d034ff159e5a520091d9381608d40af3be4042dd27c20ad7d3e938422d75850ac56a3758d6801d65df701557af4bd244b
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.12.11, @babel/generator@npm:^7.12.5, @babel/generator@npm:^7.17.7, @babel/generator@npm:^7.18.6, @babel/generator@npm:^7.19.6, @babel/generator@npm:^7.20.1, @babel/generator@npm:^7.20.2":
   version: 7.20.4
   resolution: "@babel/generator@npm:7.20.4"
@@ -1326,6 +1349,17 @@ __metadata:
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
   checksum: 967b59f18e5ce999e5a741825bcecb2be4bbfc1824a92c21b47d0b5694e0eb09314a70f8b9142e9591c149c7fb83d51f73ae8fbd96d30a42666425889e51ceb1
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.20.5":
+  version: 7.20.5
+  resolution: "@babel/generator@npm:7.20.5"
+  dependencies:
+    "@babel/types": ^7.20.5
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: 31c10d1e122f08cf755a24bd6f5d197f47eceba03f1133759687d00ab72d210e60ba4011da42f368b6e9fa85cbfda7dc4adb9889c2c20cc5c34bb2d57c1deab7
   languageName: node
   linkType: hard
 
@@ -1615,6 +1649,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.20.5":
+  version: 7.20.6
+  resolution: "@babel/helpers@npm:7.20.6"
+  dependencies:
+    "@babel/template": ^7.18.10
+    "@babel/traverse": ^7.20.5
+    "@babel/types": ^7.20.5
+  checksum: f03ec6eb2bf8dc7cdfe2569ee421fd9ba6c7bac6c862d90b608ccdd80281ebe858bc56ca175fc92b3ac50f63126b66bbd5ec86f9f361729289a20054518f1ac5
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.16.7, @babel/highlight@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/highlight@npm:7.18.6"
@@ -1641,6 +1686,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 33bcdb45de65a3cf27ed376cb34f32be3c3485a10e3252f8d0126f6a034efc3145c0d219e57fcd5a8956361552008bc30b9bae4a723823fb3633027071be8a45
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.20.5":
+  version: 7.20.5
+  resolution: "@babel/parser@npm:7.20.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: e8d514ce0aa74d56725bd102919a49fa367afef9cd8208cf52f670f54b061c4672f51b4b7980058ab1f5fe73615fe4dc90720ab47bbcebae07ad08d667eda318
   languageName: node
   linkType: hard
 
@@ -2859,6 +2913,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.20.5":
+  version: 7.20.5
+  resolution: "@babel/traverse@npm:7.20.5"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.20.5
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.20.5
+    "@babel/types": ^7.20.5
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: c7fed468614aab1cf762dda5df26e2cfcd2b1b448c9d3321ac44786c4ee773fb0e10357e6593c3c6a648ae2e0be6d90462d855998dc10e3abae84de99291e008
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.12.11, @babel/types@npm:^7.12.7, @babel/types@npm:^7.17.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.4, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.20.2
   resolution: "@babel/types@npm:7.20.2"
@@ -2867,6 +2939,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
   checksum: 57e76e5f21876135f481bfd4010c87f2d38196bb0a2bc60a28d6e55e3afa90cdd9accf164e4cb71bdfb620517fa0a0cb5600cdce36c21d59fdaccfbb899c024c
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.20.5":
+  version: 7.20.5
+  resolution: "@babel/types@npm:7.20.5"
+  dependencies:
+    "@babel/helper-string-parser": ^7.19.4
+    "@babel/helper-validator-identifier": ^7.19.1
+    to-fast-properties: ^2.0.0
+  checksum: 773f0a1ad9f6ca5c5beaf751d1d8d81b9130de87689d1321fc911d73c3b1167326d66f0ae086a27fb5bfc8b4ee3ffebf1339be50d3b4d8015719692468c31f2d
   languageName: node
   linkType: hard
 
@@ -3555,7 +3638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
+"@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.13":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
@@ -8930,7 +9013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^2.0.0, @vitejs/plugin-react@npm:^2.2.0":
+"@vitejs/plugin-react@npm:^2.0.0":
   version: 2.2.0
   resolution: "@vitejs/plugin-react@npm:2.2.0"
   dependencies:
@@ -8944,6 +9027,21 @@ __metadata:
   peerDependencies:
     vite: ^3.0.0
   checksum: cc85ab31b4689ab137c4b1e65383dccce494371523eb164c579096e513a2abbaa7efb49ba08655fae9f6692f5b7b2602ad339bdce4ae5982fc08fe444fb8a4e5
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-react@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@vitejs/plugin-react@npm:3.0.0"
+  dependencies:
+    "@babel/core": ^7.20.5
+    "@babel/plugin-transform-react-jsx-self": ^7.18.6
+    "@babel/plugin-transform-react-jsx-source": ^7.19.6
+    magic-string: ^0.27.0
+    react-refresh: ^0.14.0
+  peerDependencies:
+    vite: ^4.0.0
+  checksum: 6004e4da8f705288ca9163ff5ba43bf7495c516af527d3b0c2799455cc2933667bd8a5be6759547525abafeecbde9d9bd25e52b0c793637ddf425a013d3435be
   languageName: node
   linkType: hard
 
@@ -20620,6 +20718,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "magic-string@npm:0.27.0"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.13
+  checksum: 273faaa50baadb7a2df6e442eac34ad611304fc08fe16e24fe2e472fd944bfcb73ffb50d2dc972dc04e92784222002af46868cb9698b1be181c81830fd95a13e
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^1.0.0":
   version: 1.3.0
   resolution: "make-dir@npm:1.3.0"
@@ -25950,7 +26057,7 @@ __metadata:
     "@types/serve-static": ^1.15.0
     "@types/styled-components": ^5.1.26
     "@vitejs/plugin-legacy": ^2.3.1
-    "@vitejs/plugin-react": ^2.2.0
+    "@vitejs/plugin-react": ^3.0.0
     algoliasearch: ^4.14.2
     cypress: "https://cdn.cypress.io/beta/npm/12.0.0/linux-arm64/release/12.0.0-e8898d2f6b65a11f36ceb2dd32ce7f1d87b103bc/cypress.tgz"
     cypress-axe: ^1.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -25991,7 +25991,7 @@ __metadata:
     ts-morph: ^17.0.1
     ts-node: ^10.9.1
     typescript: ^4.9.3
-    vite: ^3.2.4
+    vite: ^3.2.5
     vite-plugin-pwa: ^0.13.3
     vitest: ^0.25.3
     whatwg-fetch: ^3.6.2
@@ -28804,7 +28804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^3.0.0, vite@npm:^3.2.4":
+"vite@npm:^3.0.0":
   version: 3.2.4
   resolution: "vite@npm:3.2.4"
   dependencies:
@@ -28839,6 +28839,44 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 0f3e8f89c15809bd6bd8dec54b04b7c9b87374314d00928035f9d70190b4b220e8206b5d77a1e4097a5019cebf7862df4fbc11fbbb35c4f75f359999123d2c25
+  languageName: node
+  linkType: hard
+
+"vite@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "vite@npm:3.2.5"
+  dependencies:
+    esbuild: ^0.15.9
+    fsevents: ~2.3.2
+    postcss: ^8.4.18
+    resolve: ^1.22.1
+    rollup: ^2.79.1
+  peerDependencies:
+    "@types/node": ">= 14"
+    less: "*"
+    sass: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: ad35b7008c2b62a167d1d1a82f0a0c60fa457733f1969e9eedf0b0077f67a7ac74b4c9477e75a397895150f09b6551f0c17841c5b05c34d9fe302bb0b5dc28a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Edit by Johan*

Vu en pair cet après midi (le 20/12/22) :
- [ ] Généraliser la logique de `forceTheme` utilisée dans `TextInput` dans les composants `H1`, `H2`, `H{n}` et `Body` `SmallBody` dans un premier temps (on pourra faire le reste au fur et à mesure des besoins)
- [ ] Documenter cette prop dans les stories du storybook si nécessaire
- [ ] Enlever les props `$textColor` et `$backgroundColor` de partout, sauf pour les container (pour `backgroundColor`) : avec `forceTheme` on ne devrait plus en avoir besoin
- [ ] Réparer les petits bugs visuels listés dans https://github.com/betagouv/mon-entreprise/pull/2427#pullrequestreview-1224335711