### PR TITLE
Avoid feedback button to overlap buton in iframe

### DIFF
--- a/site/source/components/Feedback/index.tsx
+++ b/site/source/components/Feedback/index.tsx
@@ -263,8 +263,7 @@ const StyledButton = styled.button<{
 	$isEmbedded?: boolean
 }>`
 	position: fixed;
-	top: 10.5rem;
-	${({ $isEmbedded }) => ($isEmbedded ? `top: 2rem;` : '')}
+	top: ${({ $isEmbedded }) => ($isEmbedded ? '2rem' : '10.5rem')};
 	right: 0;
 	width: 3.75rem;
 	height: 3.75rem;

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -141,7 +141,12 @@ function TopSection({ toggles }: { toggles?: React.ReactNode }) {
 			)}
 			{toggles && (
 				<Grid item xs>
-					<ToggleSection>{toggles}</ToggleSection>
+					<ToggleSection
+						// Margin right is needed to avoid the feedback button to overlap the toggles in the iframe
+						style={inIframe ? { marginRight: '40px' } : {}}
+					>
+						{toggles}
+					</ToggleSection>
 				</Grid>
 			)}
 		</Section>


### PR DESCRIPTION
fix #2662 
J'ai ajouté un margin right pour corriger le problème, voici les pire cas :
![image](https://github.com/betagouv/mon-entreprise/assets/6691954/45010313-f061-4ce3-8e47-01f2cdb72b25)
![image](https://github.com/betagouv/mon-entreprise/assets/6691954/55da052c-4122-49cb-a861-0dfa8f4e1fdd)
![image](https://github.com/betagouv/mon-entreprise/assets/6691954/37b5a120-3cb4-4851-bf1d-6f5f1b9ecbdd)
