### PR TITLE
Mise à jour du barème de l'impôt sur le revenu et des grilles des taux neutres pour 2025

### DIFF
--- a/modele-social/règles/impôt.publicodes
+++ b/modele-social/règles/impôt.publicodes
@@ -119,6 +119,50 @@ impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martin
     Article 204 H du code des impôts: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907548/
   remplace: taux neutre d'impôt sur le revenu
   variations:
+    - si: date >= 01/05/2025
+      alors:
+        grille:
+          assiette: revenu imposable
+          tranches:
+            - montant: 0%
+              plafond: 1858 €/mois
+            - montant: 0.5%
+              plafond: 1971 €/mois
+            - montant: 1.3%
+              plafond: 2171 €/mois
+            - montant: 2.1%
+              plafond: 2371 €/mois
+            - montant: 2.9%
+              plafond: 2618 €/mois
+            - montant: 3.5%
+              plafond: 2761 €/mois
+            - montant: 4.1%
+              plafond: 2855 €/mois
+            - montant: 5.3%
+              plafond: 3142 €/mois
+            - montant: 7.5%
+              plafond: 3885 €/mois
+            - montant: 9.9%
+              plafond: 4971 €/mois
+            - montant: 11.9%
+              plafond: 5646 €/mois
+            - montant: 13.8%
+              plafond: 6540 €/mois
+            - montant: 15.8%
+              plafond: 7836 €/mois
+            - montant: 17.9%
+              plafond: 8711 €/mois
+            - montant: 20%
+              plafond: 9900 €/mois
+            - montant: 24%
+              plafond: 13615 €/mois
+            - montant: 28%
+              plafond: 18090 €/mois
+            - montant: 33%
+              plafond: 27610 €/mois
+            - montant: 38%
+              plafond: 60350 €/mois
+            - montant: 43%
     - si: date >= 01/01/2024
       alors:
         grille:
@@ -307,6 +351,50 @@ impôt . taux neutre d'impôt sur le revenu . barème Guyane Mayotte:
     Article 204 H du code des impôts: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907548/
 
   variations:
+    - si: date >= 01/05/2025
+      alors:
+        grille:
+          assiette: revenu imposable
+          tranches:
+            - montant: 0%
+              plafond: 1990 €/mois
+            - montant: 0.5%
+              plafond: 2151 €/mois
+            - montant: 1.3%
+              plafond: 2393 €/mois
+            - montant: 2.1%
+              plafond: 2704 €/mois
+            - montant: 2.9%
+              plafond: 2808 €/mois
+            - montant: 3.5%
+              plafond: 2904 €/mois
+            - montant: 4.1%
+              plafond: 2999 €/mois
+            - montant: 5.3%
+              plafond: 3332 €/mois
+            - montant: 7.5%
+              plafond: 4598 €/mois
+            - montant: 9.9%
+              plafond: 5951 €/mois
+            - montant: 11.9%
+              plafond: 6712 €/mois
+            - montant: 13.8%
+              plafond: 7788 €/mois
+            - montant: 15.8%
+              plafond: 8567 €/mois
+            - montant: 17.9%
+              plafond: 9492 €/mois
+            - montant: 20%
+              plafond: 11016 €/mois
+            - montant: 24%
+              plafond: 14820 €/mois
+            - montant: 28%
+              plafond: 18850 €/mois
+            - montant: 33%
+              plafond: 30210 €/mois
+            - montant: 38%
+              plafond: 63767 €/mois
+            - montant: 43%
     - si: date >= 01/01/2024
       alors:
         grille:
@@ -494,6 +582,50 @@ impôt . taux neutre d'impôt sur le revenu:
     abattu.
 
   variations:
+    - si: date >= 01/05/2025
+      alors:
+        grille:
+          assiette: revenu imposable
+          tranches:
+            - plafond: 1620 €/mois
+              montant: 0%
+            - plafond: 1683 €/mois
+              montant: 0.5 %
+            - plafond: 1791 €/mois
+              montant: 1.3 %
+            - plafond: 1911 €/mois
+              montant: 2.1 %
+            - plafond: 2042 €/mois
+              montant: 2.9 %
+            - plafond: 2151 €/mois
+              montant: 3.5 %
+            - plafond: 2294 €/mois
+              montant: 4.1 %
+            - plafond: 2714 €/mois
+              montant: 5.3 %
+            - plafond: 3107 €/mois
+              montant: 7.5 %
+            - plafond: 3539 €/mois
+              montant: 9.9 %
+            - plafond: 3983 €/mois
+              montant: 11.9 %
+            - plafond: 4648 €/mois
+              montant: 13.8 %
+            - plafond: 5574 €/mois
+              montant: 15.8 %
+            - plafond: 6974 €/mois
+              montant: 17.9 %
+            - plafond: 8711 €/mois
+              montant: 20%
+            - plafond: 12091 €/mois
+              montant: 24%
+            - plafond: 16376 €/mois
+              montant: 28 %
+            - plafond: 25706 €/mois
+              montant: 33 %
+            - plafond: 55062 €/mois
+              montant: 38 %
+            - montant: 43 %
     - si: date >= 01/01/2024
       alors:
         grille:
@@ -982,6 +1114,8 @@ impôt . foyer fiscal . impôt sur le revenu . impôt brut . par part:
       - taux: 0%
         plafond:
           variations:
+            - si: date >= 01/2025
+              alors: 11497 €/part/an
             - si: date >= 01/2024
               alors: 11294 €/part/an
             - si: date >= 01/2023
@@ -993,6 +1127,8 @@ impôt . foyer fiscal . impôt sur le revenu . impôt brut . par part:
       - taux: 11%
         plafond:
           variations:
+            - si: date >= 01/2025
+              alors: 29315 €/part/an
             - si: date >= 01/2024
               alors: 28797 €/part/an
             - si: date >= 01/2023
@@ -1004,6 +1140,8 @@ impôt . foyer fiscal . impôt sur le revenu . impôt brut . par part:
       - taux: 30%
         plafond:
           variations:
+            - si: date >= 01/2025
+              alors: 83823 €/part/an
             - si: date >= 01/2024
               alors: 82341 €/part/an
             - si: date >= 01/2023
@@ -1015,6 +1153,8 @@ impôt . foyer fiscal . impôt sur le revenu . impôt brut . par part:
       - taux: 41%
         plafond:
           variations:
+            - si: date >= 01/2025
+              alors: 180294 €/part/an
             - si: date >= 01/2024
               alors: 177106 €/part/an
             - si: date >= 01/2023

