### PR TITLE
🐛 Affichage de l'adresse du siège dans les résultats de la recherche entreprise

### DIFF
--- a/site/cypress/fixtures/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLW1hc3Rlci5kZXYuZmFicmlxdWUuc29jaWFsLmdvdXYuZnIvYXBpL3YxL3NlYXJjaD9xdWVyeT1ub2ltYSZvcGVuPXRydWUmY29udmVudGlvbj1mYWxzZSZlbXBsb3llcj1mYWxzZSZyYW5rZWQ9ZmFsc2UmbGltaXQ9MTA=.json
+++ b/site/cypress/fixtures/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLW1hc3Rlci5kZXYuZmFicmlxdWUuc29jaWFsLmdvdXYuZnIvYXBpL3YxL3NlYXJjaD9xdWVyeT1ub2ltYSZvcGVuPXRydWUmY29udmVudGlvbj1mYWxzZSZlbXBsb3llcj1mYWxzZSZyYW5rZWQ9ZmFsc2UmbGltaXQ9MTA=.json
@@ -1,296 +1,296 @@
 {
-  "entreprises": [
-    {
-      "activitePrincipale": "Conseil informatique",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2016-11-24",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NOIMA</u></b>",
-      "label": "NOIMA",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
-        "codeCommuneEtablissement": "75101",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "82397296300016",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
-          "siret": "82397296300016",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NOIMA",
-      "siren": "823972963"
-    },
-    {
-      "activitePrincipale": "Services des traiteurs",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2019-07-16",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> OURLIS <b><u>NEIMA</u></b> SUSHI",
-      "label": "NAIMA OURLIS NEIMA SUSHI",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
-        "codeCommuneEtablissement": "95637",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "85203842100016",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
-          "siret": "85203842100016",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "OURLIS",
-      "siren": "852038421"
-    },
-    {
-      "activitePrincipale": "Autres activités pour la santé humaine",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-05-20",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> NAOUAR",
-      "label": "NAIMA NAOUAR",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
-        "codeCommuneEtablissement": "13212",
-        "idccs": [],
-        "siret": "90743244700015",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
-          "siret": "90743244700015",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NAOUAR",
-      "siren": "907432447"
-    },
-    {
-      "activitePrincipale": "Nettoyage courant des bâtiments",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-15",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> EL YANDOUZI KADDOURI CLEAN SERVICES",
-      "label": "NAIMA EL YANDOUZI KADDOURI CLEAN SERVICES",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
-        "codeCommuneEtablissement": "01032",
-        "idccs": [],
-        "siret": "90757209300017",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
-          "siret": "90757209300017",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "EL YANDOUZI",
-      "siren": "907572093"
-    },
-    {
-      "activitePrincipale": "Activités de centres d'appels",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-25",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> HASSINE",
-      "label": "NAIMA HASSINE",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "76 RUE NEUVE 59278 ESCAUTPONT",
-        "codeCommuneEtablissement": "59207",
-        "idccs": [],
-        "siret": "90764729100018",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "76 RUE NEUVE 59278 ESCAUTPONT",
-          "siret": "90764729100018",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "HASSINE",
-      "siren": "907647291"
-    },
-    {
-      "activitePrincipale": "Intermédiaires du commerce en produits divers",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-22",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> HADJ BOUSSAAD BELKACEM",
-      "label": "NAIMA HADJ BOUSSAAD BELKACEM",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "9 RUE DU BOIS SAINT PIERRE 78690 LES ESSARTS-LE-ROI",
-        "codeCommuneEtablissement": "78220",
-        "idccs": [],
-        "siret": "90780285400014",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "9 RUE DU BOIS SAINT PIERRE 78690 LES ESSARTS-LE-ROI",
-          "siret": "90780285400014",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "HADJ BOUSSAAD",
-      "siren": "907802854"
-    },
-    {
-      "activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2021-09-21",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NORMA</u></b> SEPTIEME SAS",
-      "label": "NORMA SEPTIEME SAS",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
-        "codeCommuneEtablissement": "57630",
-        "idccs": [],
-        "siret": "90782107800017",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
-          "siret": "90782107800017",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NORMA SEPTIEME SAS",
-      "siren": "907821078"
-    },
-    {
-      "activitePrincipale": "Activités des sièges sociaux",
-      "categorieJuridiqueUniteLegale": "5499",
-      "dateCreationUniteLegale": "2021-12-06",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "LA <b><u>NORMA</u></b> FIME",
-      "label": "LA NORMA FIME",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "9 ALLEE DES CHANTERELLES 26250 LIVRON-SUR-DRÔME",
-        "codeCommuneEtablissement": "26165",
-        "idccs": [],
-        "siret": "90802516600012",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "9 ALLEE DES CHANTERELLES 26250 LIVRON-SUR-DRÔME",
-          "siret": "90802516600012",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "LA NORMA FIME",
-      "siren": "908025166"
-    },
-    {
-      "activitePrincipale": "Fabrication d'articles de bijouterie fantaisie et articles similaires",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-13",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NORMA</u></b> HANNOU SHERAZADE TRESORS",
-      "label": "NORMA HANNOU SHERAZADE TRESORS",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "9 RUE LUCIEN LAINÉ 60000 BEAUVAIS",
-        "codeCommuneEtablissement": "60057",
-        "idccs": [],
-        "siret": "90859515000016",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "9 RUE LUCIEN LAINÉ 60000 BEAUVAIS",
-          "siret": "90859515000016",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "HANNOU",
-      "siren": "908595150"
-    },
-    {
-      "activitePrincipale": "Enseignements divers",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2022-01-07",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> MAYOUF GARA",
-      "label": "NAIMA MAYOUF GARA",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "324 ROUTE D’ENGHIEN 95100 ARGENTEUIL",
-        "codeCommuneEtablissement": "95018",
-        "idccs": [],
-        "siret": "90859272800012",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "324 ROUTE D’ENGHIEN 95100 ARGENTEUIL",
-          "siret": "90859272800012",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MAYOUF",
-      "siren": "908592728"
-    }
-  ]
+	"entreprises": [
+		{
+			"activitePrincipale": "Conseil informatique",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2016-11-24",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NOIMA</u></b>",
+			"label": "NOIMA",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
+				"codeCommuneEtablissement": "75101",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "82397296300016",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
+					"siret": "82397296300016",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NOIMA",
+			"siren": "823972963"
+		},
+		{
+			"activitePrincipale": "Services des traiteurs",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2019-07-16",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> OURLIS <b><u>NEIMA</u></b> SUSHI",
+			"label": "NAIMA OURLIS NEIMA SUSHI",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
+				"codeCommuneEtablissement": "95637",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "85203842100016",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
+					"siret": "85203842100016",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "OURLIS",
+			"siren": "852038421"
+		},
+		{
+			"activitePrincipale": "Autres activités pour la santé humaine",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-05-20",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> NAOUAR",
+			"label": "NAIMA NAOUAR",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
+				"codeCommuneEtablissement": "13212",
+				"idccs": [],
+				"siret": "90743244700015",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
+					"siret": "90743244700015",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NAOUAR",
+			"siren": "907432447"
+		},
+		{
+			"activitePrincipale": "Nettoyage courant des bâtiments",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-15",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> EL YANDOUZI KADDOURI CLEAN SERVICES",
+			"label": "NAIMA EL YANDOUZI KADDOURI CLEAN SERVICES",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
+				"codeCommuneEtablissement": "01032",
+				"idccs": [],
+				"siret": "90757209300017",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
+					"siret": "90757209300017",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "EL YANDOUZI",
+			"siren": "907572093"
+		},
+		{
+			"activitePrincipale": "Activités de centres d'appels",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-25",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> HASSINE",
+			"label": "NAIMA HASSINE",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "76 RUE NEUVE 59278 ESCAUTPONT",
+				"codeCommuneEtablissement": "59207",
+				"idccs": [],
+				"siret": "90764729100018",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "76 RUE NEUVE 59278 ESCAUTPONT",
+					"siret": "90764729100018",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "HASSINE",
+			"siren": "907647291"
+		},
+		{
+			"activitePrincipale": "Intermédiaires du commerce en produits divers",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-22",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> HADJ BOUSSAAD BELKACEM",
+			"label": "NAIMA HADJ BOUSSAAD BELKACEM",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "9 RUE DU BOIS SAINT PIERRE 78690 LES ESSARTS-LE-ROI",
+				"codeCommuneEtablissement": "78220",
+				"idccs": [],
+				"siret": "90780285400014",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "9 RUE DU BOIS SAINT PIERRE 78690 LES ESSARTS-LE-ROI",
+					"siret": "90780285400014",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "HADJ BOUSSAAD",
+			"siren": "907802854"
+		},
+		{
+			"activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2021-09-21",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NORMA</u></b> SEPTIEME SAS",
+			"label": "NORMA SEPTIEME SAS",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
+				"codeCommuneEtablissement": "57630",
+				"idccs": [],
+				"siret": "90782107800017",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
+					"siret": "90782107800017",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NORMA SEPTIEME SAS",
+			"siren": "907821078"
+		},
+		{
+			"activitePrincipale": "Activités des sièges sociaux",
+			"categorieJuridiqueUniteLegale": "5499",
+			"dateCreationUniteLegale": "2021-12-06",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "LA <b><u>NORMA</u></b> FIME",
+			"label": "LA NORMA FIME",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "9 ALLEE DES CHANTERELLES 26250 LIVRON-SUR-DRÔME",
+				"codeCommuneEtablissement": "26165",
+				"idccs": [],
+				"siret": "90802516600012",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "9 ALLEE DES CHANTERELLES 26250 LIVRON-SUR-DRÔME",
+					"siret": "90802516600012",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "LA NORMA FIME",
+			"siren": "908025166"
+		},
+		{
+			"activitePrincipale": "Fabrication d'articles de bijouterie fantaisie et articles similaires",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-13",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NORMA</u></b> HANNOU SHERAZADE TRESORS",
+			"label": "NORMA HANNOU SHERAZADE TRESORS",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "9 RUE LUCIEN LAINÉ 60000 BEAUVAIS",
+				"codeCommuneEtablissement": "60057",
+				"idccs": [],
+				"siret": "90859515000016",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "9 RUE LUCIEN LAINÉ 60000 BEAUVAIS",
+					"siret": "90859515000016",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "HANNOU",
+			"siren": "908595150"
+		},
+		{
+			"activitePrincipale": "Enseignements divers",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2022-01-07",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> MAYOUF GARA",
+			"label": "NAIMA MAYOUF GARA",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "324 ROUTE D’ENGHIEN 95100 ARGENTEUIL",
+				"codeCommuneEtablissement": "95018",
+				"idccs": [],
+				"siret": "90859272800012",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "324 ROUTE D’ENGHIEN 95100 ARGENTEUIL",
+					"siret": "90859272800012",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MAYOUF",
+			"siren": "908592728"
+		}
+	]
 }

