### PR TITLE
docs: corrige et ajoute les drapeaux outre mer

### DIFF
--- a/modele-social/règles/entreprise/établissement.publicodes
+++ b/modele-social/règles/entreprise/établissement.publicodes
@@ -31,11 +31,14 @@
 
           avec:
             Guadeloupe Réunion Martinique:
+              icônes: 🇬🇵 🇷🇪 🇲🇶
               une de ces conditions:
                 - département = 'Guadeloupe'
                 - département = 'Martinique'
                 - département = 'La Réunion'
-            Mayotte: département = 'Mayotte'
+            Mayotte:
+              valeur: département = 'Mayotte'
+              icônes: 🇾🇹
 
     nom:
       titre: Commune

--- a/modele-social/règles/impôt.publicodes
+++ b/modele-social/règles/impôt.publicodes
@@ -112,7 +112,7 @@ impôt . revenu imposable . abattement contrat court:
     Bofip - dispositions spécifiques aux contrats courts: https://bofip.impots.gouv.fr/bofip/11252-PGP.html?identifiant=BOI-IR-PAS-20-20-30-10-20180515
 
 impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martinique:
-  icônes: 🇬🇵🇷🇪 🇲🇶
+  icônes: 🇬🇵 🇷🇪 🇲🇶
   applicable si: établissement . commune . département . outre-mer . Guadeloupe
     Réunion Martinique
   références:
@@ -340,7 +340,7 @@ impôt . taux neutre d'impôt sur le revenu . barème Guadeloupe Réunion Martin
             - montant: 43%
 
 impôt . taux neutre d'impôt sur le revenu . barème Guyane Mayotte:
-  icônes: 🇬🇾 🇾🇹
+  icônes: 🇬🇫 🇾🇹
   applicable si:
     par défaut: non
     une de ces conditions:

--- a/modele-social/règles/salarié/exonérations/lodeom.publicodes
+++ b/modele-social/règles/salarié/exonérations/lodeom.publicodes
@@ -59,6 +59,7 @@ salarié . cotisations . exonérations . lodeom . secteurs d'activité éligible
 
 salarié . cotisations . exonérations . lodeom . zone un:
   titre: Guadeloupe, Guyane, Martinique, La Réunion
+  icônes: 🇬🇵 🇬🇫 🇲🇶 🇷🇪
   par défaut: non
   une de ces conditions:
     - zones lodeom = 'zone un'


### PR DESCRIPTION
🇬🇾 est le drapeau de **Guyana**, 🇬🇫 est le drapeau non officiel de **la Guyane** française.