--- a/site/test/regressions/__snapshots__/SASU.test.ts.snap
+++ b/site/test/regressions/__snapshots__/SASU.test.ts.snap
@@ -2,28 +2,28 @@
 
 exports[`calculate assimilé salarié > ACRE 1`] = `
 "dirigeant . rémunération . totale: 25000
-impôt . montant: 220
+impôt . montant: 188
 salarié . cotisations: 506
 salarié . rémunération . brut: 1853
-salarié . rémunération . net . payé après impôt: 1559
+salarié . rémunération . net . payé après impôt: 1562
 salarié . rémunération . net . à payer avant impôt: 1577"
 `;
 
 exports[`calculate assimilé salarié > ACRE 2`] = `
 "dirigeant . rémunération . totale: 50000
-impôt . montant: 2697
+impôt . montant: 2576
 salarié . cotisations: 1429
 salarié . rémunération . brut: 3327
-salarié . rémunération . net . payé après impôt: 2513
+salarié . rémunération . net . payé après impôt: 2523
 salarié . rémunération . net . à payer avant impôt: 2738"
 `;
 
 exports[`calculate assimilé salarié > ACRE 3`] = `
 "dirigeant . rémunération . totale: 100000
-impôt . montant: 9304
+impôt . montant: 9184
 salarié . cotisations: 3640
 salarié . rémunération . brut: 5944
-salarié . rémunération . net . payé après impôt: 3918
+salarié . rémunération . net . payé après impôt: 3928
 salarié . rémunération . net . à payer avant impôt: 4693"
 `;
 
@@ -38,19 +38,19 @@ salarié . rémunération . net . à payer avant impôt: 1376"
 
 exports[`calculate assimilé salarié > ACRE 5`] = `
 "dirigeant . rémunération . totale: 25000
-impôt . montant: 220
+impôt . montant: 188
 salarié . cotisations: 506
 salarié . rémunération . brut: 1853
-salarié . rémunération . net . payé après impôt: 1559
+salarié . rémunération . net . payé après impôt: 1562
 salarié . rémunération . net . à payer avant impôt: 1577"
 `;
 
 exports[`calculate assimilé salarié > JEI 1`] = `
 "dirigeant . rémunération . totale: 48000
-impôt . montant: 2939
+impôt . montant: 2819
 salarié . cotisations: 1198
 salarié . rémunération . brut: 3574
-salarié . rémunération . net . payé après impôt: 2557
+salarié . rémunération . net . payé après impôt: 2567
 salarié . rémunération . net . à payer avant impôt: 2802"
 `;
 
@@ -128,18 +128,18 @@ salarié . rémunération . net . à payer avant impôt: 906"
 
 exports[`calculate assimilé salarié > échelle de rémunération 7`] = `
 "dirigeant . rémunération . totale: 50000
-impôt . montant: 1577
+impôt . montant: 1545
 salarié . cotisations: 1851
 salarié . rémunération . brut: 2958
-salarié . rémunération . net . payé après impôt: 2184
+salarié . rémunération . net . payé après impôt: 2186
 salarié . rémunération . net . à payer avant impôt: 2315"
 `;
 
 exports[`calculate assimilé salarié > échelle de rémunération 8`] = `
 "dirigeant . rémunération . totale: 100000
-impôt . montant: 9304
+impôt . montant: 9184
 salarié . cotisations: 3640
 salarié . rémunération . brut: 5944
-salarié . rémunération . net . payé après impôt: 3918
+salarié . rémunération . net . payé après impôt: 3928
 salarié . rémunération . net . à payer avant impôt: 4693"
 `;

--- a/site/test/regressions/__snapshots__/auto-entrepreneur.test.ts.snap
+++ b/site/test/regressions/__snapshots__/auto-entrepreneur.test.ts.snap
@@ -311,7 +311,7 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ven
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
 dirigeant . auto-entrepreneur . revenu net: undefined
 dirigeant . auto-entrepreneur . revenu net . après impôt: undefined
-dirigeant . rémunération . impôt: 670"
+dirigeant . rémunération . impôt: 637"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > activités 1`] = `
@@ -650,8 +650,8 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ser
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 819
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
 dirigeant . auto-entrepreneur . revenu net: 70000
-dirigeant . auto-entrepreneur . revenu net . après impôt: 68974
-dirigeant . rémunération . impôt: 1026"
+dirigeant . auto-entrepreneur . revenu net . après impôt: 69007
+dirigeant . rémunération . impôt: 993"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > échelle de revenus 9`] = `
@@ -670,8 +670,8 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ser
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 1170
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
 dirigeant . auto-entrepreneur . revenu net: 100000
-dirigeant . auto-entrepreneur . revenu net . après impôt: 96781
-dirigeant . rémunération . impôt: 3219"
+dirigeant . auto-entrepreneur . revenu net . après impôt: 96902
+dirigeant . rémunération . impôt: 3098"
 `;
 
 exports[`calculate simulations-auto-entrepreneur > échelle de revenus 10`] = `
@@ -690,8 +690,8 @@ dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . ser
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement: 11703
 dirigeant . auto-entrepreneur . cotisations et contributions . cotisations . vente restauration hébergement . taux: 12
 dirigeant . auto-entrepreneur . revenu net: 1000000
-dirigeant . auto-entrepreneur . revenu net . après impôt: 871425
-dirigeant . rémunération . impôt: 128575
+dirigeant . auto-entrepreneur . revenu net . après impôt: 871836
+dirigeant . rémunération . impôt: 128164
 
 Notifications affichées : entreprise . imposition . régime . micro-entreprise . alerte seuil dépassés"
 `;

--- a/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
+++ b/site/test/regressions/__snapshots__/comparateur-statuts.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`calculate comparateur-statuts > ACRE 1`] = `
 "dirigeant . rémunération . net: 44208
-dirigeant . rémunération . net . après impôt: 44105
+dirigeant . rémunération . net . après impôt: 44138
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -28,7 +28,7 @@ Notifications affichées : dirigeant . auto-entrepreneur . cotisations et contri
 
 exports[`calculate comparateur-statuts > ACRE 2`] = `
 "dirigeant . rémunération . net: 37731
-dirigeant . rémunération . net . après impôt: 32736
+dirigeant . rémunération . net . après impôt: 32856
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -52,7 +52,7 @@ protection sociale . retraite . trimestres: 4"
 
 exports[`calculate comparateur-statuts > ACRE 3`] = `
 "dirigeant . rémunération . net: 32484
