### PR TITLE
Chore: fix PR cleanup workflow for forks

### DIFF
--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -13,6 +13,7 @@ jobs:
         run: echo "name=${{ github.event.number || '${GITHUB_REF#refs/*/}' }}" >> $GITHUB_OUTPUT
 
   algolia-rm-temp-index:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: deploy-context
     runs-on: ubuntu-22.04
     steps:
@@ -26,7 +27,7 @@ jobs:
           CRISP_API_IDENTIFIER: ${{ secrets.CRISP_API_IDENTIFIER }}
           CRISP_API_KEY: ${{ secrets.CRISP_API_KEY }}
           CRISP_WEBSITE_ID: ${{ secrets.CRISP_WEBSITE_ID }}
-      - name: Remove temporary algolia index
+      - name: Remove temporary Algolia index
         run: yarn workspace site algolia:clean
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}


### PR DESCRIPTION
L'action `algolia-rm-temp-index` de `pr-cleanup` échoue pour les PR de forks.
Cela parce que ces PR n'ont pas accès aux secrets nécessaires pour se connecter à Algolia.
De plus cette action est inutile pour les forks car l'index n'a pas été modifié puisque l'action `build` qui le fait n'a pas tourné non plus.