### PR TITLE
feat(salarié): taux AGS exposé + exonérations heures supplémentaires non applicables

### DIFF
--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Ajout de la date du 1er janvier de l'année précédente (période . début d'année . N-1)
 - Ajout du SMIC horaire au 1er janvier de l'année précédente (SMIC . horaire . début d'année N-1)
 - Ajout des classes de cotisation à la retraite complémentaire de la CNBF
+- Ajout du taux AGS
 
 ### Mises à jour
 - Mise à jour de la date au 1er janvier 2025

--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Montant déductible sur les titres-restaurant en 2025
 - Évaluation forfaitaire de l'avantage en nature repas en 2025
 - Part déductible de la participation employeur aux frais de transports en commun en 2025
+- Correction des conditions de non applicabilité des exonérations des heures supplémentaires
 
 ### Corrections
 - Correction de l'opérateur de comparaison de dates

--- a/modele-social/règles/salarié/cotisations.publicodes
+++ b/modele-social/règles/salarié/cotisations.publicodes
@@ -105,7 +105,10 @@ salarié . cotisations . exonérations . heures supplémentaires:
 
   avec:
     employeur:
-      applicable si: entreprise . salariés . effectif < 250
+      applicable si:
+        toutes ces conditions:
+          - entreprise . salariés . effectif < 250
+          - temps de travail . heures supplémentaires > 0
       titre: déduction forfaitaire pour heures supplémentaires
       produit:
         - temps de travail . heures supplémentaires
@@ -120,7 +123,10 @@ salarié . cotisations . exonérations . heures supplémentaires:
         La déduction forfaitaire patronale pour heures supplémentaires: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-deduction-forfaitaire-patrona/employeurs-concernes.html
 
     salarié:
-      non applicable si: assiette = 0
+      non applicable si:
+        une de ces conditions:
+          - assiette = 0
+          - rémunération . heures supplémentaires = 0
       titre: réduction de cotisations heures supplémentaires
       produit:
         - rémunération . heures supplémentaires

--- a/modele-social/règles/salarié/cotisations.publicodes
+++ b/modele-social/règles/salarié/cotisations.publicodes
@@ -636,7 +636,11 @@ salarié . cotisations . AGS:
   produit:
     - valeur: cotisations . assiette
       plafond: 4 * temps de travail . plafond sécurité sociale
-    - variations:
+    - taux
+
+  avec:
+    taux:
+      variations:
         - si: date >= 07/2024
           alors: 0.25%
         - si: date >= 01/2024

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -8957,6 +8957,10 @@ salarié . cotisations:
   titre.en: '[automatic] contributions'
   titre.fr: cotisations
 salarié . cotisations . AGS:
+  avec:
+    taux:
+      titre.en: '[automatic] rate'
+      titre.fr: taux
   description.en: '[automatic] This contribution guarantees the salaries of the
     employees in case of difficulties of the company (safeguard, recovery,
     liquidation). It pays salaries for the last 60 days of work. It allows the


### PR DESCRIPTION
Remplace https://github.com/betagouv/mon-entreprise/pull/3283 créée par @fmata 

> Nous avons ajouté depuis longtemps une sous-règle pour le taux AGS dans nos propres règles, ça nous serait très utile qu'il soit nativement exposé dans modèle-social :) je ne pense pas que ça alourdisse la maintenance.
> Sur l'exonération des heures supplémentaires, les conditions d'applicabilité étaient incomplètes, si bien qu'en cas de situation sans aucune heure supp ces 2 règles renvoyaient 0 notamment en cas d'effectif < 250 pour la part employeur.