### PR TITLE
Màj `react-easy-emoji`

### DIFF
--- a/site/netlify.base.toml
+++ b/site/netlify.base.toml
@@ -26,7 +26,7 @@ Content-Security-Policy = "default-src 'self' mon-entreprise.fr; style-src 'self
 ## Twemoji proxy for client privacy #1219
 [[redirects]]
   from = "/twemoji/*"
-  to = "https://twemoji.maxcdn.com/:splat"
+  to = "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/"
   status = 200
 
 

--- a/site/netlify.base.toml
+++ b/site/netlify.base.toml
@@ -26,7 +26,7 @@ Content-Security-Policy = "default-src 'self' mon-entreprise.fr; style-src 'self
 ## Twemoji proxy for client privacy #1219
 [[redirects]]
   from = "/twemoji/*"
-  to = "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/"
+  to = "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/:splat"
   status = 200
 
 

--- a/site/package.json
+++ b/site/package.json
@@ -88,7 +88,7 @@
 		"react": "^18.2.0",
 		"react-colorful": "^5.6.1",
 		"react-dom": "^18.2.0",
-		"react-easy-emoji": "^1.8.0",
+		"react-easy-emoji": "^1.8.1",
 		"react-helmet-async": "^1.3.0",
 		"react-i18next": "^12.0.0",
 		"react-instantsearch": "^6.38.1",

--- a/site/source/design-system/emoji/index.tsx
+++ b/site/source/design-system/emoji/index.tsx
@@ -19,7 +19,7 @@ export function Emoji({ emoji, alt, title, ...props }: PropType) {
 	}
 
 	return emojiFn(emoji, {
-		baseUrl: '/twemoji/2/',
+		baseUrl: '/twemoji/',
 		protocol: '' as 'https', // Hack to use relative path
 		ext: '.png',
 		props: {

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -112,7 +112,7 @@ export default defineConfig(({ command, mode }) => ({
 		proxy: {
 			'/api': 'http://localhost:3004',
 			'/twemoji': {
-				target: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/',
+				target: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
 				changeOrigin: true,
 				rewrite: (path) => path.replace(/^\/twemoji/, ''),
 				timeout: 3 * 1000,

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -112,7 +112,7 @@ export default defineConfig(({ command, mode }) => ({
 		proxy: {
 			'/api': 'http://localhost:3004',
 			'/twemoji': {
-				target: 'https://twemoji.maxcdn.com',
+				target: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/',
 				changeOrigin: true,
 				rewrite: (path) => path.replace(/^\/twemoji/, ''),
 				timeout: 3 * 1000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -24309,9 +24309,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-easy-emoji@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "react-easy-emoji@npm:1.8.0"
+"react-easy-emoji@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "react-easy-emoji@npm:1.8.1"
   dependencies:
     string-replace-to-array: ^2.1.0
   peerDependencies:
@@ -24320,7 +24320,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 0f7921619f2a2876990e27ffdd673138116f657d5ed3bd93d4ee031fb59f4d1a11a15b3a1b22a2db9ee966b33a1d4a3e0190a3b68d25bc0ec863e1603951ff3c
+  checksum: 02e325563d28f6b112fee355234f0802a8d62508b24d155f2cc60e6efd9c452e865b4521d2010f1b8a3eeb66fab94fb9e17b72d6e4f00f7cf44865cfd01f2f9a
   languageName: node
   linkType: hard
 
@@ -26192,7 +26192,7 @@ __metadata:
     react: ^18.2.0
     react-colorful: ^5.6.1
     react-dom: ^18.2.0
-    react-easy-emoji: ^1.8.0
+    react-easy-emoji: ^1.8.1
     react-helmet-async: ^1.3.0
     react-i18next: ^12.0.0
     react-instantsearch: ^6.38.1


### PR DESCRIPTION
La version 1.8.1 est sensée venir corriger : https://github.com/betagouv/mon-entreprise/issues/2451

Dans les faits ce n'est pas le cas 😭 je crée une issue sur le repo Github `react-easy-emoji`

<img width="1248" alt="Capture d’écran 2023-01-16 à 10 35 41" src="https://user-images.githubusercontent.com/12382534/212645606-41fe136b-082e-4583-8bff-3c8e31f4a8ba.png">