--- a/site/cypress/fixtures/gérer/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLW1hc3Rlci5kZXYuZmFicmlxdWUuc29jaWFsLmdvdXYuZnIvYXBpL3YxL3NlYXJjaD9xdWVyeT1qb2hhbiUyMGdpcm9kJm9wZW49dHJ1ZSZjb252ZW50aW9uPWZhbHNlJmVtcGxveWVyPWZhbHNlJnJhbmtlZD1mYWxzZSZsaW1pdD0xMA==.json
+++ b/site/cypress/fixtures/gérer/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLW1hc3Rlci5kZXYuZmFicmlxdWUuc29jaWFsLmdvdXYuZnIvYXBpL3YxL3NlYXJjaD9xdWVyeT1qb2hhbiUyMGdpcm9kJm9wZW49dHJ1ZSZjb252ZW50aW9uPWZhbHNlJmVtcGxveWVyPWZhbHNlJnJhbmtlZD1mYWxzZSZsaW1pdD0xMA==.json
@@ -1,408 +1,380 @@
 {
-  "entreprises": [
-    {
-      "activitePrincipale": "Programmation informatique",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2018-02-01",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 3,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>JOHAN</u></b> <b><u>GIROD</u></b>",
-      "label": "JOHAN GIROD",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "7 PLACE DU FOIRAIL 81640 MONESTIÉS",
-        "codeCommuneEtablissement": "81170",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "83482561400037",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "7 PLACE DU FOIRAIL 81640 MONESTIÉS",
-          "siret": "83482561400037",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "834825614"
-    },
-    {
-      "activitePrincipale": "Services d'aménagement paysager",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2006-12-01",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [
-        {
-          "idcc": 7018,
-          "etat": "VIGUEUR_ETEN",
-          "id": "KALICONT000005635325",
-          "mtime": 1562614614,
-          "texte_de_base": "KALITEXT000020377916",
-          "title": "Convention collective nationale des entreprises du paysage du 10 octobre 2008",
-          "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635325",
-          "shortTitle": "Entreprises du paysage"
-        }
-      ],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>JOHAN</u></b> <b><u>GIROD</u></b> PAYSAGISTE DU CAROUX",
-      "label": "JOHAN GIROD PAYSAGISTE DU CAROUX",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "ROUTE DE SAINT PONS 34390 MONS",
-        "codeCommuneEtablissement": "34160",
-        "idccs": [
-          "7018"
-        ],
-        "categorieEntreprise": "PME",
-        "siret": "49309658000029",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "ROUTE DE SAINT PONS 34390 MONS",
-          "siret": "49309658000029",
-          "idccs": [
-            "7018"
-          ],
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "493096580"
-    },
-    {
-      "activitePrincipale": "Transports routiers de fret",
-      "categorieJuridiqueUniteLegale": "5499",
-      "dateCreationUniteLegale": "1966-01-01",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "TRANSPORTS <b><u>GIROD</u></b> PH",
-      "label": "TRANSPORTS GIROD PH",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "187 ZAC DU CROULOUP 69380 CHASSELAY",
-        "codeCommuneEtablissement": "69049",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "96650628900034",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "187 ZAC DU CROULOUP 69380 CHASSELAY",
-          "siret": "96650628900034",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "TRANSPORTS GIROD PH",
-      "siren": "966506289"
-    },
-    {
-      "activitePrincipale": "Construction de routes et autoroutes",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "1959-01-01",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [
-        {
-          "idcc": 1702,
-          "etat": "VIGUEUR_ETEN",
-          "id": "KALICONT000005635467",
-          "mtime": 1561580346,
-          "texte_de_base": "KALITEXT000005658951",
-          "title": "Convention collective nationale des ouvriers des travaux publics du 15 décembre 1992",
-          "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635467",
-          "shortTitle": "Travaux publics (Tome II : Ouvriers)"
-        },
-        {
-          "idcc": 2614,
-          "etat": "VIGUEUR_ETEN",
-          "id": "KALICONT000018926209",
-          "mtime": 1561580346,
-          "texte_de_base": "KALITEXT000018926214",
-          "title": "Convention collective nationale des employés, techniciens et agents de maîtrise des travaux publics du 12 juillet 2006",
-          "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000018926209",
-          "shortTitle": "Travaux publics (Tome III : ETAM)"
-        },
-        {
-          "idcc": 2409
-        },
-        {
-          "idcc": 3212,
-          "etat": "VIGUEUR_NON_ETEN",
-          "id": "KALICONT000032437525",
-          "mtime": 1561580346,
-          "texte_de_base": "KALITEXT000032426775",
-          "title": "Convention collective nationale des cadres des travaux publics du 20 novembre 2015",
-          "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000032437525",
-          "shortTitle": "Cadres des travaux publics"
-        }
-      ],
-      "etablissements": 13,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "SIGNAUX <b><u>GIROD</u></b> EST",
-      "label": "SIGNAUX GIROD EST",
-      "matching": 6,
-      "firstMatchingEtablissement": {
-        "address": "ZONE D'ACTIVITE DU CHENE 25170 CHAMPAGNEY",
-        "codeCommuneEtablissement": "25115",
-        "idccs": [
-          "2614",
-          "1702"
-        ],
-        "categorieEntreprise": "ETI",
-        "siret": "95950234500132",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": false
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "ZONE D'ACTIVITE DU CHENE 25170 CHAMPAGNEY",
-          "siret": "95950234500132",
-          "idccs": [
-            "1702",
-            "2614"
-          ],
-          "is_siege": false
-        },
-        {
-          "address": "60 ROUTE D’AUXERRE 89380 APPOIGNY",
-          "siret": "95950234500124",
-          "idccs": [
-            "2614"
-          ],
-          "is_siege": false
-        },
-        {
-          "address": "RUE DES FRÈRES LUMIÈRE 63100 CLERMONT-FERRAND",
-          "siret": "95950234500082",
-          "idccs": [
-            "1702",
-            "2614"
-          ],
-          "is_siege": false
-        },
-        {
-          "address": "12 CHEMIN DES MURIERS 69740 GENAS",
-          "siret": "95950234500108",
-          "idccs": [
-            "1702",
-            "2409",
-            "2614",
-            "3212"
-          ],
-          "is_siege": false
-        },
-        {
-          "address": "CHEMIN DES BERTHILLIERS 71850 CHARNAY-LÈS-MÂCON",
-          "siret": "95950234500090",
-          "idccs": [
-            "1702",
-            "2614",
-            "3212"
-          ],
-          "is_siege": true
-        },
-        {
-          "address": "4 RUE DES CHASSEURS 74950 SCIONZIER",
-          "siret": "95950234500140",
-          "idccs": [
-            "1702",
-            "2614",
-            "3212"
-          ],
-          "is_siege": false
-        }
-      ],
-      "simpleLabel": "SIGNAUX GIROD EST",
-      "siren": "959502345"
-    },
-    {
-      "activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2019-10-06",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "CHARLOTTE <b><u>GIROD</u></b>",
-      "label": "CHARLOTTE GIROD",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "27 PLACE DE L’EGLISE 71960 DAVAYÉ",
-        "codeCommuneEtablissement": "71169",
-        "idccs": [],
-        "siret": "90862098200011",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "27 PLACE DE L’EGLISE 71960 DAVAYÉ",
-          "siret": "90862098200011",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "908620982"
-    },
-    {
-      "activitePrincipale": "Traduction et interprétation",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-12-02",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "CHRISTIAN <b><u>GIROD</u></b>",
-      "label": "CHRISTIAN GIROD",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "1 AVENUE DES JADES 44300 NANTES",
-        "codeCommuneEtablissement": "44109",
-        "idccs": [],
-        "siret": "90788974500010",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "1 AVENUE DES JADES 44300 NANTES",
-          "siret": "90788974500010",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "907889745"
-    },
-    {
-      "activitePrincipale": "Enseignements divers",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-15",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "CAPUCINE <b><u>GIROD</u></b>",
-      "label": "CAPUCINE GIROD",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "10 RUE ERNEST TISSOT 92210 SAINT-CLOUD",
-        "codeCommuneEtablissement": "92064",
-        "idccs": [],
-        "siret": "90793627200018",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "10 RUE ERNEST TISSOT 92210 SAINT-CLOUD",
-          "siret": "90793627200018",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "907936272"
-    },
-    {
-      "activitePrincipale": "Autres activités pour la santé humaine",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-12-18",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "NICOLAS <b><u>GIROD</u></b>",
-      "label": "NICOLAS GIROD",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "47 RUE DE REUILLY 75012 PARIS",
-        "codeCommuneEtablissement": "75112",
-        "idccs": [],
-        "siret": "90827953200018",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "47 RUE DE REUILLY 75012 PARIS",
-          "siret": "90827953200018",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "908279532"
-    },
-    {
-      "activitePrincipale": "Autres commerces de détail hors magasin, éventaires ou marchés",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-09-13",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "PATRICIA MUTHER <b><u>GIROD</u></b>",
-      "label": "PATRICIA MUTHER GIROD",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "123 RUE DES BATTERIES 83600 FRÉJUS",
-        "codeCommuneEtablissement": "83061",
-        "idccs": [],
-        "siret": "90854766400015",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "123 RUE DES BATTERIES 83600 FRÉJUS",
-          "siret": "90854766400015",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MUTHER",
-      "siren": "908547664"
-    },
-    {
-      "activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2020-07-01",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "FRANCOIS <b><u>GIROD</u></b>",
-      "label": "FRANCOIS GIROD",
-      "matching": 2,
-      "firstMatchingEtablissement": {
-        "address": "RUE DU PUY LAS RODAS 87000 LIMOGES",
-        "codeCommuneEtablissement": "87085",
-        "idccs": [],
-        "siret": "90180592900022",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": false
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "RUE DU PUY LAS RODAS 87000 LIMOGES",
-          "siret": "90180592900022",
-          "is_siege": false
-        },
-        {
-          "address": "AVENUE THOMAS WILSON 17300 ROCHEFORT",
-          "siret": "90180592900014",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "GIROD",
-      "siren": "901805929"
-    }
-  ]
+	"entreprises": [
+		{
+			"activitePrincipale": "Programmation informatique",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2018-02-01",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 3,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>JOHAN</u></b> <b><u>GIROD</u></b>",
+			"label": "JOHAN GIROD",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "7 PLACE DU FOIRAIL 81640 MONESTIÉS",
+				"codeCommuneEtablissement": "81170",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "83482561400037",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "7 PLACE DU FOIRAIL 81640 MONESTIÉS",
+					"siret": "83482561400037",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "834825614"
+		},
+		{
+			"activitePrincipale": "Services d'aménagement paysager",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2006-12-01",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [
+				{
+					"idcc": 7018,
+					"etat": "VIGUEUR_ETEN",
+					"id": "KALICONT000005635325",
+					"mtime": 1562614614,
+					"texte_de_base": "KALITEXT000020377916",
+					"title": "Convention collective nationale des entreprises du paysage du 10 octobre 2008",
+					"url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635325",
+					"shortTitle": "Entreprises du paysage"
+				}
+			],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>JOHAN</u></b> <b><u>GIROD</u></b> PAYSAGISTE DU CAROUX",
+			"label": "JOHAN GIROD PAYSAGISTE DU CAROUX",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "ROUTE DE SAINT PONS 34390 MONS",
+				"codeCommuneEtablissement": "34160",
+				"idccs": ["7018"],
+				"categorieEntreprise": "PME",
+				"siret": "49309658000029",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "ROUTE DE SAINT PONS 34390 MONS",
+					"siret": "49309658000029",
+					"idccs": ["7018"],
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "493096580"
+		},
+		{
+			"activitePrincipale": "Transports routiers de fret",
+			"categorieJuridiqueUniteLegale": "5499",
+			"dateCreationUniteLegale": "1966-01-01",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "TRANSPORTS <b><u>GIROD</u></b> PH",
+			"label": "TRANSPORTS GIROD PH",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "187 ZAC DU CROULOUP 69380 CHASSELAY",
+				"codeCommuneEtablissement": "69049",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "96650628900034",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "187 ZAC DU CROULOUP 69380 CHASSELAY",
+					"siret": "96650628900034",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "TRANSPORTS GIROD PH",
+			"siren": "966506289"
+		},
+		{
+			"activitePrincipale": "Construction de routes et autoroutes",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "1959-01-01",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [
+				{
+					"idcc": 1702,
+					"etat": "VIGUEUR_ETEN",
+					"id": "KALICONT000005635467",
+					"mtime": 1561580346,
+					"texte_de_base": "KALITEXT000005658951",
+					"title": "Convention collective nationale des ouvriers des travaux publics du 15 décembre 1992",
+					"url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635467",
+					"shortTitle": "Travaux publics (Tome II : Ouvriers)"
+				},
+				{
+					"idcc": 2614,
+					"etat": "VIGUEUR_ETEN",
+					"id": "KALICONT000018926209",
+					"mtime": 1561580346,
+					"texte_de_base": "KALITEXT000018926214",
+					"title": "Convention collective nationale des employés, techniciens et agents de maîtrise des travaux publics du 12 juillet 2006",
+					"url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000018926209",
+					"shortTitle": "Travaux publics (Tome III : ETAM)"
+				},
+				{
+					"idcc": 2409
+				},
+				{
+					"idcc": 3212,
+					"etat": "VIGUEUR_NON_ETEN",
+					"id": "KALICONT000032437525",
+					"mtime": 1561580346,
+					"texte_de_base": "KALITEXT000032426775",
+					"title": "Convention collective nationale des cadres des travaux publics du 20 novembre 2015",
+					"url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000032437525",
+					"shortTitle": "Cadres des travaux publics"
+				}
+			],
+			"etablissements": 13,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "SIGNAUX <b><u>GIROD</u></b> EST",
+			"label": "SIGNAUX GIROD EST",
+			"matching": 6,
+			"firstMatchingEtablissement": {
+				"address": "ZONE D'ACTIVITE DU CHENE 25170 CHAMPAGNEY",
+				"codeCommuneEtablissement": "25115",
+				"idccs": ["2614", "1702"],
+				"categorieEntreprise": "ETI",
+				"siret": "95950234500132",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": false
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "ZONE D'ACTIVITE DU CHENE 25170 CHAMPAGNEY",
+					"siret": "95950234500132",
+					"idccs": ["1702", "2614"],
+					"etablissementSiege": false
+				},
+				{
+					"address": "60 ROUTE D’AUXERRE 89380 APPOIGNY",
+					"siret": "95950234500124",
+					"idccs": ["2614"],
+					"etablissementSiege": false
+				},
+				{
+					"address": "RUE DES FRÈRES LUMIÈRE 63100 CLERMONT-FERRAND",
+					"siret": "95950234500082",
+					"idccs": ["1702", "2614"],
+					"etablissementSiege": false
+				},
+				{
+					"address": "12 CHEMIN DES MURIERS 69740 GENAS",
+					"siret": "95950234500108",
+					"idccs": ["1702", "2409", "2614", "3212"],
+					"etablissementSiege": false
+				},
+				{
+					"address": "CHEMIN DES BERTHILLIERS 71850 CHARNAY-LÈS-MÂCON",
+					"siret": "95950234500090",
+					"idccs": ["1702", "2614", "3212"],
+					"etablissementSiege": true
+				},
+				{
+					"address": "4 RUE DES CHASSEURS 74950 SCIONZIER",
+					"siret": "95950234500140",
+					"idccs": ["1702", "2614", "3212"],
+					"etablissementSiege": false
+				}
+			],
+			"simpleLabel": "SIGNAUX GIROD EST",
+			"siren": "959502345"
+		},
+		{
+			"activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2019-10-06",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "CHARLOTTE <b><u>GIROD</u></b>",
+			"label": "CHARLOTTE GIROD",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "27 PLACE DE L’EGLISE 71960 DAVAYÉ",
+				"codeCommuneEtablissement": "71169",
+				"idccs": [],
+				"siret": "90862098200011",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "27 PLACE DE L’EGLISE 71960 DAVAYÉ",
+					"siret": "90862098200011",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "908620982"
+		},
+		{
+			"activitePrincipale": "Traduction et interprétation",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-12-02",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "CHRISTIAN <b><u>GIROD</u></b>",
+			"label": "CHRISTIAN GIROD",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "1 AVENUE DES JADES 44300 NANTES",
+				"codeCommuneEtablissement": "44109",
+				"idccs": [],
+				"siret": "90788974500010",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "1 AVENUE DES JADES 44300 NANTES",
+					"siret": "90788974500010",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "907889745"
+		},
+		{
+			"activitePrincipale": "Enseignements divers",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-15",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "CAPUCINE <b><u>GIROD</u></b>",
+			"label": "CAPUCINE GIROD",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "10 RUE ERNEST TISSOT 92210 SAINT-CLOUD",
+				"codeCommuneEtablissement": "92064",
+				"idccs": [],
+				"siret": "90793627200018",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "10 RUE ERNEST TISSOT 92210 SAINT-CLOUD",
+					"siret": "90793627200018",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "907936272"
+		},
+		{
+			"activitePrincipale": "Autres activités pour la santé humaine",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-12-18",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "NICOLAS <b><u>GIROD</u></b>",
+			"label": "NICOLAS GIROD",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "47 RUE DE REUILLY 75012 PARIS",
+				"codeCommuneEtablissement": "75112",
+				"idccs": [],
+				"siret": "90827953200018",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "47 RUE DE REUILLY 75012 PARIS",
+					"siret": "90827953200018",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "908279532"
+		},
+		{
+			"activitePrincipale": "Autres commerces de détail hors magasin, éventaires ou marchés",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-09-13",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "PATRICIA MUTHER <b><u>GIROD</u></b>",
+			"label": "PATRICIA MUTHER GIROD",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "123 RUE DES BATTERIES 83600 FRÉJUS",
+				"codeCommuneEtablissement": "83061",
+				"idccs": [],
+				"siret": "90854766400015",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "123 RUE DES BATTERIES 83600 FRÉJUS",
+					"siret": "90854766400015",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MUTHER",
+			"siren": "908547664"
+		},
+		{
+			"activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2020-07-01",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "FRANCOIS <b><u>GIROD</u></b>",
+			"label": "FRANCOIS GIROD",
+			"matching": 2,
+			"firstMatchingEtablissement": {
+				"address": "RUE DU PUY LAS RODAS 87000 LIMOGES",
+				"codeCommuneEtablissement": "87085",
+				"idccs": [],
+				"siret": "90180592900022",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": false
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "RUE DU PUY LAS RODAS 87000 LIMOGES",
+					"siret": "90180592900022",
+					"etablissementSiege": false
+				},
+				{
+					"address": "AVENUE THOMAS WILSON 17300 ROCHEFORT",
+					"siret": "90180592900014",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "GIROD",
+			"siren": "901805929"
+		}
+	]
 }

