### PR TITLE
🏓 Permettre l'export PDF ou impression du comparateur de statut #2406

### DIFF
--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -262,6 +262,10 @@ const StyledContent = styled(animated.div)<{
 	$variant?: 'light'
 }>`
 	overflow: hidden;
+	@media print {
+		overflow: visible;
+		display: table;
+	}
 	> div {
 		margin: ${({ theme, $variant }) =>
 			$variant !== 'light' && theme.spacings.lg};

--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -103,7 +103,7 @@ export const Accordion = <T extends object>(
 				<StyledGrid container>
 					<Grid item>{title}</Grid>
 					{isFoldable && (
-						<Grid item>
+						<Grid item className="print-hidden">
 							<StyledFoldButton
 								underline
 								onClick={() => (allItemsOpen ? closeAll() : openAll())}

--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -204,10 +204,17 @@ const StyledTitle = styled.h3`
 const StyledAccordionItem = styled.div`
 	&:not(:first-child) {
 		border-top: 1px solid ${({ theme }) => theme.colors.bases.primary[400]};
+		@media print {
+			border-top: none;
+		}
 	}
 `
 
 const StyledButton = styled.button<{ $variant?: 'light' }>`
+@media print {
+	margin: 0;
+	padding: 0;
+}
 	display: flex;
 	width: 100%;
 	background: none;
@@ -265,6 +272,7 @@ const StyledContent = styled(animated.div)<{
 	@media print {
 		overflow: visible;
 		display: table;
+		> div {margin: 1rem 0 !important;} 
 	}
 	> div {
 		margin: ${({ theme, $variant }) =>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
@@ -102,7 +102,7 @@ function Comparateur({ namedEngines }: { namedEngines: EngineComparison }) {
 							paddingTop: '1rem',
 						}}
 					>
-						<ModifierOptions namedEngines={namedEngines} />
+						<ModifierOptions namedEngines={namedEngines} className="print-hidden" />
 					</div>
 				</Container>
 				<Détails namedEngines={namedEngines} expandRevenuSection />

--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -90,9 +90,8 @@ const DetailsRowCards = ({
 		<Grid container spacing={4}>
 			{groupedOptions.map((sameValueOptions) => {
 				const statusObject = sameValueOptions[0]
-
 				return (
-					<Grid
+					<StyledGrid
 						key={statusObject.name}
 						item
 						{...getGridSizes(sameValueOptions.length, options.length)}
@@ -189,7 +188,7 @@ const DetailsRowCards = ({
 								)}
 							</StyledBody>
 						</StatusCard>
-					</Grid>
+					</StyledGrid>
 				)
 			})}
 		</Grid>
@@ -231,6 +230,11 @@ const StyledDiv = styled.div`
 	width: 100%;
 	display: flex;
 	align-items: center;
+`
+const StyledGrid = styled(Grid)`
+	@media print {
+		width: 33%;
+}
 `
 
 export default DetailsRowCards

--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -87,7 +87,7 @@ const DetailsRowCards = ({
 		.filter((arrayOfStatus) => arrayOfStatus.length > 0)
 
 	return (
-		<Grid container spacing={4}>
+		<StyledGridContainer container spacing={4}>
 			{groupedOptions.map((sameValueOptions) => {
 				const statusObject = sameValueOptions[0]
 				return (
@@ -191,7 +191,7 @@ const DetailsRowCards = ({
 					</StyledGrid>
 				)
 			})}
-		</Grid>
+		</StyledGridContainer>
 	)
 }
 const StyledSmall = styled.small`
@@ -234,6 +234,13 @@ const StyledDiv = styled.div`
 const StyledGrid = styled(Grid)`
 	@media print {
 		width: 33%;
+  	padding: 5px;
+}
+`
+
+const StyledGridContainer = styled(Grid)`
+	@media print {
+		margin-left: -5px;
 }
 `
 
@@ -246,4 +253,7 @@ const StyledBody = styled(Body)`
 	font-weight: 700;
 	margin: 0;
 	margin-top: 0.75rem;
