### PR TITLE
fix: Garder l'année précédente comme date de l'exercice

### DIFF
--- a/modele-social/règles/entreprise/entreprise.yaml
+++ b/modele-social/règles/entreprise/entreprise.yaml
@@ -272,6 +272,16 @@ entreprise . résultat fiscal . rémunération dirigeant déductible:
 
 entreprise . exercice:
   avec:
+    début n-1:
+      titre: début
+      type: date
+      par défaut: période . début . n-1
+
+    fin n-1:
+      titre: fin
+      type: date
+      par défaut: période . fin . n-1
+
     début:
       type: date
       par défaut: période . début d'année

--- a/modele-social/règles/période.yaml
+++ b/modele-social/règles/période.yaml
@@ -27,3 +27,21 @@ période . fin d'année:
       alors: 31/12/2022
     - si: date <= 31/12/2023
       alors: 31/12/2023
+
+période . début . n-1:
+  variations:
+    - si: date >= 01/2023
+      alors: 01/01/2022
+    - si: date >= 01/2022
+      alors: 01/01/2021
+    - si: date >= 01/2021
+      alors: 01/01/2020
+
+période . fin . n-1:
+  variations:
+    - si: date <= 31/12/2021
+      alors: 31/12/2020
+    - si: date <= 31/12/2022
+      alors: 31/12/2021
+    - si: date <= 31/12/2023
+      alors: 31/12/2022

--- a/site/source/components/conversation/DateInput.tsx
+++ b/site/source/components/conversation/DateInput.tsx
@@ -56,6 +56,7 @@ export default function DateInput({
 						onSecondClick={() => onSubmit?.('suggestion')}
 					/>
 				)}
+
 				<DateField
 					value={missing ? undefined : dateValue}
 					autoFocus={autoFocus}

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -92,6 +92,7 @@ export default function RuleInput<Names extends string = DottedName>({
 	const rule = engineValue.getRule(dottedName)
 	const evaluation = engineValue.evaluate({ valeur: dottedName, ...modifiers })
 	const value = evaluation.nodeValue
+
 	const shouldFocusField = useShouldFocusField()
 
 	const commonProps: InputProps<Names> = {

--- a/site/source/pages/simulateurs/impot-societe/index.tsx
+++ b/site/source/pages/simulateurs/impot-societe/index.tsx
@@ -64,7 +64,7 @@ function ExerciceDate() {
 				dottedName={'entreprise . exercice . fin n-1'}
 				showDefaultDateValue
 				onChange={(x) =>
-					dispatch(updateSituation('entreprise . exercice . fin', x))
+					dispatch(updateSituation('entreprise . exercice . fin n-1', x))
 				}
 			/>
 		</ExerciceDateContainer>

--- a/site/source/pages/simulateurs/impot-societe/index.tsx
+++ b/site/source/pages/simulateurs/impot-societe/index.tsx
@@ -54,14 +54,14 @@ function ExerciceDate() {
 	return (
 		<ExerciceDateContainer>
 			<RuleInput
-				dottedName={'entreprise . exercice . début'}
+				dottedName={'entreprise . exercice . début n-1'}
 				showDefaultDateValue
 				onChange={(x) =>
-					dispatch(updateSituation('entreprise . exercice . début', x))
+					dispatch(updateSituation('entreprise . exercice . début n-1', x))
 				}
-			/>{' '}
+			/>
 			<RuleInput
-				dottedName={'entreprise . exercice . fin'}
+				dottedName={'entreprise . exercice . fin n-1'}
 				showDefaultDateValue
 				onChange={(x) =>
 					dispatch(updateSituation('entreprise . exercice . fin', x))


### PR DESCRIPTION
Petite modification pour garder la date de l'année précédente (par défaut) comme date de l'exercice dans l'outil de simulation 😀.

PR en lien avec #2515