-dirigeant . rémunération . net . après impôt: 29895
+dirigeant . rémunération . net . après impôt: 30015
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: 1309
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: 818
@@ -76,7 +76,7 @@ protection sociale . retraite . trimestres: 4"
 
 exports[`calculate comparateur-statuts > EI à l'IS 1`] = `
 "dirigeant . rémunération . net: 27619
-dirigeant . rémunération . net . après impôt: 26169
+dirigeant . rémunération . net . après impôt: 26202
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -172,7 +172,7 @@ protection sociale . retraite . trimestres: 0"
 
 exports[`calculate comparateur-statuts > base 1`] = `
 "dirigeant . rémunération . net: 40548
-dirigeant . rémunération . net . après impôt: 40445
+dirigeant . rémunération . net . après impôt: 40478
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -196,7 +196,7 @@ protection sociale . retraite . trimestres: 4"
 
 exports[`calculate comparateur-statuts > base 2`] = `
 "dirigeant . rémunération . net: 32989
-dirigeant . rémunération . net . après impôt: 29416
+dirigeant . rémunération . net . après impôt: 29537
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -220,7 +220,7 @@ protection sociale . retraite . trimestres: 4"
 
 exports[`calculate comparateur-statuts > base 3`] = `
 "dirigeant . rémunération . net: 26920
-dirigeant . rémunération . net . après impôt: 25474
+dirigeant . rémunération . net . après impôt: 25506
 entreprise . activité . nature . libérale . réglementée: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: 1147
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: 717
@@ -244,7 +244,7 @@ protection sociale . retraite . trimestres: 4"
 
 exports[`calculate comparateur-statuts > profession libérale non reglementée 1`] = `
 "dirigeant . rémunération . net: 30120
-dirigeant . rémunération . net . après impôt: 24954
+dirigeant . rémunération . net . après impôt: 25075
 entreprise . activité . nature . libérale . réglementée: false
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -268,7 +268,7 @@ protection sociale . retraite . trimestres: 4"
 
 exports[`calculate comparateur-statuts > profession libérale non reglementée 2`] = `
 "dirigeant . rémunération . net: 30981
-dirigeant . rémunération . net . après impôt: 28035
+dirigeant . rémunération . net . après impôt: 28156
 entreprise . activité . nature . libérale . réglementée: false
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: null
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: null
@@ -291,8 +291,8 @@ protection sociale . retraite . trimestres: 4"
 `;
 
 exports[`calculate comparateur-statuts > profession libérale non reglementée 3`] = `
-"dirigeant . rémunération . net: 25218
-dirigeant . rémunération . net . après impôt: 24030
+"dirigeant . rémunération . net: 25219
+dirigeant . rémunération . net . après impôt: 24063
 entreprise . activité . nature . libérale . réglementée: false
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente décès: 1075
 protection sociale . invalidité et décès . accidents du travail et maladies professionnelles . rente incapacité: 672

--- a/site/test/regressions/__snapshots__/dividendes.test.ts.snap
+++ b/site/test/regressions/__snapshots__/dividendes.test.ts.snap
@@ -14,8 +14,8 @@ exports[`calculate simulations-dividendes > barème couple 2 enfants 2`] = `
 "bénéficiaire . dividendes . bruts: 20000000
 bénéficiaire . dividendes . cotisations et contributions: 3440000
 bénéficiaire . dividendes . imposables: 10640000
-bénéficiaire . dividendes . nets d'impôt: 11420629
-impôt . montant: 5139371
+bénéficiaire . dividendes . nets d'impôt: 11421452
+impôt . montant: 5138548
 impôt . revenu imposable: 10640000
 impôt . taux d'imposition: 48"
 `;
@@ -35,7 +35,7 @@ exports[`calculate simulations-dividendes > barème couple 2 enfants 4`] = `
 bénéficiaire . dividendes . cotisations et contributions: 3440
 bénéficiaire . dividendes . imposables: 10640
 bénéficiaire . dividendes . nets d'impôt: 14860
-impôt . montant: 497
+impôt . montant: 480
 impôt . revenu imposable: 10640
 impôt . taux d'imposition: 5"
 `;
@@ -54,8 +54,8 @@ exports[`calculate simulations-dividendes > barème défauts 2`] = `
 "bénéficiaire . dividendes . bruts: 20000000
 bénéficiaire . dividendes . cotisations et contributions: 3440000
 bénéficiaire . dividendes . imposables: 10640000
-bénéficiaire . dividendes . nets d'impôt: 11381756
-impôt . montant: 5178244
+bénéficiaire . dividendes . nets d'impôt: 11382167
+impôt . montant: 5177833
 impôt . revenu imposable: 10640000
 impôt . taux d'imposition: 49"
 `;
@@ -75,7 +75,7 @@ exports[`calculate simulations-dividendes > barème défauts 4`] = `
 bénéficiaire . dividendes . cotisations et contributions: 3440
 bénéficiaire . dividendes . imposables: 10640
 bénéficiaire . dividendes . nets d'impôt: 13368
-impôt . montant: 2014
+impôt . montant: 1993
 impôt . revenu imposable: 10640
 impôt . taux d'imposition: 19"
 `;

--- a/site/test/regressions/__snapshots__/indépendant.test.ts.snap
+++ b/site/test/regressions/__snapshots__/indépendant.test.ts.snap
@@ -53,11 +53,11 @@ exports[`calculate simulations-indépendant > Année incomplète 5`] = `
 dirigeant . indépendant . revenu professionnel: 103803
 dirigeant . rémunération . cotisations: 40189
 dirigeant . rémunération . net: 100000
-dirigeant . rémunération . net . après impôt: 73212
+dirigeant . rémunération . net . après impôt: 73496
 dirigeant . rémunération . totale: 140189
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 140189
-impôt . montant: 26788"
+impôt . montant: 26504"
 `;
 
 exports[`calculate simulations-indépendant > Année incomplète 6`] = `
@@ -65,11 +65,11 @@ exports[`calculate simulations-indépendant > Année incomplète 6`] = `
 dirigeant . indépendant . revenu professionnel: 1033726
 dirigeant . rémunération . cotisations: 242158
 dirigeant . rémunération . net: 1000000
-dirigeant . rémunération . net . après impôt: 528830
+dirigeant . rémunération . net . après impôt: 529241
 dirigeant . rémunération . totale: 1242158
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 1242158
-impôt . montant: 471170"
+impôt . montant: 470759"
 `;
 
 exports[`calculate simulations-indépendant > DROM 1`] = `
