### PR TITLE
fix: Corrige la valeur du taux service BIC avec l'ACRE

### DIFF
--- a/modele-social/règles/dirigeant/auto-entrepreneur/auto-entrepreneur.publicodes
+++ b/modele-social/règles/dirigeant/auto-entrepreneur/auto-entrepreneur.publicodes
@@ -445,7 +445,6 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations:
       déprécié: oui
       valeur: vente restauration hébergement . taux
 
-
 dirigeant . auto-entrepreneur . impôt: oui
 dirigeant . auto-entrepreneur . impôt . revenu imposable: entreprise . imposition . régime . micro-entreprise . revenu abattu
 

--- a/modele-social/règles/dirigeant/auto-entrepreneur/exonérations.publicodes
+++ b/modele-social/règles/dirigeant/auto-entrepreneur/exonérations.publicodes
@@ -119,7 +119,7 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . tau
 
     service BIC:
       remplace: cotisations . service BIC . taux
-      valeur: cotisations . service BIC . taux
+      valeur: taux ACRE * cotisations . service BIC . taux
       arrondi: 1 décimale
 
     service BNC:

--- a/modele-social/règles/dirigeant/auto-entrepreneur/exonérations.publicodes
+++ b/modele-social/règles/dirigeant/auto-entrepreneur/exonérations.publicodes
@@ -1,147 +1,146 @@
 
 dirigeant . auto-entrepreneur . DROM:
-    experimental: oui
-    description: |
-      En tant qu’auto-entrepreneur en début d’activité, vous bénéficiez d’une exonération qui se traduit par l’application de taux réduits de cotisations sur trois ans, correspondant à :
+  experimental: oui
+  description: |
+    En tant qu’auto-entrepreneur en début d’activité, vous bénéficiez d’une exonération qui se traduit par l’application de taux réduits de cotisations sur trois ans, correspondant à :
 
-       - 1/6 des taux pleins de métropole si vous êtes artisan, commerçant ou professionnel libéral non réglementé, 1/3 si vous êtes un professionnel libéral réglementé, jusqu’à la fin du 7ème trimestre qui suit celui au cours duquel vous avez débuté votre activité,
-       - ½ des taux pleins de métropole que vous soyez artisan, commerçant ou professionnel libéral, pour la période qui court entre la fin du 8ème trimestre d’activité jusqu’à la fin de la 3ème année civile d’activité,
-    note : Les taux DOM sont définis comme un pourcentage des taux métropole, mais les règles d'arrondi ne sont pas claires
-    applicable si: établissement . commune . département . outre-mer
-    valeur: oui
-    rend non applicable: exonérations . ACRE
-    références:
-        'Vous êtes auto-entrepreneur dans les DROM ?': https://www.autoentrepreneur.urssaf.fr/portail/accueil/sinformer-sur-le-statut/lessentiel-du-statut.html#vous-etes-auto-entrepreneur-dans
-    references:
-        Taux auto-entrepreneur dans les Drom (PDF): https://www.autoentrepreneur.urssaf.fr/portail/files/Guides/Urssaf-AutoEntrepreneur-Drom.pdf#page=13
-    avec:
-        première période:
-            titre: Jusqu'à la fin du 8ème trimestre d'activité
-            privé: oui
-            valeur: entreprise . durée d'activité . trimestres civils <= 8
-        seconde période:
-            titre: Entre le 9ème trimestre civil et la fin de la 3ème année civile d'activité
-            privé: oui
-            valeur: entreprise . durée d'activité . années civiles <= 3
+      - 1/6 des taux pleins de métropole si vous êtes artisan, commerçant ou professionnel libéral non réglementé, 1/3 si vous êtes un professionnel libéral réglementé, jusqu’à la fin du 7ème trimestre qui suit celui au cours duquel vous avez débuté votre activité,
+      - ½ des taux pleins de métropole que vous soyez artisan, commerçant ou professionnel libéral, pour la période qui court entre la fin du 8ème trimestre d’activité jusqu’à la fin de la 3ème année civile d’activité,
+  note : Les taux DOM sont définis comme un pourcentage des taux métropole, mais les règles d'arrondi ne sont pas claires
+  applicable si: établissement . commune . département . outre-mer
+  valeur: oui
+  rend non applicable: exonérations . ACRE
+  références:
+    'Vous êtes auto-entrepreneur dans les DROM ?': https://www.autoentrepreneur.urssaf.fr/portail/accueil/sinformer-sur-le-statut/lessentiel-du-statut.html#vous-etes-auto-entrepreneur-dans
+  references:
+    Taux auto-entrepreneur dans les Drom (PDF): https://www.autoentrepreneur.urssaf.fr/portail/files/Guides/Urssaf-AutoEntrepreneur-Drom.pdf#page=13
+  avec:
+    première période:
+      titre: Jusqu'à la fin du 8ème trimestre d'activité
+      privé: oui
+      valeur: entreprise . durée d'activité . trimestres civils <= 8
+    seconde période:
+      titre: Entre le 9ème trimestre civil et la fin de la 3ème année civile d'activité
+      privé: oui
+      valeur: entreprise . durée d'activité . années civiles <= 3
 
