### PR TITLE
Isole les checks de `cypress-axe` dans des fonctions `it` distinctes

### DIFF
--- a/site/cypress/integration/mon-entreprise/covid19.ts
+++ b/site/cypress/integration/mon-entreprise/covid19.ts
@@ -35,7 +35,9 @@ describe('Page covid-19', { testIsolation: 'off' }, function () {
 		cy.get('[data-test-id=comparaison-total]').contains(
 			/Soit [\d]{1} % du coût habituel/
 		)
+	})
 
+	it('should be RGAA compliant', function () {
 		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/demande-mobilité.ts
+++ b/site/cypress/integration/mon-entreprise/demande-mobilité.ts
@@ -2,181 +2,187 @@ import { checkA11Y, fr } from '../../support/utils'
 
 const writeFixtures = Cypress.env('record_http') !== undefined
 
-describe(`Formulaire demande mobilité (${
-	writeFixtures ? 'record mode' : 'stubbed mode'
-})`, function () {
-	if (!fr) {
-		return
+describe(
+	`Formulaire demande mobilité (${
+		writeFixtures ? 'record mode' : 'stubbed mode'
+	})`,
+	{ testIsolation: 'off' },
+	function () {
+		if (!fr) {
+			return
+		}
+		const FIXTURES_FOLDER = 'cypress/fixtures'
+		const DEMANDE_MOBILITE_FIXTURES_FOLDER = `${FIXTURES_FOLDER}/demande-mobilité`
+
+		let pendingRequests = new Set()
+		let responses = {}
+		const hostnamesToRecord = ['geo.api.gouv.fr']
+
+		before(function () {
+			pendingRequests = new Set()
+			responses = {}
+			cy.setInterceptResponses(
+				pendingRequests,
+				responses,
+				hostnamesToRecord,
+				DEMANDE_MOBILITE_FIXTURES_FOLDER
+			)
+			cy.clearLocalStorage() // Try to avoid flaky tests
+			cy.visit(encodeURI('/gérer/demande-mobilité'))
+		})
+
+		after(function () {
+			cy.writeInterceptResponses(
+				pendingRequests,
+				responses,
+				DEMANDE_MOBILITE_FIXTURES_FOLDER
+			)
+		})
+
+		it('should allow to select salarié', function () {
+			cy.intercept({
+				method: 'GET',
+				hostname: 'geo.api.gouv.fr',
+				url: '/communes*',
+			}).as('communes')
+
+			cy.contains('Employeur adhérent au TESE ou au CEA').click()
+
+			cy.contains('Informations concernant le salarié')
+
+			cy.contains('Êtes-vous adhérent au TESE ou au CEA')
+				.parent()
+				.next()
+				.contains('TESE')
+				.click()
+
+			// "coordonnées" section
+			cy.contains('Nom')
+				.parent()
+				.click()
+				.focused()
+				.type('Deaux')
+				.tab()
+				.type('Jean Bernard')
+				.tab()
+				.type('1 91 07 468 054 75')
+				.tab()
+				.type('Française')
+				.tab()
+				.type('1991-07-25')
+
+			cy.contains('Non')
+				.click()
+				.focused()
+				.tab()
+				.type('Pouts')
+				.wait('@communes')
+				.focused()
+			cy.contains('65100').type('{enter}').focused().tab().type('{downarrow}')
+
+			cy.focused().tab().type('Brest')
+
+			cy.wait('@communes')
+
+			cy.contains('29200')
+				.type('{enter}')
+				.focused()
+				.tab()
+				.type('3 rue de la Rhumerie')
+				.tab()
+
+			cy.focused()
+				.type('614540144500')
+				.tab()
+				.type('Deaux & Cie')
+				.tab()
+				.type('14 chemin des Docks')
+				.tab()
+				.type('Bre')
+			cy.contains('29200')
+				.click()
+				.focused()
+				.tab()
+				.type('Deaux')
+				.tab()
+				.type('Alphonse')
+				.tab()
+				.type('alphonse.deaux@gamil.com')
+				.tab()
+				.type('06 85 69 78 54')
+
+			// "activité en France" section
+			cy.contains('Pour une période déterminée et dans un seul pays').click()
+			cy.contains('Date de début').click({ force: true })
+			cy.focused().type('2020-11-06').tab().type('2021-04-09').tab()
+			cy.focused().type('Argen{enter}')
+
+			cy.contains('Agent contractuel').click()
+			cy.contains("Nom de l'entreprise")
+				.parent()
+				.click()
+				.focused()
+				.type('Haldithet Docks')
+				.tab()
+				.type('64E45 12-654')
+				.tab()
+				.type('Handstath street, 9th')
+				.tab()
+				.type('654004')
+				.tab()
+				.type('Egrageoiria')
+
+			cy.focused().tab().type('you@ajido.com').tab().type('+94655487015')
+
+			cy.contains("Dans le pays d'accueil").click()
+			cy.focused().tab().type('{downarrow}{downarrow}')
+
+			cy.focused().tab().type('{downarrow}')
+			cy.focused().tab().type('{downarrow}')
+			cy.focused().tab().type('{downarrow}')
+			cy.focused().tab().type('{downarrow}')
+			cy.focused().tab().type('{downarrow}')
+			cy.focused().tab().type('{downarrow}')
+			cy.focused().tab()
+
+			cy.focused().type('Docker').tab().type('Docker').tab()
+			cy.focused().type('{downarrow}{enter}')
+
+			cy.contains("Le salarié sera-t'il accompagné d'ayants droits")
+				.parent()
+				.next()
+				.contains('Oui')
+				.click()
+			cy.contains("Combien d'ayants droits partiront").parent().next().type('1')
+			cy.contains('Ayant droit n°1')
+			cy.focused()
+				.tab()
+				.type('Deladj')
+				.tab()
+				.type('Sophie')
+				.tab()
+				.type('1978-04-21')
+				.tab()
+			cy.focused().type('{downarrow}{enter}')
+
+			cy.contains("Souhaitez-vous partager d'autres informations")
+				.parent()
+				.next()
+				.contains('Non')
+				.click()
+
+			// download PDF
+			cy.contains(
+				'Je certifie l’exactitude des informations communiquées ci-dessus'
+			).click()
+			cy.contains('Fait à').click({ force: true })
+			cy.focused().type('Plougastel')
+			cy.contains('Générer la demande').click()
+			cy.contains('Télécharger le fichier').click()
+		})
+
+		it('should be RGAA compliant', function () {
+			checkA11Y()
+		})
 	}
-	const FIXTURES_FOLDER = 'cypress/fixtures'
-	const DEMANDE_MOBILITE_FIXTURES_FOLDER = `${FIXTURES_FOLDER}/demande-mobilité`
-
-	let pendingRequests = new Set()
-	let responses = {}
-	const hostnamesToRecord = ['geo.api.gouv.fr']
-
-	before(function () {
-		pendingRequests = new Set()
-		responses = {}
-		cy.setInterceptResponses(
-			pendingRequests,
-			responses,
-			hostnamesToRecord,
-			DEMANDE_MOBILITE_FIXTURES_FOLDER
-		)
-		cy.clearLocalStorage() // Try to avoid flaky tests
-		cy.visit(encodeURI('/gérer/demande-mobilité'))
-	})
-
-	after(function () {
-		cy.writeInterceptResponses(
-			pendingRequests,
-			responses,
-			DEMANDE_MOBILITE_FIXTURES_FOLDER
-		)
-	})
-
-	it('should allow to select salarié', function () {
-		cy.intercept({
-			method: 'GET',
-			hostname: 'geo.api.gouv.fr',
-			url: '/communes*',
-		}).as('communes')
-
-		cy.contains('Employeur adhérent au TESE ou au CEA').click()
-
-		cy.contains('Informations concernant le salarié')
-
-		cy.contains('Êtes-vous adhérent au TESE ou au CEA')
-			.parent()
-			.next()
-			.contains('TESE')
-			.click()
-
-		// "coordonnées" section
-		cy.contains('Nom')
-			.parent()
-			.click()
-			.focused()
-			.type('Deaux')
-			.tab()
-			.type('Jean Bernard')
-			.tab()
-			.type('1 91 07 468 054 75')
-			.tab()
-			.type('Française')
-			.tab()
-			.type('1991-07-25')
-
-		cy.contains('Non')
-			.click()
-			.focused()
-			.tab()
-			.type('Pouts')
-			.wait('@communes')
-			.focused()
-		cy.contains('65100').type('{enter}').focused().tab().type('{downarrow}')
-
-		cy.focused().tab().type('Brest')
-
-		cy.wait('@communes')
-
-		cy.contains('29200')
-			.type('{enter}')
-			.focused()
-			.tab()
-			.type('3 rue de la Rhumerie')
-			.tab()
-
-		cy.focused()
-			.type('614540144500')
-			.tab()
-			.type('Deaux & Cie')
-			.tab()
-			.type('14 chemin des Docks')
-			.tab()
-			.type('Bre')
-		cy.contains('29200')
-			.click()
-			.focused()
-			.tab()
-			.type('Deaux')
-			.tab()
-			.type('Alphonse')
-			.tab()
-			.type('alphonse.deaux@gamil.com')
-			.tab()
-			.type('06 85 69 78 54')
-
-		// "activité en France" section
-		cy.contains('Pour une période déterminée et dans un seul pays').click()
-		cy.contains('Date de début').click({ force: true })
-		cy.focused().type('2020-11-06').tab().type('2021-04-09').tab()
-		cy.focused().type('Argen{enter}')
-
-		cy.contains('Agent contractuel').click()
-		cy.contains("Nom de l'entreprise")
-			.parent()
-			.click()
-			.focused()
-			.type('Haldithet Docks')
-			.tab()
-			.type('64E45 12-654')
-			.tab()
-			.type('Handstath street, 9th')
-			.tab()
-			.type('654004')
-			.tab()
-			.type('Egrageoiria')
-
-		cy.focused().tab().type('you@ajido.com').tab().type('+94655487015')
-
-		cy.contains("Dans le pays d'accueil").click()
-		cy.focused().tab().type('{downarrow}{downarrow}')
-
-		cy.focused().tab().type('{downarrow}')
-		cy.focused().tab().type('{downarrow}')
-		cy.focused().tab().type('{downarrow}')
-		cy.focused().tab().type('{downarrow}')
-		cy.focused().tab().type('{downarrow}')
-		cy.focused().tab().type('{downarrow}')
-		cy.focused().tab()
-
-		cy.focused().type('Docker').tab().type('Docker').tab()
-		cy.focused().type('{downarrow}{enter}')
-
-		cy.contains("Le salarié sera-t'il accompagné d'ayants droits")
-			.parent()
-			.next()
-			.contains('Oui')
-			.click()
-		cy.contains("Combien d'ayants droits partiront").parent().next().type('1')
-		cy.contains('Ayant droit n°1')
-		cy.focused()
-			.tab()
-			.type('Deladj')
-			.tab()
-			.type('Sophie')
-			.tab()
-			.type('1978-04-21')
-			.tab()
-		cy.focused().type('{downarrow}{enter}')
-
-		cy.contains("Souhaitez-vous partager d'autres informations")
-			.parent()
-			.next()
-			.contains('Non')
-			.click()
-
-		// download PDF
-		cy.contains(
-			'Je certifie l’exactitude des informations communiquées ci-dessus'
-		).click()
-		cy.contains('Fait à').click({ force: true })
-		cy.focused().type('Plougastel')
-		cy.contains('Générer la demande').click()
-		cy.contains('Télécharger le fichier').click()
-
-		checkA11Y()
-	})
-})
+)

--- a/site/cypress/integration/mon-entreprise/landing.ts
+++ b/site/cypress/integration/mon-entreprise/landing.ts
@@ -9,8 +9,6 @@ const FIXTURES_FOLDER = 'cypress/fixtures/landing'
 describe('Landing page', function () {
 	it('should not crash', function () {
 		cy.visit('/')
-
-		checkA11Y()
 	})
 
 	it('should display logo', function () {
@@ -64,5 +62,10 @@ describe('Landing page', function () {
 		cy.url().should('include', '/g%C3%A9rer')
 
 		cy.writeInterceptResponses(pendingRequests, responses, FIXTURES_FOLDER)
+	})
+
+	it('should be RGAA compliant', function () {
+		cy.visit('/')
+		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/recherche.ts
+++ b/site/cypress/integration/mon-entreprise/recherche.ts
@@ -1,6 +1,6 @@
 import { checkA11Y, fr } from '../../support/utils'
 
-describe('Recherche globales', function () {
+describe('Recherche globales', { testIsolation: 'off' }, function () {
 	if (!fr) {
 		return
 	}
@@ -28,7 +28,10 @@ describe('Recherche globales', function () {
 			.next()
 			.find('li')
 			.should('have.length.of.at.least', 1)
+	})
 
+	it('should be RGAA compliant', function () {
+		cy.visit('/')
 		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/secondary-pages.ts
+++ b/site/cypress/integration/mon-entreprise/secondary-pages.ts
@@ -7,11 +7,12 @@ describe('Secondary pages', function () {
 
 	it("page stats doesn't crash", function () {
 		cy.visit('/stats')
-		cy.contains('Statistiques détaillées')
+		cy.contains('Statistiques')
 	})
 
 	it('Statistics page should be RGAA compliant', function () {
 		cy.visit('/stats')
+		cy.contains('Statistiques')
 		checkA11Y()
 	})
 
@@ -22,6 +23,8 @@ describe('Secondary pages', function () {
 	})
 	it('News page should be RGAA compliant', function () {
 		cy.visit('/nouveautés')
+		cy.contains('←').click()
+		cy.url({ decode: true }).should('match', /\/nouveautés\/[^/]*$/)
 		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/secondary-pages.ts
+++ b/site/cypress/integration/mon-entreprise/secondary-pages.ts
@@ -8,7 +8,10 @@ describe('Secondary pages', function () {
 	it("page stats doesn't crash", function () {
 		cy.visit('/stats')
 		cy.contains('Statistiques détaillées')
+	})
 
+	it('Statistics page should be RGAA compliant', function () {
+		cy.visit('/stats')
 		checkA11Y()
 	})
 
@@ -16,7 +19,9 @@ describe('Secondary pages', function () {
 		cy.visit('/nouveautés')
 		cy.contains('←').click()
 		cy.url({ decode: true }).should('match', /\/nouveautés\/[^/]*$/)
-
+	})
+	it('News page should be RGAA compliant', function () {
+		cy.visit('/nouveautés')
 		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/simulateur-ae.ts
+++ b/site/cypress/integration/mon-entreprise/simulateur-ae.ts
@@ -73,7 +73,9 @@ describe('Simulateur auto-entrepreneur', { testIsolation: 'off' }, function () {
 			expect(activitéMixtes[0]).to.be.equal(activitéMixtes[2])
 			expect(activitéMixtes[1]).to.be.equal(activitéMixtes[0] * 2)
 		})
+	})
 
+	it('should be RGAA compliant', function () {
 		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/simulateur-dividendes.js
+++ b/site/cypress/integration/mon-entreprise/simulateur-dividendes.js
@@ -3,7 +3,7 @@ import { checkA11Y } from '../../support/utils'
 const inputSelector = 'div[id="simulator-legend"] input'
 const fr = Cypress.env('language') === 'fr'
 
-describe('Simulateur dividendes', function () {
+describe('Simulateur dividendes', { testIsolation: 'off' }, function () {
 	if (!fr) {
 		return
 	}
@@ -13,7 +13,9 @@ describe('Simulateur dividendes', function () {
 		cy.get(inputSelector).first().type('{selectall}5000')
 		cy.contains(/[cC]otisations\s+17,2\s*%/)
 		cy.contains(/[Ii]mpôt\s+12,8\s*%/)
+	})
 
+	it('should be RGAA compliant', function () {
 		checkA11Y()
 	})
 })

--- a/site/cypress/integration/mon-entreprise/simulateur-salarie.ts
+++ b/site/cypress/integration/mon-entreprise/simulateur-salarie.ts
@@ -50,7 +50,10 @@ describe('Simulateur salarié : part time contract', function () {
 				.replace(/[\s,.€]/g, '')
 			expect(parseInt(val)).to.be.below(1000)
 		})
+	})
 
+	it('should be RGAA compliant', function () {
+		cy.visit('/')
 		checkA11Y()
 	})
 })

--- a/site/cypress/support/simulateur.js
+++ b/site/cypress/support/simulateur.js
@@ -71,6 +71,9 @@ export const runSimulateurTest = (simulateur) => {
 				.first()
 				.invoke('val')
 				.should('match', /2[\s,]000/)
+		})
+
+		it('should be RGAA compliant', function () {
 			checkA11Y()
 		})
 	})


### PR DESCRIPTION
Permet d'éviter les faux positifs douteux et d'avoir un label d'erreur clair renvoyé quand une erreur d'accessibilité est renvoyée.