@@ -91,11 +91,11 @@ exports[`calculate simulations-indépendant > acre 1`] = `
 dirigeant . indépendant . revenu professionnel: 51978
 dirigeant . rémunération . cotisations: 22950
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41120
+dirigeant . rémunération . net . après impôt: 41241
 dirigeant . rémunération . totale: 72950
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 72950
-impôt . montant: 8880"
+impôt . montant: 8759"
 `;
 
 exports[`calculate simulations-indépendant > activité 1`] = `
@@ -103,11 +103,11 @@ exports[`calculate simulations-indépendant > activité 1`] = `
 dirigeant . indépendant . revenu professionnel: 20764
 dirigeant . rémunération . cotisations: 8257
 dirigeant . rémunération . net: 20000
-dirigeant . rémunération . net . après impôt: 19360
+dirigeant . rémunération . net . après impôt: 19392
 dirigeant . rémunération . totale: 28257
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 28257
-impôt . montant: 640"
+impôt . montant: 608"
 `;
 
 exports[`calculate simulations-indépendant > activité 2`] = `
@@ -115,11 +115,11 @@ exports[`calculate simulations-indépendant > activité 2`] = `
 dirigeant . indépendant . revenu professionnel: 20764
 dirigeant . rémunération . cotisations: 8276
 dirigeant . rémunération . net: 20000
-dirigeant . rémunération . net . après impôt: 19360
+dirigeant . rémunération . net . après impôt: 19392
 dirigeant . rémunération . totale: 28276
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 28276
-impôt . montant: 640"
+impôt . montant: 608"
 `;
 
 exports[`calculate simulations-indépendant > années précédentes 1`] = `
@@ -163,11 +163,11 @@ exports[`calculate simulations-indépendant > conjoint collaborateur 1`] = `
 dirigeant . indépendant . revenu professionnel: 52104
 dirigeant . rémunération . cotisations: 27632
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41083
+dirigeant . rémunération . net . après impôt: 41203
 dirigeant . rémunération . totale: 77632
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 77632
-impôt . montant: 8917"
+impôt . montant: 8797"
 `;
 
 exports[`calculate simulations-indépendant > conjoint collaborateur 2`] = `
@@ -175,11 +175,11 @@ exports[`calculate simulations-indépendant > conjoint collaborateur 2`] = `
 dirigeant . indépendant . revenu professionnel: 52117
 dirigeant . rémunération . cotisations: 28114
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41079
+dirigeant . rémunération . net . après impôt: 41199
 dirigeant . rémunération . totale: 78114
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 78114
-impôt . montant: 8921"
+impôt . montant: 8801"
 `;
 
 exports[`calculate simulations-indépendant > conjoint collaborateur 3`] = `
@@ -187,11 +187,11 @@ exports[`calculate simulations-indépendant > conjoint collaborateur 3`] = `
 dirigeant . indépendant . revenu professionnel: 52185
 dirigeant . rémunération . cotisations: 30631
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41058
+dirigeant . rémunération . net . après impôt: 41179
 dirigeant . rémunération . totale: 80631
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 80631
-impôt . montant: 8942"
+impôt . montant: 8821"
 `;
 
 exports[`calculate simulations-indépendant > conjoint collaborateur 4`] = `
@@ -199,11 +199,11 @@ exports[`calculate simulations-indépendant > conjoint collaborateur 4`] = `
 dirigeant . indépendant . revenu professionnel: 52006
 dirigeant . rémunération . cotisations: 24034
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41112
+dirigeant . rémunération . net . après impôt: 41233
 dirigeant . rémunération . totale: 74034
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 74034
-impôt . montant: 8888"
+impôt . montant: 8767"
 `;
 
 exports[`calculate simulations-indépendant > conjoint collaborateur 5`] = `
@@ -211,11 +211,11 @@ exports[`calculate simulations-indépendant > conjoint collaborateur 5`] = `
 dirigeant . indépendant . revenu professionnel: 52006
 dirigeant . rémunération . cotisations: 24035
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41112
+dirigeant . rémunération . net . après impôt: 41233
 dirigeant . rémunération . totale: 74035
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 74035
-impôt . montant: 8888"
+impôt . montant: 8767"
 `;
 
 exports[`calculate simulations-indépendant > conjoint collaborateur 6`] = `
@@ -223,11 +223,11 @@ exports[`calculate simulations-indépendant > conjoint collaborateur 6`] = `
 dirigeant . indépendant . revenu professionnel: 517913
 dirigeant . rémunération . cotisations: 159841
 dirigeant . rémunération . net: 500000
-dirigeant . rémunération . net . après impôt: 281578
+dirigeant . rémunération . net . après impôt: 281989
 dirigeant . rémunération . totale: 659841
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 659841
-impôt . montant: 218422"
+impôt . montant: 218011"
 `;
 
 exports[`calculate simulations-indépendant > cotisations facultatives 1`] = `
@@ -235,11 +235,11 @@ exports[`calculate simulations-indépendant > cotisations facultatives 1`] = `
 dirigeant . indépendant . revenu professionnel: 18162
 dirigeant . rémunération . cotisations: 12649
 dirigeant . rémunération . net: 17351
-dirigeant . rémunération . net . après impôt: 17127
+dirigeant . rémunération . net . après impôt: 17159
 dirigeant . rémunération . totale: 30000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 30000
-impôt . montant: 224"
+impôt . montant: 192"
 `;
 
 exports[`calculate simulations-indépendant > cotisations facultatives 2`] = `
@@ -247,11 +247,11 @@ exports[`calculate simulations-indépendant > cotisations facultatives 2`] = `
 dirigeant . indépendant . revenu professionnel: 17991
 dirigeant . rémunération . cotisations: 13849
 dirigeant . rémunération . net: 16151
-dirigeant . rémunération . net . après impôt: 15954
+dirigeant . rémunération . net . après impôt: 15986
 dirigeant . rémunération . totale: 30000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 30000
-impôt . montant: 197"
+impôt . montant: 165"
 `;
 
 exports[`calculate simulations-indépendant > cotisations facultatives 3`] = `
@@ -259,11 +259,11 @@ exports[`calculate simulations-indépendant > cotisations facultatives 3`] = `
 dirigeant . indépendant . revenu professionnel: 20962
 dirigeant . rémunération . cotisations: 9849
 dirigeant . rémunération . net: 20151
-dirigeant . rémunération . net . après impôt: 19479
+dirigeant . rémunération . net . après impôt: 19512
 dirigeant . rémunération . totale: 30000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 30000
