### PR TITLE
Prestations maternité : ajustement durée affiliation

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -239,7 +239,7 @@ Pour un décès survenu dans le cadre d’un <2>accident professionnel</2>, le c
 Pour une invalidité causée par un <2>accident professionnel</2>, vous pouvez bénéficier d’une <4>rente d’incapacité</4>.:
   If you are disabled as a result of an <2>accident at work</2>, you may be
   entitled to a <4>disability pension</4>.
-Pour y prétendre, vous devez avoir cotisé <2>au moins 10 mois</2>.: To qualify, you must have paid contributions for <2>at least 10 months</2>.
+Pour y prétendre, vous devez avoir cotisé <2>au moins 6 mois</2>.: To qualify, you must have paid contributions for <2>at least 6 months</2>.
 Pour y prétendre, vous devez avoir cotisé au moins <2><0></0></2>: To qualify, you must have contributed at least <2><0></0></2>
 Pour y prétendre, vous devez respecter <2>certaines règles<1></1></2>.: To qualify, you must comply with <2>certain rules<1></1></2>.
 Pourcentage: Percentage

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -253,7 +253,7 @@ Pour un décès survenu dans le cadre d’un <2>accident professionnel</2>, le c
 Pour une invalidité causée par un <2>accident professionnel</2>, vous pouvez bénéficier d’une <4>rente d’incapacité</4>.:
   Pour une invalidité causée par un <2>accident professionnel</2>, vous pouvez
   bénéficier d’une <4>rente d’incapacité</4>.
-Pour y prétendre, vous devez avoir cotisé <2>au moins 10 mois</2>.: Pour y prétendre, vous devez avoir cotisé <2>au moins 10 mois</2>.
+Pour y prétendre, vous devez avoir cotisé <2>au moins 6 mois</2>.: Pour y prétendre, vous devez avoir cotisé <2>au moins 6 mois</2>.
 Pour y prétendre, vous devez avoir cotisé au moins <2><0></0></2>: Pour y prétendre, vous devez avoir cotisé au moins <2><0></0></2>
 Pour y prétendre, vous devez respecter <2>certaines règles<1></1></2>.: Pour y prétendre, vous devez respecter <2>certaines règles<1></1></2>.
 Pourcentage: Pourcentage

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -375,7 +375,7 @@ const Détails = ({
 					>
 						<Trans>
 							Pour y prétendre, vous devez avoir cotisé{' '}
-							<Strong>au moins 10 mois</Strong>.
+							<Strong>au moins 6 mois</Strong>.
 						</Trans>
 					</Body>
 


### PR DESCRIPTION
La durée requise d'affiliation est de 6 mois et non de 10 mois.

Base juridique : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047983306
Décret modifiant la durée : https://www.legifrance.gouv.fr/loda/id/LEGIARTI000047981710