### PR TITLE
fix(iframe): suppression des barres de défilement des iframes

### DIFF
--- a/site/source/entries/template.html
+++ b/site/source/entries/template.html
@@ -159,6 +159,10 @@
 		<script>
 			const isIframe = document.location.pathname.startsWith('/iframes/')
 
+			if (isIframe) {
+				document.documentElement.style.overflow = 'hidden'
+			}
+
 			function getItem(key) {
 				try {
 					return window.localStorage.getItem(key)


### PR DESCRIPTION
Cette PR résout un problème où la barre de défilement des iframes apparaît lors du redimensionnement dynamique de leur contenu.

fixes #2972