### PR TITLE
Ajout de la CET dans les cotisations salariales

### DIFF
--- a/modele-social/règles/salarié/cotisations.publicodes
+++ b/modele-social/règles/salarié/cotisations.publicodes
@@ -39,6 +39,7 @@ salarié . cotisations:
         - maladie . salarié
         - retraite complémentaire . salarié
         - CEG . salarié
+        - CET . salarié
         - chômage . salarié
         - CSG-CRDS
         - APEC . salarié


### PR DESCRIPTION
Bonjour,

Il manque la part salariale de la CET dans la somme globale des charges salariales alors qu'elle est bien calculée dans `modele-social/règles/salarié/cotisations.publicodes:459`.

Désolé pour les tests non mis à jour, au moins vous avez déjà la modification de faite.