### PR TITLE
Anonymisation des clés pour le cache de l'api

### DIFF
--- a/api/source/rate-limiter.ts
+++ b/api/source/rate-limiter.ts
@@ -13,8 +13,9 @@ const rateLimiter =
 		? new RateLimiterRedis({
 				storeClient: new Redis(process.env.SCALINGO_REDIS_URL, {
 					enableOfflineQueue: false,
+					keyPrefix: 'rate-limiter',
 				}),
-				keyPrefix: 'middleware',
+				keyPrefix: 'rate-limiter',
 				points: 5, // 5 requests for ctx.ip
 				duration: 1, // per 1 second
 		  })

--- a/api/source/redis-cache.ts
+++ b/api/source/redis-cache.ts
@@ -13,6 +13,7 @@ const redis =
 	process.env.NODE_ENV === 'production' && process.env.SCALINGO_REDIS_URL
 		? new Redis(process.env.SCALINGO_REDIS_URL, {
 				enableOfflineQueue: false,
+				keyPrefix: 'cache',
 		  })
 		: new RedisMock()
 

--- a/api/source/redis-cache.ts
+++ b/api/source/redis-cache.ts
@@ -8,8 +8,8 @@ import { koaBody } from 'koa-body'
 const Redis = IORedis.default
 const RedisMock = IORedisMock.default
 
-// cache expires in 2 hours
-const CACHE_EXPIRE = 2 * 60 * 60
+// cache expires in 12 hours
+const CACHE_EXPIRE = 12 * 60 * 60
 
 const redis =
 	process.env.NODE_ENV === 'production' && process.env.SCALINGO_REDIS_URL

--- a/api/source/redis-cache.ts
+++ b/api/source/redis-cache.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto'
+
 import Router from '@koa/router'
 import IORedis from 'ioredis'
 import IORedisMock from 'ioredis-mock'
@@ -27,7 +29,10 @@ export const redisCacheMiddleware = () => {
 			return
 		}
 
-		const cacheKey = JSON.stringify(ctx.request.body)
+		const cacheKey = createHash('sha1')
+			.update(JSON.stringify(ctx.request.body))
+			.digest('base64')
+
 		const cachedResponse = await redis.get(cacheKey)
 		if (cachedResponse) {
 			ctx.body = JSON.parse(cachedResponse) as unknown


### PR DESCRIPTION
Actuellement on utilise le json qu'on reçois comme clé de cache, il y a donc toute les données envoyé qui sont stocké dans le Redis.
Ce fix hash le json en sha1 avant de l'utiliser comme clé. 