-impôt . montant: 672"
+impôt . montant: 639"
 `;
 
 exports[`calculate simulations-indépendant > cotisations facultatives 4`] = `
@@ -283,11 +283,11 @@ exports[`calculate simulations-indépendant > cotisations facultatives 5`] = `
 dirigeant . indépendant . revenu professionnel: 226731
 dirigeant . rémunération . cotisations: 81412
 dirigeant . rémunération . net: 218588
-dirigeant . rémunération . net . après impôt: 139414
+dirigeant . rémunération . net . après impôt: 139826
 dirigeant . rémunération . totale: 300000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 300000
-impôt . montant: 79174"
+impôt . montant: 78762"
 `;
 
 exports[`calculate simulations-indépendant > cotisations facultatives 6`] = `
@@ -295,11 +295,11 @@ exports[`calculate simulations-indépendant > cotisations facultatives 6`] = `
 dirigeant . indépendant . revenu professionnel: 223232
 dirigeant . rémunération . cotisations: 84912
 dirigeant . rémunération . net: 215088
-dirigeant . rémunération . net . après impôt: 137489
+dirigeant . rémunération . net . après impôt: 137901
 dirigeant . rémunération . totale: 300000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 300000
-impôt . montant: 77599"
+impôt . montant: 77187"
 `;
 
 exports[`calculate simulations-indépendant > cotisations forfaitaires début d'activité 1`] = `
