### PR TITLE
feat: ajoute un délai avant la disparition du tooltip

### DIFF
--- a/site/source/design-system/tooltip/Tooltip.tsx
+++ b/site/source/design-system/tooltip/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
 import { CSSProperties, ReactNode, useId, useState } from 'react'
 import { styled } from 'styled-components'
 
+import { useDelayedExit } from '@/hooks/useDelayedExit'
 import { useOnKeyDown } from '@/hooks/useOnKeyDown'
 
 export const Tooltip = ({
@@ -44,6 +45,12 @@ export const Tooltip = ({
 		setIsFocused(false)
 	})
 
+	const { handleExit, handleEnter } = useDelayedExit({
+		onEnter: () => setIsFocused(true),
+		onExit: () => setIsFocused(false),
+		delay: 1000,
+	})
+
 	const id = useId()
 
 	return (
@@ -52,8 +59,8 @@ export const Tooltip = ({
 				className={className}
 				style={style}
 				ref={refs.setReference}
-				onMouseEnter={() => setIsHovered(true)}
-				onMouseLeave={() => setIsHovered(false)}
+				onMouseEnter={handleEnter}
+				onMouseLeave={handleExit}
 				onFocus={() => setIsFocused(true)}
 				onBlur={() => setIsFocused(false)}
 				aria-describedby={id}
@@ -66,6 +73,8 @@ export const Tooltip = ({
 					id={id}
 					ref={refs.setFloating}
 					role="tooltip"
+					onMouseEnter={handleEnter}
+					onMouseLeave={handleExit}
 					style={{
 						position: strategy,
 						top: y ?? 0,

--- a/site/source/hooks/useDelayedExit.ts
+++ b/site/source/hooks/useDelayedExit.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react'
+
+type Params = {
+	onEnter: () => void
+	onExit: () => void
+	delay: number
+}
+
+export function useDelayedExit({
+	onEnter = () => {},
+	onExit = () => {},
+	delay = 100,
+}: Params) {
+	const timeout = useRef<NodeJS.Timeout | undefined>()
+
+	const cancelTimeout = () => {
+		if (timeout.current) {
+			clearTimeout(timeout.current)
+		}
+	}
+
+	const handleEnter = () => {
+		cancelTimeout()
+		onEnter()
+	}
+	const handleExit = () => {
+		timeout.current = setTimeout(() => onExit(), delay)
+	}
+
+	useEffect(() => cancelTimeout, [])
+
+	return {
+		handleEnter,
+		handleExit,
+	}
+}


### PR DESCRIPTION
En testant la story «With Link» de «tooltip», je me suis rendu compte qu'il était impossible de cliquer sur le lien dans le toolip !

J'ai donc ajouté un délai de 1 seconde après être sorti de la zone de la cible **et** du tooltip avant qu'il ne disparaisse, afin de rendre la manipulation plus accessible.

![image](https://github.com/betagouv/mon-entreprise/assets/3037833/43fc7998-e20f-42d8-a291-249c7b7661e5)
