### PR TITLE
Fix date limit

### DIFF
--- a/site/source/components/conversation/DateInput.tsx
+++ b/site/source/components/conversation/DateInput.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import { InputProps } from '@/components/conversation/RuleInput'
 import { DateField } from '@/design-system/field'
+import { DateFieldProps } from '@/design-system/field/DateField'
 
 import { useEngine } from '../utils/EngineContext'
 import InputSuggestions from './InputSuggestions'
@@ -14,7 +15,8 @@ export default function DateInput({
 	onSubmit,
 	required,
 	value,
-}: InputProps) {
+	type,
+}: InputProps & { type: DateFieldProps['type'] }) {
 	const engine = useEngine()
 
 	const convertDate = (val?: unknown) => {
@@ -66,6 +68,7 @@ export default function DateInput({
 					onChange={handleDateChange}
 					aria-label={title}
 					label={title}
+					type={type}
 				/>
 			</div>
 		</div>

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -12,6 +12,7 @@ import React, { useContext } from 'react'
 import NumberInput from '@/components/conversation/NumberInput'
 import SelectCommune from '@/components/conversation/select/SelectCommune'
 import { EngineContext } from '@/components/utils/EngineContext'
+import { DateFieldProps } from '@/design-system/field/DateField'
 import { getMeta } from '@/utils'
 
 import { Choice, MultipleAnswerInput, OuiNonInput } from './ChoicesInput'
@@ -167,8 +168,13 @@ export default function RuleInput<Names extends string = DottedName>({
 		return <SelectAtmp {...commonProps} />
 	}
 
-	if (rule.rawNode.type === 'date') {
-		return <DateInput {...commonProps} />
+	if (rule.rawNode.type?.startsWith('date')) {
+		return (
+			<DateInput
+				{...commonProps}
+				type={rule.rawNode.type as DateFieldProps['type']}
+			/>
+		)
 	}
 
 	if (

--- a/site/source/design-system/field/DateField.tsx
+++ b/site/source/design-system/field/DateField.tsx
@@ -56,7 +56,10 @@ export default function DateField(props: DateFieldProps) {
 		required: true,
 		locale: language === 'fr' ? fr : enUS,
 		fromDate: type === 'date futur' ? new Date() : new Date('1800-01-01'),
-		toDate: type === 'date passé' ? new Date() : undefined,
+		toDate:
+			type === 'date passé'
+				? new Date()
+				: new Date(`${new Date().getFullYear() + 100}-01-01`),
 	})
 
 	const [inputValue, setInputValue] = useState<string>(

--- a/site/source/design-system/field/DateField.tsx
+++ b/site/source/design-system/field/DateField.tsx
@@ -18,7 +18,7 @@ import { Emoji } from '../emoji'
 import { Body } from '../typography/paragraphs'
 import TextField from './TextField'
 
-interface DateFieldProps {
+export interface DateFieldProps {
 	defaultSelected?: Date
 	onChange?: (value?: string) => void
 	placeholder?: string
@@ -26,6 +26,7 @@ interface DateFieldProps {
 	isRequired?: boolean
 	'aria-label'?: string
 	'aria-labelby'?: string
+	type?: 'date passé' | 'date' | 'date futur'
 }
 
 export default function DateField(props: DateFieldProps) {
@@ -36,6 +37,7 @@ export default function DateField(props: DateFieldProps) {
 		label,
 		isRequired,
 		onChange,
+		type = 'date',
 	} = rest
 
 	const { t, i18n } = useTranslation()
@@ -53,8 +55,8 @@ export default function DateField(props: DateFieldProps) {
 		format,
 		required: true,
 		locale: language === 'fr' ? fr : enUS,
-		fromDate: new Date('1800-01-01'),
-		toDate: new Date(),
+		fromDate: type === 'date futur' ? new Date() : new Date('1800-01-01'),
+		toDate: type === 'date passé' ? new Date() : undefined,
 	})
 
 	const [inputValue, setInputValue] = useState<string>(

--- a/site/source/design-system/field/DateField.tsx
+++ b/site/source/design-system/field/DateField.tsx
@@ -264,6 +264,12 @@ const StyledBody = styled(Body)`
 			: theme.colors.extended.grey[200]};
 	box-shadow: ${({ theme }) =>
 		theme.darkMode ? theme.elevationsDarkMode[3] : theme.elevations[3]};
+
+	.rdp-dropdown:focus-visible:not([disabled]) + .rdp-caption_label,
+	.rdp-button:focus-visible:not([disabled]) {
+		background-color: ${({ theme }) =>
+			theme.darkMode && theme.colors.extended.grey[600]};
+	}
 `
 
 const Wrapper = styled.div`

--- a/site/source/pages/assistants/demande-mobilité/demande-mobilité.yaml
+++ b/site/source/pages/assistants/demande-mobilité/demande-mobilité.yaml
@@ -211,7 +211,7 @@ données assuré:
       type: texte
       titre: Nationalité
     date de naissance:
-      type: date
+      type: date passé
       titre: Date de naissance
 
     titre: commune de naissance
@@ -818,7 +818,7 @@ détachement . formulaire pays hors UE: &convention-bilatérale-formulaire
               type: texte
             date de naissance:
               titre: Date de naissance
-              type: date
+              type: date passé
             lien de parenté:
               titre: Lien de parenté
 
@@ -1055,7 +1055,7 @@ pluriactivité . période:
     fin:
       applicable si: date de fin connue
       titre: date de fin
-      type: date
+      type: date futur
 
 pluriactivité . activité substantielle en France:
   non applicable si:


### PR DESCRIPTION
Actuellement le champ de date est limité entre 1800 et aujourd'hui, cela pose problème pour une date futur car ce n'est pas une date valide, exemple :
![image](https://github.com/betagouv/mon-entreprise/assets/6691954/409a476e-d4b4-4946-b9f6-2c20536600fd)

j'ai donc créé trois type de date :
- `date passé`: date compris entre 1800 et aujourd'hui
- `date futur`: date compris entre aujourd'hui et aujourd'hui+100ans
- `date`: date compris entre 1800 et aujourd'hui+100ans
