### PR TITLE
🎨 Implémentation du remaniement de `<Footer />`

### DIFF
--- a/site/cypress/integration/mon-entreprise/english/navigation.ts
+++ b/site/cypress/integration/mon-entreprise/english/navigation.ts
@@ -7,7 +7,9 @@ describe('General navigation', function () {
 		cy.visit(
 			fr ? encodeURI('/créer/auto-entrepreneur') : '/create/auto-entrepreneur'
 		)
-		cy.contains(fr ? 'Switch to English' : 'Passer en français').click()
+		cy.get(
+			fr ? '[data-test-id=en-switch-button]' : '[data-test-id=fr-switch-button]'
+		).click()
 		cy.url().should(
 			'include',
 			fr ? '/create/auto-entrepreneur' : encodeURI('/créer/auto-entrepreneur')

--- a/site/cypress/integration/mon-entreprise/simulateur-ae.ts
+++ b/site/cypress/integration/mon-entreprise/simulateur-ae.ts
@@ -15,7 +15,7 @@ describe('Simulateur auto-entrepreneur', { testIsolation: 'off' }, function () {
 		cy.get(inputSelector).first().type('{selectall}50000')
 		cy.contains('button', 'Passer').click()
 		cy.contains('button', 'Passer').click()
-		cy.contains('Début 2022').click()
+		cy.contains('Début 2023').click()
 		cy.contains('ACRE')
 	})
 

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -216,7 +216,10 @@ function RadioChoice<Names extends string = DottedName>({
 									rootDottedName,
 									node.dottedName
 								)}'`}
-								id={`radio-input-${node.dottedName.replace(/\s|\./g, '')}`}
+								id={`radio-input-${node.dottedName.replace(
+									/\s|\./g,
+									''
+								)}-${rootDottedName.replace(/\s|\./g, '')}`}
 							>
 								{node.title}{' '}
 								{node.rawNode.icônes && <Emoji emoji={node.rawNode.icônes} />}

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -93,26 +93,26 @@ export default function Footer() {
 								{language === 'fr' && (
 									<nav title="Première colonne du menu">
 										<ul>
-											<li>
+											<StyledLi>
 												<Link to={absoluteSitePaths.plan} noUnderline>
 													<Trans>Plan du site</Trans> <Emoji emoji="🧭" />
 												</Link>
-											</li>
-											<li>
+											</StyledLi>
+											<StyledLi>
 												<Link to={absoluteSitePaths.nouveautés} noUnderline>
 													Nouveautés <Emoji emoji="✨" />
 												</Link>
-											</li>
-											<li>
+											</StyledLi>
+											<StyledLi>
 												<Link to={absoluteSitePaths.budget} noUnderline>
 													Budget <Emoji emoji="🔦" />
 												</Link>
-											</li>
-											<li>
+											</StyledLi>
+											<StyledLi>
 												<Link to={absoluteSitePaths.stats} noUnderline>
 													Statistiques <Emoji emoji="📊" />
 												</Link>
-											</li>
+											</StyledLi>
 										</ul>
 									</nav>
 								)}
@@ -120,7 +120,7 @@ export default function Footer() {
 							<FooterColumn>
 								<nav title="Deuxième colonne du menu">
 									<ul>
-										<li>
+										<StyledLi>
 											<Link
 												to={absoluteSitePaths.développeur.index}
 												noUnderline
@@ -128,50 +128,47 @@ export default function Footer() {
 												<Trans>Intégrer nos simulateurs</Trans>{' '}
 												<Emoji emoji="📥" />
 											</Link>
-										</li>
+										</StyledLi>
 										{language === 'fr' && (
-											<li>
+											<StyledLi>
 												<InscriptionBetaTesteur /> <Emoji emoji="💌" />
-											</li>
+											</StyledLi>
 										)}
 										{hrefLink && (
-											<>
-												<Spacing md />
-												<li key={hrefLink.hrefLang}>
-													<Grid container>
-														<Grid item>
-															<StyledButton
-																openInSameWindow
-																href={hrefLink.href}
-																aria-disabled={isFrenchMode}
-																aria-label={t(
-																	isFrenchMode
-																		? 'Version française du site activée.'
-																		: 'Passer à la version française du site'
-																)}
-																lang="fr"
-															>
-																FR <Emoji emoji="🇫🇷" />
-															</StyledButton>
-														</Grid>
-														<Grid item>
-															<StyledButton
-																href={hrefLink.href}
-																openInSameWindow
-																lang="en"
-																aria-disabled={!isFrenchMode}
-																aria-label={t(
-																	!isFrenchMode
-																		? 'English version of the website enabled.'
-																		: 'Switch to the english version of the website'
-																)}
-															>
-																EN <Emoji emoji="🇬🇧" />
-															</StyledButton>
-														</Grid>
+											<StyledLi key={hrefLink.hrefLang}>
+												<Grid container spacing={2}>
+													<Grid item>
+														<StyledButton
+															openInSameWindow
+															href={hrefLink.href}
+															aria-disabled={isFrenchMode}
+															aria-label={t(
+																isFrenchMode
+																	? 'Version française du site activée.'
+																	: 'Passer à la version française du site'
+															)}
+															lang="fr"
+														>
+															FR <Emoji emoji="🇫🇷" />
+														</StyledButton>
 													</Grid>
-												</li>
-											</>
+													<Grid item>
+														<StyledButton
+															href={hrefLink.href}
+															openInSameWindow
+															lang="en"
+															aria-disabled={!isFrenchMode}
+															aria-label={t(
+																!isFrenchMode
+																	? 'English version of the website enabled.'
+																	: 'Switch to the english version of the website'
+															)}
+														>
+															EN <Emoji emoji="🇬🇧" />
+														</StyledButton>
+													</Grid>
+												</Grid>
+											</StyledLi>
 										)}
 									</ul>
 								</nav>
@@ -180,14 +177,14 @@ export default function Footer() {
 							<FooterColumn>
 								<nav title="Troisième colonne du menu">
 									<ul>
-										<li>
+										<StyledLi>
 											<LegalNotice />
-										</li>
-										<li>
+										</StyledLi>
+										<StyledLi>
 											<Privacy />
-										</li>
+										</StyledLi>
 										{language === 'fr' && (
-											<li>
+											<StyledLi>
 												<Link
 													to={absoluteSitePaths.accessibilité}
 													aria-label={t(
@@ -200,7 +197,7 @@ export default function Footer() {
 														Accessibilité : non conforme
 													</Trans>
 												</Link>
-											</li>
+											</StyledLi>
 										)}
 									</ul>
 								</nav>
@@ -221,4 +218,8 @@ const StyledButton = styled(Button)`
 		background-color: ${({ theme }) => theme.colors.bases.primary[300]};
 		pointer-events: none;
 	}
+`
+
+const StyledLi = styled.li`
+	margin-top: ${({ theme }) => theme.spacings.sm};
 `

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -148,6 +148,7 @@ export default function Footer() {
 																	: 'Passer à la version française du site'
 															)}
 															lang="fr"
+															data-test-id="fr-switch-button"
 														>
 															FR <Emoji emoji="🇫🇷" />
 														</StyledButton>
@@ -163,6 +164,7 @@ export default function Footer() {
 																	? 'English version of the website enabled.'
 																	: 'Switch to the english version of the website'
 															)}
+															data-test-id="en-switch-button"
 														>
 															EN <Emoji emoji="🇬🇧" />
 														</StyledButton>

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -1,13 +1,14 @@
 import { Helmet } from 'react-helmet-async'
 import { Trans, useTranslation } from 'react-i18next'
-import { ThemeProvider } from 'styled-components'
+import styled, { ThemeProvider } from 'styled-components'
 
 import PageFeedback from '@/components/Feedback'
 import LegalNotice from '@/components/LegalNotice'
+import { Button } from '@/design-system/buttons'
 import { Emoji } from '@/design-system/emoji'
 import { FooterContainer } from '@/design-system/footer'
 import { FooterColumn } from '@/design-system/footer/column'
-import { Container } from '@/design-system/layout'
+import { Container, Grid, Spacing } from '@/design-system/layout'
 import { Link } from '@/design-system/typography/link'
 import { Body } from '@/design-system/typography/paragraphs'
 import { alternateLinks, useSitePaths } from '@/sitePaths'
@@ -34,7 +35,11 @@ export default function Footer() {
 		currentEnv === 'production'
 			? (encodedUri || '').replace(/\/$/, '')
 			: encodedUri || ''
-	const hrefLink = hrefLangLink[language][uri]
+	const hrefLink =
+		hrefLangLink[language][uri] ?? hrefLangLink[language][uri + '/']
+
+	// hrefLink.hrefLang ne représente pas la langue actuelle mais l'autre à activer
+	const isFrenchMode = hrefLink.hrefLang === 'en'
 
 	return (
 		<>
@@ -87,11 +92,11 @@ export default function Footer() {
 						>
 							<FooterColumn>
 								{language === 'fr' && (
-									<nav title="firstColumnNav">
+									<nav title="Première colonne du menu">
 										<ul>
 											<li>
 												<Link to={absoluteSitePaths.plan} noUnderline>
-													<Trans>Plan du site</Trans>
+													<Trans>Plan du site</Trans> <Emoji emoji="🧭" />
 												</Link>
 											</li>
 											<li>
@@ -100,13 +105,13 @@ export default function Footer() {
 												</Link>
 											</li>
 											<li>
-												<Link to={absoluteSitePaths.stats} noUnderline>
-													Stats <Emoji emoji="📊" />
+												<Link to={absoluteSitePaths.budget} noUnderline>
+													Budget <Emoji emoji="🔦" />
 												</Link>
 											</li>
 											<li>
-												<Link to={absoluteSitePaths.budget} noUnderline>
-													Budget <Emoji emoji="💶" />
+												<Link to={absoluteSitePaths.stats} noUnderline>
+													Statistiques <Emoji emoji="📊" />
 												</Link>
 											</li>
 										</ul>
@@ -114,49 +119,67 @@ export default function Footer() {
 								)}
 							</FooterColumn>
 							<FooterColumn>
-								<nav title="secondColumnNav">
+								<nav title="Deuxième colonne du menu">
 									<ul>
 										<li>
 											<Link
 												to={absoluteSitePaths.développeur.index}
 												noUnderline
 											>
-												<Trans>Intégrer nos simulateurs</Trans>
+												<Trans>Intégrer nos simulateurs</Trans>{' '}
+												<Emoji emoji="📥" />
 											</Link>
 										</li>
 										{language === 'fr' && (
 											<li>
-												<InscriptionBetaTesteur />
+												<InscriptionBetaTesteur /> <Emoji emoji="💌" />
 											</li>
 										)}
 										{hrefLink && (
-											<li key={hrefLink.hrefLang}>
-												<Link
-													href={hrefLink.href}
-													openInSameWindow
-													lang={hrefLink.hrefLang === 'en' ? 'en' : 'fr'}
-													noUnderline
-												>
-													{hrefLink.hrefLang === 'fr' ? (
-														<>
-															Passer en français <Emoji emoji="🇫🇷" />
-														</>
-													) : hrefLink.hrefLang === 'en' ? (
-														<>
-															Switch to English <Emoji emoji="🇬🇧" />
-														</>
-													) : (
-														hrefLink.hrefLang
-													)}
-												</Link>
-											</li>
+											<>
+												<Spacing md />
+												<li key={hrefLink.hrefLang}>
+													<Grid container>
+														<Grid item>
+															<StyledButton
+																openInSameWindow
+																href={hrefLink.href}
+																aria-disabled={isFrenchMode}
+																aria-label={t(
+																	isFrenchMode
+																		? 'Version française du site activée.'
+																		: 'Passer à la version française du site'
+																)}
+																lang="fr"
+															>
+																FR <Emoji emoji="🇫🇷" />
+															</StyledButton>
+														</Grid>
+														<Grid item>
+															<StyledButton
+																href={hrefLink.href}
+																openInSameWindow
+																lang="en"
+																aria-disabled={!isFrenchMode}
+																aria-label={t(
+																	!isFrenchMode
+																		? 'English version of the website enabled.'
+																		: 'Switch to the english version of the website'
+																)}
+															>
+																EN <Emoji emoji="🇬🇧" />
+															</StyledButton>
+														</Grid>
+													</Grid>
+												</li>
+											</>
 										)}
 									</ul>
 								</nav>
 							</FooterColumn>
 
 							<FooterColumn>
-								<nav title="thirdColumnNav">
+								<nav title="Troisième colonne du menu">
 									<ul>
 										<li>
 											<LegalNotice />
@@ -190,3 +213,13 @@ export default function Footer() {
 		</>
 	)
 }
+
+const StyledButton = styled(Button)`
+	padding: 10px 16px 10px 16px;
+	border-radius: 4px;
+
+	&[aria-disabled='true'] {
+		background-color: ${({ theme }) => theme.colors.bases.primary[300]};
+		pointer-events: none;
+	}
+`

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -38,8 +38,7 @@ export default function Footer() {
 	const hrefLink =
 		hrefLangLink[language][uri] ?? hrefLangLink[language][uri + '/']
 
-	// hrefLink.hrefLang ne représente pas la langue actuelle mais l'autre à activer
-	const isFrenchMode = hrefLink.hrefLang === 'en'
+	const isFrenchMode = language === 'fr'
 
 	return (
 		<>

--- a/site/source/design-system/buttons/Button.tsx
+++ b/site/source/design-system/buttons/Button.tsx
@@ -18,6 +18,8 @@ type ButtonProps = GenericButtonOrNavLinkProps & {
 	size?: Size
 	light?: boolean
 	role?: string
+	['aria-disabled']?: boolean
+	lang?: string
 }
 
 export const Button = forwardRef(function Button(
@@ -27,6 +29,7 @@ export const Button = forwardRef(function Button(
 		color = 'primary' as const,
 		isDisabled,
 		role,
+		lang,
 		...ariaButtonProps
 	}: ButtonProps,
 	forwardedRef: ForwardedRef<HTMLAnchorElement | HTMLButtonElement | null>
@@ -44,6 +47,8 @@ export const Button = forwardRef(function Button(
 			$color={color}
 			$isDisabled={isDisabled}
 			role={role}
+			aria-disabled={ariaButtonProps?.['aria-disabled']}
+			lang={lang}
 		/>
 	)
 })

--- a/site/source/pages/Landing/SearchOrCreate.tsx
+++ b/site/source/pages/Landing/SearchOrCreate.tsx
@@ -50,9 +50,11 @@ export default function SearchOrCreate() {
 									to={generatePath(absoluteSitePaths.gérer.entreprise, {
 										entreprise: companySIREN as string,
 									})}
-									aria-label="Voir ma situation, accéder à la page de gestion de mon entreprise"
+									aria-label={t(
+										'Voir ma situation, accéder à la page de gestion de mon entreprise'
+									)}
 								>
-									Voir ma situation
+									{t('Voir ma situation')}
 								</Button>
 								<PopoverConfirm
 									trigger={(buttonProps) => (
@@ -61,7 +63,7 @@ export default function SearchOrCreate() {
 											aria-label={t('Réinitialiser la situation enregistrée')}
 											{...buttonProps}
 										>
-											Réinitialiser
+											{t('Réinitialiser')}
 										</Button>
 									)}
 									onConfirm={() => dispatch(resetCompany())}


### PR DESCRIPTION
Implémente le footer remanié d'après la maquette suivante : [https://www.figma.com/file/ZbrOYsD3s5fcwetxL4XXkX/Assistant-au-choix-du-statut?node-id=387%3A12124&t=89pipYrXLCexUxNq-0](https://www.figma.com/file/ZbrOYsD3s5fcwetxL4XXkX/Assistant-au-choix-du-statut?node-id=387%3A12124&t=89pipYrXLCexUxNq-0)