### PR TITLE
feat(auto-entrepreneur): ajoute un avertissement sur la retraite pour les ACRE et les DROM

### DIFF
--- a/site/source/components/simulationExplanation/DroitsRetraite.tsx
+++ b/site/source/components/simulationExplanation/DroitsRetraite.tsx
@@ -26,6 +26,19 @@ export function DroitsRetraite() {
 	return (
 		<Trans i18nKey="pages.simulateurs.indépendant.retraite-droits-acquis">
 			<H3 as="h2">Retraite : droits acquis sur l'année</H3>
+			<WhenApplicable dottedName="dirigeant . auto-entrepreneur . DROM">
+				<Message type="info" border>
+					Les exonérations DROM n'ont aucune incidence sur la détermination des
+					droits à la retraite de base et complémentaire des auto-entrepreneurs
+				</Message>
+			</WhenApplicable>
+			<WhenApplicable dottedName="dirigeant . exonérations . ACRE">
+				<Message type="info" border>
+					L’exonération ACRE n'a aucune incidence sur la détermination des
+					droits à la retraite de base et complémentaire des auto-entrepreneurs
+				</Message>
+			</WhenApplicable>
+
 			<Condition expression={exonérationRetraiteActive}>
 				<Message type="info" icon={<Emoji emoji="🚧" />} border={false}>
 					Le calcul des droits ouverts à la retraite n'est pas encore implémenté

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -8266,19 +8266,26 @@ salarié . contrat . temps de travail . temps partiel:
   titre.fr: temps partiel
 salarié . convention collective:
   avec:
-    contrôle décharge:
-      description.en: '[automatic] Attention: the implementation of collective
-        agreements is still partial and not verified. Nevertheless, it allows us
-        to obtain a first estimate, more precise than the general scheme.'
+    avertissement autre convention collective:
+      description.en:
+        '[automatic] Please note: your collective bargaining agreement
+        is not taken into account; the simulation will be based on common law.'
       description.fr:
-        "Attention : l'implémentation des conventions collective est
+        "Attention : votre convention collective n'est pas prise en
+        charge,  la simulation se basera sur le droit commun."
+      titre.en: '[automatic] warning other collective bargaining agreement'
+      titre.fr: avertissement autre convention collective
+    avertissement convention collective:
+      description.en:
+        '[automatic] Please note: the coverage of collective bargaining
+        agreements is still partial and unverified. Nonetheless, it provides an
+        initial estimate that is more accurate than that of the general scheme.'
+      description.fr:
+        "Attention : la prise en charge des conventions collectives est
         encore partielle et non vérifiée. Néanmoins, cela permet d'obtenir une
         première estimation, plus précise que le régime général."
-      titre.en: '[automatic] control discharge'
-      titre.fr: contrôle décharge
-    droit commun:
-      titre.en: '[automatic] common law'
-      titre.fr: droit commun
+      titre.en: '[automatic] warning collective bargaining agreement'
+      titre.fr: avertissement convention collective
   question.en: '[automatic] Which collective agreement is applicable to the company?'
   question.fr: Quelle convention collective est applicable à l'entreprise ?
   titre.en: convention collective
@@ -8484,6 +8491,9 @@ salarié . convention collective . SVP . prévoyance:
     avantageuse, c'est donc cette dernière qui est prise en compte
   titre.en: '[automatic] providence'
   titre.fr: prévoyance
+salarié . convention collective . autre:
+  titre.en: '[automatic] Other collective bargaining agreement'
+  titre.fr: Autre convention collective
 salarié . convention collective . compta:
   description.en: '[automatic] This collective agreement concerns chartered
     accountants registered with the Order, statutory auditors registered with
@@ -8497,6 +8507,9 @@ salarié . convention collective . compta:
 salarié . convention collective . compta . majoration heures supplémentaires:
   titre.en: '[automatic] overtime pay'
   titre.fr: majoration heures supplémentaires
+salarié . convention collective . droit commun:
+  titre.en: '[automatic] No collective bargaining agreement'
+  titre.fr: Pas de convention collective
 salarié . convention collective . optique:
   titre.en: '[automatic] Optics'
   titre.fr: Optique

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -1381,15 +1381,19 @@ pages:
           vice versa
         title: "Self-employed: income simulator"
       retraite-droits-acquis: "<0>Retirement: rights acquired over the
-        year</0><1><0>The calculation of pension entitlements has not yet been
-        implemented for cases involving exemptions from contributions (ACRE,
-        disability pension, etc.).</0></1><2><0><0>Basic pension :
-        <2></2></0><1><0>Basic pension points acquired (CNAVPL) :
-        <2></2></0></1><2><0>Contribution income taken into account for basic
-        retirement : <2></2></0></2><3>Supplementary pension points acquired:
-        <2><0></0> points acquired</2><3><0>not known</0><1><0>This simulator
-        does not manage acquired supplementary pension rights for the liberal
-        professions.</0></1></3></3></0></2>"
+        year</0><1><0>DROM exemptions have no impact on determining basic and
+        supplementary pension rights for auto-entrepreneurs</0></1><2><0>The
+        ACRE exemption has no impact on the calculation of basic and
+        supplementary pension rights for auto-entrepreneurs.</0></2><3><0>The
+        calculation of open pension rights has not yet been implemented for
+        cases involving contribution exemptions (ACRE, disability pension,
+        etc.).</0></3><4><0><0>Basic pension : <2></2></0><1><0>Basic pension
+        points acquired (CNAVPL) : <2></2></0></1><2><0>Contribution income
+        taken into account for basic retirement :
+        <2></2></0></2><3>Supplementary pension points acquired: <2><0></0>
+        points acquired</2><3><0>not known</0><1><0>This simulator does not
+        manage acquired supplementary pension rights for the liberal
+        professions.</0></1></3></3></0></4>"
       shortname: Independent
       title: Income simulator for the self-employed
     is:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -1468,16 +1468,20 @@ pages:
         description: Calcul du revenu net après impôt et des cotisations à partir du
           chiffre d'affaires et inversement
         title: "Indépendant : simulateur de revenus"
-      retraite-droits-acquis: "<0>Retraite : droits acquis sur l'année</0><1><0>Le
-        calcul des droits ouverts à la retraite n'est pas encore implémenté pour
-        les cas incluants des d'exonérations de cotisations (ACRE, pension
-        invalidité, etc).</0></1><2><0><0>Retraite de base :
-        <2></2></0><1><0>Points de retraite de base acquis (CNAVPL) :
-        <2></2></0></1><2><0>Revenu cotisé pris en compte pour la retraite de
-        base : <2></2></0></2><3>Points de retraite complémentaire acquis :
-        <2><0></0> points acquis</2><3><0>non connue</0><1><0>Ce simulateur ne
-        gère pas les droits acquis de retraite complémentaire pour les
-        professions libérales</0></1></3></3></0></2>"
+      retraite-droits-acquis: "<0>Retraite : droits acquis sur l'année</0><1><0>Les
+        exonérations DROM n'ont aucune incidence sur la détermination des droits
+        à la retraite de base et complémentaire des
+        auto-entrepreneurs</0></1><2><0>L’exonération ACRE n'a aucune incidence
+        sur la détermination des droits à la retraite de base et complémentaire
+        des auto-entrepreneurs</0></2><3><0>Le calcul des droits ouverts à la
+        retraite n'est pas encore implémenté pour les cas incluants des
+        d'exonérations de cotisations (ACRE, pension invalidité,
+        etc).</0></3><4><0><0>Retraite de base : <2></2></0><1><0>Points de
+        retraite de base acquis (CNAVPL) : <2></2></0></1><2><0>Revenu cotisé
+        pris en compte pour la retraite de base : <2></2></0></2><3>Points de
+        retraite complémentaire acquis : <2><0></0> points acquis</2><3><0>non
+        connue</0><1><0>Ce simulateur ne gère pas les droits acquis de retraite
+        complémentaire pour les professions libérales</0></1></3></3></0></4>"
       shortname: Indépendant
       title: Simulateur de revenus pour indépendant
     is:


### PR DESCRIPTION
Les exonérations ACRE et DROM n'ont aucune incidence sur la détermination des droits à la retraite de base et complémentaire des auto-entrepreneurs.

Closes #2939 