--- a/site/cypress/fixtures/gérer/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLW1hc3Rlci5kZXYuZmFicmlxdWUuc29jaWFsLmdvdXYuZnIvYXBpL3YxL3NlYXJjaD9xdWVyeT1tZW5veiZvcGVuPXRydWUmY29udmVudGlvbj1mYWxzZSZlbXBsb3llcj1mYWxzZSZyYW5rZWQ9ZmFsc2UmbGltaXQ9MTA=.json
+++ b/site/cypress/fixtures/gérer/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLW1hc3Rlci5kZXYuZmFicmlxdWUuc29jaWFsLmdvdXYuZnIvYXBpL3YxL3NlYXJjaD9xdWVyeT1tZW5veiZvcGVuPXRydWUmY29udmVudGlvbj1mYWxzZSZlbXBsb3llcj1mYWxzZSZyYW5rZWQ9ZmFsc2UmbGltaXQ9MTA=.json
@@ -1,321 +1,317 @@
 {
-  "entreprises": [
-    {
-      "activitePrincipale": "Commerce de détail de quincaillerie, peintures et verres en magasin spécialisé",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2019-06-18",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [
-        {
-          "idcc": 1383,
-          "etat": "VIGUEUR_ETEN",
-          "id": "KALICONT000005635591",
-          "mtime": 1555615456,
-          "texte_de_base": "KALITEXT000018000548",
-          "title": "Convention collective nationale des employés et agents de maîtrise des commerces de quincaillerie, fournitures industrielles, fers, métaux et équipement de la maison. Etendue par arrêté du 29 avril 1986 JORF 1er juin 1986.",
-          "url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635591",
-          "shortTitle": "Quincaillerie : commerces de quincaillerie, fournitures industrielles, fers-métaux et équipements de la maison"
-        }
-      ],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "TY <b><u>MENNOZ</u></b> BRICO VAL",
-      "label": "TY MENNOZ BRICO VAL",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "IMMEUBLE L'EAU VIVE 73150 VAL D'ISERE",
-        "codeCommuneEtablissement": "73304",
-        "idccs": [
-          "1383"
-        ],
-        "categorieEntreprise": "PME",
-        "siret": "85183524900026",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "IMMEUBLE L'EAU VIVE 73150 VAL D'ISERE",
-          "siret": "85183524900026",
-          "idccs": [
-            "1383"
-          ],
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "TY MENNOZ",
-      "siren": "851835249"
-    },
-    {
-      "activitePrincipale": "Location et location-bail d'autres biens personnels et domestiques",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2018-06-05",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "MAXIME BOUQUET <b><u>MENOZ</u></b>",
-      "label": "MAXIME BOUQUET MENOZ",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "12 RUE DES ORMEAUX 35510 CESSON-SÉVIGNÉ",
-        "codeCommuneEtablissement": "35051",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "84028487100018",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "12 RUE DES ORMEAUX 35510 CESSON-SÉVIGNÉ",
-          "siret": "84028487100018",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "BOUQUET",
-      "siren": "840284871"
-    },
-    {
-      "activitePrincipale": "Activités des organisations associatives n.c.a.",
-      "categorieJuridiqueUniteLegale": "9220",
-      "dateCreationUniteLegale": "2017-12-05",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>MENOZ</u></b> COMPAGNIE YADO",
-      "label": "MENOZ COMPAGNIE YADO",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "39 RUE AUGUSTE BRIZEUX 56100 LORIENT",
-        "codeCommuneEtablissement": "56121",
-        "idccs": [],
-        "siret": "83798530800019",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "39 RUE AUGUSTE BRIZEUX 56100 LORIENT",
-          "siret": "83798530800019",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MENOZ COMPAGNIE YADO",
-      "siren": "837985308"
-    },
-    {
-      "activitePrincipale": "Programmation informatique",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2018-01-02",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>MENOZ</u></b>",
-      "label": "MENOZ",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "55 RUE DES PYRÉNÉES 75020 PARIS",
-        "codeCommuneEtablissement": "75120",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "83436429100015",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "55 RUE DES PYRÉNÉES 75020 PARIS",
-          "siret": "83436429100015",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MENOZ",
-      "siren": "834364291"
-    },
-    {
-      "activitePrincipale": "Récupération de déchets triés",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "1970-01-01",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "FERNAND <b><u>MUNOZ</u></b>",
-      "label": "FERNAND MUNOZ",
-      "matching": 2,
-      "firstMatchingEtablissement": {
-        "address": "8 RUE PASTEUR 69740 GENAS",
-        "codeCommuneEtablissement": "69277",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "97041672300017",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": false
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "8 RUE PASTEUR 69740 GENAS",
-          "siret": "97041672300017",
-          "is_siege": false
-        },
-        {
-          "address": "19 RUE DE L’INDUSTRIE 69740 GENAS",
-          "siret": "97041672300033",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MUNOZ",
-      "siren": "970416723"
-    },
-    {
-      "activitePrincipale": "Commerce de voitures et de véhicules automobiles légers",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "1900-01-01",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "RENE <b><u>MUNOZ</u></b>",
-      "label": "RENE MUNOZ",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "20 ROUTE DE SAINT PRIVAT 30340 SAINT-PRIVAT-DES-VIEUX",
-        "codeCommuneEtablissement": "30294",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "97042380200044",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "20 ROUTE DE SAINT PRIVAT 30340 SAINT-PRIVAT-DES-VIEUX",
-          "siret": "97042380200044",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MUNOZ",
-      "siren": "970423802"
-    },
-    {
-      "activitePrincipale": "Commerce de détail alimentaire sur éventaires et marchés",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "1900-01-01",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [],
-      "etablissements": 2,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "DARYO <b><u>MUNOZ</u></b>",
-      "label": "DARYO MUNOZ",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "41 HAMEAU DES ACACIAS 14590 MOYAUX",
-        "codeCommuneEtablissement": "14460",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "95064477300034",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "41 HAMEAU DES ACACIAS 14590 MOYAUX",
-          "siret": "95064477300034",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MUNOZ",
-      "siren": "950644773"
-    },
-    {
-      "activitePrincipale": "Activités des sociétés holding",
-      "categorieJuridiqueUniteLegale": "6599",
-      "dateCreationUniteLegale": "2021-11-20",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "AR <b><u>MENEZ</u></b>",
-      "label": "AR MENEZ",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "LIEU-DIT ILBRAT 29460 DIRINON",
-        "codeCommuneEtablissement": "29045",
-        "idccs": [],
-        "siret": "90750463300013",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "LIEU-DIT ILBRAT 29460 DIRINON",
-          "siret": "90750463300013",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "AR MENEZ",
-      "siren": "907504633"
-    },
-    {
-      "activitePrincipale": "Activités photographiques",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-12-01",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "MEGANE <b><u>MUNOZ</u></b>-MURIEL EDEONA",
-      "label": "MEGANE MUNOZ-MURIEL EDEONA",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "5 ALLÉE DE L’AUBIER 85430 AUBIGNY-LES CLOUZEAUX",
-        "codeCommuneEtablissement": "85008",
-        "idccs": [],
-        "siret": "90763707800011",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "5 ALLÉE DE L’AUBIER 85430 AUBIGNY-LES CLOUZEAUX",
-          "siret": "90763707800011",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MUNOZ-MURIEL",
-      "siren": "907637078"
-    },
-    {
-      "activitePrincipale": "Activités juridiques",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-16",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "MELISSA <b><u>MUNOZ</u></b>",
-      "label": "MELISSA MUNOZ",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "103 BOULEVARD MALESHERBES 75008 PARIS",
-        "codeCommuneEtablissement": "75108",
-        "idccs": [],
-        "siret": "90766551700013",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "103 BOULEVARD MALESHERBES 75008 PARIS",
-          "siret": "90766551700013",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "MUNOZ",
-      "siren": "907665517"
-    }
-  ]
+	"entreprises": [
+		{
+			"activitePrincipale": "Commerce de détail de quincaillerie, peintures et verres en magasin spécialisé",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2019-06-18",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [
+				{
+					"idcc": 1383,
+					"etat": "VIGUEUR_ETEN",
+					"id": "KALICONT000005635591",
+					"mtime": 1555615456,
+					"texte_de_base": "KALITEXT000018000548",
+					"title": "Convention collective nationale des employés et agents de maîtrise des commerces de quincaillerie, fournitures industrielles, fers, métaux et équipement de la maison. Etendue par arrêté du 29 avril 1986 JORF 1er juin 1986.",
+					"url": "https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635591",
+					"shortTitle": "Quincaillerie : commerces de quincaillerie, fournitures industrielles, fers-métaux et équipements de la maison"
+				}
+			],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "TY <b><u>MENNOZ</u></b> BRICO VAL",
+			"label": "TY MENNOZ BRICO VAL",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "IMMEUBLE L'EAU VIVE 73150 VAL D'ISERE",
+				"codeCommuneEtablissement": "73304",
+				"idccs": ["1383"],
+				"categorieEntreprise": "PME",
+				"siret": "85183524900026",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "IMMEUBLE L'EAU VIVE 73150 VAL D'ISERE",
+					"siret": "85183524900026",
+					"idccs": ["1383"],
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "TY MENNOZ",
+			"siren": "851835249"
+		},
+		{
+			"activitePrincipale": "Location et location-bail d'autres biens personnels et domestiques",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2018-06-05",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "MAXIME BOUQUET <b><u>MENOZ</u></b>",
+			"label": "MAXIME BOUQUET MENOZ",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "12 RUE DES ORMEAUX 35510 CESSON-SÉVIGNÉ",
+				"codeCommuneEtablissement": "35051",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "84028487100018",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "12 RUE DES ORMEAUX 35510 CESSON-SÉVIGNÉ",
+					"siret": "84028487100018",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "BOUQUET",
+			"siren": "840284871"
+		},
+		{
+			"activitePrincipale": "Activités des organisations associatives n.c.a.",
+			"categorieJuridiqueUniteLegale": "9220",
+			"dateCreationUniteLegale": "2017-12-05",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>MENOZ</u></b> COMPAGNIE YADO",
+			"label": "MENOZ COMPAGNIE YADO",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "39 RUE AUGUSTE BRIZEUX 56100 LORIENT",
+				"codeCommuneEtablissement": "56121",
+				"idccs": [],
+				"siret": "83798530800019",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "39 RUE AUGUSTE BRIZEUX 56100 LORIENT",
+					"siret": "83798530800019",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MENOZ COMPAGNIE YADO",
+			"siren": "837985308"
+		},
+		{
+			"activitePrincipale": "Programmation informatique",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2018-01-02",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>MENOZ</u></b>",
+			"label": "MENOZ",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "55 RUE DES PYRÉNÉES 75020 PARIS",
+				"codeCommuneEtablissement": "75120",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "83436429100015",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "55 RUE DES PYRÉNÉES 75020 PARIS",
+					"siret": "83436429100015",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MENOZ",
+			"siren": "834364291"
+		},
+		{
+			"activitePrincipale": "Récupération de déchets triés",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "1970-01-01",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "FERNAND <b><u>MUNOZ</u></b>",
+			"label": "FERNAND MUNOZ",
+			"matching": 2,
+			"firstMatchingEtablissement": {
+				"address": "8 RUE PASTEUR 69740 GENAS",
+				"codeCommuneEtablissement": "69277",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "97041672300017",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": false
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "8 RUE PASTEUR 69740 GENAS",
+					"siret": "97041672300017",
+					"etablissementSiege": false
+				},
+				{
+					"address": "19 RUE DE L’INDUSTRIE 69740 GENAS",
+					"siret": "97041672300033",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MUNOZ",
+			"siren": "970416723"
+		},
+		{
+			"activitePrincipale": "Commerce de voitures et de véhicules automobiles légers",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "1900-01-01",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "RENE <b><u>MUNOZ</u></b>",
+			"label": "RENE MUNOZ",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "20 ROUTE DE SAINT PRIVAT 30340 SAINT-PRIVAT-DES-VIEUX",
+				"codeCommuneEtablissement": "30294",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "97042380200044",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "20 ROUTE DE SAINT PRIVAT 30340 SAINT-PRIVAT-DES-VIEUX",
+					"siret": "97042380200044",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MUNOZ",
+			"siren": "970423802"
+		},
+		{
+			"activitePrincipale": "Commerce de détail alimentaire sur éventaires et marchés",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "1900-01-01",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [],
+			"etablissements": 2,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "DARYO <b><u>MUNOZ</u></b>",
+			"label": "DARYO MUNOZ",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "41 HAMEAU DES ACACIAS 14590 MOYAUX",
+				"codeCommuneEtablissement": "14460",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "95064477300034",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "41 HAMEAU DES ACACIAS 14590 MOYAUX",
+					"siret": "95064477300034",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MUNOZ",
+			"siren": "950644773"
+		},
+		{
+			"activitePrincipale": "Activités des sociétés holding",
+			"categorieJuridiqueUniteLegale": "6599",
+			"dateCreationUniteLegale": "2021-11-20",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "AR <b><u>MENEZ</u></b>",
+			"label": "AR MENEZ",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "LIEU-DIT ILBRAT 29460 DIRINON",
+				"codeCommuneEtablissement": "29045",
+				"idccs": [],
+				"siret": "90750463300013",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "LIEU-DIT ILBRAT 29460 DIRINON",
+					"siret": "90750463300013",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "AR MENEZ",
+			"siren": "907504633"
+		},
+		{
+			"activitePrincipale": "Activités photographiques",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-12-01",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "MEGANE <b><u>MUNOZ</u></b>-MURIEL EDEONA",
+			"label": "MEGANE MUNOZ-MURIEL EDEONA",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "5 ALLÉE DE L’AUBIER 85430 AUBIGNY-LES CLOUZEAUX",
+				"codeCommuneEtablissement": "85008",
+				"idccs": [],
+				"siret": "90763707800011",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "5 ALLÉE DE L’AUBIER 85430 AUBIGNY-LES CLOUZEAUX",
+					"siret": "90763707800011",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MUNOZ-MURIEL",
+			"siren": "907637078"
+		},
+		{
+			"activitePrincipale": "Activités juridiques",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-16",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "MELISSA <b><u>MUNOZ</u></b>",
+			"label": "MELISSA MUNOZ",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "103 BOULEVARD MALESHERBES 75008 PARIS",
+				"codeCommuneEtablissement": "75108",
+				"idccs": [],
+				"siret": "90766551700013",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "103 BOULEVARD MALESHERBES 75008 PARIS",
+					"siret": "90766551700013",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "MUNOZ",
+			"siren": "907665517"
+		}
+	]
 }