-        service BIC:
-            remplace: cotisations et contributions . cotisations . service BIC . taux
-            variations:
-                - si: première période
-                  alors: 3.60%
-                - si: seconde période
-                  alors: 10.60%
-                - sinon: 14.20%
+      service BIC:
+        remplace: cotisations et contributions . cotisations . service BIC . taux
+        variations:
+          - si: première période
+            alors: 3.60%
+          - si: seconde période
+            alors: 10.60%
+          - sinon: 14.20%
 
-        taux service BNC:
-            remplace: cotisations et contributions . cotisations . service BNC . taux
-            variations:
-                - si: première période
-                  alors: 3.60%
-                - si: seconde période
-                  alors: 10.60%
-                - sinon: 14.10%
+      taux service BNC:
+        remplace: cotisations et contributions . cotisations . service BNC . taux
+        variations:
+          - si: première période
+            alors: 3.60%
+          - si: seconde période
+            alors: 10.60%
+          - sinon: 14.10%
 
 
-        taux vente restauration hébergement:
-            remplace: cotisations et contributions . cotisations . vente restauration hébergement . taux
-            variations:
-                - si: première période
-                  alors: 2.10%
-                - si: seconde période
-                  alors: 6.20%
-                - sinon: 8.20%
+      taux vente restauration hébergement:
+        remplace: cotisations et contributions . cotisations . vente restauration hébergement . taux
+        variations:
+          - si: première période
+            alors: 2.10%
+          - si: seconde période
+            alors: 6.20%
+          - sinon: 8.20%
 
