### PR TITLE
BpiFrance Création : Ajout de liens

### DIFF
--- a/modele-social/règles/entreprise/catégorie-juridique.yaml
+++ b/modele-social/règles/entreprise/catégorie-juridique.yaml
@@ -60,6 +60,11 @@ entreprise . catégorie juridique . EI:
         Les étapes de la création d'une auto-entreprise: https://www.autoentrepreneur.urssaf.fr/portail/accueil/creer-mon-auto-entreprise.html
         Obligations comptables de l'auto-entrepreneur: https://entreprendre.service-public.fr/vosdroits/F23266
 
+        # BPI ONLY
+        Le micro-entrepreneur ou auto-entrepreneur: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/micro-entrepreneur-ou-auto-entrepreneur
+        Où et comment s'inscrire pour devenir micro-entrepreneur (ex auto-entrepreneur)?: https://bpifrance-creation.fr/encyclopedie/micro-entreprise-regime-auto-entrepreneur/lessentiel-ce-regime/ou-comment-sinscrire
+        La comptabilité du micro-entrepreneur (auto-entrepreneur): https://bpifrance-creation.fr/encyclopedie/micro-entreprise-regime-auto-entrepreneur/fiscal-social-comptable/comptabilite-du
+
     auto-entrepreneur . par défaut:
       non applicable si:
         une de ces conditions:
@@ -75,9 +80,12 @@ entreprise . catégorie juridique . EI:
       valeur: auto-entrepreneur = non
       références:
         L’entreprise individuelle (EI), un statut pour créer une entreprise facilement: https://www.economie.gouv.fr/entreprises/statut-entreprise-individuelle
-        L'entreprise individuelle en détail: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/entrepreneur-individuel
         'Entrepreneur individuel : séparation des patrimoines professionnel et personnel': https://entreprendre.service-public.fr/vosdroits/F36354
         Qu'est-ce que l'entreprise individuelle ?: https://www.urssaf.fr/portail/home/independant/je-cree-mon-entreprise/quel-statut/exercice-en-entreprise-individue/quest-ce-que-lentreprise-individ.html
+        # BPI ONLY
+        L'entreprise individuelle en détail: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/entrepreneur-individuel
+        "L'entreprise individuelle à l'impôt sur les sociétés (IS)": https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/lentreprise-individuelle-a-limpot-societes-lis
+        "Régime fiscal des entreprises soumises à l'impôt sur le revenu": https://bpifrance-creation.fr/encyclopedie/fiscalite-lentreprise/generalites/regime-fiscal-entreprises-soumises-a-limpot-revenu
 
 ### (niveau 1 code 5)	Société commerciale ###
 
@@ -107,11 +115,16 @@ entreprise . catégorie juridique . SARL:
 
       références:
         L'EURL, un statut à associé unique à fort potentiel d’évolution: https://www.economie.gouv.fr/entreprises/entreprise-unipersonnelle-responsabilite-limitee-EURL
-        L'EURL en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/eurl-ou-sarl-a-associe-unique
         Prise de décision dans une société à responsabilité limitée (SARL): https://entreprendre.service-public.fr/vosdroits/F36714
         Tout ce qu'il faut savoir sur la fiscalité d'une EURL: https://entreprendre.service-public.fr/vosdroits/F36212
         Tout ce qu'il faut savoir sur les cotisations sociales d'une EURL: https://entreprendre.service-public.fr/vosdroits/F36239
         "Création d'une EURL : rédaction et enregistrement des statuts": https://entreprendre.service-public.fr/vosdroits/F32232/personnalisation/resultat?lang=&quest0=0&quest=
+        # BPI ONLY
+        L'EURL en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/eurl-ou-sarl-a-associe-unique
+        Modèle de statut d'EURL: https://bpifrance-creation.fr/boiteaoutils/modele-statuts-deurl
+        Fiscalité de l'EURL: https://bpifrance-creation.fr/encyclopedie/fiscalite-lentreprise/regimes-fiscaux/regimes-du-benefice-reel-bic-is
+        Protection sociale du gérant d'une EURL: https://bpifrance-creation.fr/encyclopedie/statut-du-dirigeant-son-conjoint/regime-social-du-dirigeant/statut-social-fiscal-du
+        Formalités de création d'une EURL: https://bpifrance-creation.fr/encyclopedie/formalites-creation-dune-entreprise/formalites-specifiques-a-creation-societes
 
     SARL:
       résumé: Société à responsabilité limitée
