### PR TITLE
Correction d'un bug causant l'inférence de l'unité €/an au lieu de €/mois

### DIFF
--- a/modele-social/règles/salarié/rémunération.publicodes
+++ b/modele-social/règles/salarié/rémunération.publicodes
@@ -879,7 +879,8 @@ salarié . rémunération . montant net social:
     - frais professionnels
   abattement:
       somme:
-        - frais professionnels . déductible
+        - valeur: frais professionnels . déductible
+          unité: €/mois
         - activité partielle . retrait absence
         - salarié . cotisations . salarié
   références :


### PR DESCRIPTION
# Current Behavior
Lors du calcul de la règle [`salarié . rémunération . montant net social`](https://github.com/betagouv/mon-entreprise/blob/57e72f27d74b98215cf157512ab382929f9be931/modele-social/r%C3%A8gles/salari%C3%A9/r%C3%A9mun%C3%A9ration.publicodes#L860), l'unité de l'abattement est inférée en `€/an` à cause de la règle [`frais professionnels . déductible`](https://github.com/betagouv/mon-entreprise/blob/57e72f27d74b98215cf157512ab382929f9be931/modele-social/r%C3%A8gles/salari%C3%A9/r%C3%A9mun%C3%A9ration.publicodes#L882) alors que l'unité devrait être inférée en `€/mois`.
L'abattement est donc 12 fois inférieur à ce qu'il devrait être.

# Expected Behavior
L'unité de l'abattement doit être inférée en `€/mois`

En forçant l'unité en `€/mois` dans le calcul de l'abattement, la bonne unité est alors inférée.
Est-ce que ce dysfonctionnement est le résultat d'un bug dans l'inférence d'unité de `publicodes` ?