-        taux CIPAV:
-            remplace: cotisations et contributions . cotisations . cotisations CIPAV . taux
-            variations:
-                - si: première période
-                  alors: 7.10%
-                - si: seconde période
-                  alors: 10.60%
-                - sinon: 14.20%
-
+      taux CIPAV:
+        remplace: cotisations et contributions . cotisations . cotisations CIPAV . taux
+        variations:
+          - si: première période
+            alors: 7.10%
+          - si: seconde période
+            alors: 10.60%
+          - sinon: 14.20%
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
-    privé: oui
-    applicable si: dirigeant . exonérations . ACRE
-    description: |
-        Ce taux correspond à la réduction de cotisations qui s'applique pour
-        l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 75% signifie que
-        l'auto-entrepreneur doit s'acquitter de 75% du montant d'origine des
-        cotisations.
-    unité: '%'
-    variations:
-        - si: entreprise . date de création < 01/04/2019
-          alors:
-              grille:
-                  assiette: entreprise . durée d'activité
-                  tranches:
-                      - montant: 25%
-                        plafond: 1 an
-                      - montant: 50%
-                        plafond: 2 ans
-                      - montant: 90%
-                        plafond: 3 ans
-        - si: entreprise . date de création < 01/04/2020
-          alors:
-              grille:
-                  assiette: entreprise . durée d'activité
-                  tranches:
-                      - montant: 25%
-                        plafond: 1 an
-                      - montant: 75%
-                        plafond: 2 ans
-                      - montant: 90%
-                        plafond: 3 ans
-        - si: entreprise . durée d'activité < 1 an
-          alors: 50%
+  privé: oui
+  applicable si: dirigeant . exonérations . ACRE
+  description: |
+    Ce taux correspond à la réduction de cotisations qui s'applique pour
+    l'auto-entrepreneur bénéficiant de l'Acre. Un taux de 75% signifie que
+    l'auto-entrepreneur doit s'acquitter de 75% du montant d'origine des
+    cotisations.
+  unité: '%'
+  variations:
+    - si: entreprise . date de création < 01/04/2019
+      alors:
+        grille:
+          assiette: entreprise . durée d'activité
+          tranches:
+            - montant: 25%
+              plafond: 1 an
+            - montant: 50%
+              plafond: 2 ans
+            - montant: 90%
+              plafond: 3 ans
+    - si: entreprise . date de création < 01/04/2020
+      alors:
+        grille:
+          assiette: entreprise . durée d'activité
+          tranches:
+            - montant: 25%
+              plafond: 1 an
+            - montant: 75%
+              plafond: 2 ans
+            - montant: 90%
+              plafond: 3 ans
+    - si: entreprise . durée d'activité < 1 an
+      alors: 50%
 
-    références:
-        FAQ Urssaf depuis 04/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#jai-cree-mon-auto-entreprise-en
-        FAQ Urssaf avant 04/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#quest-ce-qui-change-pour-moi-si
-        service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
+  références:
+    FAQ Urssaf depuis 04/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#jai-cree-mon-auto-entreprise-en
+    FAQ Urssaf avant 04/2020: https://www.autoentrepreneur.urssaf.fr/portail/accueil/une-question/questions-frequentes.html#quest-ce-qui-change-pour-moi-si
+    service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32318
 
-    avec:
-        CIPAV:
-            remplace: cotisations CIPAV . taux
-            titre:
-            variations:
-                - si: entreprise . date de création >= 01/04/2020
-                  alors: 12.10%
-                - sinon: cotisations CIPAV . taux * taux ACRE
+  avec:
+    CIPAV:
+      remplace: cotisations CIPAV . taux
+      titre:
+      variations:
+        - si: entreprise . date de création >= 01/04/2020
+          alors: 12.10%
+        - sinon: cotisations CIPAV . taux * taux ACRE
 
-        prestation de service:
-            déprécié: oui
-            note:
-                Il y a maintenant des taux différents pour les prestations de service BIC
-                et BNC
-            valeur: service BIC
+    prestation de service:
+      déprécié: oui
+      note:
+        Il y a maintenant des taux différents pour les prestations de service BIC
+        et BNC
+      valeur: service BIC
 
-        service BIC:
-            remplace: cotisations . service BIC . taux
-            valeur: cotisations . service BIC . taux
-            arrondi: 1 décimale
+    service BIC:
+      remplace: cotisations . service BIC . taux
+      valeur: cotisations . service BIC . taux
+      arrondi: 1 décimale
 
-        service BNC:
-            remplace: cotisations . service BNC . taux
-            valeur: taux ACRE * cotisations . service BNC . taux
-            arrondi: 
-              variations:
-                - si: date >= 01/2026
-                  alors: 2 décimales
-                - sinon: 1 décimale
+    service BNC:
+      remplace: cotisations . service BNC . taux
+      valeur: taux ACRE * cotisations . service BNC . taux
+      arrondi:
+        variations:
+          - si: date >= 01/2026
+            alors: 2 décimales
+          - sinon: 1 décimale
 
