### PR TITLE
Valeur du point de base CNAVPL 2023

### DIFF
--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -289,7 +289,7 @@ protection sociale . retraite . base . CNAVPL:
       nom: valeur du point
       variations:
         - si: date >= 01/2023
-          alors: 0.6079 €/an/point
+          alors: 0.6076 €/an/point
         - si: date >= 01/2022
           alors: 0.5795 €/an/point
   avec:

--- a/modele-social/règles/protection-sociale.yaml
+++ b/modele-social/règles/protection-sociale.yaml
@@ -288,6 +288,8 @@ protection sociale . retraite . base . CNAVPL:
     facteur:
       nom: valeur du point
       variations:
+        - si: date >= 01/2023
+          alors: 0.6079 €/an/point
         - si: date >= 01/2022
           alors: 0.5795 €/an/point
   avec:


### PR DESCRIPTION
https://www.cnavpl.fr/comprendre-sa-retraite/, section "Montant de la pension"

> Depuis le 1er janvier 2023, la valeur du point est de 0,6076 €.