--- a/site/cypress/fixtures/landing/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLmZhYnJpcXVlLnNvY2lhbC5nb3V2LmZyL2FwaS92MS9zZWFyY2g/cXVlcnk9bm9pbWEmb3Blbj10cnVlJmNvbnZlbnRpb249ZmFsc2UmZW1wbG95ZXI9ZmFsc2UmcmFua2VkPWZhbHNlJmxpbWl0PTEw.json
+++ b/site/cypress/fixtures/landing/aHR0cHM6Ly9zZWFyY2gtcmVjaGVyY2hlLWVudHJlcHJpc2VzLmZhYnJpcXVlLnNvY2lhbC5nb3V2LmZyL2FwaS92MS9zZWFyY2g/cXVlcnk9bm9pbWEmb3Blbj10cnVlJmNvbnZlbnRpb249ZmFsc2UmZW1wbG95ZXI9ZmFsc2UmcmFua2VkPWZhbHNlJmxpbWl0PTEw.json
@@ -1,296 +1,296 @@
 {
-  "entreprises": [
-    {
-      "activitePrincipale": "Conseil informatique",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2016-11-24",
-      "caractereEmployeurUniteLegale": "O",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NOIMA</u></b>",
-      "label": "NOIMA",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
-        "codeCommuneEtablissement": "75101",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "82397296300016",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
-          "siret": "82397296300016",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NOIMA",
-      "siren": "823972963"
-    },
-    {
-      "activitePrincipale": "Services des traiteurs",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2019-07-16",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> OURLIS <b><u>NEIMA</u></b> SUSHI",
-      "label": "NAIMA OURLIS NEIMA SUSHI",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
-        "codeCommuneEtablissement": "95637",
-        "idccs": [],
-        "categorieEntreprise": "PME",
-        "siret": "85203842100016",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
-          "siret": "85203842100016",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "OURLIS",
-      "siren": "852038421"
-    },
-    {
-      "activitePrincipale": "Autres activités pour la santé humaine",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-05-20",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> NAOUAR",
-      "label": "NAIMA NAOUAR",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
-        "codeCommuneEtablissement": "13212",
-        "idccs": [],
-        "siret": "90743244700015",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
-          "siret": "90743244700015",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NAOUAR",
-      "siren": "907432447"
-    },
-    {
-      "activitePrincipale": "Autres activités pour la santé humaine",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-19",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "ROSE <b><u>NORMA</u></b> PAUL",
-      "label": "ROSE NORMA PAUL",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "12 CITE VERTE 94370 SUCY-EN-BRIE",
-        "codeCommuneEtablissement": "94071",
-        "idccs": [],
-        "siret": "90760048000012",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "12 CITE VERTE 94370 SUCY-EN-BRIE",
-          "siret": "90760048000012",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "PAUL",
-      "siren": "907600480"
-    },
-    {
-      "activitePrincipale": "Nettoyage courant des bâtiments",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-15",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> EL YANDOUZI KADDOURI CLEAN SERVICES",
-      "label": "NAIMA EL YANDOUZI KADDOURI CLEAN SERVICES",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
-        "codeCommuneEtablissement": "01032",
-        "idccs": [],
-        "siret": "90757209300017",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
-          "siret": "90757209300017",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "EL YANDOUZI",
-      "siren": "907572093"
-    },
-    {
-      "activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-09-15",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> BENNAMAR",
-      "label": "NAIMA BENNAMAR",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "1 BOULEVARD ANATOLE DUCROS 83270 SAINT-CYR-SUR-MER",
-        "codeCommuneEtablissement": "83112",
-        "idccs": [],
-        "siret": "90762337500017",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "1 BOULEVARD ANATOLE DUCROS 83270 SAINT-CYR-SUR-MER",
-          "siret": "90762337500017",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "BENNAMAR",
-      "siren": "907623375"
-    },
-    {
-      "activitePrincipale": "Activités de centres d'appels",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-25",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> HASSINE",
-      "label": "NAIMA HASSINE",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "76 RUE NEUVE 59278 ESCAUTPONT",
-        "codeCommuneEtablissement": "59207",
-        "idccs": [],
-        "siret": "90764729100018",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "76 RUE NEUVE 59278 ESCAUTPONT",
-          "siret": "90764729100018",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "HASSINE",
-      "siren": "907647291"
-    },
-    {
-      "activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2021-09-21",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NORMA</u></b> SIXIEME SAS",
-      "label": "NORMA SIXIEME SAS",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
-        "codeCommuneEtablissement": "57630",
-        "idccs": [],
-        "siret": "90773606000019",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
-          "siret": "90773606000019",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NORMA SIXIEME SAS",
-      "siren": "907736060"
-    },
-    {
-      "activitePrincipale": "Autres services personnels n.c.a.",
-      "categorieJuridiqueUniteLegale": "1000",
-      "dateCreationUniteLegale": "2021-11-29",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NAIMA</u></b> ABIDI AZZOUZ PIVOIAME",
-      "label": "NAIMA ABIDI AZZOUZ PIVOIAME",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "64 RUE JUPITER 34990 JUVIGNAC",
-        "codeCommuneEtablissement": "34123",
-        "idccs": [],
-        "siret": "90767852800015",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "64 RUE JUPITER 34990 JUVIGNAC",
-          "siret": "90767852800015",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "ABIDI",
-      "siren": "907678528"
-    },
-    {
-      "activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
-      "categorieJuridiqueUniteLegale": "5710",
-      "dateCreationUniteLegale": "2021-09-21",
-      "caractereEmployeurUniteLegale": "N",
-      "conventions": [],
-      "etablissements": 1,
-      "etatAdministratifUniteLegale": "A",
-      "highlightLabel": "<b><u>NORMA</u></b> CINQUIEME SAS",
-      "label": "NORMA CINQUIEME SAS",
-      "matching": 1,
-      "firstMatchingEtablissement": {
-        "address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
-        "codeCommuneEtablissement": "57630",
-        "idccs": [],
-        "siret": "90773081600010",
-        "etatAdministratifEtablissement": "A",
-        "is_siege": true
-      },
-      "allMatchingEtablissements": [
-        {
-          "address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
-          "siret": "90773081600010",
-          "is_siege": true
-        }
-      ],
-      "simpleLabel": "NORMA CINQUIEME SAS",
-      "siren": "907730816"
-    }
-  ]
+	"entreprises": [
+		{
+			"activitePrincipale": "Conseil informatique",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2016-11-24",
+			"caractereEmployeurUniteLegale": "O",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NOIMA</u></b>",
+			"label": "NOIMA",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
+				"codeCommuneEtablissement": "75101",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "82397296300016",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "3 RUE DE LA COSSONNERIE 75001 PARIS",
+					"siret": "82397296300016",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NOIMA",
+			"siren": "823972963"
+		},
+		{
+			"activitePrincipale": "Services des traiteurs",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2019-07-16",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> OURLIS <b><u>NEIMA</u></b> SUSHI",
+			"label": "NAIMA OURLIS NEIMA SUSHI",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
+				"codeCommuneEtablissement": "95637",
+				"idccs": [],
+				"categorieEntreprise": "PME",
+				"siret": "85203842100016",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "41 RUE DE LA HULOTTE 95490 VAURÉAL",
+					"siret": "85203842100016",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "OURLIS",
+			"siren": "852038421"
+		},
+		{
+			"activitePrincipale": "Autres activités pour la santé humaine",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-05-20",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> NAOUAR",
+			"label": "NAIMA NAOUAR",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
+				"codeCommuneEtablissement": "13212",
+				"idccs": [],
+				"siret": "90743244700015",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "169 AVENUE DES CAILLOLS 13012 MARSEILLE",
+					"siret": "90743244700015",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NAOUAR",
+			"siren": "907432447"
+		},
+		{
+			"activitePrincipale": "Autres activités pour la santé humaine",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-19",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "ROSE <b><u>NORMA</u></b> PAUL",
+			"label": "ROSE NORMA PAUL",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "12 CITE VERTE 94370 SUCY-EN-BRIE",
+				"codeCommuneEtablissement": "94071",
+				"idccs": [],
+				"siret": "90760048000012",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "12 CITE VERTE 94370 SUCY-EN-BRIE",
+					"siret": "90760048000012",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "PAUL",
+			"siren": "907600480"
+		},
+		{
+			"activitePrincipale": "Nettoyage courant des bâtiments",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-15",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> EL YANDOUZI KADDOURI CLEAN SERVICES",
+			"label": "NAIMA EL YANDOUZI KADDOURI CLEAN SERVICES",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
+				"codeCommuneEtablissement": "01032",
+				"idccs": [],
+				"siret": "90757209300017",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "78 RUE DU PLATEAU 01360 BÉLIGNEUX",
+					"siret": "90757209300017",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "EL YANDOUZI",
+			"siren": "907572093"
+		},
+		{
+			"activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-09-15",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> BENNAMAR",
+			"label": "NAIMA BENNAMAR",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "1 BOULEVARD ANATOLE DUCROS 83270 SAINT-CYR-SUR-MER",
+				"codeCommuneEtablissement": "83112",
+				"idccs": [],
+				"siret": "90762337500017",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "1 BOULEVARD ANATOLE DUCROS 83270 SAINT-CYR-SUR-MER",
+					"siret": "90762337500017",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "BENNAMAR",
+			"siren": "907623375"
+		},
+		{
+			"activitePrincipale": "Activités de centres d'appels",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-25",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> HASSINE",
+			"label": "NAIMA HASSINE",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "76 RUE NEUVE 59278 ESCAUTPONT",
+				"codeCommuneEtablissement": "59207",
+				"idccs": [],
+				"siret": "90764729100018",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "76 RUE NEUVE 59278 ESCAUTPONT",
+					"siret": "90764729100018",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "HASSINE",
+			"siren": "907647291"
+		},
+		{
+			"activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2021-09-21",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NORMA</u></b> SIXIEME SAS",
+			"label": "NORMA SIXIEME SAS",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
+				"codeCommuneEtablissement": "57630",
+				"idccs": [],
+				"siret": "90773606000019",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
+					"siret": "90773606000019",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NORMA SIXIEME SAS",
+			"siren": "907736060"
+		},
+		{
+			"activitePrincipale": "Autres services personnels n.c.a.",
+			"categorieJuridiqueUniteLegale": "1000",
+			"dateCreationUniteLegale": "2021-11-29",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NAIMA</u></b> ABIDI AZZOUZ PIVOIAME",
+			"label": "NAIMA ABIDI AZZOUZ PIVOIAME",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "64 RUE JUPITER 34990 JUVIGNAC",
+				"codeCommuneEtablissement": "34123",
+				"idccs": [],
+				"siret": "90767852800015",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "64 RUE JUPITER 34990 JUVIGNAC",
+					"siret": "90767852800015",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "ABIDI",
+			"siren": "907678528"
+		},
+		{
+			"activitePrincipale": "Location et exploitation de biens immobiliers propres ou loués",
+			"categorieJuridiqueUniteLegale": "5710",
+			"dateCreationUniteLegale": "2021-09-21",
+			"caractereEmployeurUniteLegale": "N",
+			"conventions": [],
+			"etablissements": 1,
+			"etatAdministratifUniteLegale": "A",
+			"highlightLabel": "<b><u>NORMA</u></b> CINQUIEME SAS",
+			"label": "NORMA CINQUIEME SAS",
+			"matching": 1,
+			"firstMatchingEtablissement": {
+				"address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
+				"codeCommuneEtablissement": "57630",
+				"idccs": [],
+				"siret": "90773081600010",
+				"etatAdministratifEtablissement": "A",
+				"etablissementSiege": true
+			},
+			"allMatchingEtablissements": [
+				{
+					"address": "1 LOTISSEMENT TERRASSE PORTE DES VOSGES 57400 SARREBOURG",
+					"siret": "90773081600010",
+					"etablissementSiege": true
+				}
+			],
+			"simpleLabel": "NORMA CINQUIEME SAS",
+			"siren": "907730816"
+		}
+	]
 }