-        vente restauration hébergement:
-            remplace: cotisations . vente restauration hébergement . taux
-            valeur: taux ACRE * cotisations . vente restauration hébergement . taux
-            arrondi: 1 décimale
+    vente restauration hébergement:
+      remplace: cotisations . vente restauration hébergement . taux
+      valeur: taux ACRE * cotisations . vente restauration hébergement . taux
+      arrondi: 1 décimale
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel:
-    experimental: oui
-    formule: dirigeant . exonérations . ACRE
-    type: notification
-    description: |
-        Le taux ACRE utilisé est celui correspondant au mois courant. Le
-        simulateur ne prend pas encore en compte le chevauchement de deux périodes
-        d'acre sur une meme année.
+  experimental: oui
+  formule: dirigeant . exonérations . ACRE
+  type: notification
+  description: |
+    Le taux ACRE utilisé est celui correspondant au mois courant. Le
+    simulateur ne prend pas encore en compte le chevauchement de deux périodes
+    d'acre sur une meme année.

--- a/modele-social/règles/dirigeant/auto-entrepreneur/exonérations.publicodes
+++ b/modele-social/règles/dirigeant/auto-entrepreneur/exonérations.publicodes
@@ -62,7 +62,6 @@ dirigeant . auto-entrepreneur . DROM:
           - sinon: 14.20%
 
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE:
-  privé: oui
   applicable si: dirigeant . exonérations . ACRE
   description: |
     Ce taux correspond à la réduction de cotisations qui s'applique pour

--- a/site/test/regressions/__snapshots__/auto-entrepreneur.test.ts.snap
+++ b/site/test/regressions/__snapshots__/auto-entrepreneur.test.ts.snap
@@ -19,10 +19,120 @@ dirigeant . auto-entrepreneur . revenu net: 20000
 dirigeant . auto-entrepreneur . revenu net . après impôt: 20000
 dirigeant . rémunération . impôt: 0
 
-Notifications affichées : entreprise . TVA . franchise de TVA . notification"
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > ACRE 2`] = `
+"dirigeant . auto-entrepreneur . chiffre d'affaires: 22676
+dirigeant . auto-entrepreneur . cotisations et contributions: 223
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 219
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 75
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 8
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 8
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 17
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 111
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 219
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 12
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: null
+dirigeant . auto-entrepreneur . revenu net: 20000
+dirigeant . auto-entrepreneur . revenu net . après impôt: 20000
+dirigeant . rémunération . impôt: 0
+
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
+`;
+
+exports[`calculate simulations-auto-entrepreneur > ACRE 3`] = `
+"dirigeant . auto-entrepreneur . chiffre d'affaires: 21442
+dirigeant . auto-entrepreneur . cotisations et contributions: 120
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 111
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 33
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 3
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 10
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 18
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 46
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 111
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 6
+dirigeant . auto-entrepreneur . revenu net: 20000
+dirigeant . auto-entrepreneur . revenu net . après impôt: 20000
+dirigeant . rémunération . impôt: 0
+
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
+`;
+
+exports[`calculate simulations-auto-entrepreneur > ACRE 4`] = `
+"dirigeant . auto-entrepreneur . chiffre d'affaires: 22568
+dirigeant . auto-entrepreneur . cotisations et contributions: 214
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 199
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 59
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 6
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 18
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 33
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 83
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 199
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 11
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: null
+dirigeant . auto-entrepreneur . revenu net: 20000
+dirigeant . auto-entrepreneur . revenu net . après impôt: 20000
+dirigeant . rémunération . impôt: 0
+
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
+`;
+
+exports[`calculate simulations-auto-entrepreneur > ACRE 5`] = `
+"dirigeant . auto-entrepreneur . chiffre d'affaires: 22410
+dirigeant . auto-entrepreneur . cotisations et contributions: 201
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 198
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 59
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 6
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 18
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 33
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 83
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 198
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 11
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: null
+dirigeant . auto-entrepreneur . revenu net: 20000
+dirigeant . auto-entrepreneur . revenu net . après impôt: 20000
+dirigeant . rémunération . impôt: 0
+
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
+`;
+
+exports[`calculate simulations-auto-entrepreneur > ACRE 6`] = `
+"dirigeant . auto-entrepreneur . chiffre d'affaires: 22410
+dirigeant . auto-entrepreneur . cotisations et contributions: 201
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 198
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 59
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 6
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 18
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 33
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 83
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 198
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 11
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: null
+dirigeant . auto-entrepreneur . revenu net: 20000
+dirigeant . auto-entrepreneur . revenu net . après impôt: 20000
+dirigeant . rémunération . impôt: 0
+
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
+`;
+
+exports[`calculate simulations-auto-entrepreneur > ACRE 7`] = `
 "dirigeant . auto-entrepreneur . chiffre d'affaires: 32017
 dirigeant . auto-entrepreneur . cotisations et contributions: 168
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 165
@@ -41,86 +151,86 @@ dirigeant . auto-entrepreneur . revenu net: 30000
 dirigeant . auto-entrepreneur . revenu net . après impôt: 30000
 dirigeant . rémunération . impôt: 0
 
