### PR TITLE
[Indépendants] Correction de l'assiette plancher pour la cotisation "Invalidité et Décès"

### DIFF
--- a/modele-social/règles/dirigeant/indépendant.publicodes
+++ b/modele-social/règles/dirigeant/indépendant.publicodes
@@ -134,6 +134,19 @@ dirigeant . indépendant . assiette minimale . maladie:
   références:
     cotisations minimales: https://www.secu-independants.fr/cotisations/calcul-cotisations/cotisations-minimales/
 
+dirigeant . indépendant . assiette minimale . invalidité et décès:
+  description: |
+    Si le revenu du chef d'entreprise est déficitaire ou inférieur aux bases de calcul, certaines cotisations seront portées à un montant minimum.
+  produit:
+    - plafond sécurité sociale
+    - 11.5%
+  unité: €/an
+  arrondi: oui
+  références:
+    cotisations minimales: https://www.secu-independants.fr/cotisations/calcul-cotisations/cotisations-minimales/
+    Article L632-1 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037951125
+    Article D632-1 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041966755
+
 dirigeant . indépendant . assiette minimale . retraite:
   description: La cotisation minimale de retraite de base permet de valider 3
     trimestres de retraite, quel que soit le revenu.
@@ -609,12 +622,15 @@ dirigeant . indépendant . cotisations et contributions . invalidité et décès
   références:
     Cotisation minimale: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
     Liste des cotisations: https://www.urssaf.fr/portail/home/artisan-commercant/comment-sont-calculees-les-cotis/liste-des-cotisations.html
+    Article L632-1 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037951125
+    Article D632-1 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041966755
+    Article D632-2 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036471466
 
   avec:
     assiette:
       experimental: oui
       valeur: assiette des cotisations
-      plancher: assiette minimale . retraite
+      plancher: assiette minimale . invalidité et décès
       plafond: plafond sécurité sociale
 
 dirigeant . indépendant . cotisations et contributions . CSG-CRDS:

--- a/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
+++ b/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
@@ -131,8 +131,8 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 `;
 
 exports[`calculate comparateur-statuts > bas revenus 2`] = `
-"dirigeant . rémunération . net: 577
-dirigeant . rémunération . net . après impôt: 577
+"dirigeant . rémunération . net: 576
+dirigeant . rémunération . net . après impôt: 576
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null

--- a/site/test/regressions/__snapshots__/indépendant.test.ts.snap
+++ b/site/test/regressions/__snapshots__/indépendant.test.ts.snap
@@ -277,12 +277,12 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 exports[`calculate simulations-indépendant > cotisations minimales 1`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
 dirigeant . indépendant . revenu professionnel: 136
-dirigeant . rémunération . cotisations: 1338
+dirigeant . rémunération . cotisations: 1339
 dirigeant . rémunération . net: 100
 dirigeant . rémunération . net . après impôt: 100
-dirigeant . rémunération . totale: 1438
+dirigeant . rémunération . totale: 1439
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 1438
+entreprise . chiffre d'affaires: 1439
 impôt . montant: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -430,10 +430,10 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 
 exports[`calculate simulations-indépendant > inversions 1`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
-dirigeant . indépendant . revenu professionnel: 628
-dirigeant . rémunération . cotisations: 1423
-dirigeant . rémunération . net: 577
-dirigeant . rémunération . net . après impôt: 577
+dirigeant . indépendant . revenu professionnel: 627
+dirigeant . rémunération . cotisations: 1424
+dirigeant . rémunération . net: 576
+dirigeant . rémunération . net . après impôt: 576
 dirigeant . rémunération . totale: 2000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 2000
@@ -529,12 +529,12 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 exports[`calculate simulations-indépendant > échelle de revenus 1`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
 dirigeant . indépendant . revenu professionnel: 549
-dirigeant . rémunération . cotisations: 1409
+dirigeant . rémunération . cotisations: 1410
 dirigeant . rémunération . net: 500
 dirigeant . rémunération . net . après impôt: 500
-dirigeant . rémunération . totale: 1909
+dirigeant . rémunération . totale: 1910
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 1909
+entreprise . chiffre d'affaires: 1910
 impôt . montant: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -543,12 +543,12 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 exports[`calculate simulations-indépendant > échelle de revenus 2`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
 dirigeant . indépendant . revenu professionnel: 1065
-dirigeant . rémunération . cotisations: 1500
+dirigeant . rémunération . cotisations: 1501
 dirigeant . rémunération . net: 1000
 dirigeant . rémunération . net . après impôt: 1000
-dirigeant . rémunération . totale: 2500
+dirigeant . rémunération . totale: 2501
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 2500
+entreprise . chiffre d'affaires: 2501
 impôt . montant: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -557,12 +557,12 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 exports[`calculate simulations-indépendant > échelle de revenus 3`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
 dirigeant . indépendant . revenu professionnel: 1581
-dirigeant . rémunération . cotisations: 1589
+dirigeant . rémunération . cotisations: 1590
 dirigeant . rémunération . net: 1500
 dirigeant . rémunération . net . après impôt: 1500
-dirigeant . rémunération . totale: 3089
+dirigeant . rémunération . totale: 3090
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 3089
+entreprise . chiffre d'affaires: 3090
 impôt . montant: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -571,12 +571,12 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 exports[`calculate simulations-indépendant > échelle de revenus 4`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
 dirigeant . indépendant . revenu professionnel: 2097
-dirigeant . rémunération . cotisations: 1679
+dirigeant . rémunération . cotisations: 1680
 dirigeant . rémunération . net: 2000
 dirigeant . rémunération . net . après impôt: 2000
-dirigeant . rémunération . totale: 3679
+dirigeant . rémunération . totale: 3680
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 3679
+entreprise . chiffre d'affaires: 3680
 impôt . montant: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"
@@ -585,12 +585,12 @@ Notifications affichées : entreprise . TVA . franchise de TVA . notification"
 exports[`calculate simulations-indépendant > échelle de revenus 5`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
 dirigeant . indépendant . revenu professionnel: 5193
-dirigeant . rémunération . cotisations: 2217
+dirigeant . rémunération . cotisations: 2218
 dirigeant . rémunération . net: 5000
 dirigeant . rémunération . net . après impôt: 5000
-dirigeant . rémunération . totale: 7217
+dirigeant . rémunération . totale: 7218
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 7217
+entreprise . chiffre d'affaires: 7218
 impôt . montant: 0
 
 Notifications affichées : entreprise . TVA . franchise de TVA . notification"


### PR DESCRIPTION
Ceci corrige la coquille indiquée en #3259

Selon l'article [D632-1](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036471466) du Code de la sécurité sociale, pour les indépendants, l'assiette plancher pour le calcul de la cotisation « Invalidité et Décès », contrairement à ce qui est implémenté, n'est pas la même que pour la retraite de base (450 x SMIC horaire), mais bien 11,5% du Plafond Annuel de la Sécurité Sociale (PASS) comme cela était le cas pour la retraite avant 2023.

Close #3259 