--- a/site/source/api/commune.ts
+++ b/site/source/api/commune.ts
@@ -58,7 +58,7 @@ export async function searchCommunes(
 
 export async function fetchCommuneDetails(
 	codeCommune: string,
-	codePostal: string
+	codePostal?: string
 ): Promise<Commune | null> {
 	const response = await fetch(
 		`https://geo.api.gouv.fr/communes/${codeCommune}?fields=nom,code,departement,region,codesPostaux`
@@ -67,6 +67,9 @@ export async function fetchCommuneDetails(
 		return null
 	}
 	const apiCommune = (await response.json()) as ApiCommuneJson
+
+	if (!codePostal) codePostal = apiCommune.codesPostaux[0]
+
 	if (!apiCommune.codesPostaux.includes(codePostal)) {
 		throw new Error(
 			'Le code postal et le code commune fournis sont incompatibles'

--- a/site/source/api/fabrique-social.ts
+++ b/site/source/api/fabrique-social.ts
@@ -64,3 +64,11 @@ async function searchFullText(
 
 	return json.entreprises
 }
+
+export function getSiegeOrFirstEtablissement(
+	entreprise: FabriqueSocialEntreprise
+): FabriqueSocialEtablissement {
+	return (entreprise.allMatchingEtablissements.find(
+		(etablissement) => etablissement.etablissementSiege
+	) || entreprise.firstMatchingEtablissement)!
+}

--- a/site/source/api/fabrique-social.ts
+++ b/site/source/api/fabrique-social.ts
@@ -38,6 +38,7 @@ export type FabriqueSocialEntreprise = {
 		address?: string
 		siret: string
 		is_siege: boolean
+		etablissementSiege: boolean
 	}>
 }
 

--- a/site/source/api/fabrique-social.ts
+++ b/site/source/api/fabrique-social.ts
@@ -1,3 +1,5 @@
+import { Company } from '@/store/reducers/companySituationReducer'
+
 export async function searchDenominationOrSiren(value: string) {
 	return searchFullText(value)
 }
@@ -66,7 +68,7 @@ async function searchFullText(
 }
 
 export function getSiegeOrFirstEtablissement(
-	entreprise: FabriqueSocialEntreprise
+	entreprise: FabriqueSocialEntreprise | Company
 ): FabriqueSocialEtablissement {
 	return (entreprise.allMatchingEtablissements.find(
 		(etablissement) => etablissement.etablissementSiege

--- a/site/source/api/fabrique-social.ts
+++ b/site/source/api/fabrique-social.ts
@@ -25,21 +25,18 @@ export type FabriqueSocialEntreprise = {
 	label: string
 	simpleLabel: string
 	siren: string
-	firstMatchingEtablissement: {
-		address?: string
-		siret: string
-		etatAdministratifEtablissement?: 'F' | 'A' // Fermé ou Actif
-		codeCommuneEtablissement: string
-		codePostalEtablissement: string
-		is_siege: boolean
-		activitePrincipaleEtablissement: string
-	}
-	allMatchingEtablissements: Array<{
-		address?: string
-		siret: string
-		is_siege: boolean
-		etablissementSiege: boolean
-	}>
+	firstMatchingEtablissement: FabriqueSocialEtablissement
+	allMatchingEtablissements: Array<FabriqueSocialEtablissement>
+}
+
+export type FabriqueSocialEtablissement = {
+	address?: string
+	siret: string
+	etatAdministratifEtablissement?: 'F' | 'A' // Fermé ou Actif
+	codeCommuneEtablissement: string
+	codePostalEtablissement: string
+	etablissementSiege: boolean
+	activitePrincipaleEtablissement: string
 }
 
 type FabriqueSocialSearchPayload = {

--- a/site/source/components/company/SearchDetails.tsx
+++ b/site/source/components/company/SearchDetails.tsx
@@ -14,8 +14,13 @@ export default function CompanySearchDetails({
 }) {
 	const { i18n } = useTranslation()
 
-	const { siren, label, dateCreationUniteLegale, firstMatchingEtablissement } =
-		entreprise
+	const {
+		siren,
+		label,
+		dateCreationUniteLegale,
+		firstMatchingEtablissement,
+		allMatchingEtablissements,
+	} = entreprise
 
 	const DateFormatter = useMemo(
 		() =>
@@ -26,6 +31,8 @@ export default function CompanySearchDetails({
 			}),
 		[i18n.language]
 	)
+
+	const siege = allMatchingEtablissements.find((x) => x.etablissementSiege)
 
 	return (
 		<CompanyContainer>
@@ -47,7 +54,9 @@ export default function CompanySearchDetails({
 			<Strong>{DateFormatter.format(new Date(dateCreationUniteLegale))}</Strong>
 			<br />
 			<Trans>Domiciliée à l'adresse :</Trans>{' '}
-			<Strong>{firstMatchingEtablissement.address}</Strong>
+			<Strong>
+				{siege ? siege.address : firstMatchingEtablissement.address}
+			</Strong>
 		</CompanyContainer>
 	)
 }

--- a/site/source/components/company/SearchDetails.tsx
+++ b/site/source/components/company/SearchDetails.tsx
@@ -2,7 +2,10 @@ import { Fragment, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
-import { FabriqueSocialEntreprise } from '@/api/fabrique-social'
+import {
+	FabriqueSocialEntreprise,
+	getSiegeOrFirstEtablissement,
+} from '@/api/fabrique-social'
 import { Spacing } from '@/design-system/layout'
 import { Strong } from '@/design-system/typography'
 import { H4 } from '@/design-system/typography/heading'
@@ -14,13 +17,7 @@ export default function CompanySearchDetails({
 }) {
 	const { i18n } = useTranslation()
 
-	const {
-		siren,
-		label,
-		dateCreationUniteLegale,
-		firstMatchingEtablissement,
-		allMatchingEtablissements,
-	} = entreprise
+	const { siren, label, dateCreationUniteLegale } = entreprise
 
 	const DateFormatter = useMemo(
 		() =>
@@ -32,7 +29,7 @@ export default function CompanySearchDetails({
 		[i18n.language]
 	)
 
-	const siege = allMatchingEtablissements.find((x) => x.etablissementSiege)
+	const siegeOrFirstEtablissement = getSiegeOrFirstEtablissement(entreprise)
 
 	return (
 		<CompanyContainer>
@@ -54,9 +51,7 @@ export default function CompanySearchDetails({
 			<Strong>{DateFormatter.format(new Date(dateCreationUniteLegale))}</Strong>
 			<br />
 			<Trans>Domiciliée à l'adresse :</Trans>{' '}
-			<Strong>
-				{siege ? siege.address : firstMatchingEtablissement.address}
-			</Strong>
+			<Strong>{siegeOrFirstEtablissement.address}</Strong>
 		</CompanyContainer>
 	)
 }

--- a/site/source/hooks/useSetEntreprise.ts
+++ b/site/source/hooks/useSetEntreprise.ts
@@ -25,15 +25,14 @@ export function useSetEntreprise() {
 		const siegeOrFirstEtablissement = getSiegeOrFirstEtablissement(entreprise)
 
 		void fetchCommuneDetails(
-			siegeOrFirstEtablissement.codeCommuneEtablissement,
-			siegeOrFirstEtablissement.codePostalEtablissement
+			siegeOrFirstEtablissement.codeCommuneEtablissement
 		).then(
 			(communeDetails) =>
 				communeDetails && dispatch(addCommuneDetails(communeDetails))
 		)
 
 		void fetchBénéfice(
-			entreprise.firstMatchingEtablissement.activitePrincipaleEtablissement
+			siegeOrFirstEtablissement.activitePrincipaleEtablissement
 		).then((bénéfice) => bénéfice && dispatch(setBénéficeType(bénéfice)))
 	}
 }

--- a/site/source/hooks/useSetEntreprise.ts
+++ b/site/source/hooks/useSetEntreprise.ts
@@ -2,7 +2,10 @@ import { useDispatch } from 'react-redux'
 
 import fetchBénéfice from '@/api/activité-vers-bénéfice'
 import { fetchCommuneDetails } from '@/api/commune'
-import { FabriqueSocialEntreprise } from '@/api/fabrique-social'
+import {
+	FabriqueSocialEntreprise,
+	getSiegeOrFirstEtablissement,
+} from '@/api/fabrique-social'
 import {
 	addCommuneDetails,
 	setBénéficeType,
@@ -19,9 +22,11 @@ export function useSetEntreprise() {
 
 		dispatch(setCompany(entreprise))
 
+		const siegeOrFirstEtablissement = getSiegeOrFirstEtablissement(entreprise)
+
 		void fetchCommuneDetails(
-			entreprise.firstMatchingEtablissement.codeCommuneEtablissement,
-			entreprise.firstMatchingEtablissement.codePostalEtablissement
+			siegeOrFirstEtablissement.codeCommuneEtablissement,
+			siegeOrFirstEtablissement.codePostalEtablissement
 		).then(
 			(communeDetails) =>
 				communeDetails && dispatch(addCommuneDetails(communeDetails))

--- a/site/source/store/reducers/companySituationReducer.ts
+++ b/site/source/store/reducers/companySituationReducer.ts
@@ -1,6 +1,9 @@
 import { DottedName } from 'modele-social'
 
-import { FabriqueSocialEntreprise } from '@/api/fabrique-social'
+import {
+	FabriqueSocialEntreprise,
+	getSiegeOrFirstEtablissement,
+} from '@/api/fabrique-social'
 import { Action } from '@/store/actions/actions'
 import { buildSituationFromObject, omit } from '@/utils'
 
@@ -84,6 +87,8 @@ export function companySituation(state: Situation = {}, action: Action) {
 }
 
 export function getCompanySituation(company: Company): Situation {
+	const siegeOrFirstEtablissement = getSiegeOrFirstEtablissement(company)
+
 	return {
 		'entreprise . date de création': company.dateCreationUniteLegale.replace(
 			/(.*)-(.*)-(.*)/,
@@ -94,7 +99,7 @@ export function getCompanySituation(company: Company): Situation {
 		)}'`,
 		'entreprise . SIREN': `'${company.siren}'`,
 		'entreprise . nom': `'${company.label}'`,
-		'établissement . SIRET': `'${company.firstMatchingEtablissement.siret}'`,
+		'établissement . SIRET': `'${siegeOrFirstEtablissement.siret}'`,
 		'entreprise . activité': `'${company.activitePrincipale}'`,
 	}
 }

--- a/site/test/fabrique-social.fixtures.ts
+++ b/site/test/fabrique-social.fixtures.ts
@@ -1,0 +1,99 @@
+import { FabriqueSocialEntreprise } from '@/api/fabrique-social'
+
+export const fabriqueSocialWithSiege: FabriqueSocialEntreprise = {
+	activitePrincipale: 'Agences immobilières',
+	allMatchingEtablissements: [
+		{
+			activitePrincipaleEtablissement: '68.31Z',
+			address: '4 RUE VOLTAIRE 44000 NANTES',
+			codeCommuneEtablissement: '44109',
+			codePostalEtablissement: '44000',
+			etablissementSiege: false,
+			siret: '84907419000034',
+		},
+		{
+			activitePrincipaleEtablissement: '68.31Z',
+			address: '23 RUE DE MOGADOR 75009 PARIS 9',
+			codeCommuneEtablissement: '75109',
+			codePostalEtablissement: '44000',
+			etablissementSiege: true,
+			siret: '84907419000042',
+		},
+	],
+	caractereEmployeurUniteLegale: 'O',
+	categorieJuridiqueUniteLegale: '5710',
+	conventions: [
+		{
+			idcc: 1527,
+			etat: 'VIGUEUR_ETEN',
+			id: 'KALICONT000005635413',
+			shortTitle:
+				'Immobilier : administrateurs de biens, sociétés immobilières, agents immobiliers',
+			texte_de_base: 'KALITEXT000023759095',
+			title:
+				"Convention collective nationale de l'immobilier, administrateurs de biens, sociétés immobilières, agents immobiliers, etc. (anciennement cabinets d'administrateurs de biens et des sociétés immobilières), du 9 septembre 1988. Etendue par arrêté du 24 février 1989 JORF 3 mars 1989. Mise à jour par avenant  n° 47 du 23 novembre 2010, JORF 18 juillet 2012 ",
+			url: 'https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635413',
+		},
+	],
+	dateCreationUniteLegale: '2019-03-11',
+	etablissements: 4,
+	etatAdministratifUniteLegale: 'A',
+	firstMatchingEtablissement: {
+		activitePrincipaleEtablissement: '68.31Z',
+		address: '4 RUE VOLTAIRE 44000 NANTES',
+		codeCommuneEtablissement: '44109',
+		codePostalEtablissement: '44000',
+		etablissementSiege: false,
+		etatAdministratifEtablissement: 'A',
+		siret: '84907419000034',
+	},
+	highlightLabel: 'SPLIIT',
+	label: 'SPLIIT',
+	simpleLabel: 'SPLIIT',
+	siren: '849074190',
+}
+
+export const fabriqueSocialWithoutSiege: FabriqueSocialEntreprise = {
+	activitePrincipale: 'Agences immobilières',
+	allMatchingEtablissements: [
+		{
+			activitePrincipaleEtablissement: '68.31Z',
+			address: '23 RUE DE MOGADOR 75009 PARIS 9',
+			codeCommuneEtablissement: '75109',
+			codePostalEtablissement: '44000',
+			etablissementSiege: false,
+			siret: '84907419000042',
+		},
+	],
+	caractereEmployeurUniteLegale: 'O',
+	categorieJuridiqueUniteLegale: '5710',
+	conventions: [
+		{
+			idcc: 1527,
+			etat: 'VIGUEUR_ETEN',
+			id: 'KALICONT000005635413',
+			shortTitle:
+				'Immobilier : administrateurs de biens, sociétés immobilières, agents immobiliers',
+			texte_de_base: 'KALITEXT000023759095',
+			title:
+				"Convention collective nationale de l'immobilier, administrateurs de biens, sociétés immobilières, agents immobiliers, etc. (anciennement cabinets d'administrateurs de biens et des sociétés immobilières), du 9 septembre 1988. Etendue par arrêté du 24 février 1989 JORF 3 mars 1989. Mise à jour par avenant  n° 47 du 23 novembre 2010, JORF 18 juillet 2012 ",
+			url: 'https://www.legifrance.gouv.fr/affichIDCC.do?idConvention=KALICONT000005635413',
+		},
+	],
+	dateCreationUniteLegale: '2019-03-11',
+	etablissements: 4,
+	etatAdministratifUniteLegale: 'A',
+	firstMatchingEtablissement: {
+		activitePrincipaleEtablissement: '68.31Z',
+		address: '4 RUE VOLTAIRE 44000 NANTES',
+		codeCommuneEtablissement: '44109',
+		codePostalEtablissement: '44000',
+		etablissementSiege: false,
+		etatAdministratifEtablissement: 'A',
+		siret: '84907419000034',
+	},
+	highlightLabel: 'SPLIIT',
+	label: 'SPLIIT',
+	simpleLabel: 'SPLIIT',
+	siren: '849074190',
+}

--- a/site/test/fabrique-social.test.ts
+++ b/site/test/fabrique-social.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSiegeOrFirstEtablissement } from '@/api/fabrique-social'
+
+import {
+	fabriqueSocialWithoutSiege,
+	fabriqueSocialWithSiege,
+} from './fabrique-social.fixtures'
+
+describe('Fabrique Social', () => {
+	describe('getSiegeOrFirstEtablissement Function', () => {
+		it('should return siege', () => {
+			const siege = getSiegeOrFirstEtablissement(fabriqueSocialWithSiege)
+			expect(siege.address).to.equal('23 RUE DE MOGADOR 75009 PARIS 9')
+		})
+		it('should return FirstEtablissement', () => {
+			const siege = getSiegeOrFirstEtablissement(fabriqueSocialWithoutSiege)
+			expect(siege.address).to.equal('4 RUE VOLTAIRE 44000 NANTES')
+		})
+	})
+})


### PR DESCRIPTION
fix #2883 

### Description de la PR

- Ne plus utiliser directement `firstMatchingEtablissement` car cela ne correspond pas nécessairement au siège.
- Récupération de l'établissement siège depuis le json de résultat retourné par l'api https://api.recherche-entreprises.fabrique.social.gouv.fr/ en parcourant le tableau des `allMatchingEtablissements`
-  Si aucun siège, affichage du premier établissement trouvé : `firstMatchingEtablissement`

### Autres modifications
- Renommer `is_siege` par `etablissementSiege` : l'api a évolué (cf [commit sur le repo SocialGouv/recherche-entreprises](https://github.com/SocialGouv/recherche-entreprises/commit/e7866837cc7fd30e277bf2955b14605b7a0ec32d#diff-6d46ba9b414103d8d16996c808542072668f2f04e3b9f9cdbeca3555b1a979a8))
- L'api ne retourne pas toujours le bon code postal dans le tableau des établissements `allMatchingEtablissements`. La fonction `fetchCommuneDetails` a été adaptée pour ne pas faire de vérification de concordance entre le code postal et le code commune dans ce cas de figure. Vérification seulement utile pour la recherche d'une commune dans le cas d'un input utilisateur. [Issue créé sur le repo de l'api socialgouv.](https://github.com/SocialGouv/recherche-entreprises/issues/230)