### PR TITLE
Ajoute 'autre' au choix de conventions collectives (issue #2992)

### DIFF
--- a/modele-social/règles/salarié/conventions-collectives/autre.publicodes
+++ b/modele-social/règles/salarié/conventions-collectives/autre.publicodes
@@ -1,0 +1,3 @@
+    salarié . convention collective . autre:
+      formule: convention collective = 'autre'
+      titre: Autre convention collective

--- a/modele-social/règles/salarié/conventions-collectives/droit-commun.publicodes
+++ b/modele-social/règles/salarié/conventions-collectives/droit-commun.publicodes
@@ -1,0 +1,3 @@
+    salarié . convention collective . droit commun:
+      formule: convention collective = 'droit commun'
+      titre: Pas de convention collective

--- a/modele-social/règles/salarié/salarié.publicodes
+++ b/modele-social/règles/salarié/salarié.publicodes
@@ -14,25 +14,36 @@ salarié . convention collective:
     une possibilité:
       choix obligatoire: oui
       possibilités:
-        - droit commun
         - HCR
         - BTP
         - sport
         - SVP
         - compta
         - optique
+        - autre
+        - droit commun
 
   avec:
-    contrôle décharge:
+    avertissement convention collective:
       type: notification
       sévérité: avertissement
-      valeur: convention collective != 'droit commun'
+      valeur:
+        toutes ces conditions:
+          - convention collective != 'droit commun'
+          - convention collective != 'autre'
       description: >-
-        Attention : l'implémentation des conventions collective est encore
+        Attention : la prise en charge des conventions collectives est encore
         partielle et non vérifiée. Néanmoins, cela permet d'obtenir une première
         estimation, plus précise que le régime général.
-    droit commun: convention collective = 'droit commun'
-
+    avertissement autre convention collective:
+      type: notification
+      sévérité: avertissement
+      valeur:
+        convention collective = 'autre'
+      description: >-
+        Attention : votre convention collective n'est pas prise en charge, 
+        la simulation se basera sur le droit commun.
+  
 salarié . régimes spécifiques:
 salarié . régimes spécifiques . alsace moselle:
   titre: Régime Alsace-Moselle

--- a/site/test/regressions/__snapshots__/convention-collective.test.ts.snap
+++ b/site/test/regressions/__snapshots__/convention-collective.test.ts.snap
@@ -7,7 +7,7 @@ salarié . coût total employeur: 3412
 salarié . rémunération . net . payé après impôt: 1909
 salarié . rémunération . net . à payer avant impôt: 1983
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN batiment 1`] = `
@@ -17,7 +17,7 @@ salarié . coût total employeur: 3766
 salarié . rémunération . net . payé après impôt: 1859
 salarié . rémunération . net . à payer avant impôt: 1931
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN batiment 2`] = `
@@ -27,7 +27,7 @@ salarié . coût total employeur: 3749
 salarié . rémunération . net . payé après impôt: 1861
 salarié . rémunération . net . à payer avant impôt: 1933
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN batiment 3`] = `
@@ -37,7 +37,7 @@ salarié . coût total employeur: 3799
 salarié . rémunération . net . payé après impôt: 1862
 salarié . rémunération . net . à payer avant impôt: 1949
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN compta 1`] = `
@@ -47,7 +47,7 @@ salarié . coût total employeur: 3293
 salarié . rémunération . net . payé après impôt: 1935
 salarié . rémunération . net . à payer avant impôt: 2006
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN optique 1`] = `
@@ -57,7 +57,7 @@ salarié . coût total employeur: 3483
 salarié . rémunération . net . payé après impôt: 1969
 salarié . rémunération . net . à payer avant impôt: 2058
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN spectacle vivant 1`] = `
@@ -67,7 +67,7 @@ salarié . coût total employeur: 3759
 salarié . rémunération . net . payé après impôt: 2065
 salarié . rémunération . net . à payer avant impôt: 2155
 
-Notifications affichées : salarié . contrat . CDD . information, salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . contrat . CDD . information, salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN sport 1`] = `
@@ -77,7 +77,7 @@ salarié . coût total employeur: 906
 salarié . rémunération . net . payé après impôt: 593
 salarié . rémunération . net . à payer avant impôt: 593
 
-Notifications affichées : salarié . rémunération . assiette de vérification du SMIC . contrôle, salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . rémunération . assiette de vérification du SMIC . contrôle, salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > CCN sport 2`] = `
@@ -87,5 +87,5 @@ salarié . coût total employeur: 1801
 salarié . rémunération . net . payé après impôt: 1400
 salarié . rémunération . net . à payer avant impôt: 1400
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;

--- a/site/test/regressions/__snapshots__/salarié.test.ts.snap
+++ b/site/test/regressions/__snapshots__/salarié.test.ts.snap
@@ -249,7 +249,7 @@ salarié . coût total employeur: 3618
 salarié . rémunération . net . payé après impôt: 1815
 salarié . rémunération . net . à payer avant impôt: 1871
 
-Notifications affichées : salarié . contrat . CDD . information, salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . contrat . CDD . information, salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > contrat pro 1`] = `
@@ -533,7 +533,7 @@ salarié . coût total employeur: 2380
 salarié . rémunération . net . payé après impôt: 1607
 salarié . rémunération . net . à payer avant impôt: 1616
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > heures supplémentaires et complémentaires 5`] = `
@@ -543,7 +543,7 @@ salarié . coût total employeur: 2349
 salarié . rémunération . net . payé après impôt: 1581
 salarié . rémunération . net . à payer avant impôt: 1589
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > heures supplémentaires et complémentaires 6`] = `
@@ -553,7 +553,7 @@ salarié . coût total employeur: 2331
 salarié . rémunération . net . payé après impôt: 1592
 salarié . rémunération . net . à payer avant impôt: 1601
 
-Notifications affichées : salarié . convention collective . contrôle décharge"
+Notifications affichées : salarié . convention collective . avertissement convention collective"
 `;
 
 exports[`calculate simulations-salarié > heures supplémentaires et complémentaires 7`] = `


### PR DESCRIPTION
close #2992

Après discussion avec @JalilArfaoui , nous sommes arrivé à cette proposition de choix de conventions collectives :

![image](https://github.com/betagouv/mon-entreprise/assets/69042083/014b91d6-fef7-4390-bbcd-07cf155896db)

Le messages d'avertissement lorsqu'une convention collective a été choisie a été retouché :

![image](https://github.com/betagouv/mon-entreprise/assets/69042083/4057ccdf-6487-4015-a632-d67a9a41fb15)

Et un message d'avertissement a été ajouté lorsqu'on choisit "Autre convention collective" :

![image](https://github.com/betagouv/mon-entreprise/assets/69042083/1ef6549d-311a-49e6-8dfc-159eab5a0037)