@@ -129,12 +142,19 @@ entreprise . catégorie juridique . SARL:
         - **Imposition des bénéfices** : Impôt sur les sociétés, avec possibilité d’opter pour l'impôt sur le revenu dans certains cas (SARL « de famille » ou certaines SARL de moins de cinq ans).
 
       références:
-        La SARL en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-a-plusieurs/sarl-societe-a-responsabilite-limitee
         La SARL, un statut avec un apport minimum flexible: https://www.economie.gouv.fr/entreprises/societe-responsabilite-limitee-sarl
         Prise de décision dans une société à responsabilité limitée (SARL): https://entreprendre.service-public.fr/vosdroits/F36714
         Tout ce qu'il faut savoir sur la fiscalité d'une SARL: https://entreprendre.service-public.fr/vosdroits/F36211
         Tout ce qu'il faut savoir sur les cotisations sociales d'une SARL: https://entreprendre.service-public.fr/vosdroits/F36235
         "Création d'une SARL : rédaction et enregistrement des statuts": https://entreprendre.service-public.fr/vosdroits/F32232/personnalisation/resultat?lang=&quest0=1&quest=
+
+        # BPI ONLY
+        La SARL en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-a-plusieurs/sarl-societe-a-responsabilite-limitee
+        Comment fixer son capital social de départ ?: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/choix-du-statut-generalites/comment-fixer-son-capital-social
+        Modèle de statuts de SARL: https://bpifrance-creation.fr/boiteaoutils/modele-gratuit-statuts-sarl
+        Fiscalité d'une SARL: https://bpifrance-creation.fr/encyclopedie/fiscalite-lentreprise/regimes-fiscaux/regimes-du-benefice-reel-bic-is
+        Gérant minoritaire ou majoritaire de SARL: https://bpifrance-creation.fr/encyclopedie/statut-du-dirigeant-son-conjoint/regime-social-du-dirigeant/gerant-minoritaire-ou
+        Formalités de création d'une SARL: https://bpifrance-creation.fr/encyclopedie/formalites-creation-dune-entreprise/formalites-specifiques-a-creation-societes
 
     unipersonnelle:
       déprécié: oui
@@ -155,12 +175,15 @@ entreprise . catégorie juridique . SAS:
       acronyme: SAS
       valeur: associés . multiples
       références:
-        La SAS en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-a-plusieurs/sas-societe-actions-simplifiee
         La SAS, un statut souple et une responsabilité limitée aux apports: https://www.economie.gouv.fr/entreprises/societe-actions-simplifiee-SAS
         Tout ce qu'il faut savoir sur la fiscalité d'une SAS: https://entreprendre.service-public.fr/vosdroits/F36006
         Tout ce qu'il faut savoir sur les cotisations sociales d'une SAS: https://entreprendre.service-public.fr/vosdroits/F36007
         Prise de décision dans une SAS: https://entreprendre.service-public.fr/vosdroits/F36625
         "Création d'une SAS : rédaction et enregistrement des statuts": https://entreprendre.service-public.fr/vosdroits/F32232/personnalisation/resultat?lang=&quest0=4&quest=
+        # BPI ONLY
+        La SAS en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-a-plusieurs/sas-societe-actions-simplifiee
+        Fiscalité de la SAS: https://bpifrance-creation.fr/encyclopedie/fiscalite-lentreprise/regimes-fiscaux/regimes-du-benefice-reel-bic-is
+        Formalités de création d'une SAS: https://bpifrance-creation.fr/encyclopedie/formalites-creation-dune-entreprise/formalites-specifiques-a-creation-societes-0
 
     SASU:
       résumé: Société par actions simplifiée unipersonnelle
@@ -168,9 +191,12 @@ entreprise . catégorie juridique . SAS:
       valeur: associés . unique
       références:
         La SASU, des démarches simplifiées: https://www.economie.gouv.fr/entreprises/societe-par-actions-simplifiee-unipersonnelle-sasu