@@ -307,11 +307,11 @@ exports[`calculate simulations-indépendant > cotisations forfaitaires début d'
 dirigeant . indépendant . revenu professionnel: 35678
 dirigeant . rémunération . cotisations: 15676
 dirigeant . rémunération . net: 34324
-dirigeant . rémunération . net . après impôt: 30334
+dirigeant . rémunération . net . après impôt: 30455
 dirigeant . rémunération . totale: 50000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 3990"
+impôt . montant: 3869"
 `;
 
 exports[`calculate simulations-indépendant > cotisations minimales 1`] = `
@@ -355,11 +355,11 @@ exports[`calculate simulations-indépendant > exonération pension invalidité 1
 dirigeant . indépendant . revenu professionnel: 41485
 dirigeant . rémunération . cotisations: 4734
 dirigeant . rémunération . net: 40266
-dirigeant . rémunération . net . après impôt: 34534
+dirigeant . rémunération . net . après impôt: 34655
 dirigeant . rémunération . totale: 45000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 45000
-impôt . montant: 5732"
+impôt . montant: 5611"
 `;
 
 exports[`calculate simulations-indépendant > exonération pension invalidité 2`] = `
@@ -403,11 +403,11 @@ exports[`calculate simulations-indépendant > exonération âge 1`] = `
 dirigeant . indépendant . revenu professionnel: 39514
 dirigeant . rémunération . cotisations: 16976
 dirigeant . rémunération . net: 38024
-dirigeant . rémunération . net . après impôt: 32884
+dirigeant . rémunération . net . après impôt: 33004
 dirigeant . rémunération . totale: 55000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 55000
-impôt . montant: 5140"
+impôt . montant: 5020"
 `;
 
 exports[`calculate simulations-indépendant > imposition à l'IS 1`] = `
@@ -415,11 +415,11 @@ exports[`calculate simulations-indépendant > imposition à l'IS 1`] = `
 dirigeant . indépendant . revenu professionnel: 72038
 dirigeant . rémunération . cotisations: 30674
 dirigeant . rémunération . net: 69326
-dirigeant . rémunération . net . après impôt: 56589
+dirigeant . rémunération . net . après impôt: 56710
 dirigeant . rémunération . totale: 100000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 100000
-impôt . montant: 12737"
+impôt . montant: 12616"
 `;
 
 exports[`calculate simulations-indépendant > imposition à l'IS 2`] = `
@@ -427,11 +427,11 @@ exports[`calculate simulations-indépendant > imposition à l'IS 2`] = `
 dirigeant . indépendant . revenu professionnel: 72038
 dirigeant . rémunération . cotisations: 30674
 dirigeant . rémunération . net: 69326
-dirigeant . rémunération . net . après impôt: 56589
+dirigeant . rémunération . net . après impôt: 56710
 dirigeant . rémunération . totale: 100000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 100000
-impôt . montant: 12737"
+impôt . montant: 12616"
 `;
 
 exports[`calculate simulations-indépendant > impôt sur le revenu 1`] = `
@@ -463,11 +463,11 @@ exports[`calculate simulations-indépendant > inversions 2`] = `
 dirigeant . indépendant . revenu professionnel: 42574
 dirigeant . rémunération . cotisations: 19052
 dirigeant . rémunération . net: 40948
-dirigeant . rémunération . net . après impôt: 36167
+dirigeant . rémunération . net . après impôt: 36288
 dirigeant . rémunération . totale: 60000
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 60001
-impôt . montant: 4781"
+impôt . montant: 4660"
 `;
 
 exports[`calculate simulations-indépendant > inversions 3`] = `
@@ -496,14 +496,14 @@ impôt . montant: 0"
 
 exports[`calculate simulations-indépendant > inversions 5`] = `
 "dirigeant . indépendant . cotisations et contributions . début activité: null
-dirigeant . indépendant . revenu professionnel: 42333
-dirigeant . rémunération . cotisations: 18936
-dirigeant . rémunération . net: 40716
+dirigeant . indépendant . revenu professionnel: 42158
+dirigeant . rémunération . cotisations: 18849
+dirigeant . rémunération . net: 40548
 dirigeant . rémunération . net . après impôt: 3000
-dirigeant . rémunération . totale: 59652
+dirigeant . rémunération . totale: 59397
 entreprise . charges: 0
-entreprise . chiffre d'affaires: 59652
-impôt . montant: 4716"
+entreprise . chiffre d'affaires: 59400
+impôt . montant: 4548"
 `;
 
 exports[`calculate simulations-indépendant > inversions 6`] = `
@@ -607,11 +607,11 @@ exports[`calculate simulations-indépendant > échelle de revenus 7`] = `
 dirigeant . indépendant . revenu professionnel: 103803
 dirigeant . rémunération . cotisations: 40167
 dirigeant . rémunération . net: 100000
-dirigeant . rémunération . net . après impôt: 73212
+dirigeant . rémunération . net . après impôt: 73496
 dirigeant . rémunération . totale: 140167
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 140167
-impôt . montant: 26788"
+impôt . montant: 26504"
 `;
 
 exports[`calculate simulations-indépendant > échelle de revenus 8`] = `
@@ -619,9 +619,9 @@ exports[`calculate simulations-indépendant > échelle de revenus 8`] = `
 dirigeant . indépendant . revenu professionnel: 1033725
 dirigeant . rémunération . cotisations: 242133
 dirigeant . rémunération . net: 1000000
-dirigeant . rémunération . net . après impôt: 528830
+dirigeant . rémunération . net . après impôt: 529242
 dirigeant . rémunération . totale: 1242133
 entreprise . charges: 0
 entreprise . chiffre d'affaires: 1242133
-impôt . montant: 471170"
+impôt . montant: 470758"
 `;

--- a/site/test/regressions/__snapshots__/professions-libérales.test.ts.snap
+++ b/site/test/regressions/__snapshots__/professions-libérales.test.ts.snap
@@ -14,9 +14,9 @@ protection sociale . retraite . trimestres: 3"
 exports[`calculate simulations-professions-libérales > CIPAV ACRE 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 6836
 dirigeant . rémunération . net: 20000
-dirigeant . rémunération . net . après impôt: 19366
+dirigeant . rémunération . net . après impôt: 19398
 entreprise . chiffre d'affaires: 26836
-impôt . montant: 634
+impôt . montant: 602
 protection sociale . retraite . base: 153
 protection sociale . retraite . complémentaire: 95
 protection sociale . retraite . trimestres: 4"
@@ -25,9 +25,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV ACRE 3`] = `
 "dirigeant . indépendant . cotisations et contributions: 20469
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41141
+dirigeant . rémunération . net . après impôt: 41262
 entreprise . chiffre d'affaires: 70469
-impôt . montant: 8859
+impôt . montant: 8738
 protection sociale . retraite . base: 347
 protection sociale . retraite . complémentaire: 269
 protection sociale . retraite . trimestres: 4"
@@ -80,9 +80,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV année incomplète 5`] = `
 "dirigeant . indépendant . cotisations et contributions: 46737
 dirigeant . rémunération . net: 100000
-dirigeant . rémunération . net . après impôt: 73139
+dirigeant . rémunération . net . après impôt: 73423
 entreprise . chiffre d'affaires: 146737
-impôt . montant: 26861
+impôt . montant: 26577
 protection sociale . retraite . base: 351
 protection sociale . retraite . complémentaire: 851
 protection sociale . retraite . trimestres: 4"
@@ -91,9 +91,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV année incomplète 6`] = `
 "dirigeant . indépendant . cotisations et contributions: 252404
 dirigeant . rémunération . net: 1000000
-dirigeant . rémunération . net . après impôt: 528693
+dirigeant . rémunération . net . après impôt: 529105
 entreprise . chiffre d'affaires: 1252404
-impôt . montant: 471307
+impôt . montant: 470895
 protection sociale . retraite . base: 360
 protection sociale . retraite . complémentaire: 1532
 protection sociale . retraite . trimestres: 4"
@@ -135,9 +135,9 @@ protection sociale . retraite . trimestres: 0"
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 1`] = `
 "dirigeant . indépendant . cotisations et contributions: 31598
 dirigeant . rémunération . net: 60000
-dirigeant . rémunération . net . après impôt: 47969
+dirigeant . rémunération . net . après impôt: 48090
 entreprise . chiffre d'affaires: 91598
-impôt . montant: 12031
+impôt . montant: 11910
 protection sociale . retraite . base: 348
 protection sociale . retraite . complémentaire: 387
 protection sociale . retraite . trimestres: 4"
@@ -146,9 +146,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 30705
 dirigeant . rémunération . net: 60000
-dirigeant . rémunération . net . après impôt: 47976
+dirigeant . rémunération . net . après impôt: 48097
 entreprise . chiffre d'affaires: 90705
-impôt . montant: 12024
+impôt . montant: 11903
 protection sociale . retraite . base: 348
 protection sociale . retraite . complémentaire: 387
 protection sociale . retraite . trimestres: 4"
@@ -157,9 +157,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 3`] = `
 "dirigeant . indépendant . cotisations et contributions: 30354
 dirigeant . rémunération . net: 60000
-dirigeant . rémunération . net . après impôt: 47979
+dirigeant . rémunération . net . après impôt: 48100
 entreprise . chiffre d'affaires: 90354
-impôt . montant: 12021
+impôt . montant: 11900
 protection sociale . retraite . base: 460
 protection sociale . retraite . complémentaire: 387
 protection sociale . retraite . trimestres: 4"
@@ -168,9 +168,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 4`] = `
 "dirigeant . indépendant . cotisations et contributions: 34697
 dirigeant . rémunération . net: 60000
-dirigeant . rémunération . net . après impôt: 47944
+dirigeant . rémunération . net . après impôt: 48065
 entreprise . chiffre d'affaires: 94697
-impôt . montant: 12056
+impôt . montant: 11935
 protection sociale . retraite . base: 348
 protection sociale . retraite . complémentaire: 388
 protection sociale . retraite . trimestres: 4"
@@ -179,9 +179,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 5`] = `
 "dirigeant . indépendant . cotisations et contributions: 32579
 dirigeant . rémunération . net: 60000
-dirigeant . rémunération . net . après impôt: 47961
+dirigeant . rémunération . net . après impôt: 48082
 entreprise . chiffre d'affaires: 92579
-impôt . montant: 12039
+impôt . montant: 11918
 protection sociale . retraite . base: 460
 protection sociale . retraite . complémentaire: 388
 protection sociale . retraite . trimestres: 4"
@@ -201,9 +201,9 @@ protection sociale . retraite . trimestres: 3"
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 7`] = `
 "dirigeant . indépendant . cotisations et contributions: 31598
 dirigeant . rémunération . net: 60000
-dirigeant . rémunération . net . après impôt: 47969
+dirigeant . rémunération . net . après impôt: 48090
 entreprise . chiffre d'affaires: 91598
-impôt . montant: 12031
+impôt . montant: 11910
 protection sociale . retraite . base: 348
 protection sociale . retraite . complémentaire: 387
 protection sociale . retraite . trimestres: 4"
@@ -212,9 +212,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV exonération incapacité 1`] = `
 "dirigeant . indépendant . cotisations et contributions: 6920
 dirigeant . rémunération . net: 40000
-dirigeant . rémunération . net . après impôt: 34333
+dirigeant . rémunération . net . après impôt: 34453
 entreprise . chiffre d'affaires: 46920
-impôt . montant: 5667
+impôt . montant: 5547
 protection sociale . retraite . base: 565
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 0"
@@ -234,9 +234,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV réduction et surcotisation 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 20469
 dirigeant . rémunération . net: 50000
-dirigeant . rémunération . net . après impôt: 41141
+dirigeant . rémunération . net . après impôt: 41262
 entreprise . chiffre d'affaires: 70469
-impôt . montant: 8859
+impôt . montant: 8738
 protection sociale . retraite . base: 347
 protection sociale . retraite . complémentaire: 269
 protection sociale . retraite . trimestres: 4"
@@ -245,9 +245,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV réduction et surcotisation 3`] = `
 "dirigeant . indépendant . cotisations et contributions: 46735
 dirigeant . rémunération . net: 100000
-dirigeant . rémunération . net . après impôt: 73139
+dirigeant . rémunération . net . après impôt: 73423
 entreprise . chiffre d'affaires: 146735
-impôt . montant: 26861
+impôt . montant: 26577
 protection sociale . retraite . base: 351
 protection sociale . retraite . complémentaire: 851
 protection sociale . retraite . trimestres: 4"
@@ -322,9 +322,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV échelle de revenu 7`] = `
 "dirigeant . indépendant . cotisations et contributions: 46735
 dirigeant . rémunération . net: 100000
-dirigeant . rémunération . net . après impôt: 73139
+dirigeant . rémunération . net . après impôt: 73423
 entreprise . chiffre d'affaires: 146735
-impôt . montant: 26861
+impôt . montant: 26577
 protection sociale . retraite . base: 351
 protection sociale . retraite . complémentaire: 851
 protection sociale . retraite . trimestres: 4"
@@ -333,9 +333,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > CIPAV échelle de revenu 8`] = `
 "dirigeant . indépendant . cotisations et contributions: 252401
 dirigeant . rémunération . net: 1000000
-dirigeant . rémunération . net . après impôt: 528693
+dirigeant . rémunération . net . après impôt: 529105
 entreprise . chiffre d'affaires: 1252401
-impôt . montant: 471307
+impôt . montant: 470895
 protection sociale . retraite . base: 360
 protection sociale . retraite . complémentaire: 1532
 protection sociale . retraite . trimestres: 4"
@@ -344,9 +344,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > auxiliaire médical 1`] = `
 "dirigeant . indépendant . cotisations et contributions: 8758
 dirigeant . rémunération . net: 21242
-dirigeant . rémunération . net . après impôt: 20396
+dirigeant . rémunération . net . après impôt: 20428
 entreprise . chiffre d'affaires: 30000
-impôt . montant: 846
+impôt . montant: 814
 protection sociale . retraite . base: 162
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -355,9 +355,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > auxiliaire médical 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 8921
 dirigeant . rémunération . net: 21079
-dirigeant . rémunération . net . après impôt: 20259
+dirigeant . rémunération . net . après impôt: 20291
 entreprise . chiffre d'affaires: 30000
-impôt . montant: 820
+impôt . montant: 788
 protection sociale . retraite . base: 161
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -366,9 +366,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > auxiliaire médical 3`] = `
 "dirigeant . indépendant . cotisations et contributions: 72843
 dirigeant . rémunération . net: 227157
-dirigeant . rémunération . net . après impôt: 144131
+dirigeant . rémunération . net . après impôt: 144542
 entreprise . chiffre d'affaires: 300000
-impôt . montant: 83026
+impôt . montant: 82615
 protection sociale . retraite . base: 360
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -377,9 +377,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > avocat 1`] = `
 "dirigeant . indépendant . cotisations et contributions: 12037
 dirigeant . rémunération . net: 37963
-dirigeant . rémunération . net . après impôt: 32881
+dirigeant . rémunération . net . après impôt: 33002
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 5082
+impôt . montant: 4961
 protection sociale . retraite . base: 289
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -388,9 +388,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > avocat 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 12037
 dirigeant . rémunération . net: 37963
-dirigeant . rémunération . net . après impôt: 32881
+dirigeant . rémunération . net . après impôt: 33002
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 5082
+impôt . montant: 4961
 protection sociale . retraite . base: 289
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -410,9 +410,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > expert-comptable 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 15185
 dirigeant . rémunération . net: 34815
-dirigeant . rémunération . net . après impôt: 30678
+dirigeant . rémunération . net . après impôt: 30799
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 4137
+impôt . montant: 4016
 protection sociale . retraite . base: 266
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -421,9 +421,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > médecin 1`] = `
 "dirigeant . indépendant . cotisations et contributions: 14577
 dirigeant . rémunération . net: 35423
-dirigeant . rémunération . net . après impôt: 31105
+dirigeant . rémunération . net . après impôt: 31226
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 4318
+impôt . montant: 4197
 protection sociale . retraite . base: 271
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -432,9 +432,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > médecin 2`] = `
 "dirigeant . indépendant . cotisations et contributions: 20204
 dirigeant . rémunération . net: 29796
-dirigeant . rémunération . net . après impôt: 27166
+dirigeant . rémunération . net . après impôt: 27287
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 2630
+impôt . montant: 2509
 protection sociale . retraite . base: 229
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -443,9 +443,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > médecin 3`] = `
 "dirigeant . indépendant . cotisations et contributions: 94757
 dirigeant . rémunération . net: 205243
-dirigeant . rémunération . net . après impôt: 132078
+dirigeant . rémunération . net . après impôt: 132489
 entreprise . chiffre d'affaires: 300000
-impôt . montant: 73165
+impôt . montant: 72754
 protection sociale . retraite . base: 358
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -454,9 +454,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > médecin 4`] = `
 "dirigeant . indépendant . cotisations et contributions: 120250
 dirigeant . rémunération . net: 279750
-dirigeant . rémunération . net . après impôt: 170617
+dirigeant . rémunération . net . après impôt: 171028
 entreprise . chiffre d'affaires: 400000
-impôt . montant: 109133
+impôt . montant: 108722
 protection sociale . retraite . base: 360
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -465,9 +465,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > médecin 5`] = `
 "dirigeant . indépendant . cotisations et contributions: 35048
 dirigeant . rémunération . net: 84952
-dirigeant . rémunération . net . après impôt: 64558
+dirigeant . rémunération . net . après impôt: 64842
 entreprise . chiffre d'affaires: 120000
-impôt . montant: 20394
+impôt . montant: 20110
 protection sociale . retraite . base: 349
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -476,9 +476,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > médecin 6`] = `
 "dirigeant . indépendant . cotisations et contributions: 14577
 dirigeant . rémunération . net: 35423
-dirigeant . rémunération . net . après impôt: 31105
+dirigeant . rémunération . net . après impôt: 31226
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 4318
+impôt . montant: 4197
 protection sociale . retraite . base: 271
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4"
@@ -487,9 +487,9 @@ protection sociale . retraite . trimestres: 4"
 exports[`calculate simulations-professions-libérales > sage-femme 1`] = `
 "dirigeant . indépendant . cotisations et contributions: 12407
 dirigeant . rémunération . net: 37593
