### PR TITLE
Redirect to page 404 instead of home

### DIFF
--- a/site/source/components/Route404.tsx
+++ b/site/source/components/Route404.tsx
@@ -5,9 +5,15 @@ import PageHeader from '@/components/PageHeader'
 import { Button } from '@/design-system/buttons'
 import { Container } from '@/design-system/layout'
 
+import DefaultHelmet from './utils/DefaultHelmet'
+
 export default function Route404() {
 	return (
 		<Container>
+			<DefaultHelmet>
+				<meta name="robots" content="noindex" />
+			</DefaultHelmet>
+
 			<PageHeader
 				titre={
 					<Trans i18nKey="404.message">

--- a/site/source/pages/assistants/pour-mon-entreprise/index.tsx
+++ b/site/source/pages/assistants/pour-mon-entreprise/index.tsx
@@ -63,7 +63,6 @@ export default function PourMonEntrepriseHome() {
 }
 
 function PourMonEntreprise() {
-	const { t, i18n } = useTranslation()
 	const dirigeantSimulateur = infereSimulateurRevenuFromSituation(useEngine())
 	const simulateurs = useSimulatorsData()
 	const engine = useEngine()
@@ -104,7 +103,7 @@ function PourMonEntreprise() {
 		(param && entrepriseNotFound) ||
 		(entreprise && !overwrite && !engineSiren)
 	) {
-		return <Navigate to={'/'} />
+		return <Navigate to={'/404'} />
 	}
 
 	return (


### PR DESCRIPTION
Un utilisateurs nous a signaler que ça page pour-mon-entreprise est toujours indexé par des moteurs de recherche alors que celle-ci n'existe plus.
En redirigeant vers une page 404 avec un `noindex` devrait fix le problème.