### PR TITLE
Ajout des unités pour quelques règles.

### DIFF
--- a/modele-social/règles/dirigeant/indépendant.publicodes
+++ b/modele-social/règles/dirigeant/indépendant.publicodes
@@ -681,6 +681,7 @@ dirigeant . indépendant . revenus étrangers . montant:
   titre: revenus perçu à l'étranger
   question: Quel est leur montant ?
   par défaut: 0 €/an
+  unité: €/an
 
 dirigeant . indépendant . cotisations et contributions . CSG-CRDS . assiette:
   note: >-
@@ -791,6 +792,7 @@ dirigeant . indépendant . IJSS . montant:
     - indemnité journalière forfaitaire d’interruption d’activité (maternité)
     - indemnité de remplacement pour maternité, paternité ou adoption
   par défaut: 0 €/an
+  unité: €/an
 
 dirigeant . indépendant . IJSS . imposable:
   titre: part imposable
@@ -809,3 +811,4 @@ dirigeant . indépendant . IJSS . imposable:
     - indemnité de remplacement pour maternité, paternité ou adoption
     - allocation journalière du proche aidant (AJPA, versée par la CAF)
   par défaut: 0 €/an
+  unité: €/an


### PR DESCRIPTION
Au-delà d'un système de questions incrémentales, certes malin, mais pas toujours très uniforme, pour formater la question, le manque de la variable unité dans certaines règles ne permet pas de différencier de manière sûre les question oui/non, à réponses multiples et à valeur.