### PR TITLE
fix: corrige la taille de la barre de progression des simulateurs

### DIFF
--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -32,7 +32,7 @@ export function Questions({
 
 	return (
 		<>
-			<Progress progress={numberCurrentStep} maxValue={numberSteps} />
+			<Progress progress={numberCurrentStep} maxValue={numberSteps + 1} />
 			<QuestionsContainer>
 				<div className="print-hidden">
 					{numberCurrentStep < numberSteps && (


### PR DESCRIPTION
Corrige #3118 [Simulateurs] La barre de progression déborde