-dirigeant . rémunération . net . après impôt: 32623
+dirigeant . rémunération . net . après impôt: 32744
 entreprise . chiffre d'affaires: 50000
-impôt . montant: 4970
+impôt . montant: 4849
 protection sociale . retraite . base: 287
 protection sociale . retraite . complémentaire: 0
 protection sociale . retraite . trimestres: 4

--- a/site/test/regressions/__snapshots__/salarié.test.ts.snap
+++ b/site/test/regressions/__snapshots__/salarié.test.ts.snap
@@ -36,7 +36,7 @@ exports[`calculate simulations-salarié > JEI 2`] = `
 "salarié . contrat . salaire brut: 20000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 26485
-salarié . rémunération . net . payé après impôt: 10951
+salarié . rémunération . net . payé après impôt: 10985
 salarié . rémunération . net . à payer avant impôt: 15966
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -64,7 +64,7 @@ exports[`calculate simulations-salarié > activité partielle 3`] = `
 "salarié . contrat . salaire brut: 8000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 1940
-salarié . rémunération . net . payé après impôt: 3790
+salarié . rémunération . net . payé après impôt: 3800
 salarié . rémunération . net . à payer avant impôt: 4484"
 `;
 
@@ -112,7 +112,7 @@ exports[`calculate simulations-salarié > aides 2`] = `
 "salarié . contrat . salaire brut: 10000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 12827
