### PR TITLE
:art: Changement de l'url redirigeant vers yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ L'application est écrite en JavaScript, elle est exécuté uniquement côté cl
 Nous utilisons :
 
 -   [TypeScript](https://www.typescriptlang.org) pour ajouter un système de typage à notre code JavaScript. Le typage n'est pas utilisé partout et il n'est pas obligatoire de le prendre en compte pour contribuer.
--   [Yarn](https://yarnpkg.com/fr) pour la gestion des dépendances (à la place de NPM qui est souvent utilisé dans les applications JavaScript)
+-   [Yarn](https://yarnpkg.com) pour la gestion des dépendances (à la place de NPM qui est souvent utilisé dans les applications JavaScript)
 -   [React](https://reactjs.org) pour la gestion de l'interface utilisateur
 -   [Redux](https://redux.js.org) pour gérer le “state” de l'application côté client
 -   [Prettier](https://prettier.io/) pour formater le code source, l'idéal est de configurer votre éditeur de texte pour que les fichiers soit formatés automatiquement quand vous sauvegardez un fichier. Si vous utilisez [VS Code](https://code.visualstudio.com/) cette configuration est automatique.


### PR DESCRIPTION
Le site web a eu un changement d'apparence entre la version 1 ( https://classic.yarnpkg.com/ ) et la version 2 ( https://classic.yarnpkg.com/ ) et l'url https://yarnpkg.com/fr/ est automatiquement redirigé vers https://classic.yarnpkg.com/fr/ , qui n'est pas valide ("404: Page Not Found").
Je n'ai pas pu trouver sur le repository une nouvelle version pour la version française de la page ( https://github.com/yarnpkg/berry/search?q=fr ), j'en déduis qu'elle n'existe plus, car d'après la WayBack Machine, cette page existait (voir: https://web.archive.org/web/20201127011058/https://classic.yarnpkg.com/fr/ ).