### PR TITLE
Correction et refacto de l'affichage des questions

### DIFF
--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-ir.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-ir.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('profession-liberale', true)
+runSimulateurTest('eirl', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-ir.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-ir.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('eirl', true)
+runSimulateurTest('eirl', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-is.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-is.js
@@ -1,5 +1,5 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('eirl', false, () =>
-	cy.contains('Impôt sur les sociétés').click()
-)
+runSimulateurTest('eirl', {
+	beforeAction: () => cy.contains('Impôt sur les sociétés').click(),
+})

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-is.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eirl-is.js
@@ -1,0 +1,5 @@
+import { runSimulateurTest } from '../../../support/simulateur'
+
+runSimulateurTest('eirl', false, () =>
+	cy.contains('Impôt sur les sociétés').click()
+)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/entreprise-individuelle.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/entreprise-individuelle.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('entreprise-individuelle', true)
+runSimulateurTest('entreprise-individuelle', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/entreprise-individuelle.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/entreprise-individuelle.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('profession-liberale', true)
+runSimulateurTest('entreprise-individuelle', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eurl-ir.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eurl-ir.js
@@ -1,5 +1,6 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('eurl', true, () =>
-	cy.contains('Impôt sur le revenu').click()
-)
+runSimulateurTest('eurl', {
+	avecCharges: true,
+	beforeAction: () => cy.contains('Impôt sur le revenu').click(),
+})

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eurl-ir.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eurl-ir.js
@@ -1,0 +1,5 @@
+import { runSimulateurTest } from '../../../support/simulateur'
+
+runSimulateurTest('eurl', true, () =>
+	cy.contains('Impôt sur le revenu').click()
+)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/eurl-is.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/eurl-is.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('profession-liberale', true)
+runSimulateurTest('eurl')

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/indépendant.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/indépendant.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('indépendant', true)
+runSimulateurTest('indépendant', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/indépendant.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/indépendant.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('indépendant')
+runSimulateurTest('indépendant', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../support/simulateur'
 
-runSimulateurTest('profession-liberale', true)
+runSimulateurTest('profession-liberale', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/auxiliaire-medical.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/auxiliaire-medical.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/auxiliaire-medical')
+runSimulateurTest('profession-liberale/auxiliaire-medical', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/auxiliaire-medical.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/auxiliaire-medical.js
@@ -1,3 +1,5 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/auxiliaire-medical', true)
+runSimulateurTest('profession-liberale/auxiliaire-medical', {
+	avecCharges: true,
+})

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/avocat.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/avocat.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/medecin', true)
+runSimulateurTest('profession-liberale/avocat', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/avocat.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/avocat.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/avocat', true)
+runSimulateurTest('profession-liberale/avocat', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/chirurgien-dentiste.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/chirurgien-dentiste.js
@@ -1,3 +1,5 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/chirurgien-dentiste', true)
+runSimulateurTest('profession-liberale/chirurgien-dentiste', {
+	avecCharges: true,
+})

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/chirurgien-dentiste.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/chirurgien-dentiste.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/chirurgien-dentiste')
+runSimulateurTest('profession-liberale/chirurgien-dentiste', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/expert-comptable.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/expert-comptable.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/medecin', true)
+runSimulateurTest('profession-liberale/expert-comptable', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/expert-comptable.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/expert-comptable.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/expert-comptable', true)
+runSimulateurTest('profession-liberale/expert-comptable', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/medecin.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/medecin.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/medecin', true)
+runSimulateurTest('profession-liberale/medecin', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/pharmacien.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/pharmacien.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/medecin', true)
+runSimulateurTest('profession-liberale/pharmacien', true)

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/pharmacien.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/pharmacien.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/pharmacien', true)
+runSimulateurTest('profession-liberale/pharmacien', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/sage-femme.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/sage-femme.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/sage-femme', true)
+runSimulateurTest('profession-liberale/sage-femme', { avecCharges: true })

--- a/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/sage-femme.js
+++ b/site/cypress/integration/mon-entreprise/simulateurs-generic/profession-liberale/sage-femme.js
@@ -1,3 +1,3 @@
 import { runSimulateurTest } from '../../../../support/simulateur'
 
-runSimulateurTest('profession-liberale/sage-femme')
+runSimulateurTest('profession-liberale/sage-femme', true)

--- a/site/cypress/support/simulateur.ts
+++ b/site/cypress/support/simulateur.ts
@@ -7,6 +7,9 @@ const lang = Cypress.env('language') as 'fr' | 'en'
 
 type Simulateur =
 	| 'auto-entrepreneur'
+	| 'eirl'
+	| 'eurl'
+	| 'entreprise-individuelle'
 	| 'salaire-brut-net'
 	| 'salary'
 	| 'sasu'
@@ -16,6 +19,9 @@ type Simulateur =
 	| 'profession-liberale/chirurgien-dentiste'
 	| 'profession-liberale/médecin'
 	| 'profession-liberale/sage-femme'
+	| 'profession-liberale/pharmacien'
+	| 'profession-liberale/avocat'
+	| 'profession-liberale/expert-comptable'
 
 const variableNames = {
 	url: {
@@ -44,13 +50,18 @@ const variableNames = {
 	},
 }
 
-export const runSimulateurTest = (simulateur: Simulateur) => {
+export const runSimulateurTest = (
+	simulateur: Simulateur,
+	avecCharges = false,
+	beforeAction = () => {}
+) => {
 	describe(
 		`Le simulateur ${simulateur}`,
 		{ testIsolation: false },
 		function () {
 			before(function () {
 				cy.visit(encodeURI(`/${variableNames.url[lang]}/${simulateur}`))
+				beforeAction?.()
 			})
 
 			it("devrait s'afficher", function () {
@@ -67,7 +78,7 @@ export const runSimulateurTest = (simulateur: Simulateur) => {
 
 			it('devrait afficher un résultat pour chaque champ rempli', function () {
 				cy.contains(variableNames.yearTab[lang]).click()
-				if (['indépendant', 'profession-liberale'].includes(simulateur)) {
+				if (avecCharges) {
 					cy.get(chargeInputSelector).type('{selectall}1000')
 				}
 				cy.get(inputSelector).each(($testedInput) => {
@@ -91,7 +102,7 @@ export const runSimulateurTest = (simulateur: Simulateur) => {
 			it("devrait permettre de changer d'échelle temporelle", function () {
 				cy.contains(variableNames.yearTab[lang]).click()
 				cy.get(inputSelector).first().type('{selectall}12000')
-				if (['indépendant', 'profession-liberale'].includes(simulateur)) {
+				if (avecCharges) {
 					cy.get(chargeInputSelector).type('{selectall}6000')
 				}
 

--- a/site/cypress/support/simulateur.ts
+++ b/site/cypress/support/simulateur.ts
@@ -50,11 +50,17 @@ const variableNames = {
 	},
 }
 
+type Options = {
+	avecCharges?: boolean
+	beforeAction?: () => void
+}
+
 export const runSimulateurTest = (
 	simulateur: Simulateur,
-	avecCharges = false,
-	beforeAction = () => {}
+	options: Options = {}
 ) => {
+	const { avecCharges = false, beforeAction = () => {} } = options
+
 	describe(
 		`Le simulateur ${simulateur}`,
 		{ testIsolation: false },

--- a/site/source/components/GuichetInfo.tsx
+++ b/site/source/components/GuichetInfo.tsx
@@ -54,7 +54,7 @@ export default function GuichetInfo({ codeApe }: { codeApe: string }) {
 	}
 
 	return (
-		<Ul noMarker>
+		<Ul $noMarker>
 			{guichetEntries.map((guichetEntry) => {
 				return (
 					<Li key={guichetEntry.code}>

--- a/site/source/components/Simulation/Banner.tsx
+++ b/site/source/components/Simulation/Banner.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
 
 import { Message } from '@/design-system'
 import { Emoji } from '@/design-system/emoji'
 import { SmallBody } from '@/design-system/typography/paragraphs'
-import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
 
 import { FadeIn } from '../ui/animate'
 
@@ -18,14 +16,9 @@ type BannerProps = {
 
 export default function SimulationBanner({
 	children,
-	hidden: hiddenProp = false,
-	hideAfterFirstStep = true,
+	hidden = false,
 	icon,
 }: BannerProps) {
-	const hiddenState = useSelector(firstStepCompletedSelector)
-
-	const hidden = hiddenProp || (hideAfterFirstStep && hiddenState)
-
 	return !hidden ? (
 		<FadeIn>
 			<Message

--- a/site/source/components/Simulation/Banner.tsx
+++ b/site/source/components/Simulation/Banner.tsx
@@ -6,7 +6,7 @@ import { Emoji } from '@/design-system/emoji'
 import { SmallBody } from '@/design-system/typography/paragraphs'
 import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
 
-import { FadeIn } from './ui/animate'
+import { FadeIn } from '../ui/animate'
 
 type BannerProps = {
 	children: React.ReactNode
@@ -16,7 +16,7 @@ type BannerProps = {
 	className?: string
 }
 
-export default function Banner({
+export default function SimulationBanner({
 	children,
 	hidden: hiddenProp = false,
 	hideAfterFirstStep = true,

--- a/site/source/components/Simulation/PreviousSimulationBanner.tsx
+++ b/site/source/components/Simulation/PreviousSimulationBanner.tsx
@@ -4,24 +4,19 @@ import { useDispatch, useSelector } from 'react-redux'
 import SimulationBanner from '@/components/Simulation/Banner'
 import { Link } from '@/design-system/typography/link'
 import { loadPreviousSimulation } from '@/store/actions/actions'
-import { RootState } from '@/store/reducers/rootReducer'
-import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
+import { previousSimulationSelector } from '@/store/selectors/simulationSelectors'
 
 export default function PreviousSimulationBanner() {
-	const previousSimulation = useSelector(
-		(state: RootState) => state.previousSimulation
-	)
-	const newSimulationStarted = useSelector(firstStepCompletedSelector)
+	const previousSimulation = useSelector(previousSimulationSelector)
 	const dispatch = useDispatch()
-
 	const { t } = useTranslation()
 
+	if (!previousSimulation) {
+		return null
+	}
+
 	return (
-		<SimulationBanner
-			className="print-hidden"
-			hidden={!previousSimulation || newSimulationStarted}
-			icon="💾"
-		>
+		<SimulationBanner className="print-hidden" icon="💾">
 			<Trans i18nKey="previousSimulationBanner.info">
 				Votre précédente simulation a été sauvegardée :
 			</Trans>{' '}

--- a/site/source/components/Simulation/PreviousSimulationBanner.tsx
+++ b/site/source/components/Simulation/PreviousSimulationBanner.tsx
@@ -1,12 +1,11 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
+import SimulationBanner from '@/components/Simulation/Banner'
 import { Link } from '@/design-system/typography/link'
 import { loadPreviousSimulation } from '@/store/actions/actions'
 import { RootState } from '@/store/reducers/rootReducer'
 import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
-
-import Banner from './Banner'
 
 export default function PreviousSimulationBanner() {
 	const previousSimulation = useSelector(
@@ -18,7 +17,7 @@ export default function PreviousSimulationBanner() {
 	const { t } = useTranslation()
 
 	return (
-		<Banner
+		<SimulationBanner
 			className="print-hidden"
 			hidden={!previousSimulation || newSimulationStarted}
 			icon="💾"
@@ -37,6 +36,6 @@ export default function PreviousSimulationBanner() {
 					Retrouver ma précédente simulation
 				</Trans>
 			</Link>
-		</Banner>
+		</SimulationBanner>
 	)
 }

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -71,11 +71,12 @@ export const SimulationGoalsContainer = styled.div<{
 	z-index: 2;
 	position: relative;
 	padding: ${({ theme }) => `${theme.spacings.sm} ${theme.spacings.lg}`};
-	border-start-end-radius: ${({ theme, $isEmbeded }) =>
-		$isEmbeded ? theme.box.borderRadius : '0'};
-	border-end-start-radius: 0;
-	border-end-end-radius: 0;
-	border-start-start-radius: ${({ theme }) => theme.box.borderRadius};
+	border-radius: ${({ theme }) => theme.box.borderRadius};
+	${({ $isEmbeded }) =>
+		!$isEmbeded &&
+		css`
+			border-top-right-radius: 0;
+		`}
 	${({ $isFirstStepCompleted }) =>
 		$isFirstStepCompleted &&
 		css`

--- a/site/source/components/Simulation/SimulationPréremplieBanner.tsx
+++ b/site/source/components/Simulation/SimulationPréremplieBanner.tsx
@@ -2,13 +2,13 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { styled } from 'styled-components'
 
+import SimulationBanner from '@/components/Simulation/Banner'
 import { PopoverWithTrigger } from '@/design-system'
 import { Link } from '@/design-system/typography/link'
 import { companySituationSelector } from '@/store/selectors/simulationSelectors'
 
-import Banner from './Banner'
-import AnswerList from './conversation/AnswerList'
-import WrongSimulateurWarning from './WrongSimulateurWarning'
+import AnswerList from '../conversation/AnswerList'
+import WrongSimulateurWarning from '../WrongSimulateurWarning'
 
 export default function SimulationPréremplieBanner() {
 	const existingCompany = !!useSelector(companySituationSelector)[
@@ -22,7 +22,7 @@ export default function SimulationPréremplieBanner() {
 	}
 
 	return (
-		<Banner icon="✏">
+		<SimulationBanner icon="✏">
 			<Trans i18nKey="simulationPréremplieBanner.info">
 				Ce simulateur a été prérempli avec la situation de votre entreprise.
 			</Trans>{' '}
@@ -47,7 +47,7 @@ export default function SimulationPréremplieBanner() {
 			<WrongSimulateurWarningContainer>
 				<WrongSimulateurWarning />
 			</WrongSimulateurWarningContainer>
-		</Banner>
+		</SimulationBanner>
 	)
 }
 

--- a/site/source/components/Simulation/SimulationPréremplieBanner.tsx
+++ b/site/source/components/Simulation/SimulationPréremplieBanner.tsx
@@ -1,3 +1,4 @@
+import { difference } from 'effect/Array'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { styled } from 'styled-components'
@@ -5,19 +6,24 @@ import { styled } from 'styled-components'
 import SimulationBanner from '@/components/Simulation/Banner'
 import { PopoverWithTrigger } from '@/design-system'
 import { Link } from '@/design-system/typography/link'
-import { companySituationSelector } from '@/store/selectors/simulationSelectors'
+import {
+	companySituationSelector,
+	situationSelector,
+} from '@/store/selectors/simulationSelectors'
 
 import AnswerList from '../conversation/AnswerList'
 import WrongSimulateurWarning from '../WrongSimulateurWarning'
 
 export default function SimulationPréremplieBanner() {
-	const existingCompany = !!useSelector(companySituationSelector)[
-		'entreprise . SIREN'
-	]
+	const companySituation = useSelector(companySituationSelector)
+	const simulationSituation = useSelector(situationSelector)
+	const preexistingCompanySituation =
+		difference(Object.keys(companySituation), Object.keys(simulationSituation))
+			.length > 0
 
 	const { t } = useTranslation()
 
-	if (!existingCompany) {
+	if (!preexistingCompanySituation) {
 		return null
 	}
 

--- a/site/source/components/Simulation/YearSelectionBanner.tsx
+++ b/site/source/components/Simulation/YearSelectionBanner.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { styled } from 'styled-components'
@@ -32,7 +33,7 @@ export const YearSelectionBanner = () => {
 					.filter((year) => year !== currentEngineYear)
 					.reverse()
 					.map((year) => (
-						<span key={year}>
+						<React.Fragment key={year}>
 							<StyledLink
 								onPress={() =>
 									dispatch(enregistreLaRéponse('date', `01/01/${year}`))
@@ -48,7 +49,7 @@ export const YearSelectionBanner = () => {
 									</Trans>
 								)}
 							</StyledLink>
-						</span>
+						</React.Fragment>
 					))}
 			</>
 		</SimulationBanner>

--- a/site/source/components/Simulation/YearSelectionBanner.tsx
+++ b/site/source/components/Simulation/YearSelectionBanner.tsx
@@ -19,7 +19,7 @@ export const YearSelectionBanner = () => {
 	const currentEngineYear = useYear()
 
 	return (
-		<SimulationBanner hideAfterFirstStep={false} icon={'📅'}>
+		<SimulationBanner icon={'📅'}>
 			<Trans i18nKey="pages.simulateurs.select-year.info">
 				Cette simulation concerne l'année{' '}
 				<Bold $bold={currentEngineYear !== currentYear}>

--- a/site/source/components/Simulation/YearSelectionBanner.tsx
+++ b/site/source/components/Simulation/YearSelectionBanner.tsx
@@ -2,7 +2,7 @@ import { Trans } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { styled } from 'styled-components'
 
-import Banner from '@/components/Banner'
+import SimulationBanner from '@/components/Simulation/Banner'
 import { Link } from '@/design-system/typography/link'
 import useYear from '@/hooks/useYear'
 import { enregistreLaRéponse } from '@/store/actions/actions'
@@ -12,14 +12,14 @@ const Bold = styled.span<{ $bold: boolean }>`
 	${({ $bold }) => ($bold ? 'font-weight: bold;' : '')}
 `
 
-export const SelectSimulationYear = () => {
+export const YearSelectionBanner = () => {
 	const dispatch = useDispatch()
 	const currentYear = getCurrentYear()
 	const choices = getYearsBetween(2023, currentYear)
 	const currentEngineYear = useYear()
 
 	return (
-		<Banner hideAfterFirstStep={false} icon={'📅'}>
+		<SimulationBanner hideAfterFirstStep={false} icon={'📅'}>
 			<Trans i18nKey="pages.simulateurs.select-year.info">
 				Cette simulation concerne l'année{' '}
 				<Bold $bold={currentEngineYear !== currentYear}>
@@ -51,7 +51,7 @@ export const SelectSimulationYear = () => {
 						</span>
 					))}
 			</>
-		</Banner>
+		</SimulationBanner>
 	)
 }
 

--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -66,6 +66,7 @@ export default function Simulation({
 	const firstStepCompleted = useSelector(firstStepCompletedSelector)
 	const ilYADesQuestions = useSelector(ilYADesQuestionsSelector)
 	const shouldShowFeedback = getShouldAskFeedback(useLocation().pathname)
+	const showQuestions = showQuestionsFromBeginning || firstStepCompleted
 
 	return (
 		<>
@@ -75,7 +76,7 @@ export default function Simulation({
 				<PrintExportRecover />
 				{children}
 				<FromTop>
-					{(firstStepCompleted || showQuestionsFromBeginning) && (
+					{showQuestions && (
 						<>
 							<div className="print-hidden">
 								<FromTop>{results}</FromTop>
@@ -88,11 +89,9 @@ export default function Simulation({
 					)}
 					<Spacing md />
 
-					<SimulationPréremplieBanner />
+					{!entrepriseSelection && <SimulationPréremplieBanner />}
 
-					{!showQuestionsFromBeginning && !firstStepCompleted && (
-						<PreviousSimulationBanner />
-					)}
+					{!showQuestions && <PreviousSimulationBanner />}
 
 					{afterQuestionsSlot}
 

--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -77,10 +77,10 @@ export default function Simulation({
 				<FromTop>
 					{(firstStepCompleted || showQuestionsFromBeginning) && (
 						<>
-							{entrepriseSelection && <EntrepriseSelection />}
 							<div className="print-hidden">
 								<FromTop>{results}</FromTop>
 							</div>
+							{entrepriseSelection && <EntrepriseSelection />}
 							{ilYADesQuestions && (
 								<Questions customEndMessages={customEndMessages} />
 							)}

--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -1,4 +1,3 @@
-import { DottedName } from 'modele-social'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
@@ -11,7 +10,6 @@ import ShareOrSaveSimulationBanner, {
 import { Button } from '@/design-system/buttons'
 import { Grid, Spacing } from '@/design-system/layout'
 import { H3 } from '@/design-system/typography/heading'
-import { RootState } from '@/store/reducers/rootReducer'
 import { ilYADesQuestionsSelector } from '@/store/selectors/ilYADesQuestions.selector'
 import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
 
@@ -50,7 +48,6 @@ type SimulationProps = {
 	id?: string
 	customSimulationbutton?: CustomSimulationButton
 	entrepriseSelection?: boolean
-	firstStepCompletedExceptions?: DottedName[]
 }
 
 export default function Simulation({
@@ -65,18 +62,15 @@ export default function Simulation({
 	id,
 	customSimulationbutton,
 	entrepriseSelection = true,
-	firstStepCompletedExceptions,
 }: SimulationProps) {
-	const firstStepCompleted = useSelector((state: RootState) =>
-		firstStepCompletedSelector(state, firstStepCompletedExceptions)
-	)
+	const isFirstStepCompleted = useSelector(firstStepCompletedSelector)
 	const ilYADesQuestions = useSelector(ilYADesQuestionsSelector)
 	const shouldShowFeedback = getShouldAskFeedback(useLocation().pathname)
-	const showQuestions = showQuestionsFromBeginning || firstStepCompleted
+	const showQuestions = showQuestionsFromBeginning || isFirstStepCompleted
 
 	return (
 		<>
-			{!firstStepCompleted && <TrackPage name="accueil" />}
+			{!isFirstStepCompleted && <TrackPage name="accueil" />}
 
 			<SimulationContainer fullWidth={fullWidth} id={id}>
 				<PrintExportRecover />
@@ -101,7 +95,7 @@ export default function Simulation({
 
 					{afterQuestionsSlot}
 
-					{firstStepCompleted && !hideDetails && (
+					{isFirstStepCompleted && !hideDetails && (
 						<>
 							{customSimulationbutton && (
 								<>
@@ -124,8 +118,8 @@ export default function Simulation({
 					)}
 				</FromTop>
 			</SimulationContainer>
-			{firstStepCompleted && !hideDetails && explanations}
-			{firstStepCompleted && !hideDetails && shouldShowFeedback && (
+			{isFirstStepCompleted && !hideDetails && explanations}
+			{isFirstStepCompleted && !hideDetails && shouldShowFeedback && (
 				<div
 					style={{
 						textAlign: 'center',

--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -16,11 +16,11 @@ import { firstStepCompletedSelector } from '@/store/selectors/simulationSelector
 import { TrackPage } from '../ATInternetTracking'
 import { Feedback, getShouldAskFeedback } from '../Feedback/Feedback'
 import PrintExportRecover from '../simulationExplanation/PrintExportRecover'
-import SimulationPréremplieBanner from '../SimulationPréremplieBanner'
-import PreviousSimulationBanner from './../PreviousSimulationBanner'
 import { FromTop } from './../ui/animate'
 import EntrepriseSelection from './EntrepriseSelection'
+import PreviousSimulationBanner from './PreviousSimulationBanner'
 import { Questions } from './Questions'
+import SimulationPréremplieBanner from './SimulationPréremplieBanner'
 
 export { Questions } from './Questions'
 export { SimulationGoal } from './SimulationGoal'

--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -1,3 +1,4 @@
+import { DottedName } from 'modele-social'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
@@ -10,6 +11,7 @@ import ShareOrSaveSimulationBanner, {
 import { Button } from '@/design-system/buttons'
 import { Grid, Spacing } from '@/design-system/layout'
 import { H3 } from '@/design-system/typography/heading'
+import { RootState } from '@/store/reducers/rootReducer'
 import { ilYADesQuestionsSelector } from '@/store/selectors/ilYADesQuestions.selector'
 import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
 
@@ -48,6 +50,7 @@ type SimulationProps = {
 	id?: string
 	customSimulationbutton?: CustomSimulationButton
 	entrepriseSelection?: boolean
+	firstStepCompletedExceptions?: DottedName[]
 }
 
 export default function Simulation({
@@ -62,8 +65,11 @@ export default function Simulation({
 	id,
 	customSimulationbutton,
 	entrepriseSelection = true,
+	firstStepCompletedExceptions,
 }: SimulationProps) {
-	const firstStepCompleted = useSelector(firstStepCompletedSelector)
+	const firstStepCompleted = useSelector((state: RootState) =>
+		firstStepCompletedSelector(state, firstStepCompletedExceptions)
+	)
 	const ilYADesQuestions = useSelector(ilYADesQuestionsSelector)
 	const shouldShowFeedback = getShouldAskFeedback(useLocation().pathname)
 	const showQuestions = showQuestionsFromBeginning || firstStepCompleted

--- a/site/source/components/entreprise/EntrepriseSearchResults.tsx
+++ b/site/source/components/entreprise/EntrepriseSearchResults.tsx
@@ -76,7 +76,7 @@ export default function EntrepriseSearchResults({
 	) : (
 		<FromTop>
 			<ForceThemeProvider>
-				<Ul noMarker data-test-id="company-search-results">
+				<Ul $noMarker data-test-id="company-search-results">
 					{results.map((entreprise) => (
 						<Li key={entreprise.siren}>
 							<StyledCard

--- a/site/source/components/layout/Menu.tsx
+++ b/site/source/components/layout/Menu.tsx
@@ -44,7 +44,7 @@ export const Menu = () => {
 			)}
 		>
 			<Nav>
-				<StyledUl noMarker>
+				<StyledUl $noMarker>
 					<PlanContent />
 				</StyledUl>
 			</Nav>

--- a/site/source/components/simulationExplanation/InstitutionsPartenaires.tsx
+++ b/site/source/components/simulationExplanation/InstitutionsPartenaires.tsx
@@ -11,7 +11,7 @@ import { FromBottom } from '@/components/ui/animate'
 import { useEngine } from '@/components/utils/EngineContext'
 import { Message } from '@/design-system'
 import { Emoji } from '@/design-system/emoji'
-import { Grid } from '@/design-system/layout'
+import { Grid, Spacing } from '@/design-system/layout'
 import { H2, H3 } from '@/design-system/typography/heading'
 import { Body, SmallBody } from '@/design-system/typography/paragraphs'
 import { targetUnitSelector } from '@/store/selectors/simulationSelectors'
@@ -248,10 +248,11 @@ export function InstitutionsPartenairesArtisteAuteur() {
 
 	return (
 		<section>
-			<H3>Vos cotisations</H3>
+			<Spacing md />
 			<Grid container>
 				<Grid item lg={12}>
 					<Message border={false} role="list">
+						<H3>Vos cotisations</H3>
 						<CotisationsUrssaf
 							rule="artiste-auteur . cotisations"
 							extraNotice={

--- a/site/source/design-system/typography/list.tsx
+++ b/site/source/design-system/typography/list.tsx
@@ -13,7 +13,7 @@ type ListProps = {
 	 * @property {boolean} - A boolean property that indicates whether or not to display markers
 	 * (such as bullets or numbers) for each item in the list.
 	 */
-	noMarker?: boolean
+	$noMarker?: boolean
 }
 
 export const Li = styled.li``
@@ -45,8 +45,8 @@ const BaseListStyle = css<ListProps>`
 
 	> ${Li} {
 		position: relative;
-		padding-left: ${({ theme, noMarker }) =>
-			noMarker ? 0 : theme.spacings.lg};
+		padding-left: ${({ theme, $noMarker }) =>
+			$noMarker ? 0 : theme.spacings.lg};
 		margin-bottom: ${({ theme }) => theme.spacings.xs};
 	}
 `
@@ -54,8 +54,8 @@ const BaseListStyle = css<ListProps>`
 export const Ul = styled.ul<ListProps>`
 	${BaseListStyle}
 	> ${Li}::before {
-		${({ noMarker }) =>
-			noMarker &&
+		${({ $noMarker }) =>
+			$noMarker &&
 			css`
 				display: none !important;
 			`}

--- a/site/source/domaine/SimulationConfig.ts
+++ b/site/source/domaine/SimulationConfig.ts
@@ -48,4 +48,6 @@ export type SimulationConfig = Partial<{
 	}
 
 	'unité par défaut'?: string
+
+	'règles à ignorer pour déclencher les questions'?: DottedName[]
 }>

--- a/site/source/hooks/useZoneLodeom.ts
+++ b/site/source/hooks/useZoneLodeom.ts
@@ -2,7 +2,7 @@ import { DottedName } from 'modele-social'
 
 import { useEngine } from '@/components/utils/EngineContext'
 
-const zones = ['zone un', 'zone deux']
+export const zones = ['zone un', 'zone deux']
 
 export type ZoneLodeom = (typeof zones)[number]
 

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -280,7 +280,6 @@ Votre message (requis): Your message (required)
 Votre rémunération totale estimée: Your estimated total remuneration
 Vous n’avez pas été satisfait(e) de votre expérience, nous en sommes désolé(e)s.: We're sorry you weren't satisfied with your experience.
 Vous pouvez réessayer avec votre SIREN ou votre SIRET pour un meilleur résultat.: You can try again with your SIREN or SIRET for a better result.
-Vous êtes dirigeant d'une SAS(U) ? <2>Accéder au simulateur de revenu dédié</2>: Are you an SAS(U) director? <2>Go to the dedicated income simulator</2>
 accessibility:
   description: Référentiel Général d'Amélioration de l'Accessibilité (General
     Accessibility Improvement Reference System)
@@ -1773,6 +1772,7 @@ pages:
       shortname: Midwife
       title: Income simulator for self-employed midwives
     salarié:
+      SASU: Are you an SAS(U) director? <2>Access the dedicated income simulator</2>
       alt-image1: Net salary (received by the employee) is equal to Gross salary
         (stated in the employment contract) minus employee contributions
         (pension, social security contributions, etc.).

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -302,7 +302,6 @@ Vous n’avez pas été satisfait(e) de votre expérience, nous en sommes désol
 Vous pouvez réessayer avec votre SIREN ou votre SIRET pour un meilleur résultat.:
   Vous pouvez réessayer avec votre SIREN ou votre SIRET pour un meilleur
   résultat.
-Vous êtes dirigeant d'une SAS(U) ? <2>Accéder au simulateur de revenu dédié</2>: Vous êtes dirigeant d'une SAS(U) ? <2>Accéder au simulateur de revenu dédié</2>
 accessibility:
   description: Référentiel Général d’Amélioration de l’Accessibilité
   title: Accessibilité
@@ -1884,6 +1883,8 @@ pages:
       shortname: Sage-femme
       title: Simulateur de revenus pour sage-femme en libéral
     salarié:
+      SASU: Vous êtes dirigeant d'une SAS(U) ? <2>Accédez au simulateur de revenu
+        dédié</2>
       alt-image1: Salaire net (perçu par le salarié) est égal à Salaire brut (inscrit
         dans le contrat de travail) moins cotisations salariales (retraite, csg,
         etc)

--- a/site/source/pages/Plan.tsx
+++ b/site/source/pages/Plan.tsx
@@ -27,7 +27,7 @@ export default function Plan() {
 			/>
 			<TrackPage chapter1="navigation" name="plan-du-site" />
 
-			<Ul size="XL" noMarker>
+			<Ul size="XL" $noMarker>
 				<PlanContent />
 			</Ul>
 		</>

--- a/site/source/pages/assistants/choix-du-statut/_components/StatutsPossibles.tsx
+++ b/site/source/pages/assistants/choix-du-statut/_components/StatutsPossibles.tsx
@@ -33,7 +33,7 @@ export default function StatutsPossibles() {
 		<StyledMessage>
 			<H5 as="h2"> Statuts disponibles</H5>
 
-			<StyledUl noMarker as={FlipMove} typeName="ul">
+			<StyledUl $noMarker as={FlipMove} typeName="ul">
 				{statuts.map((statut) => (
 					<Statut key={statut} statut={statut} />
 				))}

--- a/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
+++ b/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
@@ -3,12 +3,12 @@ import { useLocation } from 'react-router-dom'
 
 import { Condition } from '@/components/EngineValue/Condition'
 import PeriodSwitch from '@/components/PeriodSwitch'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation, {
 	SimulationGoal,
 	SimulationGoals,
 } from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { DistributionBranch } from '@/components/simulationExplanation/DistributionDesCotisations'
 import { InstitutionsPartenairesArtisteAuteur } from '@/components/simulationExplanation/InstitutionsPartenaires'
 import { useEngine } from '@/components/utils/EngineContext'
@@ -27,7 +27,7 @@ export default function ArtisteAuteur() {
 			<Simulation
 				results={<InstitutionsPartenairesArtisteAuteur />}
 				explanations={<CotisationsResult />}
-				afterQuestionsSlot={<SelectSimulationYear />}
+				afterQuestionsSlot={<YearSelectionBanner />}
 			>
 				<SimulateurWarning
 					simulateur="artiste-auteur"

--- a/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
+++ b/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
@@ -25,6 +25,7 @@ export default function ArtisteAuteur() {
 	return (
 		<>
 			<Simulation
+				results={<InstitutionsPartenairesArtisteAuteur />}
 				explanations={<CotisationsResult />}
 				afterQuestionsSlot={<SelectSimulationYear />}
 			>
@@ -47,8 +48,6 @@ export default function ArtisteAuteur() {
 					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . recettes" />
 					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . frais réels" />
 				</SimulationGoals>
-
-				<InstitutionsPartenairesArtisteAuteur />
 			</Simulation>
 		</>
 	)

--- a/site/source/pages/simulateurs/auto-entrepreneur/AutoEntrepreneur.tsx
+++ b/site/source/pages/simulateurs/auto-entrepreneur/AutoEntrepreneur.tsx
@@ -3,12 +3,12 @@ import { Trans } from 'react-i18next'
 import ChiffreAffairesActivitéMixte from '@/components/ChiffreAffairesActivitéMixte'
 import { WhenAlreadyDefined } from '@/components/EngineValue/WhenAlreadyDefined'
 import PeriodSwitch from '@/components/PeriodSwitch'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation, {
 	SimulationGoal,
 	SimulationGoals,
 } from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Link } from '@/design-system/typography/link'
 import { DarkLi, Ul } from '@/design-system/typography/list'
 import { AutoEntrepreneurDétails } from '@/pages/simulateurs/auto-entrepreneur/AutoEntrepreneurDétails'
@@ -18,7 +18,7 @@ export default function AutoEntrepreneur() {
 		<>
 			<Simulation
 				explanations={<AutoEntrepreneurDétails />}
-				afterQuestionsSlot={<SelectSimulationYear />}
+				afterQuestionsSlot={<YearSelectionBanner />}
 			>
 				<SimulateurWarning
 					simulateur="auto-entrepreneur"

--- a/site/source/pages/simulateurs/cessation-activité/CessationActivité.tsx
+++ b/site/source/pages/simulateurs/cessation-activité/CessationActivité.tsx
@@ -1,4 +1,3 @@
-import { DottedName } from 'modele-social'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -32,14 +31,8 @@ export const CessationActivitéSimulation = () => {
 
 	const { t } = useTranslation()
 
-	const firstStepCompletedExceptions = [
-		'entreprise . date de cessation' as DottedName,
-		'entreprise . imposition' as DottedName,
-	]
-
 	return (
 		<Simulation
-			firstStepCompletedExceptions={firstStepCompletedExceptions}
 			customSimulationbutton={{
 				href: lien,
 				title: t('Vos cotisations pour l’année précédente'),

--- a/site/source/pages/simulateurs/cessation-activité/CessationActivité.tsx
+++ b/site/source/pages/simulateurs/cessation-activité/CessationActivité.tsx
@@ -1,3 +1,4 @@
+import { DottedName } from 'modele-social'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -31,8 +32,14 @@ export const CessationActivitéSimulation = () => {
 
 	const { t } = useTranslation()
 
+	const firstStepCompletedExceptions = [
+		'entreprise . date de cessation' as DottedName,
+		'entreprise . imposition' as DottedName,
+	]
+
 	return (
 		<Simulation
+			firstStepCompletedExceptions={firstStepCompletedExceptions}
 			customSimulationbutton={{
 				href: lien,
 				title: t('Vos cotisations pour l’année précédente'),

--- a/site/source/pages/simulateurs/cessation-activité/simulationConfig.ts
+++ b/site/source/pages/simulateurs/cessation-activité/simulationConfig.ts
@@ -16,4 +16,8 @@ export const configCessationActivité: SimulationConfig = {
 			'entreprise . date de cessation',
 		],
 	},
+	'règles à ignorer pour déclencher les questions': [
+		'entreprise . date de cessation',
+		'entreprise . imposition',
+	],
 }

--- a/site/source/pages/simulateurs/dividendes/Dividendes.tsx
+++ b/site/source/pages/simulateurs/dividendes/Dividendes.tsx
@@ -6,12 +6,12 @@ import { useTheme } from 'styled-components'
 
 import { Condition } from '@/components/EngineValue/Condition'
 import Notifications from '@/components/Notifications'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation, {
 	SimulationGoal,
 	SimulationGoals,
 } from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import StackedBarChart from '@/components/StackedBarChart'
 import { useEngine } from '@/components/utils/EngineContext'
 import { Radio, ToggleGroup } from '@/design-system/field'
@@ -26,7 +26,7 @@ export default function DividendesSimulation() {
 			<Notifications />
 			<Simulation
 				explanations={<DividendesExplanation />}
-				afterQuestionsSlot={<SelectSimulationYear />}
+				afterQuestionsSlot={<YearSelectionBanner />}
 			>
 				<SimulateurWarning
 					simulateur="dividendes"

--- a/site/source/pages/simulateurs/dividendes/Dividendes.tsx
+++ b/site/source/pages/simulateurs/dividendes/Dividendes.tsx
@@ -21,10 +21,15 @@ import { Body } from '@/design-system/typography/paragraphs'
 import { enregistreLaRéponse } from '@/store/actions/actions'
 
 export default function DividendesSimulation() {
+	const firstStepCompletedExceptions = [
+		'impôt . méthode de calcul' as DottedName,
+	]
+
 	return (
 		<>
 			<Notifications />
 			<Simulation
+				firstStepCompletedExceptions={firstStepCompletedExceptions}
 				explanations={<DividendesExplanation />}
 				afterQuestionsSlot={<YearSelectionBanner />}
 			>

--- a/site/source/pages/simulateurs/dividendes/Dividendes.tsx
+++ b/site/source/pages/simulateurs/dividendes/Dividendes.tsx
@@ -21,15 +21,10 @@ import { Body } from '@/design-system/typography/paragraphs'
 import { enregistreLaRéponse } from '@/store/actions/actions'
 
 export default function DividendesSimulation() {
-	const firstStepCompletedExceptions = [
-		'impôt . méthode de calcul' as DottedName,
-	]
-
 	return (
 		<>
 			<Notifications />
 			<Simulation
-				firstStepCompletedExceptions={firstStepCompletedExceptions}
 				explanations={<DividendesExplanation />}
 				afterQuestionsSlot={<YearSelectionBanner />}
 			>

--- a/site/source/pages/simulateurs/dividendes/simulationConfig.ts
+++ b/site/source/pages/simulateurs/dividendes/simulationConfig.ts
@@ -20,4 +20,7 @@ export const configDividendes: SimulationConfig = {
 		'impôt . méthode de calcul': "'PFU'",
 		'dirigeant . rémunération . net . imposable': '0 €/an',
 	},
+	'règles à ignorer pour déclencher les questions': [
+		'impôt . méthode de calcul',
+	],
 }

--- a/site/source/pages/simulateurs/impot-societe/index.tsx
+++ b/site/source/pages/simulateurs/impot-societe/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { styled } from 'styled-components'
@@ -78,7 +79,7 @@ function ExerciceDate() {
 			<ExerciceDateContainer>
 				<StyledInputSuggestion>
 					{[yearN2, yearN1].map((year) => (
-						<span key={year}>
+						<React.Fragment key={year}>
 							<Link
 								aria-label={t(
 									'pages.simulateurs.impot-société.préremplir',
@@ -100,7 +101,7 @@ function ExerciceDate() {
 									{ year }
 								)}
 							</Link>{' '}
-						</span>
+						</React.Fragment>
 					))}
 				</StyledInputSuggestion>
 			</ExerciceDateContainer>

--- a/site/source/pages/simulateurs/impot-societe/index.tsx
+++ b/site/source/pages/simulateurs/impot-societe/index.tsx
@@ -78,7 +78,7 @@ function ExerciceDate() {
 			<ExerciceDateContainer>
 				<StyledInputSuggestion>
 					{[yearN2, yearN1].map((year) => (
-						<>
+						<span key={year}>
 							<Link
 								aria-label={t(
 									'pages.simulateurs.impot-société.préremplir',
@@ -100,7 +100,7 @@ function ExerciceDate() {
 									{ year }
 								)}
 							</Link>{' '}
-						</>
+						</span>
 					))}
 				</StyledInputSuggestion>
 			</ExerciceDateContainer>

--- a/site/source/pages/simulateurs/indépendant/EntrepriseIndividuelle.tsx
+++ b/site/source/pages/simulateurs/indépendant/EntrepriseIndividuelle.tsx
@@ -1,6 +1,6 @@
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import IndépendantExplanation from '@/components/simulationExplanation/IndépendantExplanation'
 import { IndépendantSimulationGoals } from '@/pages/simulateurs/indépendant/Goals'
 
@@ -8,7 +8,7 @@ export const EntrepriseIndividuelle = () => (
 	<>
 		<Simulation
 			explanations={<IndépendantExplanation />}
-			afterQuestionsSlot={<SelectSimulationYear />}
+			afterQuestionsSlot={<YearSelectionBanner />}
 		>
 			<SimulateurWarning simulateur="entreprise-individuelle" />
 			<IndépendantSimulationGoals legend="Vos revenus d'entreprise individuelle" />

--- a/site/source/pages/simulateurs/indépendant/Indépendant.tsx
+++ b/site/source/pages/simulateurs/indépendant/Indépendant.tsx
@@ -18,12 +18,9 @@ export default function IndépendantSimulation() {
 	const dispatch = useDispatch()
 	const year = useYear()
 
-	const firstStepCompletedExceptions = ['entreprise . imposition' as DottedName]
-
 	return (
 		<>
 			<Simulation
-				firstStepCompletedExceptions={firstStepCompletedExceptions}
 				explanations={<IndépendantExplanation />}
 				afterQuestionsSlot={<YearSelectionBanner />}
 			>

--- a/site/source/pages/simulateurs/indépendant/Indépendant.tsx
+++ b/site/source/pages/simulateurs/indépendant/Indépendant.tsx
@@ -4,9 +4,9 @@ import { useDispatch } from 'react-redux'
 
 import RuleInput from '@/components/conversation/RuleInput'
 import PeriodSwitch from '@/components/PeriodSwitch'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import IndépendantExplanation from '@/components/simulationExplanation/IndépendantExplanation'
 import { Body } from '@/design-system/typography/paragraphs'
 import { SimpleRuleEvaluation } from '@/domaine/engine/SimpleRuleEvaluation'
@@ -22,7 +22,7 @@ export default function IndépendantSimulation() {
 		<>
 			<Simulation
 				explanations={<IndépendantExplanation />}
-				afterQuestionsSlot={<SelectSimulationYear />}
+				afterQuestionsSlot={<YearSelectionBanner />}
 			>
 				<SimulateurWarning
 					simulateur="indépendant"

--- a/site/source/pages/simulateurs/indépendant/Indépendant.tsx
+++ b/site/source/pages/simulateurs/indépendant/Indépendant.tsx
@@ -18,9 +18,12 @@ export default function IndépendantSimulation() {
 	const dispatch = useDispatch()
 	const year = useYear()
 
+	const firstStepCompletedExceptions = ['entreprise . imposition' as DottedName]
+
 	return (
 		<>
 			<Simulation
+				firstStepCompletedExceptions={firstStepCompletedExceptions}
 				explanations={<IndépendantExplanation />}
 				afterQuestionsSlot={<YearSelectionBanner />}
 			>

--- a/site/source/pages/simulateurs/indépendant/IndépendantPLSimulation.tsx
+++ b/site/source/pages/simulateurs/indépendant/IndépendantPLSimulation.tsx
@@ -1,8 +1,8 @@
 import { Trans } from 'react-i18next'
 
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import IndépendantExplanation from '@/components/simulationExplanation/IndépendantExplanation'
 import { DarkLi, Ul } from '@/design-system/typography/list'
 import useYear from '@/hooks/useYear'
@@ -15,7 +15,7 @@ export const IndépendantPLSimulation = () => {
 		<>
 			<Simulation
 				explanations={<IndépendantExplanation />}
-				afterQuestionsSlot={<SelectSimulationYear />}
+				afterQuestionsSlot={<YearSelectionBanner />}
 			>
 				<SimulateurWarning
 					simulateur="profession-libérale"

--- a/site/source/pages/simulateurs/indépendant/simulationConfig.ts
+++ b/site/source/pages/simulateurs/indépendant/simulationConfig.ts
@@ -73,6 +73,7 @@ export const configIndépendant: SimulationConfig = {
 		'entreprise . catégorie juridique': "''",
 		salarié: 'non',
 	},
+	'règles à ignorer pour déclencher les questions': ['entreprise . imposition'],
 }
 
 export const configEntrepriseIndividuelle: SimulationConfig = {

--- a/site/source/pages/simulateurs/location-de-meublé/simulationConfig.ts
+++ b/site/source/pages/simulateurs/location-de-meublé/simulationConfig.ts
@@ -1,9 +1,6 @@
 import { SimulationConfig } from '@/domaine/SimulationConfig'
 
 export const configLocationDeMeublé: SimulationConfig = {
-	'objectifs exclusifs': [
-		'location de logement meublé . courte durée . recettes',
-	],
 	objectifs: ['location de logement meublé . cotisations'],
 	'unité par défaut': '€/an',
 	situation: {},

--- a/site/source/pages/simulateurs/lodeom/Lodeom.tsx
+++ b/site/source/pages/simulateurs/lodeom/Lodeom.tsx
@@ -4,9 +4,9 @@ import { Trans, useTranslation } from 'react-i18next'
 import PeriodSwitch from '@/components/PeriodSwitch'
 import EffectifSwitch from '@/components/RéductionDeCotisations/EffectifSwitch'
 import RégularisationSwitch from '@/components/RéductionDeCotisations/RégularisationSwitch'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Emoji } from '@/design-system/emoji'
 import { Body } from '@/design-system/typography/paragraphs'
 import { useZoneLodeom } from '@/hooks/useZoneLodeom'
@@ -42,7 +42,7 @@ export default function LodeomSimulation() {
 
 	return (
 		<>
-			<Simulation afterQuestionsSlot={<SelectSimulationYear />}>
+			<Simulation afterQuestionsSlot={<YearSelectionBanner />}>
 				<SimulateurWarning
 					simulateur="lodeom"
 					informationsComplémentaires={

--- a/site/source/pages/simulateurs/lodeom/Lodeom.tsx
+++ b/site/source/pages/simulateurs/lodeom/Lodeom.tsx
@@ -1,3 +1,4 @@
+import { DottedName } from 'modele-social'
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -9,7 +10,12 @@ import Simulation from '@/components/Simulation'
 import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Emoji } from '@/design-system/emoji'
 import { Body } from '@/design-system/typography/paragraphs'
-import { useZoneLodeom } from '@/hooks/useZoneLodeom'
+import { barèmeLodeomDottedName } from '@/hooks/useBarèmeLodeom'
+import {
+	useZoneLodeom,
+	zones,
+	zonesLodeomDottedName,
+} from '@/hooks/useZoneLodeom'
 import { RégularisationMethod } from '@/utils/réductionDeCotisations'
 
 import BarèmeSwitch from './components/BarèmeSwitch'
@@ -40,9 +46,18 @@ export default function LodeomSimulation() {
 	const [régularisationMethod, setRégularisationMethod] =
 		useState<RégularisationMethod>('progressive')
 
+	const firstStepCompletedExceptions = [
+		zonesLodeomDottedName,
+		...zones.map((zone) => barèmeLodeomDottedName(zone)),
+		'entreprise . salariés . effectif' as DottedName,
+	]
+
 	return (
 		<>
-			<Simulation afterQuestionsSlot={<YearSelectionBanner />}>
+			<Simulation
+				firstStepCompletedExceptions={firstStepCompletedExceptions}
+				afterQuestionsSlot={<YearSelectionBanner />}
+			>
 				<SimulateurWarning
 					simulateur="lodeom"
 					informationsComplémentaires={

--- a/site/source/pages/simulateurs/lodeom/Lodeom.tsx
+++ b/site/source/pages/simulateurs/lodeom/Lodeom.tsx
@@ -1,4 +1,3 @@
-import { DottedName } from 'modele-social'
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -10,12 +9,7 @@ import Simulation from '@/components/Simulation'
 import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Emoji } from '@/design-system/emoji'
 import { Body } from '@/design-system/typography/paragraphs'
-import { barèmeLodeomDottedName } from '@/hooks/useBarèmeLodeom'
-import {
-	useZoneLodeom,
-	zones,
-	zonesLodeomDottedName,
-} from '@/hooks/useZoneLodeom'
+import { useZoneLodeom } from '@/hooks/useZoneLodeom'
 import { RégularisationMethod } from '@/utils/réductionDeCotisations'
 
 import BarèmeSwitch from './components/BarèmeSwitch'
@@ -46,18 +40,9 @@ export default function LodeomSimulation() {
 	const [régularisationMethod, setRégularisationMethod] =
 		useState<RégularisationMethod>('progressive')
 
-	const firstStepCompletedExceptions = [
-		zonesLodeomDottedName,
-		...zones.map((zone) => barèmeLodeomDottedName(zone)),
-		'entreprise . salariés . effectif' as DottedName,
-	]
-
 	return (
 		<>
-			<Simulation
-				firstStepCompletedExceptions={firstStepCompletedExceptions}
-				afterQuestionsSlot={<YearSelectionBanner />}
-			>
+			<Simulation afterQuestionsSlot={<YearSelectionBanner />}>
 				<SimulateurWarning
 					simulateur="lodeom"
 					informationsComplémentaires={

--- a/site/source/pages/simulateurs/lodeom/simulationConfig.ts
+++ b/site/source/pages/simulateurs/lodeom/simulationConfig.ts
@@ -46,4 +46,10 @@ export const configLodeom: SimulationConfig = {
 		'entreprise . catégorie juridique': "''",
 		'entreprise . imposition': 'non',
 	},
+	'règles à ignorer pour déclencher les questions': [
+		'entreprise . salariés . effectif',
+		'salarié . cotisations . exonérations . zones lodeom',
+		'salarié . cotisations . exonérations . lodeom . zone un . barèmes',
+		'salarié . cotisations . exonérations . lodeom . zone deux . barèmes',
+	],
 }

--- a/site/source/pages/simulateurs/lodeom/simulationConfig.ts
+++ b/site/source/pages/simulateurs/lodeom/simulationConfig.ts
@@ -1,9 +1,6 @@
 import { SimulationConfig } from '@/domaine/SimulationConfig'
 
 export const configLodeom: SimulationConfig = {
-	// TODO: remplacer 'salarié . cotisations . assiette' par 'salarié . rémunération . brut'
-	// lorsque cette dernière n'incluera plus les frais professionnels.
-	'objectifs exclusifs': ['salarié . cotisations . assiette'],
 	objectifs: ['salarié . cotisations . exonérations . lodeom . montant'],
 	questions: {
 		"à l'affiche": [

--- a/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
@@ -1,4 +1,3 @@
-import { DottedName } from 'modele-social'
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -10,10 +9,7 @@ import Simulation from '@/components/Simulation'
 import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Strong } from '@/design-system/typography'
 import { Body } from '@/design-system/typography/paragraphs'
-import {
-	réductionGénéraleDottedName,
-	RégularisationMethod,
-} from '@/utils/réductionDeCotisations'
+import { RégularisationMethod } from '@/utils/réductionDeCotisations'
 
 import CongésPayésSwitch from './components/CongésPayésSwitch'
 import RéductionGénéraleSimulationGoals from './Goals'
@@ -47,17 +43,9 @@ export default function RéductionGénéraleSimulation() {
 	const [régularisationMethod, setRégularisationMethod] =
 		useState<RégularisationMethod>('progressive')
 
-	const firstStepCompletedExceptions = [
-		'entreprise . salariés . effectif' as DottedName,
-		`${réductionGénéraleDottedName} . caisse de congés payés` as DottedName,
-	]
-
 	return (
 		<>
-			<Simulation
-				firstStepCompletedExceptions={firstStepCompletedExceptions}
-				afterQuestionsSlot={<YearSelectionBanner />}
-			>
+			<Simulation afterQuestionsSlot={<YearSelectionBanner />}>
 				<SimulateurWarning
 					simulateur="réduction-générale"
 					informationsComplémentaires={

--- a/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
@@ -4,9 +4,9 @@ import { Trans, useTranslation } from 'react-i18next'
 import PeriodSwitch from '@/components/PeriodSwitch'
 import EffectifSwitch from '@/components/RéductionDeCotisations/EffectifSwitch'
 import RégularisationSwitch from '@/components/RéductionDeCotisations/RégularisationSwitch'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Strong } from '@/design-system/typography'
 import { Body } from '@/design-system/typography/paragraphs'
 import { RégularisationMethod } from '@/utils/réductionDeCotisations'
@@ -45,7 +45,7 @@ export default function RéductionGénéraleSimulation() {
 
 	return (
 		<>
-			<Simulation afterQuestionsSlot={<SelectSimulationYear />}>
+			<Simulation afterQuestionsSlot={<YearSelectionBanner />}>
 				<SimulateurWarning
 					simulateur="réduction-générale"
 					informationsComplémentaires={

--- a/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
@@ -1,3 +1,4 @@
+import { DottedName } from 'modele-social'
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -9,7 +10,10 @@ import Simulation from '@/components/Simulation'
 import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import { Strong } from '@/design-system/typography'
 import { Body } from '@/design-system/typography/paragraphs'
-import { RégularisationMethod } from '@/utils/réductionDeCotisations'
+import {
+	réductionGénéraleDottedName,
+	RégularisationMethod,
+} from '@/utils/réductionDeCotisations'
 
 import CongésPayésSwitch from './components/CongésPayésSwitch'
 import RéductionGénéraleSimulationGoals from './Goals'
@@ -43,9 +47,17 @@ export default function RéductionGénéraleSimulation() {
 	const [régularisationMethod, setRégularisationMethod] =
 		useState<RégularisationMethod>('progressive')
 
+	const firstStepCompletedExceptions = [
+		'entreprise . salariés . effectif' as DottedName,
+		`${réductionGénéraleDottedName} . caisse de congés payés` as DottedName,
+	]
+
 	return (
 		<>
-			<Simulation afterQuestionsSlot={<YearSelectionBanner />}>
+			<Simulation
+				firstStepCompletedExceptions={firstStepCompletedExceptions}
+				afterQuestionsSlot={<YearSelectionBanner />}
+			>
 				<SimulateurWarning
 					simulateur="réduction-générale"
 					informationsComplémentaires={

--- a/site/source/pages/simulateurs/reduction-generale/simulationConfig.ts
+++ b/site/source/pages/simulateurs/reduction-generale/simulationConfig.ts
@@ -1,9 +1,6 @@
 import { SimulationConfig } from '@/domaine/SimulationConfig'
 
 export const configRéductionGénérale: SimulationConfig = {
-	// TODO: remplacer 'salarié . cotisations . assiette' par 'salarié . rémunération . brut'
-	// lorsque cette dernière n'incluera plus les frais professionnels.
-	'objectifs exclusifs': ['salarié . cotisations . assiette'],
 	objectifs: ['salarié . cotisations . exonérations . réduction générale'],
 	questions: {
 		"à l'affiche": [

--- a/site/source/pages/simulateurs/reduction-generale/simulationConfig.ts
+++ b/site/source/pages/simulateurs/reduction-generale/simulationConfig.ts
@@ -41,4 +41,8 @@ export const configRéductionGénérale: SimulationConfig = {
 		'entreprise . catégorie juridique': "''",
 		'entreprise . imposition': 'non',
 	},
+	'règles à ignorer pour déclencher les questions': [
+		'entreprise . salariés . effectif',
+		'salarié . cotisations . exonérations . réduction générale . caisse de congés payés',
+	],
 }

--- a/site/source/pages/simulateurs/salarié/Salarié.tsx
+++ b/site/source/pages/simulateurs/salarié/Salarié.tsx
@@ -4,7 +4,6 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { css, styled } from 'styled-components'
 
-import Banner from '@/components/Banner'
 import { ConseillersEntreprisesButton } from '@/components/ConseillersEntreprisesButton'
 import { Condition } from '@/components/EngineValue/Condition'
 import Value from '@/components/EngineValue/Value'
@@ -17,9 +16,10 @@ import Simulation, {
 	SimulationGoals,
 } from '@/components/Simulation'
 import SalaryExplanation from '@/components/simulationExplanation/SalaryExplanation'
-import { Appear, FromTop } from '@/components/ui/animate'
+import { FadeIn, FromTop } from '@/components/ui/animate'
 import BrowserOnly from '@/components/utils/BrowserOnly'
 import { useEngine } from '@/components/utils/EngineContext'
+import { Message } from '@/design-system'
 import { Emoji } from '@/design-system/emoji'
 import { Strong } from '@/design-system/typography'
 import { H2 } from '@/design-system/typography/heading'
@@ -60,16 +60,23 @@ export default function SalariéSimulation() {
 						{!import.meta.env.SSR &&
 							!document.referrer?.includes('code.travail.gouv.fr') && (
 								<WhenNotAlreadyDefined dottedName="entreprise . catégorie juridique">
-									<Appear>
-										<Banner icon={'👨‍✈️'}>
-											<Trans>
-												Vous êtes dirigeant d'une SAS(U) ?{' '}
-												<Link to={absoluteSitePaths.simulateurs.sasu}>
-													Accéder au simulateur de revenu dédié
-												</Link>
-											</Trans>
-										</Banner>
-									</Appear>
+									<FadeIn>
+										<Message
+											border={false}
+											mini
+											icon={<Emoji emoji="👨‍✈️" />}
+											className="print-hidden"
+										>
+											<SmallBody>
+												<Trans i18nKey="pages.simulateurs.salarié.SASU">
+													Vous êtes dirigeant d'une SAS(U) ?{' '}
+													<Link to={absoluteSitePaths.simulateurs.sasu}>
+														Accédez au simulateur de revenu dédié
+													</Link>
+												</Trans>
+											</SmallBody>
+										</Message>
+									</FadeIn>
 								</WhenNotAlreadyDefined>
 							)}
 					</BrowserOnly>

--- a/site/source/pages/simulateurs/sasu/SASU.tsx
+++ b/site/source/pages/simulateurs/sasu/SASU.tsx
@@ -2,12 +2,12 @@ import { Trans } from 'react-i18next'
 
 import PeriodSwitch from '@/components/PeriodSwitch'
 import RuleLink from '@/components/RuleLink'
-import { SelectSimulationYear } from '@/components/SelectSimulationYear'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation, {
 	SimulationGoal,
 	SimulationGoals,
 } from '@/components/Simulation'
+import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
 import SalaryExplanation from '@/components/simulationExplanation/SalaryExplanation'
 import { H2 } from '@/design-system/typography/heading'
 import { Body } from '@/design-system/typography/paragraphs'
@@ -17,7 +17,7 @@ export function SASUSimulation() {
 		<>
 			<Simulation
 				explanations={<SalaryExplanation />}
-				afterQuestionsSlot={<SelectSimulationYear />}
+				afterQuestionsSlot={<YearSelectionBanner />}
 			>
 				<SimulateurWarning
 					simulateur="sasu"

--- a/site/source/store/selectors/simulationSelectors.ts
+++ b/site/source/store/selectors/simulationSelectors.ts
@@ -1,4 +1,5 @@
-import { intersection, NonEmptyArray } from 'effect/Array'
+import { difference, NonEmptyArray } from 'effect/Array'
+import { DottedName } from 'modele-social'
 import { createSelector } from 'reselect'
 
 import { isComparateurConfig } from '@/domaine/ComparateurConfig'
@@ -52,12 +53,17 @@ export const rawSituationsSelonContextesSelector = createSelector(
 			: [rawSituation]) as NonEmptyArray<Situation>
 )
 
-export const firstStepCompletedSelector = (state: RootState) => {
-	const situation = situationSelector(state)
-	const objectifs = configObjectifsSelector(state)
+export const firstStepCompletedSelector = createSelector(
+	[
+		situationSelector,
+		(_: unknown, exceptions?: DottedName[]) => exceptions || [],
+	],
+	(situation, exceptions) =>
+		difference(Object.keys(situation), exceptions).length > 0
+)
 
-	return intersection(objectifs, Object.keys(situation)).length > 0
-}
+export const previousSimulationSelector = (state: RootState) =>
+	state.previousSimulation
 
 export const targetUnitSelector = (state: RootState) =>
 	state.simulation?.targetUnit ?? '€/mois'

--- a/site/source/store/selectors/simulationSelectors.ts
+++ b/site/source/store/selectors/simulationSelectors.ts
@@ -1,5 +1,4 @@
 import { difference, NonEmptyArray } from 'effect/Array'
-import { DottedName } from 'modele-social'
 import { createSelector } from 'reselect'
 
 import { isComparateurConfig } from '@/domaine/ComparateurConfig'
@@ -54,12 +53,12 @@ export const rawSituationsSelonContextesSelector = createSelector(
 )
 
 export const firstStepCompletedSelector = createSelector(
-	[
-		situationSelector,
-		(_: unknown, exceptions?: DottedName[]) => exceptions || [],
-	],
-	(situation, exceptions) =>
-		difference(Object.keys(situation), exceptions).length > 0
+	[situationSelector, configSelector],
+	(situation, config) =>
+		difference(
+			Object.keys(situation),
+			config['règles à ignorer pour déclencher les questions'] || []
+		).length > 0
 )
 
 export const previousSimulationSelector = (state: RootState) =>

--- a/site/test/regressions/__snapshots__/réduction-générale.test.ts.snap
+++ b/site/test/regressions/__snapshots__/réduction-générale.test.ts.snap
@@ -1,176 +1,154 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`calculate réduction générale > DFS 1`] = `
-"salarié . cotisations . assiette: 1802
-salarié . cotisations . exonérations . réduction générale: 575
+"salarié . cotisations . exonérations . réduction générale: 575
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 73
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 108
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 467"
 `;
 
 exports[`calculate réduction générale > DFS 2`] = `
-"salarié . cotisations . assiette: 1802
-salarié . cotisations . exonérations . réduction générale: 575
+"salarié . cotisations . exonérations . réduction générale: 575
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 73
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 108
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 467"
 `;
 
 exports[`calculate réduction générale > DFS 3`] = `
-"salarié . cotisations . assiette: 1802
-salarié . cotisations . exonérations . réduction générale: 575
+"salarié . cotisations . exonérations . réduction générale: 575
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 73
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 108
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 467"
 `;
 
 exports[`calculate réduction générale > DFS 4`] = `
-"salarié . cotisations . assiette: 1802
-salarié . cotisations . exonérations . réduction générale: 575
+"salarié . cotisations . exonérations . réduction générale: 575
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 73
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 108
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 467"
 `;
 
 exports[`calculate réduction générale > DFS 5`] = `
-"salarié . cotisations . assiette: 1802
-salarié . cotisations . exonérations . réduction générale: 575
+"salarié . cotisations . exonérations . réduction générale: 575
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 73
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 108
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 467"
 `;
 
 exports[`calculate réduction générale > JEI 1`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: null
+"salarié . cotisations . exonérations . réduction générale: null
 salarié . cotisations . exonérations . réduction générale . imputation chômage: null
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: null
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: null"
 `;
 
 exports[`calculate réduction générale > effectif 1`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: 523
+"salarié . cotisations . exonérations . réduction générale: 523
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 66
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 98
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 425"
 `;
 
 exports[`calculate réduction générale > effectif 2`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: 530
+"salarié . cotisations . exonérations . réduction générale: 530
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 66
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 98
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 431"
 `;
 
 exports[`calculate réduction générale > heures complémentaires 1`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: 483
+"salarié . cotisations . exonérations . réduction générale: 483
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 61
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 91
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 392"
 `;
 
 exports[`calculate réduction générale > heures supplémentaires 1`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: 607
+"salarié . cotisations . exonérations . réduction générale: 607
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 77
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 114
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 493"
 `;
 
 exports[`calculate réduction générale > salaire 1`] = `
-"salarié . cotisations . assiette: 100
-salarié . cotisations . exonérations . réduction générale: 32
+"salarié . cotisations . exonérations . réduction générale: 32
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 4
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 6
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 26"
 `;
 
 exports[`calculate réduction générale > salaire 2`] = `
-"salarié . cotisations . assiette: 250
-salarié . cotisations . exonérations . réduction générale: 80
+"salarié . cotisations . exonérations . réduction générale: 80
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 10
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 15
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 65"
 `;
 
 exports[`calculate réduction générale > salaire 3`] = `
-"salarié . cotisations . assiette: 500
-salarié . cotisations . exonérations . réduction générale: 160
+"salarié . cotisations . exonérations . réduction générale: 160
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 20
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 30
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 130"
 `;
 
 exports[`calculate réduction générale > salaire 4`] = `
-"salarié . cotisations . assiette: 750
-salarié . cotisations . exonérations . réduction générale: 240
+"salarié . cotisations . exonérations . réduction générale: 240
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 30
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 45
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 194"
 `;
 
 exports[`calculate réduction générale > salaire 5`] = `
-"salarié . cotisations . assiette: 1000
-salarié . cotisations . exonérations . réduction générale: 319
+"salarié . cotisations . exonérations . réduction générale: 319
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 41
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 60
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 259"
 `;
 
 exports[`calculate réduction générale > salaire 6`] = `
-"salarié . cotisations . assiette: 1250
-salarié . cotisations . exonérations . réduction générale: 399
+"salarié . cotisations . exonérations . réduction générale: 399
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 51
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 75
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 324"
 `;
 
 exports[`calculate réduction générale > salaire 7`] = `
-"salarié . cotisations . assiette: 1500
-salarié . cotisations . exonérations . réduction générale: 479
+"salarié . cotisations . exonérations . réduction générale: 479
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 61
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 90
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 389"
 `;
 
 exports[`calculate réduction générale > salaire 8`] = `
-"salarié . cotisations . assiette: 2000
-salarié . cotisations . exonérations . réduction générale: 470
+"salarié . cotisations . exonérations . réduction générale: 470
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 60
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 88
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 382"
 `;
 
 exports[`calculate réduction générale > salaire 9`] = `
-"salarié . cotisations . assiette: 2500
-salarié . cotisations . exonérations . réduction générale: 204
+"salarié . cotisations . exonérations . réduction générale: 204
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 26
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 38
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 165"
 `;
 
 exports[`calculate réduction générale > salaire 10`] = `
-"salarié . cotisations . assiette: 3000
-salarié . cotisations . exonérations . réduction générale: 0
+"salarié . cotisations . exonérations . réduction générale: 0
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 0
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 0
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 0"
 `;
 
 exports[`calculate réduction générale > stage 1`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: 523
+"salarié . cotisations . exonérations . réduction générale: 523
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 66
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 98
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 425"
 `;
 
 exports[`calculate réduction générale > temps partiel 1`] = `
-"salarié . cotisations . assiette: 1900
-salarié . cotisations . exonérations . réduction générale: 392
+"salarié . cotisations . exonérations . réduction générale: 392
 salarié . cotisations . exonérations . réduction générale . imputation chômage: 50
 salarié . cotisations . exonérations . réduction générale . imputation retraite complémentaire: 74
 salarié . cotisations . exonérations . réduction générale . imputation sécurité sociale: 318"


### PR DESCRIPTION
#3417 

- Refactorisation du composant `Banner`
  - déplacement dans le dossier `Simulation`
  - renommage cohérent
  - déplacement de la gestion de la disparition après la 1ère étape dans les parents

- Refactorisation de `SelectSimulationYear`
  - déplacement dans le dossier `Simulation`
  - renommage cohérent

- Refactorisation de `SimulationPréremplieBanner`
  - déplacement dans le dossier `Simulation`
  - ne s'affiche que lorsqu'il n'y a pas la sélection d'entreprise (peu pertinent sinon)
  - reste affiché même après le début de la simulation (car toujours pertinent)

- Refactorisation de  `PreviousSimulationBanner`
  - déplacement dans le dossier `Simulation`
  - déplacement de la gestion de la disparition après la 1ère étape dans le parent `Simulation`

- Ajout d'une variable `exceptions` à `firstStepCompletedSelector`, transmise par `Simulation` et remplie au besoin par le simulateur (cessation d'activité, dividendes, indépendant, lodeom et RGCP)

- Correction de 2 avertissements console (`prop` inconnue et absence de `key`)
- Ajout de tests sur les simulateurs génériques
- Ajout de paramètres aux tests des simulateurs génériques