-salarié . rémunération . net . payé après impôt: 7729
+salarié . rémunération . net . payé après impôt: 7739
 salarié . rémunération . net . à payer avant impôt: 8912
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -198,7 +198,7 @@ exports[`calculate simulations-salarié > cadre 2`] = `
 "salarié . contrat . salaire brut: 8000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 11579
-salarié . rémunération . net . payé après impôt: 5013
+salarié . rémunération . net . payé après impôt: 5023
 salarié . rémunération . net . à payer avant impôt: 6233"
 `;
 
@@ -580,7 +580,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 3000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 4076
-salarié . rémunération . net . payé après impôt: 2298
+salarié . rémunération . net . payé après impôt: 2302
 salarié . rémunération . net . à payer avant impôt: 2353"
 `;
 
@@ -604,7 +604,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 3000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 4076
-salarié . rémunération . net . payé après impôt: 1964
+salarié . rémunération . net . payé après impôt: 1970
 salarié . rémunération . net . à payer avant impôt: 2353"
 `;
 
@@ -612,7 +612,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 3000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 4076
-salarié . rémunération . net . payé après impôt: 2211
+salarié . rémunération . net . payé après impôt: 2214
 salarié . rémunération . net . à payer avant impôt: 2353"
 `;
 
@@ -620,7 +620,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 9000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 12905
-salarié . rémunération . net . payé après impôt: 6264
+salarié . rémunération . net . payé après impôt: 6284
 salarié . rémunération . net . à payer avant impôt: 7150"
 `;
 
@@ -628,7 +628,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 9000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 12905
-salarié . rémunération . net . payé après impôt: 6725
+salarié . rémunération . net . payé après impôt: 6731
 salarié . rémunération . net . à payer avant impôt: 7150"
 `;
 
@@ -636,7 +636,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 9000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 12905
-salarié . rémunération . net . payé après impôt: 6954
+salarié . rémunération . net . payé après impôt: 6968
 salarié . rémunération . net . à payer avant impôt: 7150"
 `;
 
@@ -644,7 +644,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 3000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 4076
-salarié . rémunération . net . payé après impôt: 2222
+salarié . rémunération . net . payé après impôt: 2225
 salarié . rémunération . net . à payer avant impôt: 2353"
 `;
 
@@ -660,7 +660,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 20000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 28464
-salarié . rémunération . net . payé après impôt: 13031
+salarié . rémunération . net . payé après impôt: 13061
 salarié . rémunération . net . à payer avant impôt: 15966
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -670,7 +670,7 @@ exports[`calculate simulations-salarié > impôt sur le revenu - quotient famili
 "salarié . contrat . salaire brut: 20000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 28464
-salarié . rémunération . net . payé après impôt: 11296
+salarié . rémunération . net . payé après impôt: 11331
 salarié . rémunération . net . à payer avant impôt: 15966
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -1110,7 +1110,7 @@ exports[`calculate simulations-salarié > échelle de salaires 13`] = `
 "salarié . contrat . salaire brut: 10000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 14336
-salarié . rémunération . net . payé après impôt: 6219
+salarié . rémunération . net . payé après impôt: 6243
 salarié . rémunération . net . à payer avant impôt: 7952
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -1120,7 +1120,7 @@ exports[`calculate simulations-salarié > échelle de salaires 14`] = `
 "salarié . contrat . salaire brut: 20000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 28464
-salarié . rémunération . net . payé après impôt: 10951
+salarié . rémunération . net . payé après impôt: 10985
 salarié . rémunération . net . à payer avant impôt: 15966
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -1130,7 +1130,7 @@ exports[`calculate simulations-salarié > échelle de salaires 15`] = `
 "salarié . contrat . salaire brut: 100000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 129386
-salarié . rémunération . net . payé après impôt: 46346
+salarié . rémunération . net . payé après impôt: 46381
 salarié . rémunération . net . à payer avant impôt: 86762
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"
@@ -1140,7 +1140,7 @@ exports[`calculate simulations-salarié > échelle de salaires 16`] = `
 "salarié . contrat . salaire brut: 1000000
 salarié . contrat . salaire brut . équivalent temps plein: null
 salarié . coût total employeur: 1245800
-salarié . rémunération . net . payé après impôt: 446198
+salarié . rémunération . net . payé après impôt: 446233
 salarié . rémunération . net . à payer avant impôt: 895862
 
 Notifications affichées : salarié . contrat . salaire brut . contrôle salaire élevé"


### PR DESCRIPTION
Les nouveaux seuils pour les taux neutres ne sont à priori pas encore publiés au BOFIP.