### PR TITLE
Correction référence vers Contrats Madelin

### DIFF
--- a/modele-social/règles/dirigeant/indépendant.yaml
+++ b/modele-social/règles/dirigeant/indépendant.yaml
@@ -204,7 +204,7 @@ dirigeant . indépendant . cotisations facultatives:
     Ils sont déductible d'impôts (dans la limite d'un plafond), mais non déductible pour l'assiette des cotisations et contributions sociales.
   par défaut: non
   références:
-    Contrats Madelin: https://www.economie.gouv.fr/particuliers/reduction-impot-revenu-investissements-entreprise-pme-madelin
+    Contrats Madelin: https://www.impots.gouv.fr/particulier/questions/je-cotise-un-contrat-madelin-quel-est-mon-avantage-fiscal
     PER: https://www.economie.gouv.fr/PER-epargne-retraite
 
 dirigeant . indépendant . cotisations facultatives . montant:


### PR DESCRIPTION
L'ancien lien n'était pas destiné aux contrats Madelin destinés aux TNS mais du dispositif d'investissement dans les PME Madelin