### PR TITLE
Enlève la section des demandes usagers de la page stat

### DIFF
--- a/site/source/pages/statistiques/DemandesUtilisateurs.tsx
+++ b/site/source/pages/statistiques/DemandesUtilisateurs.tsx
@@ -14,6 +14,9 @@ import { useFetchData } from '@/hooks/useFetchData'
 import { StatsStruct } from './types'
 
 export default function DemandeUtilisateurs() {
+	// Waiting for #2552 to be implemented
+	return null
+
 	const { data: stats } = useFetchData<StatsStruct>('/data/stats.json')
 	const { t } = useTranslation()
 


### PR DESCRIPTION
En attendant que #2552 soit réparé, sinon les chiffres ne sont pas bons : 
![image](https://github.com/betagouv/mon-entreprise/assets/1775934/0d40a538-6865-4dcf-97b0-00d8b2d6cfd0)
