### PR TITLE
a11y/Change labels simulateurs

### DIFF
--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -20,8 +20,8 @@ import RuleLink from '../RuleLink'
 import { Appear } from '../ui/animate'
 import AnimatedTargetValue from '../ui/AnimatedTargetValue'
 import { useEngine } from '../utils/EngineContext'
+import { normalizeRuleName } from '../utils/normalizeRuleName'
 import { useInitialRender } from '../utils/useInitialRender'
-import {normalizeRuleName} from '../utils/normalizeRuleName';
 
 type SimulationGoalProps = {
 	dottedName: DottedName
@@ -103,9 +103,7 @@ export function SimulationGoal({
 									}}
 								>
 									<Grid item>
-										<StyledBody
-											id={normalizeRuleName.Label(dottedName)}
-										>
+										<StyledBody id={normalizeRuleName.Label(dottedName)}>
 											<Strong>{label || rule.title}</Strong>
 										</StyledBody>
 									</Grid>
@@ -116,10 +114,10 @@ export function SimulationGoal({
 									</Grid>
 								</Grid>
 							) : (
-								<RuleLink
-									dottedName={dottedName}
-								>
-									<StyledLabel htmlFor={normalizeRuleName.Input(dottedName)}>{label || rule.title}</StyledLabel>
+								<RuleLink dottedName={dottedName}>
+									<StyledLabel htmlFor={normalizeRuleName.Input(dottedName)}>
+										{label || rule.title}
+									</StyledLabel>
 								</RuleLink>
 							)}
 
@@ -195,6 +193,7 @@ const StyledBody = styled(Body)`
 	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	margin: 0;
 `
+
 const StyledLabel = styled.label`
-	cursor: pointer
-`;
+	cursor: pointer;
+`

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -119,7 +119,7 @@ export function SimulationGoal({
 								<RuleLink
 									dottedName={dottedName}
 								>
-									<label htmlFor={normalizeRuleName.Input(dottedName)} style={{cursor: "pointer"}}>{label || rule.title}</label>
+									<StyledLabel htmlFor={normalizeRuleName.Input(dottedName)}>{label || rule.title}</StyledLabel>
 								</RuleLink>
 							)}
 
@@ -195,3 +195,6 @@ const StyledBody = styled(Body)`
 	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	margin: 0;
 `
+const StyledLabel = styled.label`
+	cursor: pointer
+`;

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -21,6 +21,7 @@ import { Appear } from '../ui/animate'
 import AnimatedTargetValue from '../ui/AnimatedTargetValue'
 import { useEngine } from '../utils/EngineContext'
 import { useInitialRender } from '../utils/useInitialRender'
+import {normalizeRuleName} from '../utils/normalizeRuleName';
 
 type SimulationGoalProps = {
 	dottedName: DottedName
@@ -103,7 +104,7 @@ export function SimulationGoal({
 								>
 									<Grid item>
 										<StyledBody
-											id={`${dottedName.replace(/\s|\./g, '_')}-label`}
+											id={normalizeRuleName.Label(dottedName)}
 										>
 											<Strong>{label || rule.title}</Strong>
 										</StyledBody>
@@ -116,17 +117,16 @@ export function SimulationGoal({
 								</Grid>
 							) : (
 								<RuleLink
-									id={`${dottedName.replace(/\s|\./g, '_')}-label`}
 									dottedName={dottedName}
 								>
-									{label || rule.title}
+									<label htmlFor={normalizeRuleName.Input(dottedName)} style={{cursor: "pointer"}}>{label || rule.title}</label>
 								</RuleLink>
 							)}
 
 							{rule.rawNode.résumé && (
 								<StyledSmallBody
 									className={small ? 'sr-only' : ''}
-									id={`${dottedName.replace(/\s|\./g, '_')}-description`}
+									id={normalizeRuleName.Description(dottedName)}
 								>
 									{rule.rawNode.résumé}
 								</StyledSmallBody>
@@ -147,12 +147,8 @@ export function SimulationGoal({
 										  }
 										: undefined
 								}
-								aria-label={engine.getRule(dottedName)?.title}
-								aria-describedby={`${dottedName.replace(
-									/\s|\./g,
-									'_'
-								)}-description`}
-								aria-labelledby="simu-update-explaining"
+								// aria-label={engine.getRule(dottedName)?.title}
+								aria-describedby={normalizeRuleName.Description(dottedName)}
 								hideDefaultValue
 								displayedUnit={displayedUnit}
 								dottedName={dottedName}
@@ -168,7 +164,7 @@ export function SimulationGoal({
 						</Grid>
 					) : (
 						<Grid item>
-							<Body id={`${dottedName.replace(/\s|\./g, '_')}-value`}>
+							<Body id={normalizeRuleName.Value(dottedName)}>
 								{formatValue(evaluation, {
 									displayedUnit,
 									precision: round ? 0 : 2,

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -147,7 +147,6 @@ export function SimulationGoal({
 										  }
 										: undefined
 								}
-								// aria-label={engine.getRule(dottedName)?.title}
 								aria-describedby={normalizeRuleName.Description(dottedName)}
 								hideDefaultValue
 								displayedUnit={displayedUnit}

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -59,7 +59,7 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 }: {
 	choices: Choice
 	type?: 'radio' | 'card' | 'toggle' | 'select'
-} & InputProps<Names>) {
+} & InputProps) {
 	const { t } = useTranslation()
 
 	// seront stockées ainsi dans le state :
@@ -264,7 +264,7 @@ const StyledSubRadioGroup = styled.div`
 `
 
 export function OuiNonInput<Names extends string = DottedName>(
-	props: InputProps<Names>
+	props: InputProps
 ) {
 	const { t } = useTranslation()
 
@@ -303,7 +303,7 @@ export function useSelection<Names extends string = DottedName>({
 	value,
 	onChange,
 	missing,
-}: InputProps<Names>) {
+}: InputProps) {
 	const serializeValue = (nodeValue: Evaluation) =>
 		serializeEvaluation({ nodeValue } as EvaluatedNode)
 

--- a/site/source/components/conversation/MulipleChoicesInput.tsx
+++ b/site/source/components/conversation/MulipleChoicesInput.tsx
@@ -10,7 +10,7 @@ import { ExplicableRule } from './Explicable'
 import { InputProps } from './RuleInput'
 
 export function MultipleChoicesInput<Names extends string = DottedName>(
-	props: Omit<InputProps<Names>, 'onChange'> & {
+	props: Omit<InputProps, 'onChange'> & {
 		choices: Array<RuleNode<Names>>
 		onChange: (value: PublicodesExpression, name: Names) => void
 	}

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -24,20 +24,21 @@ import ParagrapheInput from './ParagrapheInput'
 import SelectPaysDétachement from './select/SelectPaysDétachement'
 import SelectAtmp from './select/SelectTauxRisque'
 import TextInput from './TextInput'
+import {normalizeRuleName} from '../utils/normalizeRuleName';
 
 type InputType = 'radio' | 'card' | 'toggle' | 'select'
 
-type Props<Names extends string = DottedName> = Omit<
+type Props = Omit<
 	React.HTMLAttributes<HTMLInputElement>,
 	'onChange' | 'defaultValue' | 'onSubmit'
 > & {
 	required?: boolean
 	autoFocus?: boolean
 	small?: boolean
-	dottedName: Names
+	dottedName: DottedName
 	label?: string
 	missing?: boolean
-	onChange: (value: PublicodesExpression | undefined, dottedName: Names) => void
+	onChange: (value: PublicodesExpression | undefined, dottedName: DottedName) => void
 	// TODO: It would be preferable to replace this "showSuggestions" parameter by
 	// a build-in logic in the engine, by setting the "applicability" of
 	// suggestions.
@@ -51,8 +52,8 @@ type Props<Names extends string = DottedName> = Omit<
 	engine?: Engine<DottedName>
 }
 
-export type InputProps<Name extends string = string> = Omit<
-	Props<Name>,
+export type InputProps = Omit<
+	Props,
 	'onChange' | 'engine'
 > &
 	Pick<RuleNode, 'suggestions'> & {
@@ -60,7 +61,7 @@ export type InputProps<Name extends string = string> = Omit<
 		description: RuleNode['rawNode']['description']
 		value: EvaluatedNode['nodeValue']
 		onChange: (value: PublicodesExpression | undefined) => void
-		engine: Engine<Name>
+		engine: Engine<DottedName>
 	}
 
 export const binaryQuestion = [
@@ -72,7 +73,7 @@ export const binaryQuestion = [
 // be displayed to get a user input through successive if statements
 // That's not great, but we won't invest more time until we have more diverse
 // input components and a better type system.
-export default function RuleInput<Names extends string = DottedName>({
+export default function RuleInput({
 	dottedName,
 	onChange,
 	showSuggestions = true,
@@ -83,16 +84,16 @@ export default function RuleInput<Names extends string = DottedName>({
 	modifiers = {},
 	engine,
 	...props
-}: Props<Names>) {
+}: Props) {
 	const defaultEngine = useEngine() as Engine<string>
 
-	const engineValue = (engine ?? defaultEngine) as Engine<Names>
+	const engineValue = (engine ?? defaultEngine) as Engine<DottedName>
 
 	const rule = engineValue.getRule(dottedName)
 	const evaluation = engineValue.evaluate({ valeur: dottedName, ...modifiers })
 	const value = evaluation.nodeValue
 
-	const commonProps: InputProps<Names> = {
+	const commonProps: InputProps = {
 		dottedName,
 		value,
 		hideDefaultValue,
@@ -107,8 +108,7 @@ export default function RuleInput<Names extends string = DottedName>({
 		suggestions: showSuggestions ? rule.suggestions : {},
 		engine: engineValue,
 		...props,
-		// Les espaces ne sont pas autorisés dans un id, les points sont assimilés à une déclaration de class CSS par Cypress
-		id: props?.id?.replace(/\s|\.]/g, '_') ?? dottedName.replace(/\s|\./g, '_'),
+		id: props?.id ?? normalizeRuleName.Input(dottedName),
 	}
 	const meta = getMeta<{ affichage?: string }>(rule.rawNode, {})
 
@@ -141,7 +141,7 @@ export default function RuleInput<Names extends string = DottedName>({
 					type={type}
 				/>
 				{!hideDefaultValue && (
-					<DefaultValue dottedName={dottedName as DottedName} />
+					<DefaultValue dottedName={dottedName } />
 				)}
 			</>
 		)
@@ -199,7 +199,7 @@ export default function RuleInput<Names extends string = DottedName>({
 			<>
 				<OuiNonInput {...commonProps} />
 				{!hideDefaultValue && (
-					<DefaultValue dottedName={dottedName as DottedName} />
+					<DefaultValue dottedName={dottedName } />
 				)}
 			</>
 		)
@@ -244,9 +244,9 @@ const isOnePossibility = (node: RuleNode) =>
 		node
 	)
 
-export const getOnePossibilityOptions = <Name extends string>(
-	engine: Engine<Name>,
-	path: Name
+export const getOnePossibilityOptions = (
+	engine: Engine<DottedName>,
+	path: DottedName
 ): Choice => {
 	const node = engine.getRule(path)
 	if (!node) {
@@ -271,7 +271,7 @@ export const getOnePossibilityOptions = <Name extends string>(
 							(explanation) => engine.evaluate(explanation).nodeValue !== null
 						)
 						.map(({ dottedName }) =>
-							getOnePossibilityOptions(engine, dottedName as Name)
+							getOnePossibilityOptions(engine, dottedName as DottedName)
 						),
 			  }
 			: null
@@ -283,21 +283,21 @@ type RuleWithMultiplePossibilities = RuleNode & {
 		'plusieurs possibilités'?: Array<string>
 	}
 }
-function isMultiplePossibilities<Name extends string>(
-	engine: Engine<Name>,
-	dottedName: Name
+function isMultiplePossibilities(
+	engine: Engine<DottedName>,
+	dottedName: DottedName
 ): boolean {
 	return !!(engine.getRule(dottedName) as RuleWithMultiplePossibilities)
 		.rawNode['plusieurs possibilités']
 }
 
-function getMultiplePossibilitiesOptions<Name extends string>(
-	engine: Engine<Name>,
-	dottedName: Name
-): RuleNode<Name>[] {
+function getMultiplePossibilitiesOptions(
+	engine: Engine<DottedName>,
+	dottedName: DottedName
+): RuleNode<DottedName>[] {
 	return (
 		(engine.getRule(dottedName) as RuleWithMultiplePossibilities).rawNode[
 			'plusieurs possibilités'
 		] ?? []
-	).map((name) => engine.getRule(`${dottedName} . ${name}` as Name))
+	).map((name) => engine.getRule(`${dottedName} . ${name}` as DottedName))
 }

--- a/site/source/components/utils/normalizeRuleName.tsx
+++ b/site/source/components/utils/normalizeRuleName.tsx
@@ -1,0 +1,21 @@
+import { DottedName } from 'modele-social'
+
+export const normalizeRuleName = (
+	dottedName: DottedName
+)=> dottedName.replace(/\s|\./g, '_')
+
+normalizeRuleName.Label= (
+	dottedName: DottedName
+)=> `${normalizeRuleName(dottedName)}-label`
+
+normalizeRuleName.Input= (
+	dottedName: DottedName
+)=> `${normalizeRuleName(dottedName)}-input`
+
+normalizeRuleName.Value= (
+	dottedName: DottedName
+)=> `${normalizeRuleName(dottedName)}-value`
+
+normalizeRuleName.Description= (
+	dottedName: DottedName
+)=> `${normalizeRuleName(dottedName)}-description`

--- a/site/source/design-system/field/NumberField.tsx
+++ b/site/source/design-system/field/NumberField.tsx
@@ -79,8 +79,6 @@ export default function NumberField(props: NumberFieldProps) {
 		ref
 	)
 
-	console.log(props, labelProps, inputProps)
-
 	const inputWithCursorHandlingProps = useKeepCursorPositionOnUpdate(
 		inputProps,
 		ref

--- a/site/source/design-system/field/NumberField.tsx
+++ b/site/source/design-system/field/NumberField.tsx
@@ -78,6 +78,9 @@ export default function NumberField(props: NumberFieldProps) {
 		state as NumberFieldState,
 		ref
 	)
+
+	console.log(props, labelProps, inputProps)
+
 	const inputWithCursorHandlingProps = useKeepCursorPositionOnUpdate(
 		inputProps,
 		ref

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -231,6 +231,8 @@ export function useButtonOrLink(
 		ref,
 	}
 
+	console.log(props, initialProps, buttonProps, useExternalLinkProps(props))
+
 	return buttonOrLinkProps
 }
 

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -231,8 +231,6 @@ export function useButtonOrLink(
 		ref,
 	}
 
-	console.log(props, initialProps, buttonProps, useExternalLinkProps(props))
-
 	return buttonOrLinkProps
 }
 

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -958,6 +958,17 @@ pages:
         "9": "Net income from contract activity :"
       shortname: PAMC tax return assistant
       title: PAMC tax return assistant
+      warning: <0>This assistant is designed for <2>practitioners and medical
+        auxiliaries under contract (PAMC).</2></0><1>It manages the <1>micro-tax
+        system</1> only.</1><2>Its purpose is to help you fill in the <2>social
+        section of your tax return</2> on <5>impots.gouv.fr</5>.</2><3><0>In the
+        event of a deficit</0>, enter a "-" in front of the amount.</3><4><0>The
+        wizard does not take into account the following
+        situations:</0><1><0>foreign income</0><1>non-professional
+        income,</1><2>change of tax regime during the year,</2><3>commitment
+        accounting,</3><4>doctors enrolled in the RSPM scheme.</4></1>If you
+        find yourself in one of these situations, we invite you to contact your
+        Urssaf office for assistance.</4>
     pour-mon-entreprise:
       avertissement-entreprise-non-traitée: <0>There is no income simulator for your
         type of business on this site yet.</0><1>If you would like us to develop

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -1017,6 +1017,18 @@ pages:
         "9": "Revenus nets de l’activité conventionnée :"
       shortname: Assistant à la déclaration de revenus des PAMC
       title: Assistant à la déclaration de revenus pour les PAMC
+      warning: <0>Cet assistant est à destination des <2>praticiens et auxiliaires
+        médicaux conventionnés (PAMC)</2>.</0><1>Il gère uniquement le <1>régime
+        micro-fiscal</1>.</1><2>Il a pour but de vous aider à remplir le
+        <2>volet social de votre déclaration de revenus</2> à réaliser sur
+        <5>impots.gouv.fr</5>.</2><3><0>En cas de déficit</0>, renseignez le
+        signe « - » devant le montant.</3><4><0>L’assistant ne prend pas en
+        compte les situations suivantes :</0><1><0>revenus
+        étrangers,</0><1>revenus non professionnels,</1><2>changement de régime
+        en cours d’année,</2><3>comptabilités d’engagement,</3><4>médecins
+        adhérents au dispositif RSPM.</4></1>Si vous êtes dans l’une de ces
+        situations, nous vous invitons à contacter votre Urssaf pour vous
+        accompagner.</4>
     pour-mon-entreprise:
       avertissement-entreprise-non-traitée: <0>Il n'existe pas encore de simulateur de
         revenu pour votre type d'entreprise sur ce site.</0><1>Si vous souhaitez

--- a/site/source/pages/assistants/declaration-revenus-pamc/index.tsx
+++ b/site/source/pages/assistants/declaration-revenus-pamc/index.tsx
@@ -40,43 +40,48 @@ export default function DéclarationRevenusPAMC() {
 
 			<Warning localStorageKey="pages.assistants.declaration-revenus-pamc.warning">
 				<Ul>
-					<StyledLi>
-						Cet assistant est à destination des{' '}
-						<Strong>
-							praticiens et auxiliaires médicaux conventionnés (PAMC)
-						</Strong>
-						.
-					</StyledLi>
-					<StyledLi>
-						Il a pour but de vous aider à remplir le{' '}
-						<Strong>volet social de votre déclaration de revenus</Strong> à
-						réaliser sur{' '}
-						<Link
-							href="https://www.impots.gouv.fr"
-							aria-label="impots.gouv.fr, nouvelle fenêtre"
-						>
-							impots.gouv.fr
-						</Link>
-						.
-					</StyledLi>
-					<StyledLi>
-						<Strong>En cas de déficit</Strong>, renseignez le signe « - » devant
-						le montant.
-					</StyledLi>
-					<StyledLi>
-						<Strong>
-							L’assistant ne prend pas en compte les situations suivantes :
-						</Strong>
-						<Ul>
-							<Li>revenus étrangers,</Li>
-							<Li>revenus non professionnels,</Li>
-							<Li>changement de régime en cours d’année,</Li>
-							<Li>comptabilités d’engagement,</Li>
-							<Li>médecins adhérents au dispositif RSPM.</Li>
-						</Ul>
-						Si vous êtes dans l’une de ces situations, nous vous invitons à
-						contacter votre Urssaf pour vous accompagner.
-					</StyledLi>
+					<Trans i18nKey="pages.assistants.declaration-revenus-pamc.warning">
+						<StyledLi>
+							Cet assistant est à destination des{' '}
+							<Strong>
+								praticiens et auxiliaires médicaux conventionnés (PAMC)
+							</Strong>
+							.
+						</StyledLi>
+						<StyledLi>
+							Il gère uniquement le <Strong>régime micro-fiscal</Strong>.
+						</StyledLi>
+						<StyledLi>
+							Il a pour but de vous aider à remplir le{' '}
+							<Strong>volet social de votre déclaration de revenus</Strong> à
+							réaliser sur{' '}
+							<Link
+								href="https://www.impots.gouv.fr"
+								aria-label="impots.gouv.fr, nouvelle fenêtre"
+							>
+								impots.gouv.fr
+							</Link>
+							.
+						</StyledLi>
+						<StyledLi>
+							<Strong>En cas de déficit</Strong>, renseignez le signe « - »
+							devant le montant.
+						</StyledLi>
+						<StyledLi>
+							<Strong>
+								L’assistant ne prend pas en compte les situations suivantes :
+							</Strong>
+							<Ul>
+								<Li>revenus étrangers,</Li>
+								<Li>revenus non professionnels,</Li>
+								<Li>changement de régime en cours d’année,</Li>
+								<Li>comptabilités d’engagement,</Li>
+								<Li>médecins adhérents au dispositif RSPM.</Li>
+							</Ul>
+							Si vous êtes dans l’une de ces situations, nous vous invitons à
+							contacter votre Urssaf pour vous accompagner.
+						</StyledLi>
+					</Trans>
 				</Ul>
 				<Body>
 					<Trans i18nKey="simulateurs.warning.general">


### PR DESCRIPTION
Dans les simulateurs, transforme des div en label pour les inputs de revenus.

Remplace https://github.com/betagouv/mon-entreprise/pull/3450