### PR TITLE
feat : Ajout du bouton de lien de partage

### DIFF
--- a/site/source/pages/simulateurs/impot-societe/index.tsx
+++ b/site/source/pages/simulateurs/impot-societe/index.tsx
@@ -19,6 +19,7 @@ import { Link } from '@/design-system/typography/link'
 import { Body, Intro } from '@/design-system/typography/paragraphs'
 import { batchUpdateSituation, updateSituation } from '@/store/actions/actions'
 import { situationSelector } from '@/store/selectors/simulationSelectors'
+import ShareOrSaveSimulationBanner from '@/components/ShareSimulationBanner'
 
 export default function ISSimulation() {
 	return (
@@ -154,6 +155,7 @@ function Explanations() {
 				>
 					<Trans>Montant de l'impôt sur les sociétés</Trans>
 				</Body>
+				<ShareOrSaveSimulationBanner share />
 			</ExplanationsContainer>
 		</FromTop>
 	)


### PR DESCRIPTION
fix #2514 

Contexte :
[comparaison de statut](https://mon-entreprise.urssaf.fr/simulateurs/comparaison-r%C3%A9gimes-sociaux)
    [impôt sociétés](https://mon-entreprise.urssaf.fr/simulateurs/impot-societe)

Sur ces outils on ne peut donc pas partager un lien avec le pré-remplissage d'une situation

Description de la PR :
Le bouton permettant de générer un lien de partage est désormais disponible sur la page "impôt sociétés".
L'implémentation de ce dernier a été réalisé en ajoutant l'import du composant "ShareOrSaveSimulationBanner" et en ajoutant la balise correspondante dans le corps de la page.