### PR TITLE
A11y/improve dark mode switch and Switch component

### DIFF
--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -170,7 +170,6 @@ function ActivitéMixte() {
 						defaultSelected={defaultChecked}
 						onChange={onMixteChecked}
 						light
-						aria-label="Activité mixte"
 					>
 						Activité mixte
 					</Switch>

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -20,7 +20,6 @@ import {
 import { Emoji } from '@/design-system/emoji'
 import { Select } from '@/design-system/field/Select'
 import { Spacing } from '@/design-system/layout'
-import { Switch } from '@/design-system/switch'
 import { H3, H4 } from '@/design-system/typography/heading'
 
 import { ExplicableRule } from './Explicable'
@@ -345,29 +344,4 @@ export function useSelection<Names extends string = DottedName>({
 	}, [value, missing, currentSelection])
 
 	return { currentSelection, handleChange, defaultValue }
-}
-
-export const SwitchInput = (props: {
-	onChange?: (isSelected: boolean) => void
-	defaultSelected?: boolean
-	label?: string
-	id?: string
-	key?: string
-	invertLabel?: boolean
-}) => {
-	const { onChange, id, label, defaultSelected, key, invertLabel } = props
-
-	return (
-		<Switch
-			defaultSelected={defaultSelected}
-			onChange={(isSelected: boolean) => onChange && onChange(isSelected)}
-			light
-			id={id}
-			key={key}
-			invertLabel={invertLabel}
-			aria-label={label}
-		>
-			{label}
-		</Switch>
-	)
 }

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -62,7 +62,6 @@ export default function Header() {
 							<Switch
 								isSelected={darkMode}
 								onChange={setDarkMode}
-								role="checkbox"
 								aria-label={
 									darkMode
 										? t(

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useRef } from 'react'
 import { css, styled } from 'styled-components'
 
 import { FocusStyle, SROnly } from '@/design-system/global-style'
+import { generateUuid } from '@/utils'
 
 import { Body } from '../typography/paragraphs'
 
@@ -19,14 +20,7 @@ const sizeDico = {
 	XL: '4rem',
 } as { [K in Size]: string }
 
-interface StyledProps {
-	checked: boolean
-	disabled: boolean
-	$size: Size
-	$light: boolean
-}
-
-const StyledSpan = styled.span<StyledProps>`
+const StyledSpan = styled.span<{ checked: boolean }>`
 	position: relative;
 	left: ${({ checked }) =>
 		checked ? 'calc(100% - 2 * (var(--switch-size) / 5))' : '0'};
@@ -42,7 +36,14 @@ const StyledSpan = styled.span<StyledProps>`
 	color: inherit;
 `
 
-const StyledSwitch = styled.span<StyledProps>`
+interface StyledSwitchProps {
+	checked: boolean
+	disabled: boolean
+	$size: Size
+	$light: boolean
+}
+
+const StyledSwitch = styled.span<StyledSwitchProps>`
 	--switch-size: ${({ $size }) => sizeDico[$size]};
 	display: inline-flex;
 	transition: all 0.15s ease-in-out;
@@ -131,8 +132,39 @@ export const Switch = (props: SwitchProps) => {
 	const { isDisabled = false } = ariaProps
 	const { isSelected } = state
 
+	const id = generateUuid()
+
+	const hiddenInput = (
+		<HiddenInput
+			// eslint-disable-next-line react/jsx-props-no-spreading
+			{...inputProps}
+			id={id}
+			type="switch"
+			tabIndex={0}
+			ref={ref}
+			role={props?.role}
+		/>
+	)
+
+	const styledSpan = <StyledSpan aria-hidden checked={isSelected} />
+
+	if (!children) {
+		return (
+			<StyledSwitch
+				$light={light}
+				$size={size}
+				checked={isSelected}
+				disabled={isDisabled}
+				aria-label={props['aria-label']}
+			>
+				{hiddenInput}
+				{styledSpan}
+			</StyledSwitch>
+		)
+	}
+
 	return (
-		<LabelBody as="label" htmlFor={inputProps.id} className={className}>
+		<LabelBody as="label" htmlFor={id} className={className}>
 			{children && !invertLabel && (
 				<Text $invertLabel={invertLabel}>{children}</Text>
 			)}
@@ -141,23 +173,9 @@ export const Switch = (props: SwitchProps) => {
 				$size={size}
 				checked={isSelected}
 				disabled={isDisabled}
-				aria-label={props['aria-label']}
 			>
-				<HiddenInput
-					// eslint-disable-next-line react/jsx-props-no-spreading
-					{...inputProps}
-					type="checkbox"
-					tabIndex={0}
-					ref={ref}
-					role={props?.role}
-				/>
-				<StyledSpan
-					$light={light}
-					$size={size}
-					aria-hidden
-					checked={isSelected}
-					disabled={isDisabled}
-				/>
+				{hiddenInput}
+				{styledSpan}
 			</StyledSwitch>
 			{children && invertLabel && (
 				<Text $invertLabel={invertLabel}>{children}</Text>

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -91,40 +91,22 @@ const LabelBody = styled(Body)`
 	cursor: pointer;
 `
 
-const Text = styled.span<{ $invertLabel?: boolean }>`
-	${({ theme, $invertLabel }) =>
-		$invertLabel
-			? css`
-					margin-left: ${theme.spacings.xxs};
-			  `
-			: css`
-					margin-right: ${theme.spacings.xxs};
-			  `};
+const Text = styled.span`
+	${({ theme }) => css`
+		margin-left: ${theme.spacings.xxs};
+	`}
 `
 
 type AriaSwitchProps = Parameters<typeof useSwitch>[0]
 
-export type SwitchProps = AriaSwitchProps & {
+type SwitchProps = AriaSwitchProps & {
 	size?: Size
 	light?: boolean
 	children?: ReactNode
-	className?: string
-	role?: string
-	/**
-	 * Invert the position of the label and the switch
-	 */
-	invertLabel?: boolean
 }
 
 export const Switch = (props: SwitchProps) => {
-	const {
-		size = 'MD',
-		light = false,
-		children,
-		className,
-		invertLabel = false,
-		...ariaProps
-	} = props
+	const { size = 'MD', light = false, children, ...ariaProps } = props
 	const state = useToggleState(ariaProps)
 	const ref = useRef<HTMLInputElement>(null)
 	const { inputProps } = useSwitch(ariaProps, state, ref)
@@ -139,10 +121,10 @@ export const Switch = (props: SwitchProps) => {
 			// eslint-disable-next-line react/jsx-props-no-spreading
 			{...inputProps}
 			id={id}
-			type="switch"
+			type="checkbox"
+			role="switch"
 			tabIndex={0}
 			ref={ref}
-			role={props?.role}
 		/>
 	)
 
@@ -164,10 +146,7 @@ export const Switch = (props: SwitchProps) => {
 	}
 
 	return (
-		<LabelBody as="label" htmlFor={id} className={className}>
-			{children && !invertLabel && (
-				<Text $invertLabel={invertLabel}>{children}</Text>
-			)}
+		<LabelBody as="label" htmlFor={id}>
 			<StyledSwitch
 				$light={light}
 				$size={size}
@@ -177,9 +156,7 @@ export const Switch = (props: SwitchProps) => {
 				{hiddenInput}
 				{styledSpan}
 			</StyledSwitch>
-			{children && invertLabel && (
-				<Text $invertLabel={invertLabel}>{children}</Text>
-			)}
+			<Text>{children}</Text>
 		</LabelBody>
 	)
 }

--- a/site/source/design-system/switch/index.stories.tsx
+++ b/site/source/design-system/switch/index.stories.tsx
@@ -32,3 +32,15 @@ export const Disabled: Story = {
 		isDisabled: true,
 	},
 }
+
+export const Light: Story = {
+	args: {
+		light: true,
+	},
+}
+
+export const XS: Story = {
+	args: {
+		size: 'XS',
+	},
+}

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -87,7 +87,6 @@ const ModifierOptions = () => {
 							id="activation-acre"
 							onChange={(value: boolean) => set[DOTTEDNAME_ACRE](value)}
 							defaultSelected={values[DOTTEDNAME_ACRE] as boolean}
-							invertLabel
 							light
 						>
 							<Trans>Activer l'ACRE dans la simulation</Trans>
@@ -112,7 +111,6 @@ const ModifierOptions = () => {
 									defaultSelected={
 										values[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE] as boolean
 									}
-									invertLabel
 									light
 								>
 									Je suis éligible à l'ACRE pour mon auto-entreprise
@@ -195,7 +193,6 @@ const ModifierOptions = () => {
 								DOTTEDNAME_AUTOENTREPRENEUR_VERSEMENT_LIBERATOIRE
 							] as boolean
 						}
-						invertLabel
 						light
 					>
 						Activer le versement libératoire dans la simulation.

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -2,7 +2,6 @@ import { PublicodesExpression } from 'publicodes'
 import { Trans, useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
-import { SwitchInput } from '@/components/conversation/ChoicesInput'
 import { ExplicableRule } from '@/components/conversation/Explicable'
 import RuleInput from '@/components/conversation/RuleInput'
 import { Message } from '@/design-system'
@@ -10,6 +9,7 @@ import { Button } from '@/design-system/buttons'
 import { Drawer } from '@/design-system/drawer'
 import { ArrowRightIcon, InfoIcon } from '@/design-system/icons'
 import { Grid, Spacing } from '@/design-system/layout'
+import { Switch } from '@/design-system/switch'
 import { Strong } from '@/design-system/typography'
 import { H2, H3, H5 } from '@/design-system/typography/heading'
 import { Link, StyledLink } from '@/design-system/typography/link'
@@ -83,13 +83,15 @@ const ModifierOptions = () => {
 				<H5 as="h4">Choisir mon option de simulation</H5>
 				<div aria-live="polite">
 					<FlexCentered>
-						<SwitchInput
+						<Switch
 							id="activation-acre"
 							onChange={(value: boolean) => set[DOTTEDNAME_ACRE](value)}
 							defaultSelected={values[DOTTEDNAME_ACRE] as boolean}
-							label="Activer l'ACRE dans la simulation"
 							invertLabel
-						/>
+							light
+						>
+							<Trans>Activer l'ACRE dans la simulation</Trans>
+						</Switch>
 					</FlexCentered>
 
 					{values[DOTTEDNAME_ACRE] && (
@@ -102,7 +104,7 @@ const ModifierOptions = () => {
 								à l'ACRE sont plus restrictives pour les auto-entrepreneurs.
 							</Body>
 							<FlexCentered>
-								<SwitchInput
+								<Switch
 									id="activation-acre-ae"
 									onChange={(value: boolean) =>
 										set[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE](value)
@@ -110,9 +112,11 @@ const ModifierOptions = () => {
 									defaultSelected={
 										values[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE] as boolean
 									}
-									label="Je suis éligible à l'ACRE pour mon auto-entreprise"
 									invertLabel
-								/>
+									light
+								>
+									Je suis éligible à l'ACRE pour mon auto-entreprise
+								</Switch>
 							</FlexCentered>
 						</>
 					)}
@@ -183,7 +187,7 @@ const ModifierOptions = () => {
 					/>
 				</H5>
 				<FlexCentered>
-					<SwitchInput
+					<Switch
 						id="versement-liberatoire"
 						onChange={set[DOTTEDNAME_AUTOENTREPRENEUR_VERSEMENT_LIBERATOIRE]}
 						defaultSelected={
@@ -191,9 +195,11 @@ const ModifierOptions = () => {
 								DOTTEDNAME_AUTOENTREPRENEUR_VERSEMENT_LIBERATOIRE
 							] as boolean
 						}
-						label="Activer le versement libératoire dans la simulation."
 						invertLabel
-					/>
+						light
+					>
+						Activer le versement libératoire dans la simulation.
+					</Switch>
 				</FlexCentered>
 			</>
 		</Drawer>


### PR DESCRIPTION
Cette PR :
- règle une erreur relevée par Wave concernant le switch du dark mode (son label n'avait pas de contenu textuel)
- réusine le composant <Switch /> en mettant systématiquement son label à droite du "bouton"

-----

## Outils mentionnés durant la session de mob programming

### Documentations de référence
- les WAI Patterns pour l'accessibilité des composants complexes : https://www.w3.org/WAI/ARIA/apg/patterns/
- les notices d'AcceDe Web (de l'agence spécialisée Atalan), qui constituent une très bonne porte d'entrée au sujet de l'accessibilité (et qui ne s'adressent pas qu'aux devs) : https://www.accede-web.com/notices/

### Devtools builtin de Chrome :
- l'accessibility tree, à côté des styles dans l'inspecteur, utile par exemple pour déterminer qui "l'emporter" entre `label`, `aria-label`, `aria-labelledby`, `title`, ... :

![image](https://github.com/user-attachments/assets/f257dcf7-866f-4a9a-9ddc-808a370e1ea3)

- le panneau CSS Overview, qui va par exemple immédiatement repérer les contrastes de couleurs insuffisants (on le récupère dans les "More tools") :

![image](https://github.com/user-attachments/assets/f3a55708-6f28-4993-8992-2c09bacef667)

J'ai aussi découvert tout récemment que Firefox intégrait un lecteur d'écran, accessible depuis la barre d'adresse (mais je ne l'ai pas encore vraiment essayé) :

![image](https://github.com/user-attachments/assets/a87df9e8-7866-4803-b19c-7b6acdba226a)

### Extensions de navigateur

- l'Assistant RGAA qui permet d'afficher les critères dans un panneau latéral : https://assistant-rgaa.empreintedigitale.fr/
- Silktide, pour simuler divers handicaps (dyslexies, daltonisme, cataracte, ...), mais cette extension n'a plus l'air d'être disponible, remplacée par un auditeur d'accessibilité du même nom (que j'ai découvert en complétant cette description de la PR)
- Wave et Axe, mais vous les connaissez
- ARIA DevTools, qui donne un aperçu rapide et complet de la sémantique d'une page (balises HTML, rôles WAI-ARIA et textes) :
https://chromewebstore.google.com/detail/aria-devtools/dneemiigcbbgbdjlcdjjnianlikimpck

![image](https://github.com/user-attachments/assets/45a5a482-12c4-4bad-ac83-70f665ed371b)

- Web Developer, que j'ai utilisé pour désactiver le CSS facilement : https://chromewebstore.google.com/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm

Voilà, je crois ne rien avoir oublié. 🙂