### PR TITLE
feat(choix-statut): Inclue l'EURL dans le choix de statut sans associé

### DIFF
--- a/site/source/pages/assistants/choix-du-statut/associé.tsx
+++ b/site/source/pages/assistants/choix-du-statut/associé.tsx
@@ -246,10 +246,6 @@ function useAssociésSelection(): [
 					newState.question2 === 'oui' || newState.question3 === 'oui'
 						? 'non'
 						: undefined,
-				'entreprise . catégorie juridique . SARL . EURL':
-					newState.question2 === 'non' && newState.question3 === 'non'
-						? 'non'
-						: undefined,
 			})
 		)
 	}

--- a/site/source/pages/assistants/choix-du-statut/comparateur.tsx
+++ b/site/source/pages/assistants/choix-du-statut/comparateur.tsx
@@ -107,7 +107,7 @@ function useStatutComparaison(): EngineComparison {
 	return namedEngines
 }
 
-const SASUEIAE: StatutType[] = ['SASU', 'EI', 'AE']
+const SASUEIAE: StatutType[] = ['SASU', 'EURL', 'EI', 'AE']
 const SASUEURL: StatutType[] = ['SASU', 'EURL']
 const SASSARL: StatutType[] = ['SAS', 'SARL']
 function usePossibleStatuts(): Array<StatutType> {


### PR DESCRIPTION
Corrige [#2930 [Choix du statut] EURL écartée abusivement dans un cas de figure](https://github.com/betagouv/mon-entreprise/issues/2930)