+	@media print {
+		font-size: 18px;
+}
 `

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -37,7 +37,7 @@ const Détails = ({
 					: theme.colors.bases.primary[200]
 			}
 		>
-			<Accordion
+			<StyledAccordion
 				$variant="light"
 				defaultExpandedKeys={expandRevenuSection ? ['revenus'] : []}
 				title={
@@ -48,7 +48,7 @@ const Détails = ({
 				isFoldable
 			>
 				
-				<Item
+				<StyledItem
 					title={
 						<ItemTitle>
 							<Trans>Vos revenus</Trans>&nbsp;
@@ -58,7 +58,6 @@ const Détails = ({
 					key="revenus"
 					hasChildItems={false}
 				>
-				<OuterContainer>
 				<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Revenu net mensuel après impôts</Trans>
@@ -161,9 +160,8 @@ const Détails = ({
 						)}
 					/>
 				</OuterOuterContainer>
-				</OuterContainer>
-				</Item>
-				<Item
+				</StyledItem>
+				<StyledItem
 					title={
 						<ItemTitle>
 							<Trans>Vos droits pour la retraite</Trans>&nbsp;
@@ -173,7 +171,6 @@ const Détails = ({
 					key="retraite"
 					hasChildItems={false}
 				>
-					<OuterContainer>
 					<OuterOuterContainer>
 					<Body>
 						<Trans>
@@ -232,9 +229,8 @@ const Détails = ({
 						evolutionLabel={<Trans>au bout de 10 ans</Trans>}
 					/>
 				</OuterOuterContainer>
-				</OuterContainer>
-				</Item>
-				<Item
+				</StyledItem>
+				<StyledItem
 					title={
 						<ItemTitle>
 							<Trans>Vos prestations santé</Trans>&nbsp;
@@ -244,8 +240,6 @@ const Détails = ({
 					key="santé"
 					hasChildItems={false}
 				>
-									
-					<OuterContainer>
 					<OuterOuterContainer>
 					<Body
 						style={{
@@ -354,9 +348,8 @@ const Détails = ({
 						evolutionLabel={<Trans>à partir du 29ème jour</Trans>}
 					/>
 					</OuterOuterContainer>
-					</OuterContainer>
-				</Item>
-				<Item
+				</StyledItem>
+				<StyledItem
 					title={
 						<ItemTitle>
 							<Trans>La maternité, paternité et adoption</Trans>&nbsp;
@@ -366,7 +359,6 @@ const Détails = ({
 					key="enfants"
 					hasChildItems={false}
 				>
-					<OuterContainer>
 					<OuterOuterContainer>
 					<Body
 						style={{
@@ -438,9 +430,8 @@ const Détails = ({
 						label={<Trans>versés en une fois</Trans>}
 					/>
 					</OuterOuterContainer>
-					</OuterContainer>
-				</Item>
-				<Item
+				</StyledItem>
+				<StyledItem
 					title={
 						<ItemTitle>
 							<Trans>Votre couverture invalidité et décès</Trans>&nbsp;
@@ -450,7 +441,6 @@ const Détails = ({
 					key="maladie"
 					hasChildItems={false}
 				>
-					<OuterContainer>
 					<OuterOuterContainer>
 					<Body>
 						<Trans>
@@ -588,9 +578,8 @@ const Détails = ({
 						unit="€/enfant"
 					/>
 					</OuterOuterContainer>
-					</OuterContainer>
-				</Item>
-				<Item
+				</StyledItem>
+				<StyledItem
 					title={
 						<ItemTitle>
 							<Trans>
@@ -601,7 +590,6 @@ const Détails = ({
 					key="administratif"
 					hasChildItems={false}
 				>
-					<OuterContainer>
 					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Coût de création</Trans>
@@ -664,9 +652,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 					/>
 				</OuterOuterContainer>
-				</OuterContainer>
-				</Item>
-			</Accordion>
+				</StyledItem>
+			</StyledAccordion>
 		</Container>
 	)
 }
@@ -698,7 +685,7 @@ const Precisions = styled.span`
 
 const StyledDiv = styled.div`
 	display: flex;
-
+	
 	svg {
 		width: 2.5rem;
 		margin-right: 1rem;
@@ -718,16 +705,21 @@ const BlackColoredLink = styled(StyledLink)`
 	color: ${({ theme }) => theme.colors.extended.grey[800]};
 `
 
-
 const OuterOuterContainer = styled.div`
 	@media print {
 		page-break-inside: avoid;
 	}
 `
 
-const OuterContainer = styled.div`
+const StyledAccordion = styled(Accordion)`
 @media print {
-	page-break-after: always;
+	page-break-after: avoid;
+}
+`
+
+const StyledItem = styled(Item)`
+@media print {
+	page-break-inside: avoid;
 }
 `
 

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -47,6 +47,7 @@ const Détails = ({
 				}
 				isFoldable
 			>
+				
 				<Item
 					title={
 						<ItemTitle>
@@ -57,6 +58,8 @@ const Détails = ({
 					key="revenus"
 					hasChildItems={false}
 				>
+				<OuterContainer>
+				<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Revenu net mensuel après impôts</Trans>
 
@@ -157,8 +160,9 @@ const Détails = ({
 							</Condition>
 						)}
 					/>
+				</OuterOuterContainer>
+				</OuterContainer>
 				</Item>
-
 				<Item
 					title={
 						<ItemTitle>
@@ -169,6 +173,8 @@ const Détails = ({
 					key="retraite"
 					hasChildItems={false}
 				>
+					<OuterContainer>
+					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Le montant de votre retraite est constitué de{' '}
@@ -197,7 +203,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/mois"
 					/>
-
+				</OuterOuterContainer>
+				<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Retraite complémentaire</Trans>
 						<ExplicableRule dottedName="protection sociale . retraite . complémentaire" />
@@ -224,6 +231,8 @@ const Détails = ({
 						unit="€/mois"
 						evolutionLabel={<Trans>au bout de 10 ans</Trans>}
 					/>
+				</OuterOuterContainer>
+				</OuterContainer>
 				</Item>
 				<Item
 					title={
@@ -235,6 +244,9 @@ const Détails = ({
 					key="santé"
 					hasChildItems={false}
 				>
+									
+					<OuterContainer>
+					<OuterOuterContainer>
 					<Body
 						style={{
 							marginBottom: '0',
@@ -320,7 +332,8 @@ const Détails = ({
 							</Condition>
 						)}
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Accident du travail et maladie professionnelle</Trans>
 						<ExplicableRule dottedName="protection sociale . maladie . accidents du travail et maladies professionnelles . indemmnités" />
@@ -340,6 +353,8 @@ const Détails = ({
 						evolutionDottedName="protection sociale . maladie . accidents du travail et maladies professionnelles . indemmnités . à partir du 29ème jour"
 						evolutionLabel={<Trans>à partir du 29ème jour</Trans>}
 					/>
+					</OuterOuterContainer>
+					</OuterContainer>
 				</Item>
 				<Item
 					title={
@@ -351,6 +366,8 @@ const Détails = ({
 					key="enfants"
 					hasChildItems={false}
 				>
+					<OuterContainer>
+					<OuterOuterContainer>
 					<Body
 						style={{
 							marginBottom: '0',
@@ -378,7 +395,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/jour"
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Maternité</Trans>
 						<ExplicableRule dottedName="protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel" />
@@ -398,7 +416,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						label={<Trans>versés en deux fois</Trans>}
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Adoption</Trans>
 						<ExplicableRule dottedName="protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption" />
@@ -418,6 +437,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						label={<Trans>versés en une fois</Trans>}
 					/>
+					</OuterOuterContainer>
+					</OuterContainer>
 				</Item>
 				<Item
 					title={
@@ -429,6 +450,8 @@ const Détails = ({
 					key="maladie"
 					hasChildItems={false}
 				>
+					<OuterContainer>
+					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Tous les statuts cotisent pour une{' '}
@@ -485,6 +508,8 @@ const Détails = ({
 							</span>
 						}
 					/>
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Pour une invalidité causée par un{' '}
@@ -497,7 +522,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/mois"
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Décès</Trans>
 						<ExplicableRule dottedName="protection sociale . invalidité et décès . capital décès" />
@@ -514,7 +540,8 @@ const Détails = ({
 						label="pour vos proches"
 						namedEngines={namedEngines}
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							En plus du capital décès, une{' '}
@@ -529,7 +556,8 @@ const Détails = ({
 						label={'maximum'}
 						namedEngines={namedEngines}
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Pour un décès survenu dans le cadre d’un{' '}
@@ -544,7 +572,8 @@ const Détails = ({
 						unit="€/mois"
 						label={t("en cas d'accident pro")}
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Un <Strong>capital « orphelin »</Strong> est versé aux{' '}
@@ -558,6 +587,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/enfant"
 					/>
+					</OuterOuterContainer>
+					</OuterContainer>
 				</Item>
 				<Item
 					title={
@@ -570,6 +601,8 @@ const Détails = ({
 					key="administratif"
 					hasChildItems={false}
 				>
+					<OuterContainer>
+					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Coût de création</Trans>
 						<ExplicableRule dottedName="entreprise . coût formalités . création" />
@@ -588,7 +621,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						leastIsBest
 					/>
-
+					</OuterOuterContainer>
+					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Statut du conjoint</Trans>
 					</StyledH4>
@@ -629,6 +663,8 @@ const Détails = ({
 						}}
 						namedEngines={namedEngines}
 					/>
+				</OuterOuterContainer>
+				</OuterContainer>
 				</Item>
 			</Accordion>
 		</Container>
@@ -680,6 +716,19 @@ const StyledExternalLinkIcon = styled(ExternalLinkIcon)`
 
 const BlackColoredLink = styled(StyledLink)`
 	color: ${({ theme }) => theme.colors.extended.grey[800]};
+`
+
+
+const OuterOuterContainer = styled.div`
+	@media print {
+		page-break-inside: avoid;
+	}
+`
+
+const OuterContainer = styled.div`
+@media print {
+	page-break-after: always;
+}
 `
 
 export default Détails

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -660,6 +660,10 @@ const Détails = ({
 
 const StyledH4 = styled(H4)`
 	color: ${({ theme }) => theme.colors.bases.primary[600]};
+	@media print {
+		margin: 0 0 1rem 0;
+	}
+	
 `
 // TODO : décommenter une fois l'implémentation du calcul des coûts de créations
 // ajouté à modèle-social
@@ -707,13 +711,14 @@ const BlackColoredLink = styled(StyledLink)`
 
 const OuterOuterContainer = styled.div`
 	@media print {
-		page-break-inside: avoid;
+		page-break-inside: avoid !important;
 	}
 `
 
 const StyledAccordion = styled(Accordion)`
 @media print {
-	page-break-after: avoid;
+	page-break-after: avoid !important;
+	border: none !important;
 }
 `
 

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -28,8 +28,10 @@ const DOTTEDNAME_ACRE = 'dirigeant . exonérations . ACRE'
 
 const ModifierOptions = ({
 	namedEngines,
+	className
 }: {
-	namedEngines: EngineComparison
+	namedEngines: EngineComparison,
+	className?: string
 }) => {
 	const notAutoEntrepreneur = namedEngines.find(({ name }) =>
 		['EI', 'EURL', 'SARL', 'SELARL', 'SELARLU'].includes(name)
@@ -74,6 +76,7 @@ const ModifierOptions = ({
 			trigger={(buttonProps) => (
 				<Button
 					color="secondary"
+					className={className}
 					// eslint-disable-next-line react/jsx-props-no-spreading
 					{...buttonProps}
 				>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/StatusCard.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/StatusCard.tsx
@@ -72,4 +72,7 @@ const CardFooter = styled.div`
 	width: 100%;
 	border-top: 1px solid ${({ theme }) => theme.colors.extended.grey[300]};
 	padding: 1.5rem;
+	@media print {
+		>ul >li {font-size: 14px !important;}
+	}
 `

--- a/site/source/pages/simulateurs/comparaison-statuts/index.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/index.tsx
@@ -14,6 +14,7 @@ import {
 	CasParticuliersProvider,
 	useCasParticuliers,
 } from './contexts/CasParticuliers'
+import ShareOrSaveSimulationBanner from '@/components/ShareSimulationBanner'
 
 function ComparateurStatutsUI() {
 	const engine = useEngine()
@@ -100,6 +101,7 @@ export default function ComparateurStatuts() {
 	return (
 		<CasParticuliersProvider>
 			<ComparateurStatutsUI />
+			<ShareOrSaveSimulationBanner print />
 		</CasParticuliersProvider>
 	)
 }


### PR DESCRIPTION
fix #2406 

**Contexte :** 
US
En tant qu'usager je souhaite pouvoir extraire en PDF ou via une impression les résultats du comparateur de statut

Complexité
S

Description du retour utilisateur
Un utilisatrice regrette qu'il ne soit pas possible d'exporter au format PDF ou d'impression les résultats du comparateur de statut.

URL de la page
https://mon-entreprise.urssaf.fr/simulateurs/comparaison-r%C3%A9gimes-sociaux


**Description de la PR**
Le bouton <Imprimer ou sauvegarder en PDF> est désormais affiché sur la page comparateur de statut. Je me suis inspiré des travaux de la PR " 🐛🎨 Fix des éléments qui apparaissent à l'impression #1966 " afin d'améliorer la mise en page de l'impression. 

Il reste cependant un bug d'affichage au niveau de l'impression, certains points de comparaison du comparateur étant absents ou incomplets (le point Adoption notamment). 