### PR TITLE
fix #2850: lien de partage en local

### DIFF
--- a/site/source/components/ShareSimulationBanner/index.tsx
+++ b/site/source/components/ShareSimulationBanner/index.tsx
@@ -27,7 +27,7 @@ export function useUrl() {
 
 	const searchParams = useParamsFromSituation(situation)
 	const { currentSimulatorData } = useCurrentSimulatorData()
-
+	1
 	const { path = '' } = currentSimulatorData ?? {}
 	const siteUrl =
 		language === 'fr'
@@ -35,8 +35,26 @@ export function useUrl() {
 			: import.meta.env.VITE_EN_BASE_URL
 
 	searchParams.set('utm_source', 'sharing')
+	const linkRootFR = 'https://mon-entreprise.urssaf.fr'
+	const linkRootEN = 'https://mycompanyinfrance.urssaf.fr'
 
-	return siteUrl + path + '?' + searchParams.toString()
+	if (language == 'fr') {
+		if (siteUrl != linkRootFR) {
+			return linkRootFR + path + '?' + searchParams.toString()
+		}
+		else {
+			return siteUrl + path + '?' + searchParams.toString()
+		}
+	}
+	else {
+		if (siteUrl != linkRootEN) {
+			return linkRootEN + path + '?' + searchParams.toString()
+		}
+		else {
+			return siteUrl + path + '?' + searchParams.toString()
+		}
+	}
+
 }
 
 const ButtonLabel = styled.span`


### PR DESCRIPTION
fix #2850 

Contexte :
Le test du lien de partage sur les simulateurs ne fonctionne pas sur l'environnement de développement local.
[Peek 15-12-2023 09-58.webm](https://github.com/betagouv/mon-entreprise/assets/1775934/425bc9a0-5f29-434c-84b2-d764cc9ae4f0)

Description de la PR : 
Ajout d'une condition permettant de générer le lien à partir de la racine de l'url lorsque la variable siteUrl retourne un "undefined". Cette solution permet pour l'instant d'obtenir un lien de partage qui fonctionne sur un environnement de développement local. Elle mériterait, néanmoins, une version plus optimale.
