### PR TITLE
Revert "🏓 Permettre l'export PDF ou impression du comparateur de statut #2406"

### DIFF
--- a/site/source/design-system/accordion/index.tsx
+++ b/site/source/design-system/accordion/index.tsx
@@ -103,7 +103,7 @@ export const Accordion = <T extends object>(
 				<StyledGrid container>
 					<Grid item>{title}</Grid>
 					{isFoldable && (
-						<Grid item className="print-hidden">
+						<Grid item>
 							<StyledFoldButton
 								underline
 								onClick={() => (allItemsOpen ? closeAll() : openAll())}
@@ -204,17 +204,10 @@ const StyledTitle = styled.h3`
 const StyledAccordionItem = styled.div`
 	&:not(:first-child) {
 		border-top: 1px solid ${({ theme }) => theme.colors.bases.primary[400]};
-		@media print {
-			border-top: none;
-		}
 	}
 `
 
 const StyledButton = styled.button<{ $variant?: 'light' }>`
-@media print {
-	margin: 0;
-	padding: 0;
-}
 	display: flex;
 	width: 100%;
 	background: none;
@@ -269,11 +262,6 @@ const StyledContent = styled(animated.div)<{
 	$variant?: 'light'
 }>`
 	overflow: hidden;
-	@media print {
-		overflow: visible;
-		display: table;
-		> div {margin: 1rem 0 !important;} 
-	}
 	> div {
 		margin: ${({ theme, $variant }) =>
 			$variant !== 'light' && theme.spacings.lg};

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
@@ -102,7 +102,7 @@ function Comparateur({ namedEngines }: { namedEngines: EngineComparison }) {
 							paddingTop: '1rem',
 						}}
 					>
-						<ModifierOptions namedEngines={namedEngines} className="print-hidden" />
+						<ModifierOptions namedEngines={namedEngines} />
 					</div>
 				</Container>
 				<Détails namedEngines={namedEngines} expandRevenuSection />

--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -87,11 +87,12 @@ const DetailsRowCards = ({
 		.filter((arrayOfStatus) => arrayOfStatus.length > 0)
 
 	return (
-		<StyledGridContainer container spacing={4}>
+		<Grid container spacing={4}>
 			{groupedOptions.map((sameValueOptions) => {
 				const statusObject = sameValueOptions[0]
+
 				return (
-					<StyledGrid
+					<Grid
 						key={statusObject.name}
 						item
 						{...getGridSizes(sameValueOptions.length, options.length)}
@@ -188,10 +189,10 @@ const DetailsRowCards = ({
 								)}
 							</StyledBody>
 						</StatusCard>
-					</StyledGrid>
+					</Grid>
 				)
 			})}
-		</StyledGridContainer>
+		</Grid>
 	)
 }
 const StyledSmall = styled.small`
@@ -231,18 +232,6 @@ const StyledDiv = styled.div`
 	display: flex;
 	align-items: center;
 `
-const StyledGrid = styled(Grid)`
-	@media print {
-		width: 33%;
-  	padding: 5px;
-}
-`
-
-const StyledGridContainer = styled(Grid)`
-	@media print {
-		margin-left: -5px;
-}
-`
 
 export default DetailsRowCards
 const StyledBody = styled(Body)`
@@ -253,7 +242,4 @@ const StyledBody = styled(Body)`
 	font-weight: 700;
 	margin: 0;
 	margin-top: 0.75rem;
-	@media print {
-		font-size: 18px;
-}
 `

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -37,7 +37,7 @@ const Détails = ({
 					: theme.colors.bases.primary[200]
 			}
 		>
-			<StyledAccordion
+			<Accordion
 				$variant="light"
 				defaultExpandedKeys={expandRevenuSection ? ['revenus'] : []}
 				title={
@@ -47,8 +47,7 @@ const Détails = ({
 				}
 				isFoldable
 			>
-				
-				<StyledItem
+				<Item
 					title={
 						<ItemTitle>
 							<Trans>Vos revenus</Trans>&nbsp;
@@ -58,7 +57,6 @@ const Détails = ({
 					key="revenus"
 					hasChildItems={false}
 				>
-				<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Revenu net mensuel après impôts</Trans>
 
@@ -159,9 +157,9 @@ const Détails = ({
 							</Condition>
 						)}
 					/>
-				</OuterOuterContainer>
-				</StyledItem>
-				<StyledItem
+				</Item>
+
+				<Item
 					title={
 						<ItemTitle>
 							<Trans>Vos droits pour la retraite</Trans>&nbsp;
@@ -171,7 +169,6 @@ const Détails = ({
 					key="retraite"
 					hasChildItems={false}
 				>
-					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Le montant de votre retraite est constitué de{' '}
@@ -200,8 +197,7 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/mois"
 					/>
-				</OuterOuterContainer>
-				<OuterOuterContainer>
+
 					<StyledH4>
 						<Trans>Retraite complémentaire</Trans>
 						<ExplicableRule dottedName="protection sociale . retraite . complémentaire" />
@@ -228,9 +224,8 @@ const Détails = ({
 						unit="€/mois"
 						evolutionLabel={<Trans>au bout de 10 ans</Trans>}
 					/>
-				</OuterOuterContainer>
-				</StyledItem>
-				<StyledItem
+				</Item>
+				<Item
 					title={
 						<ItemTitle>
 							<Trans>Vos prestations santé</Trans>&nbsp;
@@ -240,7 +235,6 @@ const Détails = ({
 					key="santé"
 					hasChildItems={false}
 				>
-					<OuterOuterContainer>
 					<Body
 						style={{
 							marginBottom: '0',
@@ -326,8 +320,7 @@ const Détails = ({
 							</Condition>
 						)}
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<StyledH4>
 						<Trans>Accident du travail et maladie professionnelle</Trans>
 						<ExplicableRule dottedName="protection sociale . maladie . accidents du travail et maladies professionnelles . indemmnités" />
@@ -347,9 +340,8 @@ const Détails = ({
 						evolutionDottedName="protection sociale . maladie . accidents du travail et maladies professionnelles . indemmnités . à partir du 29ème jour"
 						evolutionLabel={<Trans>à partir du 29ème jour</Trans>}
 					/>
-					</OuterOuterContainer>
-				</StyledItem>
-				<StyledItem
+				</Item>
+				<Item
 					title={
 						<ItemTitle>
 							<Trans>La maternité, paternité et adoption</Trans>&nbsp;
@@ -359,7 +351,6 @@ const Détails = ({
 					key="enfants"
 					hasChildItems={false}
 				>
-					<OuterOuterContainer>
 					<Body
 						style={{
 							marginBottom: '0',
@@ -387,8 +378,7 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/jour"
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<StyledH4>
 						<Trans>Maternité</Trans>
 						<ExplicableRule dottedName="protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel" />
@@ -408,8 +398,7 @@ const Détails = ({
 						namedEngines={namedEngines}
 						label={<Trans>versés en deux fois</Trans>}
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<StyledH4>
 						<Trans>Adoption</Trans>
 						<ExplicableRule dottedName="protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption" />
@@ -429,9 +418,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						label={<Trans>versés en une fois</Trans>}
 					/>
-					</OuterOuterContainer>
-				</StyledItem>
-				<StyledItem
+				</Item>
+				<Item
 					title={
 						<ItemTitle>
 							<Trans>Votre couverture invalidité et décès</Trans>&nbsp;
@@ -441,7 +429,6 @@ const Détails = ({
 					key="maladie"
 					hasChildItems={false}
 				>
-					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Tous les statuts cotisent pour une{' '}
@@ -498,8 +485,6 @@ const Détails = ({
 							</span>
 						}
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
 					<Body>
 						<Trans>
 							Pour une invalidité causée par un{' '}
@@ -512,8 +497,7 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/mois"
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<StyledH4>
 						<Trans>Décès</Trans>
 						<ExplicableRule dottedName="protection sociale . invalidité et décès . capital décès" />
@@ -530,8 +514,7 @@ const Détails = ({
 						label="pour vos proches"
 						namedEngines={namedEngines}
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<Body>
 						<Trans>
 							En plus du capital décès, une{' '}
@@ -546,8 +529,7 @@ const Détails = ({
 						label={'maximum'}
 						namedEngines={namedEngines}
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<Body>
 						<Trans>
 							Pour un décès survenu dans le cadre d’un{' '}
@@ -562,8 +544,7 @@ const Détails = ({
 						unit="€/mois"
 						label={t("en cas d'accident pro")}
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<Body>
 						<Trans>
 							Un <Strong>capital « orphelin »</Strong> est versé aux{' '}
@@ -577,9 +558,8 @@ const Détails = ({
 						namedEngines={namedEngines}
 						unit="€/enfant"
 					/>
-					</OuterOuterContainer>
-				</StyledItem>
-				<StyledItem
+				</Item>
+				<Item
 					title={
 						<ItemTitle>
 							<Trans>
@@ -590,7 +570,6 @@ const Détails = ({
 					key="administratif"
 					hasChildItems={false}
 				>
-					<OuterOuterContainer>
 					<StyledH4>
 						<Trans>Coût de création</Trans>
 						<ExplicableRule dottedName="entreprise . coût formalités . création" />
@@ -609,8 +588,7 @@ const Détails = ({
 						namedEngines={namedEngines}
 						leastIsBest
 					/>
-					</OuterOuterContainer>
-					<OuterOuterContainer>
+
 					<StyledH4>
 						<Trans>Statut du conjoint</Trans>
 					</StyledH4>
@@ -651,19 +629,14 @@ const Détails = ({
 						}}
 						namedEngines={namedEngines}
 					/>
-				</OuterOuterContainer>
-				</StyledItem>
-			</StyledAccordion>
+				</Item>
+			</Accordion>
 		</Container>
 	)
 }
 
 const StyledH4 = styled(H4)`
 	color: ${({ theme }) => theme.colors.bases.primary[600]};
-	@media print {
-		margin: 0 0 1rem 0;
-	}
-	
 `
 // TODO : décommenter une fois l'implémentation du calcul des coûts de créations
 // ajouté à modèle-social
@@ -689,7 +662,7 @@ const Precisions = styled.span`
 
 const StyledDiv = styled.div`
 	display: flex;
-	
+
 	svg {
 		width: 2.5rem;
 		margin-right: 1rem;
@@ -707,25 +680,6 @@ const StyledExternalLinkIcon = styled(ExternalLinkIcon)`
 
 const BlackColoredLink = styled(StyledLink)`
 	color: ${({ theme }) => theme.colors.extended.grey[800]};
-`
-
-const OuterOuterContainer = styled.div`
-	@media print {
-		page-break-inside: avoid !important;
-	}
-`
-
-const StyledAccordion = styled(Accordion)`
-@media print {
-	page-break-after: avoid !important;
-	border: none !important;
-}
-`
-
-const StyledItem = styled(Item)`
-@media print {
-	page-break-inside: avoid;
-}
 `
 
 export default Détails

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -28,10 +28,8 @@ const DOTTEDNAME_ACRE = 'dirigeant . exonérations . ACRE'
 
 const ModifierOptions = ({
 	namedEngines,
-	className
 }: {
-	namedEngines: EngineComparison,
-	className?: string
+	namedEngines: EngineComparison
 }) => {
 	const notAutoEntrepreneur = namedEngines.find(({ name }) =>
 		['EI', 'EURL', 'SARL', 'SELARL', 'SELARLU'].includes(name)
@@ -76,7 +74,6 @@ const ModifierOptions = ({
 			trigger={(buttonProps) => (
 				<Button
 					color="secondary"
-					className={className}
 					// eslint-disable-next-line react/jsx-props-no-spreading
 					{...buttonProps}
 				>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/StatusCard.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/StatusCard.tsx
@@ -72,7 +72,4 @@ const CardFooter = styled.div`
 	width: 100%;
 	border-top: 1px solid ${({ theme }) => theme.colors.extended.grey[300]};
 	padding: 1.5rem;
-	@media print {
-		>ul >li {font-size: 14px !important;}
-	}
 `

--- a/site/source/pages/simulateurs/comparaison-statuts/index.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/index.tsx
@@ -14,7 +14,6 @@ import {
 	CasParticuliersProvider,
 	useCasParticuliers,
 } from './contexts/CasParticuliers'
-import ShareOrSaveSimulationBanner from '@/components/ShareSimulationBanner'
 
 function ComparateurStatutsUI() {
 	const engine = useEngine()
@@ -101,7 +100,6 @@ export default function ComparateurStatuts() {
 	return (
 		<CasParticuliersProvider>
 			<ComparateurStatutsUI />
-			<ShareOrSaveSimulationBanner print />
 		</CasParticuliersProvider>
 	)
 }


### PR DESCRIPTION
Casse le style de la page de comparaison
@Grunt471, je suis obliger de revert ta PR car les modifications apportées cassent le style de la page de comparaison 
![image](https://github.com/betagouv/mon-entreprise/assets/1775934/0c286b0a-0d27-4ca8-9a3a-221391e372db)


Reverts betagouv/mon-entreprise#2835