### PR TITLE
🐛 Corrige la transition de background sur les titres

### DIFF
--- a/site/source/design-system/typography/heading.tsx
+++ b/site/source/design-system/typography/heading.tsx
@@ -8,7 +8,7 @@ const baseHeading = css`
 		theme.darkMode
 			? theme.colors.extended.grey[100]
 			: theme.colors.bases.primary[700]};
-	background-color: inherit;
+	background-color: transparent;
 `
 
 export const HeadingUnderline = css`


### PR DESCRIPTION
Au survol, un effet de transition background bizarre se produisait au niveau des titres des card de simulateurs.