-Notifications affichées : entreprise . TVA . franchise de TVA . notification"
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > DROM 1`] = `
 "dirigeant . auto-entrepreneur . chiffre d'affaires: 20000
-dirigeant . auto-entrepreneur . cotisations et contributions: 213
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 211
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 64
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 7
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 17
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 32
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 92
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 142
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 14
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 35
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 14
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 34
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 8
-dirigeant . auto-entrepreneur . revenu net: 17440
-dirigeant . auto-entrepreneur . revenu net . après impôt: 17440
+dirigeant . auto-entrepreneur . cotisations et contributions: 323
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 321
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 98
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 10
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 26
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 48
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 139
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 212
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 21
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 58
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 23
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 51
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
+dirigeant . auto-entrepreneur . revenu net: 16125
+dirigeant . auto-entrepreneur . revenu net . après impôt: 16125
 dirigeant . rémunération . impôt: 0"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > DROM 2`] = `
 "dirigeant . auto-entrepreneur . chiffre d'affaires: 45000
-dirigeant . auto-entrepreneur . cotisations et contributions: 312
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 307
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 91
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 10
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 27
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 51
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 129
+dirigeant . auto-entrepreneur . cotisations et contributions: 466
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 461
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 137
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 14
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 41
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 76
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 193
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: null
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 14
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: null
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: null
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 14
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 307
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 8
-dirigeant . auto-entrepreneur . revenu net: 41253
-dirigeant . auto-entrepreneur . revenu net . après impôt: 41253
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: null
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 461
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
+dirigeant . auto-entrepreneur . revenu net: 39408
+dirigeant . auto-entrepreneur . revenu net . après impôt: 39408
 dirigeant . rémunération . impôt: 0"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > DROM 3`] = `
 "dirigeant . auto-entrepreneur . chiffre d'affaires: 20000
-dirigeant . auto-entrepreneur . cotisations et contributions: 56
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 54
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 16
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 2
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 4
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 8
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 23
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 36
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 4
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 9
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 4
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 9
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 2
-dirigeant . auto-entrepreneur . revenu net: 19332
-dirigeant . auto-entrepreneur . revenu net . après impôt: 19332
+dirigeant . auto-entrepreneur . cotisations et contributions: 323
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 321
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 98
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 10
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 26
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 48
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 139
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 212
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 21
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 58
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 23
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 51
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
+dirigeant . auto-entrepreneur . revenu net: 16125
+dirigeant . auto-entrepreneur . revenu net . après impôt: 16125
 dirigeant . rémunération . impôt: 0"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > DROM 4`] = `
 "dirigeant . auto-entrepreneur . chiffre d'affaires: 20000
