### PR TITLE
Met à jour les liens morts

### DIFF
--- a/modele-social/règles/entreprise/établissement.publicodes
+++ b/modele-social/règles/entreprise/établissement.publicodes
@@ -58,7 +58,7 @@
   unité: '%'
   par défaut: taux collectif
   références:
-    Connaître le taux AT/MP de votre entreprise sur votre compte AT/MP: https://www.net-entreprises.fr/declaration/compte-atmp/#lessentiel
+    Connaître le taux AT/MP de votre entreprise sur votre compte AT/MP: https://www.ameli.fr/entreprise/votre-entreprise/cotisation-atmp
     Comment calculer les cotisations accidents du travail et maladies professionnelles (AT/MP) ?: https://entreprendre.service-public.fr/vosdroits/F33665
   plancher: salarié . cotisations . ATMP . taux minimum
   avec:

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -1023,8 +1023,8 @@ pages:
       CasParticuliers: "<0>Find out more about...</0><1><0>How do I run a simulation
         in the past?</0><1>Since the end of 2021, simulator calculation rules
         have been historicized. This means that you can run a simulation using
-        the legislation in force at an earlier date. To do so, simply enter the
-        parameter <2><0>date</0></2> parameter in the
+        the legislation in force at an earlier date. To do this, simply enter
+        the parameter <2><0>date</0></2> parameter in the
         situation.</1></1><2><0><1>MissingVariables</1></0><1>In return for your
         call to <1>evaluate</1>, you'll get a <3>missingVariables</3> object.
         This contains a list of all the rules used in the calculation whose
@@ -1060,9 +1060,9 @@ pages:
         <2>dedicated service on urssaf.fr</2></1></1></5><6>The collective AT/MP
         rate</6><7><0><0>establishment . rate ATMP . collective
         rate</0></0></7><8>This collective rate must be found manually. You can
-        use :<1><0><0>A csv export</0> of the table of collective net rates
-        published in the Journal Officiel.</0><1>net-entreprise's <2>Compte
-        AT/MP</2> service</1></1></8></4>"
+        use :<1><0><0>a csv export</0> of the table of collective net rates
+        published in the Journal Officiel</0><1>The Assurance Maladie's \"
+        <2>Cotisations AT/MP\"</2> documentation</1></1></8></4>"
       StepByStep: <0><0>Choose the simulator according to the calculation you're
         interested in</0><1></1>For example, the <4>employee simulator</4> to
         calculate net income from gross income.</0><1><0>Run a simulation with

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -1124,8 +1124,9 @@ pages:
         AT/MP</6><7><0><0>établissement . taux ATMP . taux
         collectif</0></0></7><8>Ce taux collectif doit être retrouvé
         manuellement. Vous pouvez utiliser :<1><0><0>Un export csv</0> du
-        tableau des taux nets collectifs paru au Journal Officiel</0><1>Le
-        service <2>Compte AT/MP</2> de net-entreprise</1></1></8></4>"
+        tableau des taux nets collectifs paru au Journal Officiel</0><1>La
+        documentation <2>Cotisations AT/MP</2> de l’Assurance
+        Maladie</1></1></8></4>"
       StepByStep: <0><0>Choisir le simulateur en fonction du calcul qui nous
         intéresse</0><1></1>Par exemple le <4>simulateur salarié</4> pour
         calculer un net à partir du brut.</0><1><0>Effectuer une simulation avec

--- a/site/source/pages/assistants/declaration-charges-sociales-independant/components/RésultatSimple.tsx
+++ b/site/source/pages/assistants/declaration-charges-sociales-independant/components/RésultatSimple.tsx
@@ -39,7 +39,7 @@ export default function ResultatsSimples() {
 					intégrée à la déclaration fiscale des revenus (déclaration 2042) sur
 					impots.gouv.fr.{' '}
 					<Link
-						href="https://www.impots.gouv.fr/portail/www2/minisite/declaration/independants.html?11"
+						href="https://www.impots.gouv.fr/www2/minisite/declaration/rub_1/independants.html"
 						target="_blank"
 						rel="noreferrer"
 						aria-label={t(

--- a/site/source/pages/integration/components/CasParticuliers.tsx
+++ b/site/source/pages/integration/components/CasParticuliers.tsx
@@ -165,14 +165,14 @@ export function CasParticuliers() {
 							du tableau des taux nets collectifs paru au Journal Officiel
 						</Li>
 						<Li>
-							Le service{' '}
+							La documentation{' '}
 							<Link
-								href="https://www.net-entreprises.fr/declaration/compte-atmp/"
-								aria-label="Compte AT/MP, voir le service en ligne de déclaration pour ATMP, nouvelle fenêtre"
+								href="https://www.ameli.fr/entreprise/votre-entreprise/cotisation-atmp"
+								aria-label="Trouver son taux de cotisation AT/MP"
 							>
-								Compte AT/MP
+								Cotisations AT/MP
 							</Link>{' '}
-							de net-entreprise
+							de l’Assurance Maladie
 						</Li>
 					</Ul>
 				</Body>


### PR DESCRIPTION
J'ai remplacé :
- https://www.impots.gouv.fr/portail/www2/minisite/declaration/independants.html?11 par https://www.impots.gouv.fr/www2/minisite/declaration/rub_1/independants.html
- https://www.net-entreprises.fr/declaration/compte-atmp/ par https://www.net-entreprises.fr/obligation-legale-dinscription-au-compte-at-mp-quel-que-soit-leffectif-de-lentreprise/

Ça vous parait bien @VeroniqueR75 @glopezrios  ?

Closes #2165 