### PR TITLE
fix(économie-collaborative): les logements classés ne sont pas encore pris en compte

### DIFF
--- a/modele-social/règles/économie-collaborative/location-de-meublé/courte-durée.publicodes
+++ b/modele-social/règles/économie-collaborative/location-de-meublé/courte-durée.publicodes
@@ -2,7 +2,7 @@ location de logement meublé . courte durée:
   avec:
 
     recettes:
-      résumé: Recettes pour un logement meublé de courte durée ou de tourisme classé de courte durée
+      résumé: Recettes pour un logement meublé de courte durée
       unité: €/an
 
     cotisations:

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -7164,10 +7164,8 @@ location de logement meublé . courte durée:
         accommodation'
       titre.fr: Cotisations dues pour la location d’un logement meublé de courte durée
     recettes:
-      résumé.en: '[automatic] Receipts for short-term furnished accommodation or
-        short-term classified tourist accommodation'
-      résumé.fr: Recettes pour un logement meublé de courte durée ou de tourisme
-        classé de courte durée
+      résumé.en: '[automatic] Revenue for short-term furnished accommodation'
+      résumé.fr: Recettes pour un logement meublé de courte durée
       titre.en: '[automatic] revenues'
       titre.fr: recettes
   titre.en: '[automatic] short term'


### PR DESCRIPTION
Supprime la mention des logements de tourisme, qui ne sont pas encore pris en compte par le simulateur.