-dirigeant . auto-entrepreneur . cotisations et contributions: 160
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 158
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 48
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 5
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 13
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 24
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 69
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 106
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 11
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 27
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 11
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 26
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 6
-dirigeant . auto-entrepreneur . revenu net: 18077
-dirigeant . auto-entrepreneur . revenu net . après impôt: 18077
+dirigeant . auto-entrepreneur . cotisations et contributions: 323
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 321
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 98
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 10
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 26
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire: 48
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite de base: 139
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC: 212
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BIC . taux: 21
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC: 58
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 23
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 51
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
+dirigeant . auto-entrepreneur . revenu net: 16125
+dirigeant . auto-entrepreneur . revenu net . après impôt: 16125
 dirigeant . rémunération . impôt: 0"
 `;
 
@@ -234,8 +344,8 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 
 exports[`calculate simulations-auto-entrepreneur > activités 2`] = `
 "dirigeant . auto-entrepreneur . chiffre d'affaires: 20000
-dirigeant . auto-entrepreneur . cotisations et contributions: 390
-dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 4640
+dirigeant . auto-entrepreneur . cotisations et contributions: 205
+dirigeant . auto-entrepreneur . cotisations et contributions . cotisations: 2420
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . autres contributions: 132
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . invalidité-décès: 14
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . maladie-maternité: 14
@@ -247,8 +357,8 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ser
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . service BNC . taux: 23
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: null
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: null
-dirigeant . auto-entrepreneur . revenu net: 15320
-dirigeant . auto-entrepreneur . revenu net . après impôt: 15320
+dirigeant . auto-entrepreneur . revenu net: 17540
+dirigeant . auto-entrepreneur . revenu net . après impôt: 17540
 dirigeant . rémunération . impôt: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"

--- a/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
+++ b/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
@@ -23,7 +23,7 @@ protection sociale . retraite . base: 725
 protection sociale . retraite . complémentaire: 27
 protection sociale . retraite . trimestres: 4
 
-Notifications affichées : entreprise . TVA . franchise de TVA . notification"
+Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
 `;
 
 exports[`calculate comparateur-statuts > ACRE 2`] = `

--- a/site/test/regressions/auto-entrepreneur.yaml
+++ b/site/test/regressions/auto-entrepreneur.yaml
@@ -25,6 +25,30 @@ ACRE:
   - dirigeant . auto-entrepreneur . revenu net: 20000 €/an
     entreprise . date de création: période . début d'année
     dirigeant . exonérations . ACRE: oui
+  - dirigeant . auto-entrepreneur . revenu net: 20000 €/an
+    entreprise . date de création: période . début d'année
+    dirigeant . exonérations . ACRE: oui
+    entreprise . activité . nature: "'libérale'"
+  - dirigeant . auto-entrepreneur . revenu net: 20000 €/an
+    entreprise . date de création: période . début d'année
+    dirigeant . exonérations . ACRE: oui
+    entreprise . activité . nature: "'artisanale'"
+    entreprise . activités . service ou vente: "'vente'"
+  - dirigeant . auto-entrepreneur . revenu net: 20000 €/an
+    entreprise . date de création: période . début d'année
+    dirigeant . exonérations . ACRE: oui
+    entreprise . activité . nature: "'artisanale'"
+    entreprise . activités . service ou vente: "'service'"
+  - dirigeant . auto-entrepreneur . revenu net: 20000 €/an
+    entreprise . date de création: période . début d'année
+    dirigeant . exonérations . ACRE: oui
+    entreprise . activité . nature: "'commerciale'"
+    entreprise . activités . service ou vente: "'service'"
+  - dirigeant . auto-entrepreneur . revenu net: 20000 €/an
+    entreprise . date de création: période . début d'année
+    dirigeant . exonérations . ACRE: oui
+    entreprise . activité . nature: "'commerciale'"
+    entreprise . activités . service ou vente: "'service'"
   - dirigeant . auto-entrepreneur . revenu net: 30000 €/an
     entreprise . date de création: 01/06/2024
     dirigeant . exonérations . ACRE: oui


### PR DESCRIPTION
Corrige [#3054 [Auto-entrepreneur] Bug à corriger: ACRE indisponible pour activité commerciale ou artisanale de services, même pour entreprise de moins de 1 ans](https://github.com/betagouv/mon-entreprise/issues/3054)