### PR TITLE
Mise à jour lien vers fiche modulation des cotisations Urssaf

### DIFF
--- a/modele-social/règles/dirigeant/indépendant.publicodes
+++ b/modele-social/règles/dirigeant/indépendant.publicodes
@@ -396,12 +396,12 @@ dirigeant . indépendant . cotisations et contributions . régularisation:
 
 
     Si vos revenus d'activité changent beaucoup par rapport à l'année précédente,
-    vous avez la possibilité de communiquer à l'URSSAF un
+    vous avez la possibilité de communiquer à l'Urssaf un
     **montant prévisionnel pour l'année en cours, qui sera pris comme base de calcul**
     (attention cependant, vous serez tenus de faire une estimation précise).
 
   références:
-    Fiche Urssaf: https://www.urssaf.fr/portail/cms/render/live/fr/sites/urssaf/home/independant/mes-cotisations/les-etapes-de-calcul/le-mode-de-calcul/les-cotisations-provisionnelles/demande-de-modulation.html
+    Fiche Urssaf: https://www.urssaf.fr/accueil/independant/comprendre-payer-cotisations/adapter-cotisations-revenus.html
     Article L131-6-2 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037062224/
     Article D131-3 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000038786941/2021-03-01/?isSuggest=true
 


### PR DESCRIPTION
Le précédent lien était mort. Je corrige aussi une erreur de casse pour l'Urssaf.