### PR TITLE
fix(auto-entrepreneur): Corrige le nombre de points acquis pour la retraite complémentaire des auto-entrepreneurs

### DIFF
--- a/modele-social/règles/protection-sociale.publicodes
+++ b/modele-social/règles/protection-sociale.publicodes
@@ -259,6 +259,7 @@ protection sociale . retraite . complémentaire . RCI:
         références à:
           dirigeant . indépendant . cotisations et contributions . retraite complémentaire
         dans: points acquis
+      unité: €/an
       valeur: dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . répartition . retraite complémentaire
       références:
         Décret n° 2024-484 du 30 mai 2024 modifiant les taux globaux de cotisations et contributions de certains travailleurs indépendants exerçant dans le cadre de la microentreprise: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000049620955

--- a/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
+++ b/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
@@ -20,7 +20,7 @@ protection sociale . maladie . maternité paternité adoption: 64
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption: 1932
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel: 3864
 protection sociale . retraite . base: 725
-protection sociale . retraite . complémentaire: 27
+protection sociale . retraite . complémentaire: 33
 protection sociale . retraite . trimestres: 4
 
 Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . taux ACRE . notification calcul ACRE annuel, entreprise . TVA . franchise de TVA . notification"
@@ -124,7 +124,7 @@ protection sociale . maladie . maternité paternité adoption: 6
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption: 193
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel: 386
 protection sociale . retraite . base: 24
-protection sociale . retraite . complémentaire: 0
+protection sociale . retraite . complémentaire: 2
 protection sociale . retraite . trimestres: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -202,7 +202,7 @@ protection sociale . maladie . maternité paternité adoption: 64
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption: 1932
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel: 3864
 protection sociale . retraite . base: 725
-protection sociale . retraite . complémentaire: 66
+protection sociale . retraite . complémentaire: 65
 protection sociale . retraite . trimestres: 4
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -280,7 +280,7 @@ protection sociale . maladie . maternité paternité adoption: 64
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption: 1932
 protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel: 3864
 protection sociale . retraite . base: 1650
-protection sociale . retraite . complémentaire: 53
+protection sociale . retraite . complémentaire: 58
 protection sociale . retraite . trimestres: 4"
 `;
 


### PR DESCRIPTION
Corrige [#3103 [Auto-entrepreneur] Le nombre de points de retraite complémentaire correspond à un mois (et non à un an)](https://github.com/betagouv/mon-entreprise/issues/3103)