### PR TITLE
feat(salarié): taux AGS exposé + exonérations heures supplémentaires non applicables

### DIFF
--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Journal des modifications
 ## next
+### Nouveautés
+- Ajout du taux AGS
+
 ### Corrections
 - Mise à jour des valeurs de la Retraite Complémentaire des Indépendants
 - Mise à jour des valeurs Agirc-Arrco

--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Corrections
 - Mise à jour des valeurs de la Retraite Complémentaire des Indépendants
 - Mise à jour des valeurs Agirc-Arrco
+- Mise à jour des conditions de non applicabilité des exonérations des heures supplémentaires
 
 ## 4.0.0
 ### Breaking changes

--- a/modele-social/règles/salarié/cotisations.publicodes
+++ b/modele-social/règles/salarié/cotisations.publicodes
@@ -105,7 +105,10 @@ salarié . cotisations . exonérations . heures supplémentaires:
 
   avec:
     employeur:
-      applicable si: entreprise . salariés . effectif < 250
+      applicable si:
+        toutes ces conditions:
+          - entreprise . salariés . effectif < 250
+          - temps de travail . heures supplémentaires > 0
       titre: déduction forfaitaire pour heures supplémentaires
       produit:
         - temps de travail . heures supplémentaires
@@ -120,7 +123,10 @@ salarié . cotisations . exonérations . heures supplémentaires:
         La déduction forfaitaire patronale pour heures supplémentaires: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-deduction-forfaitaire-patrona/employeurs-concernes.html
 
     salarié:
-      non applicable si: assiette = 0
+      non applicable si:
+        une de ces conditions:
+          - assiette = 0
+          - rémunération . heures supplémentaires = 0
       titre: réduction de cotisations heures supplémentaires
       produit:
         - rémunération . heures supplémentaires

--- a/modele-social/règles/salarié/cotisations.publicodes
+++ b/modele-social/règles/salarié/cotisations.publicodes
@@ -636,7 +636,11 @@ salarié . cotisations . AGS:
   produit:
     - valeur: cotisations . assiette
       plafond: 4 * temps de travail . plafond sécurité sociale
-    - variations:
+    - taux
+
+  avec:
+    taux:
+      variations:
         - si: date >= 07/2024
           alors: 0.25%
         - si: date >= 01/2024


### PR DESCRIPTION
Nous avons ajouté depuis longtemps une sous-règle pour le taux AGS dans nos propres règles, ça nous serait très utile qu'il soit nativement exposé dans modèle-social :) je ne pense pas que ça alourdisse la maintenance.
Sur l'exonération des heures supplémentaires, les conditions d'applicabilité étaient incomplètes, si bien qu'en cas de situation sans aucune heure supp ces 2 règles renvoyaient 0 notamment en cas d'effectif < 250 pour la part employeur.