-        La SASU en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/sasu-societe-actions-simplifiee-unipersonnelle
         Tout ce qu'il faut savoir sur la fiscalité d'une SASU: https://entreprendre.service-public.fr/vosdroits/F36215
-        Tout ce qu'il faut savoir sur les cotisations sociales s'une SASU: https://entreprendre.service-public.fr/vosdroits/F36240
+        Tout ce qu'il faut savoir sur les cotisations sociales d'une SASU: https://entreprendre.service-public.fr/vosdroits/F36240
+        # BPI ONLY
+        La SASU en détails: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-seul/sasu-societe-actions-simplifiee-unipersonnelle
+        Formalités de création d'une SASU: https://bpifrance-creation.fr/encyclopedie/formalites-creation-dune-entreprise/formalites-specifiques-a-creation-societes-0
+        Fiscalité de la SASU: https://bpifrance-creation.fr/encyclopedie/fiscalite-lentreprise/regimes-fiscaux/regimes-du-benefice-reel-bic-is
 
     unipersonnelle:
       déprécié: oui
@@ -226,6 +252,9 @@ entreprise . catégorie juridique . association:
     non applicable si: activité . nature . libérale . réglementée
   références:
     Tout savoir sur l'association: https://www.service-public.fr/particuliers/vosdroits/N31931
+    # BPI ONLY
+    L'association en détail: https://bpifrance-creation.fr/encyclopedie/structures-juridiques/entreprendre-a-plusieurs/association
+    Formalités de création d'une association: https://bpifrance-creation.fr/encyclopedie/formalites-creation-dune-entreprise/formalites-generalites/formalites-creation-dune-0
     'associations.gouv.fr : créer, gérer et développer son association': https://www.associations.gouv.fr/
 
 entreprise . catégorie juridique . autre:

--- a/site/source/pages/assistants/choix-du-statut/_components/useIsEmbededBPI.tsx
+++ b/site/source/pages/assistants/choix-du-statut/_components/useIsEmbededBPI.tsx
@@ -1,0 +1,20 @@
+import { createContext, PropsWithChildren, useContext, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const BPIContext = createContext(false)
+
+export const IsBPIProvider = ({ children }: PropsWithChildren) => {
+	const [isBPI, setIsBPI] = useState(false)
+	const BPIInSearchParams = useLocation().search.includes('bpifrance-creation')
+	const BPIInReferer =
+		!import.meta.env.SSR && document.referrer?.includes('bpifrance-creation')
+	if (!isBPI && (BPIInSearchParams || BPIInReferer)) {
+		setIsBPI(true)
+	}
+
+	return <BPIContext.Provider value={isBPI}>{children}</BPIContext.Provider>
+}
+
+export default function useIsEmbededOnBPISite() {
+	return useContext(BPIContext)
+}

--- a/site/source/pages/assistants/choix-du-statut/index.tsx
+++ b/site/source/pages/assistants/choix-du-statut/index.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import { ScrollToTop } from '@/components/utils/Scroll'
 import { useSitePaths } from '@/sitePaths'
 
+import { IsBPIProvider } from './_components/useIsEmbededBPI'
 import { useCurrentStep } from './_components/useSteps'
 import Association from './association'
 import Associé from './associé'
@@ -20,7 +21,7 @@ export default function ChoixDuStatut() {
 	const childrenPaths = relativeSitePaths.assistants['choix-du-statut']
 
 	return (
-		<>
+		<IsBPIProvider>
 			<ScrollToTop key={currentStep} />
 			<Routes>
 				<Route index element={<AccueilChoixStatut />} />
@@ -51,6 +52,6 @@ export default function ChoixDuStatut() {
 					element={<Comparateur />}
 				/>
 			</Routes>
-		</>
+		</IsBPIProvider>
 	)
 }


### PR DESCRIPTION
Pour intégrer l'assistant au choix du statut sur leur site, la BPI nous a demandé d'afficher uniquement des liens interne (et d'enlever ceux pointant sur les autres sites). 

Cette fonctionnalité est limitée au site BPI et a été financée par eux.