### PR TITLE
A11y / réusinage des Switch, notamment celui du dark mode

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -96,6 +96,7 @@
 		"reselect": "^4.1.8",
 		"styled-components": "^6.0.8",
 		"stylis": "^4.3.0",
+		"uuid": "^11.1.0",
 		"whatwg-fetch": "^3.6.19"
 	},
 	"devDependencies": {

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -170,7 +170,6 @@ function ActivitéMixte() {
 						defaultSelected={defaultChecked}
 						onChange={onMixteChecked}
 						light
-						aria-label="Activité mixte"
 					>
 						Activité mixte
 					</Switch>

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -170,6 +170,8 @@ function ActivitéMixte() {
 						defaultSelected={defaultChecked}
 						onChange={onMixteChecked}
 						light
+						/* Need this useless aria-label to silence a React-Aria warning */
+						aria-label=""
 					>
 						Activité mixte
 					</Switch>

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -20,7 +20,6 @@ import {
 import { Emoji } from '@/design-system/emoji'
 import { Select } from '@/design-system/field/Select'
 import { Spacing } from '@/design-system/layout'
-import { Switch } from '@/design-system/switch'
 import { H3, H4 } from '@/design-system/typography/heading'
 
 import { ExplicableRule } from './Explicable'
@@ -341,29 +340,4 @@ export function useSelection({ value, onChange, missing }: InputProps) {
 	}, [value, missing, currentSelection])
 
 	return { currentSelection, handleChange, defaultValue }
-}
-
-export const SwitchInput = (props: {
-	onChange?: (isSelected: boolean) => void
-	defaultSelected?: boolean
-	label?: string
-	id?: string
-	key?: string
-	invertLabel?: boolean
-}) => {
-	const { onChange, id, label, defaultSelected, key, invertLabel } = props
-
-	return (
-		<Switch
-			defaultSelected={defaultSelected}
-			onChange={(isSelected: boolean) => onChange && onChange(isSelected)}
-			light
-			id={id}
-			key={key}
-			invertLabel={invertLabel}
-			aria-label={label}
-		>
-			{label}
-		</Switch>
-	)
 }

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
 import { Logo } from '@/components/Logo'
@@ -71,19 +71,9 @@ export default function Header() {
 							className="print-hidden"
 						>
 							<Emoji emoji="☀️" aria-hidden />
-							<Switch
-								isSelected={darkMode}
-								onChange={setDarkMode}
-								role="checkbox"
-								aria-label={
-									darkMode
-										? t(
-												'navbar.deactivate-darkmode',
-												'Désactiver le mode sombre'
-										  )
-										: t('navbar.activate-darkmode', 'Activer le mode sombre')
-								}
-							/>
+							<Switch isSelected={darkMode} onChange={setDarkMode} srOnlyLabel>
+								<Trans>Activer le mode sombre</Trans>
+							</Switch>
 							<Emoji emoji="🌙" aria-hidden />
 						</div>
 

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -71,7 +71,13 @@ export default function Header() {
 							className="print-hidden"
 						>
 							<Emoji emoji="☀️" aria-hidden />
-							<Switch isSelected={darkMode} onChange={setDarkMode} srOnlyLabel>
+							<Switch
+								isSelected={darkMode}
+								onChange={setDarkMode}
+								srOnlyLabel
+								/* Need this useless aria-label to silence a React-Aria warning */
+								aria-label=""
+							>
 								<Trans>Activer le mode sombre</Trans>
 							</Switch>
 							<Emoji emoji="🌙" aria-hidden />

--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
 import { Logo } from '@/components/Logo'
@@ -35,16 +35,22 @@ export default function Header() {
 			>
 				<ul className="skip-link print-hidden">
 					<li>
-						<a href={`${fullURL}#main`}>{t('Aller au contenu principal')}</a>
+						<a href={`${fullURL}#main`}>
+							{t('header.main-shortcut.text', 'Aller au contenu principal')}
+						</a>
 					</li>
 					<li>
 						<a
 							href={`${fullURL}#footer`}
 							aria-label={t(
+								'header.footer-shortcut.aria-label',
 								'Passer le contenu principal et aller directement au pied de page'
 							)}
 						>
-							{t('Aller directement au pied de page')}
+							{t(
+								'header.footer-shortcut.text',
+								'Aller directement au pied de page'
+							)}
 						</a>
 					</li>
 				</ul>
@@ -53,7 +59,8 @@ export default function Header() {
 						<Link
 							to={absoluteSitePaths.index}
 							aria-label={t(
-								"Urssaf Mon entreprise, accéder à la page d'accueil"
+								'header.logo.aria-label',
+								'Urssaf Mon entreprise, accéder à la page d’accueil'
 							)}
 						>
 							<StyledLogo>
@@ -78,7 +85,10 @@ export default function Header() {
 								/* Need this useless aria-label to silence a React-Aria warning */
 								aria-label=""
 							>
-								<Trans>Activer le mode sombre</Trans>
+								{t(
+									'header.dark-mode-switch.activate-dark-mode',
+									'Activer le mode sombre'
+								)}
 							</Switch>
 							<Emoji emoji="🌙" aria-hidden />
 						</div>

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useRef } from 'react'
 import { css, styled } from 'styled-components'
 
 import { FocusStyle, SROnly } from '@/design-system/global-style'
+import { generateUuid } from '@/utils'
 
 import { Body } from '../typography/paragraphs'
 
@@ -19,14 +20,7 @@ const sizeDico = {
 	XL: '4rem',
 } as { [K in Size]: string }
 
-interface StyledProps {
-	checked: boolean
-	disabled: boolean
-	$size: Size
-	$light: boolean
-}
-
-const StyledSpan = styled.span<StyledProps>`
+const StyledSpan = styled.span<{ checked: boolean }>`
 	position: relative;
 	left: ${({ checked }) =>
 		checked ? 'calc(100% - 2 * (var(--switch-size) / 5))' : '0'};
@@ -41,8 +35,14 @@ const StyledSpan = styled.span<StyledProps>`
 	background-color: #ffffff;
 	color: inherit;
 `
+interface StyledSwitchProps {
+	checked: boolean
+	disabled: boolean
+	$size: Size
+	$light: boolean
+}
 
-const StyledSwitch = styled.span<StyledProps>`
+const StyledSwitch = styled.span<StyledSwitchProps>`
 	--switch-size: ${({ $size }) => sizeDico[$size]};
 	display: inline-flex;
 	transition: all 0.15s ease-in-out;
@@ -90,38 +90,31 @@ const LabelBody = styled(Body)`
 	cursor: pointer;
 `
 
-const Text = styled.span<{ $invertLabel?: boolean }>`
-	${({ theme, $invertLabel }) =>
-		$invertLabel
-			? css`
-					margin-left: ${theme.spacings.xxs};
-			  `
-			: css`
-					margin-right: ${theme.spacings.xxs};
-			  `};
+const Text = styled.span`
+	${({ theme }) => css`
+		margin-left: ${theme.spacings.xxs};
+	`}
+`
+
+const SrOnlyText = styled.span`
+	${SROnly}
 `
 
 type AriaSwitchProps = Parameters<typeof useSwitch>[0]
 
-export type SwitchProps = AriaSwitchProps & {
+type SwitchProps = AriaSwitchProps & {
 	size?: Size
 	light?: boolean
+	srOnlyLabel?: boolean
 	children?: ReactNode
-	className?: string
-	role?: string
-	/**
-	 * Invert the position of the label and the switch
-	 */
-	invertLabel?: boolean
 }
 
 export const Switch = (props: SwitchProps) => {
 	const {
 		size = 'MD',
 		light = false,
+		srOnlyLabel = false,
 		children,
-		className,
-		invertLabel = false,
 		...ariaProps
 	} = props
 	const state = useToggleState(ariaProps)
@@ -131,36 +124,32 @@ export const Switch = (props: SwitchProps) => {
 	const { isDisabled = false } = ariaProps
 	const { isSelected } = state
 
+	const uuid = generateUuid()
+
 	return (
-		<LabelBody as="label" htmlFor={inputProps.id} className={className}>
-			{children && !invertLabel && (
-				<Text $invertLabel={invertLabel}>{children}</Text>
-			)}
+		<LabelBody as="label" htmlFor={uuid}>
 			<StyledSwitch
 				$light={light}
 				$size={size}
 				checked={isSelected}
 				disabled={isDisabled}
-				aria-label={props['aria-label']}
 			>
 				<HiddenInput
 					// eslint-disable-next-line react/jsx-props-no-spreading
 					{...inputProps}
+					id={uuid}
 					type="checkbox"
+					role="switch"
 					tabIndex={0}
 					ref={ref}
-					role={props?.role}
 				/>
-				<StyledSpan
-					$light={light}
-					$size={size}
-					aria-hidden
-					checked={isSelected}
-					disabled={isDisabled}
-				/>
+				<StyledSpan aria-hidden checked={isSelected} />
 			</StyledSwitch>
-			{children && invertLabel && (
-				<Text $invertLabel={invertLabel}>{children}</Text>
+
+			{srOnlyLabel ? (
+				<SrOnlyText>{children}</SrOnlyText>
+			) : (
+				<Text>{children}</Text>
 			)}
 		</LabelBody>
 	)

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -2,9 +2,9 @@ import { useSwitch } from '@react-aria/switch'
 import { useToggleState } from '@react-stately/toggle'
 import { ReactNode, useRef } from 'react'
 import { css, styled } from 'styled-components'
+import { v4 as uuidv4 } from 'uuid'
 
 import { FocusStyle, SROnly } from '@/design-system/global-style'
-import { generateUuid } from '@/utils'
 
 import { Body } from '../typography/paragraphs'
 
@@ -118,7 +118,7 @@ export const Switch = (props: SwitchProps) => {
 	const { isDisabled = false } = ariaProps
 	const { isSelected } = state
 
-	const uuid = generateUuid()
+	const uuid = uuidv4()
 
 	return (
 		<LabelBody as="label" htmlFor={uuid}>

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -63,18 +63,6 @@ const StyledSwitch = styled.span<StyledSwitchProps>`
 			  `
 			: ''}
 
-	&:hover ${StyledSpan} {
-		box-shadow: 0 0 0 0.5rem
-			${({ disabled, checked, theme }) =>
-				disabled
-					? ''
-					: checked
-					? theme.colors.bases.primary[700]
-					: theme.colors.extended.grey[500]}42; // 42 is alpha
-	}
-	&:focus-within {
-		${FocusStyle}
-	}
 	${({ disabled, theme }) =>
 		disabled
 			? css`
@@ -87,12 +75,18 @@ const StyledSwitch = styled.span<StyledSwitchProps>`
 const LabelBody = styled(Body)`
 	display: inline-flex;
 	align-items: center;
+	border-radius: ${({ theme }) => theme.box.borderRadius};
 	cursor: pointer;
+
+	&:hover,
+	&:focus-within {
+		${FocusStyle}
+	}
 `
 
 const Text = styled.span`
 	${({ theme }) => css`
-		margin-left: ${theme.spacings.xxs};
+		margin: 0 ${theme.spacings.xxs};
 	`}
 `
 
@@ -106,7 +100,7 @@ type SwitchProps = AriaSwitchProps & {
 	size?: Size
 	light?: boolean
 	srOnlyLabel?: boolean
-	children?: ReactNode
+	children: ReactNode
 }
 
 export const Switch = (props: SwitchProps) => {

--- a/site/source/design-system/switch/index.stories.tsx
+++ b/site/source/design-system/switch/index.stories.tsx
@@ -32,3 +32,15 @@ export const Disabled: Story = {
 		isDisabled: true,
 	},
 }
+
+export const Light: Story = {
+	args: {
+		light: true,
+	},
+}
+
+export const XS: Story = {
+	args: {
+		size: 'XS',
+	},
+}

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -35,6 +35,8 @@ API REST de simulation: Simulation REST API
 API REST, en savoir plus sur l'API REST: API REST, more about API REST
 Accessibilité: Accessibility
 Accéder au site mon-entreprise, nouvelle fenêtre: Go to mon-entreprise, new window
+Activer l'ACRE dans la simulation: Activate ACRE in simulation
+Activer le versement libératoire dans la simulation: Activate payment in full discharge in simulation
 Activités relevant de l’économie collaborative, voir la page: Collaborative economy activities, see page
 Afficher le détail: Show details
 "Afficher les données par :": "Display data by:"
@@ -130,6 +132,7 @@ Je donne mon avis, donner mon avis sur jedonnemonavis:
     gouv:
       fr, nouvelle fenêtre: I give my opinion, give my opinion on
         jedonnemonavis.numerique.gouv.fr, new window
+Je suis éligible à l'ACRE pour mon auto-entreprise: I am eligible for ACRE for my auto-enterprise
 Jours: Days
 Le montant demandé n'est <2>pas calculable...</2>: The amount requested <2>cannot be calculated.</2>..
 Les données de simulations se mettront automatiquement à jour après la modification d'un champ. <2>Un panneau s'ouvrira pour vous permettre d'apporter des précisions à la simulation, des résultats détaillés s'afficheront en dessous du formulaire et seront mis à jour quand vous modifierez ce dernier.</2>:

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -13,12 +13,6 @@
   to remove it from the site. It was too difficult to keep the information and
   calculations up to date.</0><1>To find up-to-date information, please visit
   the Urssaf website:</1><2>Collaborative economy activities</2></0>
-<0><0>Les simulateurs et assistants de ce site ont pour but de <2>répondre à une question</2> (par exemple « combien mon entreprise doit-elle payer pour embaucher une personne ? » ou « Quel est le meilleur statut juridique pour débuter mon activité ? »</0><1>Pour calculer le nombre de questions répondues, nous multiplions le <1>nombre de simulations</1> par le <4>taux de satisfaction</4> moyen du simulateur.</1> </0>:
-  <0><0>The simulators and wizards on this site are designed to <2>answer a
-  question</2> (e.g. "How much should my company pay to hire someone?" or "What
-  is the best legal status for starting my business?").</0><1>To calculate the
-  number of questions answered, we multiply the <1>number of simulations</1> by
-  the simulator's average <4>satisfaction rate</4>.</1> </0>
 <0><0>Nous avons détecté une ancienne situation, êtes-vous sûr de vouloir l'écraser ?</0></0><1><0><0>Ecraser</0></0><1><0>Annuler</0></1></1>:
   <0><0>We've detected an old situation. Are you sure you want to overwrite
   it?</0></0><1><0><0>Overwrite</0></0><1><0>Cancel</0></1></1>
@@ -35,16 +29,10 @@ API REST de simulation: Simulation REST API
 API REST, en savoir plus sur l'API REST: API REST, more about API REST
 Accessibilité: Accessibility
 Accéder au site mon-entreprise, nouvelle fenêtre: Go to mon-entreprise, new window
-Activer l'ACRE dans la simulation: Activate ACRE in simulation
-Activer le mode accessibilité sur cette section: Enable accessibility mode on this section
-Activer le mode sombre: Activate dark mode
-Activer le versement libératoire dans la simulation: Activate payment in full discharge in simulation
 Activités relevant de l’économie collaborative, voir la page: Collaborative economy activities, see page
 Afficher le détail: Show details
 "Afficher les données par :": "Display data by:"
 Afficher les détails de l'entreprise, la modifier ou la supprimer.: View company details, modify or delete.
-Aller au contenu principal: Go to main content
-Aller directement au pied de page: Go directly to footer
 Annuler: Cancel
 Attention: Warning
 Attention, vos données sauvegardées seront supprimées de manière définitive.: Please note that your saved data will be permanently deleted.
@@ -108,7 +96,6 @@ ExportSimulation:
 Fermer: Close
 Fermer le module "Donner son avis": Close the "Give your opinion" module
 Fiche de paie: Pay slip
-Fond de la boite de dialogue: Dialog box background
 Frais de transport: Transport costs
 Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section):
   Graph detailing the number of visits per simulator (alternative accessible via
@@ -134,7 +121,6 @@ Je donne mon avis, donner mon avis sur jedonnemonavis:
     gouv:
       fr, nouvelle fenêtre: I give my opinion, give my opinion on
         jedonnemonavis.numerique.gouv.fr, new window
-Je suis éligible à l'ACRE pour mon auto-entreprise: I am eligible for ACRE for my auto-enterprise
 Jours: Days
 Le montant demandé n'est <2>pas calculable...</2>: The amount requested <2>cannot be calculated.</2>..
 Les données de simulations se mettront automatiquement à jour après la modification d'un champ. <2>Un panneau s'ouvrira pour vous permettre d'apporter des précisions à la simulation, des résultats détaillés s'afficheront en dessous du formulaire et seront mis à jour quand vous modifierez ce dernier.</2>:
@@ -148,7 +134,6 @@ Masquer les détails de l'entreprise.: Hide company details.
 Menu de navigation: Navigation menu
 Message à caractère informatif: Informative message
 Mode d'affichage: Display mode
-Modifier mes options: Modify my options
 Modifier mes réponses: Modify my answers
 Moins de 50 salariés: Less than 50 employees
 Mois: Month
@@ -179,7 +164,6 @@ PFU (<1>"flat tax"</1>): PFU (<1>"flat tax"</1>)
 Page d'accueil: Home page
 "Par exemple : coiffure, boulangerie ou restauration": "For example: hairdressing, bakery or catering"
 Passer: Pass
-Passer le contenu principal et aller directement au pied de page: Skip the main content and go directly to the footer
 Passer, passer la question sans répondre: Pass, pass the question without answering
 Personnalisez l'intégration: Customize integration
 Plan du site: Site map
@@ -255,7 +239,6 @@ Tout réinitialiser: Reset all
 Trimestre: Quarter
 Type: Type
 Un avis sur cette page ?: What do you think of this page?
-Urssaf Mon entreprise, accéder à la page d'accueil: Urssaf Mon entreprise, go to home page
 Urssaf, voir le site urssaf:
   fr, nouvelle fenêtre: Urssaf, see the urssaf.fr website, new window
 Utiliser avec un tableur: Using a spreadsheet
@@ -561,6 +544,16 @@ gérer:
         reduction in contributions.
       cta: Consult the guide
       title: General reduction in contributions
+header:
+  dark-mode-switch:
+    activate-dark-mode: Activate dark mode
+  footer-shortcut:
+    aria-label: Skip the main content and go directly to the footer
+    text: Go directly to footer
+  logo:
+    aria-label: Urssaf Mon entreprise, go to home page
+  main-shortcut:
+    text: Go to main content
 iframe:
   description: Tools for developers
   title: Integrate a simulator
@@ -632,6 +625,15 @@ library:
 loading: Loading in progress...
 mai: May
 mars: March
+modifier-options:
+  acre:
+    title: Benefit from Acre
+  activer-acre: Activate Acre in simulation
+  disclaimer: At present, this comparator does not include income tax calculations
+    for SAS(U).
+  texte: Modify my options
+  versement-libératoire: Activate final payment in simulation
+  éligible-acre: I'm eligible for Acre for my self-employed business
 moins: less
 mois: month
 navbar:
@@ -1860,6 +1862,24 @@ pages:
       access: Access the simulator {{year}}
       back: Back to simulator {{year}}
       info: "This simulation concerns the year <2>{{currentEngineYear}}</2>. "
+  statistiques:
+    a11y-switch: Enable accessibility mode on this section
+    anonymous: The data collected is anonymized.
+    explanation: <0><0>The simulators and wizards on this site are designed to
+      <2>answer a specific question</2> (e.g. "How much should my company pay to
+      hire a new employee?" or "What is the best legal status for starting my
+      business?)</0><1>To calculate the number of questions answered, we
+      multiply the <1>number of simulations</1> by the simulator's average
+      <4>satisfaction rate</4>.</1> </0>
+    h1: Statistics
+    h2:
+      evolution: Trends over several months
+      selection: Simulator selection
+    h3:
+      repartition: Breakdown of visits by simulator
+      satisfaction: Satisfaction
+      visits: Visit
+    intro: Discover our usage statistics, updated daily.
 payslip:
   disclaimer: "This payslip is the result of the simulation you made. It helps you
     to understand your pay slip: you can click on the links to understand how
@@ -2129,9 +2149,6 @@ warning:
     situation: Do you want to crush your situation?
 "{{title}}, voir la demande sur github":
   com, nouvelle fenêtre: "{{title}}view request on github.com, new window"
-À ce jour, ce comparateur ne prend pas en compte le calcul de l'impôt sur le revenu pour les SAS(U).:
-  At present, this comparator does not include income tax calculations for
-  SAS(U).
 À quoi servent mes cotisations ?: What are my contributions used for?
 Échanger avec un conseiller: Talk to an advisor
 "Établissement recherché :": "Establishment sought:"

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -36,6 +36,7 @@ API REST, en savoir plus sur l'API REST: API REST, more about API REST
 Accessibilité: Accessibility
 Accéder au site mon-entreprise, nouvelle fenêtre: Go to mon-entreprise, new window
 Activer l'ACRE dans la simulation: Activate ACRE in simulation
+Activer le mode sombre: Activate dark mode
 Activer le versement libératoire dans la simulation: Activate payment in full discharge in simulation
 Activités relevant de l’économie collaborative, voir la page: Collaborative economy activities, see page
 Afficher le détail: Show details
@@ -633,8 +634,6 @@ mars: March
 moins: less
 mois: month
 navbar:
-  activate-darkmode: Activate dark mode
-  deactivate-darkmode: Disable dark mode
   logo: logo My company
 news:
   description: We're constantly improving the site based on your feedback.

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -36,6 +36,7 @@ API REST, en savoir plus sur l'API REST: API REST, more about API REST
 Accessibilité: Accessibility
 Accéder au site mon-entreprise, nouvelle fenêtre: Go to mon-entreprise, new window
 Activer l'ACRE dans la simulation: Activate ACRE in simulation
+Activer le mode accessibilité sur cette section: Enable accessibility mode on this section
 Activer le mode sombre: Activate dark mode
 Activer le versement libératoire dans la simulation: Activate payment in full discharge in simulation
 Activités relevant de l’économie collaborative, voir la page: Collaborative economy activities, see page

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -38,6 +38,8 @@ API REST de simulation: API REST de simulation
 API REST, en savoir plus sur l'API REST: API REST, en savoir plus sur l'API REST
 Accessibilité: Accessibilité
 Accéder au site mon-entreprise, nouvelle fenêtre: Accéder au site mon-entreprise, nouvelle fenêtre
+Activer l'ACRE dans la simulation: Activer l'ACRE dans la simulation
+Activer le versement libératoire dans la simulation: Activer le versement libératoire dans la simulation
 Activités relevant de l’économie collaborative, voir la page: Activités relevant de l’économie collaborative, voir la page
 Afficher le détail: Afficher le détail
 "Afficher les données par :": "Afficher les données par :"
@@ -136,6 +138,7 @@ Je donne mon avis, donner mon avis sur jedonnemonavis:
     gouv:
       fr, nouvelle fenêtre: Je donne mon avis, donner mon avis sur
         jedonnemonavis.numerique.gouv.fr, nouvelle fenêtre
+Je suis éligible à l'ACRE pour mon auto-entreprise: Je suis éligible à l'ACRE pour mon auto-entreprise
 Jours: Jours
 Le montant demandé n'est <2>pas calculable...</2>: Le montant demandé n'est <2>pas calculable...</2>
 Les données de simulations se mettront automatiquement à jour après la modification d'un champ. <2>Un panneau s'ouvrira pour vous permettre d'apporter des précisions à la simulation, des résultats détaillés s'afficheront en dessous du formulaire et seront mis à jour quand vous modifierez ce dernier.</2>:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -39,6 +39,7 @@ API REST, en savoir plus sur l'API REST: API REST, en savoir plus sur l'API REST
 Accessibilité: Accessibilité
 Accéder au site mon-entreprise, nouvelle fenêtre: Accéder au site mon-entreprise, nouvelle fenêtre
 Activer l'ACRE dans la simulation: Activer l'ACRE dans la simulation
+Activer le mode accessibilité sur cette section: Activer le mode accessibilité sur cette section
 Activer le mode sombre: Activer le mode sombre
 Activer le versement libératoire dans la simulation: Activer le versement libératoire dans la simulation
 Activités relevant de l’économie collaborative, voir la page: Activités relevant de l’économie collaborative, voir la page

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -39,6 +39,7 @@ API REST, en savoir plus sur l'API REST: API REST, en savoir plus sur l'API REST
 Accessibilité: Accessibilité
 Accéder au site mon-entreprise, nouvelle fenêtre: Accéder au site mon-entreprise, nouvelle fenêtre
 Activer l'ACRE dans la simulation: Activer l'ACRE dans la simulation
+Activer le mode sombre: Activer le mode sombre
 Activer le versement libératoire dans la simulation: Activer le versement libératoire dans la simulation
 Activités relevant de l’économie collaborative, voir la page: Activités relevant de l’économie collaborative, voir la page
 Afficher le détail: Afficher le détail
@@ -667,8 +668,6 @@ mars: mars
 moins: moins
 mois: mois
 navbar:
-  activate-darkmode: Activer le mode sombre
-  deactivate-darkmode: Désactiver le mode sombre
   logo: logo Mon entreprise
 news:
   description: Nous améliorons le site en continu à partir de vos retours.

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -15,13 +15,6 @@
   les informations et les calculs.</0><1>Pour retrouver les informations à
   jours, vous pouvez vous rendre sur le site de l'Urssaf :</1><2>Activités
   relevant de l’économie collaborative</2></0>
-<0><0>Les simulateurs et assistants de ce site ont pour but de <2>répondre à une question</2> (par exemple « combien mon entreprise doit-elle payer pour embaucher une personne ? » ou « Quel est le meilleur statut juridique pour débuter mon activité ? »</0><1>Pour calculer le nombre de questions répondues, nous multiplions le <1>nombre de simulations</1> par le <4>taux de satisfaction</4> moyen du simulateur.</1> </0>:
-  <0><0>Les simulateurs et assistants de ce site ont pour but de <2>répondre à
-  une question</2> (par exemple « combien mon entreprise doit-elle payer pour
-  embaucher une personne ? » ou « Quel est le meilleur statut juridique pour
-  débuter mon activité ? »</0><1>Pour calculer le nombre de questions répondues,
-  nous multiplions le <1>nombre de simulations</1> par le <4>taux de
-  satisfaction</4> moyen du simulateur.</1> </0>
 <0><0>Nous avons détecté une ancienne situation, êtes-vous sûr de vouloir l'écraser ?</0></0><1><0><0>Ecraser</0></0><1><0>Annuler</0></1></1>:
   <0><0>Nous avons détecté une ancienne situation, êtes-vous sûr de vouloir
   l'écraser ?</0></0><1><0><0>Ecraser</0></0><1><0>Annuler</0></1></1>
@@ -38,16 +31,10 @@ API REST de simulation: API REST de simulation
 API REST, en savoir plus sur l'API REST: API REST, en savoir plus sur l'API REST
 Accessibilité: Accessibilité
 Accéder au site mon-entreprise, nouvelle fenêtre: Accéder au site mon-entreprise, nouvelle fenêtre
-Activer l'ACRE dans la simulation: Activer l'ACRE dans la simulation
-Activer le mode accessibilité sur cette section: Activer le mode accessibilité sur cette section
-Activer le mode sombre: Activer le mode sombre
-Activer le versement libératoire dans la simulation: Activer le versement libératoire dans la simulation
 Activités relevant de l’économie collaborative, voir la page: Activités relevant de l’économie collaborative, voir la page
 Afficher le détail: Afficher le détail
 "Afficher les données par :": "Afficher les données par :"
 Afficher les détails de l'entreprise, la modifier ou la supprimer.: Afficher les détails de l'entreprise, la modifier ou la supprimer.
-Aller au contenu principal: Aller au contenu principal
-Aller directement au pied de page: Aller directement au pied de page
 Annuler: Annuler
 Attention: Attention
 Attention, vos données sauvegardées seront supprimées de manière définitive.: Attention, vos données sauvegardées seront supprimées de manière définitive.
@@ -114,7 +101,6 @@ ExportSimulation:
 Fermer: Fermer
 Fermer le module "Donner son avis": Fermer le module "Donner son avis"
 Fiche de paie: Fiche de paie
-Fond de la boite de dialogue: Fond de la boite de dialogue
 Frais de transport: Frais de transport
 Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section):
   Graphique détaillant la part des visites par simulateur (alternative
@@ -140,7 +126,6 @@ Je donne mon avis, donner mon avis sur jedonnemonavis:
     gouv:
       fr, nouvelle fenêtre: Je donne mon avis, donner mon avis sur
         jedonnemonavis.numerique.gouv.fr, nouvelle fenêtre
-Je suis éligible à l'ACRE pour mon auto-entreprise: Je suis éligible à l'ACRE pour mon auto-entreprise
 Jours: Jours
 Le montant demandé n'est <2>pas calculable...</2>: Le montant demandé n'est <2>pas calculable...</2>
 Les données de simulations se mettront automatiquement à jour après la modification d'un champ. <2>Un panneau s'ouvrira pour vous permettre d'apporter des précisions à la simulation, des résultats détaillés s'afficheront en dessous du formulaire et seront mis à jour quand vous modifierez ce dernier.</2>:
@@ -156,7 +141,6 @@ Masquer les détails de l'entreprise.: Masquer les détails de l'entreprise.
 Menu de navigation: Menu de navigation
 Message à caractère informatif: Message à caractère informatif
 Mode d'affichage: Mode d'affichage
-Modifier mes options: Modifier mes options
 Modifier mes réponses: Modifier mes réponses
 Moins de 50 salariés: Moins de 50 salariés
 Mois: Mois
@@ -188,7 +172,6 @@ PFU (<1>"flat tax"</1>): PFU (<1>"flat tax"</1>)
 Page d'accueil: Page d'accueil
 "Par exemple : coiffure, boulangerie ou restauration": "Par exemple : coiffure, boulangerie ou restauration"
 Passer: Passer
-Passer le contenu principal et aller directement au pied de page: Passer le contenu principal et aller directement au pied de page
 Passer, passer la question sans répondre: Passer, passer la question sans répondre
 Personnalisez l'intégration: Personnalisez l'intégration
 Plan du site: Plan du site
@@ -269,7 +252,6 @@ Tout réinitialiser: Tout réinitialiser
 Trimestre: Trimestre
 Type: Type
 Un avis sur cette page ?: Un avis sur cette page ?
-Urssaf Mon entreprise, accéder à la page d'accueil: Urssaf Mon entreprise, accéder à la page d'accueil
 Urssaf, voir le site urssaf:
   fr, nouvelle fenêtre: Urssaf, voir le site urssaf.fr, nouvelle fenêtre
 Utiliser avec un tableur: Utiliser avec un tableur
@@ -591,6 +573,16 @@ gérer:
         réduction générale des cotisations.
       cta: Consulter le guide
       title: La réduction générale des cotisations
+header:
+  dark-mode-switch:
+    activate-dark-mode: Activer le mode sombre
+  footer-shortcut:
+    aria-label: Passer le contenu principal et aller directement au pied de page
+    text: Aller directement au pied de page
+  logo:
+    aria-label: Urssaf Mon entreprise, accéder à la page d’accueil
+  main-shortcut:
+    text: Aller au contenu principal
 iframe:
   description: Outils pour les développeurs
   title: Intégrer un simulateur
@@ -666,6 +658,15 @@ library:
 loading: Chargement en cours...
 mai: mai
 mars: mars
+modifier-options:
+  acre:
+    title: Bénéficier de l’Acre
+  activer-acre: Activer l’Acre dans la simulation
+  disclaimer: À ce jour, ce comparateur ne prend pas en compte le calcul de
+    l’impôt sur le revenu pour les SAS(U).
+  texte: Modifier mes options
+  versement-libératoire: Activer le versement libératoire dans la simulation
+  éligible-acre: Je suis éligible à l’Acre pour mon auto-entreprise
 moins: moins
 mois: mois
 navbar:
@@ -1976,6 +1977,25 @@ pages:
       access: Accéder au simulateur {{year}}
       back: Retourner au simulateur {{year}}
       info: "Cette simulation concerne l'année <2>{{currentEngineYear}}</2>. "
+  statistiques:
+    a11y-switch: Activer le mode accessibilité sur cette section
+    anonymous: Les données recueillies sont anonymisées.
+    explanation: <0><0>Les simulateurs et assistants de ce site ont pour but de
+      <2>répondre à une question</2> (par exemple « combien mon entreprise
+      doit-elle payer pour embaucher une personne ? » ou « Quel est le meilleur
+      statut juridique pour débuter mon activité ? »)</0><1>Pour calculer le
+      nombre de questions répondues, nous multiplions le <1>nombre de
+      simulations</1> par le <4>taux de satisfaction</4> moyen du
+      simulateur.</1> </0>
+    h1: Statistiques
+    h2:
+      evolution: Évolution sur plusieurs mois
+      selection: Selection du simulateur
+    h3:
+      repartition: Répartition des visites par simulateurs
+      satisfaction: Satisfaction
+      visits: Visites
+    intro: Découvrez nos statistiques d’utilisation mises à jour quotidiennement.
 payslip:
   disclaimer: "Cette fiche de paie est issue de la simulation que vous avez faite.
     Elle vous aide à comprendre votre bulletin de paie : vous pouvez cliquer sur
@@ -2263,9 +2283,6 @@ warning:
     situation: Voulez-vous écraser votre situation ?
 "{{title}}, voir la demande sur github":
   com, nouvelle fenêtre: "{{title}}, voir la demande sur github.com, nouvelle fenêtre"
-À ce jour, ce comparateur ne prend pas en compte le calcul de l'impôt sur le revenu pour les SAS(U).:
-  À ce jour, ce comparateur ne prend pas en compte le calcul de l'impôt sur le
-  revenu pour les SAS(U).
 À quoi servent mes cotisations ?: À quoi servent mes cotisations ?
 Échanger avec un conseiller: Échanger avec un conseiller
 "Établissement recherché :": "Établissement recherché :"

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -88,6 +88,8 @@ const ModifierOptions = () => {
 							onChange={(value: boolean) => set[DOTTEDNAME_ACRE](value)}
 							defaultSelected={values[DOTTEDNAME_ACRE] as boolean}
 							light
+							/* Need this useless aria-label to silence a React-Aria warning */
+							aria-label=""
 						>
 							<Trans>Activer l'ACRE dans la simulation</Trans>
 						</Switch>
@@ -112,6 +114,8 @@ const ModifierOptions = () => {
 										values[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE] as boolean
 									}
 									light
+									/* Need this useless aria-label to silence a React-Aria warning */
+									aria-label=""
 								>
 									<Trans>
 										Je suis éligible à l'ACRE pour mon auto-entreprise
@@ -196,6 +200,8 @@ const ModifierOptions = () => {
 							] as boolean
 						}
 						light
+						/* Need this useless aria-label to silence a React-Aria warning */
+						aria-label=""
 					>
 						<Trans>Activer le versement libératoire dans la simulation</Trans>
 					</Switch>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -87,7 +87,6 @@ const ModifierOptions = () => {
 							id="activation-acre"
 							onChange={(value: boolean) => set[DOTTEDNAME_ACRE](value)}
 							defaultSelected={values[DOTTEDNAME_ACRE] as boolean}
-							invertLabel
 							light
 						>
 							<Trans>Activer l'ACRE dans la simulation</Trans>
@@ -112,7 +111,6 @@ const ModifierOptions = () => {
 									defaultSelected={
 										values[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE] as boolean
 									}
-									invertLabel
 									light
 								>
 									<Trans>
@@ -197,7 +195,6 @@ const ModifierOptions = () => {
 								DOTTEDNAME_AUTOENTREPRENEUR_VERSEMENT_LIBERATOIRE
 							] as boolean
 						}
-						invertLabel
 						light
 					>
 						<Trans>Activer le versement libératoire dans la simulation</Trans>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -1,5 +1,5 @@
 import { PublicodesExpression } from 'publicodes'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
 import { ExplicableRule } from '@/components/conversation/Explicable'
@@ -43,7 +43,8 @@ const ModifierOptions = () => {
 					// eslint-disable-next-line react/jsx-props-no-spreading
 					{...buttonProps}
 				>
-					<Trans>Modifier mes options</Trans> <StyledArrowRightIcon />
+					{t('modifier-options.texte', 'Modifier mes options')}{' '}
+					<StyledArrowRightIcon />
 				</Button>
 			)}
 			confirmLabel="Enregistrer les options"
@@ -51,15 +52,13 @@ const ModifierOptions = () => {
 			onCancel={cancel}
 		>
 			<>
-				<H2>
-					<Trans>Modifier mes options</Trans>
-				</H2>
+				<H2>{t('modifier-options.texte', 'Modifier mes options')}</H2>
 
 				<H3>
-					Bénéficier de l'ACRE{' '}
+					{t('modifier-options.acre.title', 'Bénéficier de l’Acre')}{' '}
 					<ExplicableRule
-						dottedName="dirigeant . exonérations . ACRE"
-						title="Bénéficier de l'ACRE"
+						dottedName={DOTTEDNAME_ACRE}
+						title={t('modifier-options.acre.title', 'Bénéficier de l’Acre')}
 					/>
 				</H3>
 
@@ -77,7 +76,7 @@ const ModifierOptions = () => {
 						light
 						size="XS"
 					>
-						<Trans>En savoir plus</Trans>
+						{t('En savoir plus')}
 					</Button>
 				}
 				<H5 as="h4">Choisir mon option de simulation</H5>
@@ -91,7 +90,10 @@ const ModifierOptions = () => {
 							/* Need this useless aria-label to silence a React-Aria warning */
 							aria-label=""
 						>
-							<Trans>Activer l'ACRE dans la simulation</Trans>
+							{t(
+								'modifier-options.activer-acre',
+								'Activer l’Acre dans la simulation'
+							)}
 						</Switch>
 					</FlexCentered>
 
@@ -102,7 +104,7 @@ const ModifierOptions = () => {
 								<StyledLink href="https://www.urssaf.fr/portail/home/independant/je-beneficie-dexonerations/accre/qui-peut-en-beneficier.html">
 									conditions d'accès
 								</StyledLink>{' '}
-								à l'ACRE sont plus restrictives pour les auto-entrepreneurs.
+								à l’Acre sont plus restrictives pour les auto-entrepreneurs.
 							</Body>
 							<FlexCentered>
 								<Switch
@@ -117,9 +119,10 @@ const ModifierOptions = () => {
 									/* Need this useless aria-label to silence a React-Aria warning */
 									aria-label=""
 								>
-									<Trans>
-										Je suis éligible à l'ACRE pour mon auto-entreprise
-									</Trans>
+									{t(
+										'modifier-options.éligible-acre',
+										'Je suis éligible à l’Acre pour mon auto-entreprise'
+									)}
 								</Switch>
 							</FlexCentered>
 						</>
@@ -168,10 +171,10 @@ const ModifierOptions = () => {
 									fontSize: '0.875rem',
 								}}
 							>
-								<Trans>
-									À ce jour, ce comparateur ne prend pas en compte le calcul de
-									l'impôt sur le revenu pour les SAS(U).
-								</Trans>
+								{t(
+									'modifier-options.disclaimer',
+									'À ce jour, ce comparateur ne prend pas en compte le calcul de l’impôt sur le revenu pour les SAS(U).'
+								)}
 							</Body>
 						</Grid>
 					</Grid>
@@ -203,7 +206,10 @@ const ModifierOptions = () => {
 						/* Need this useless aria-label to silence a React-Aria warning */
 						aria-label=""
 					>
-						<Trans>Activer le versement libératoire dans la simulation</Trans>
+						{t(
+							'modifier-options.versement-libératoire',
+							'Activer le versement libératoire dans la simulation'
+						)}
 					</Switch>
 				</FlexCentered>
 			</>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/ModifierOptions.tsx
@@ -2,7 +2,6 @@ import { PublicodesExpression } from 'publicodes'
 import { Trans, useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
-import { SwitchInput } from '@/components/conversation/ChoicesInput'
 import { ExplicableRule } from '@/components/conversation/Explicable'
 import RuleInput from '@/components/conversation/RuleInput'
 import { Message } from '@/design-system'
@@ -10,6 +9,7 @@ import { Button } from '@/design-system/buttons'
 import { Drawer } from '@/design-system/drawer'
 import { ArrowRightIcon, InfoIcon } from '@/design-system/icons'
 import { Grid, Spacing } from '@/design-system/layout'
+import { Switch } from '@/design-system/switch'
 import { Strong } from '@/design-system/typography'
 import { H2, H3, H5 } from '@/design-system/typography/heading'
 import { Link, StyledLink } from '@/design-system/typography/link'
@@ -83,13 +83,15 @@ const ModifierOptions = () => {
 				<H5 as="h4">Choisir mon option de simulation</H5>
 				<div aria-live="polite">
 					<FlexCentered>
-						<SwitchInput
+						<Switch
 							id="activation-acre"
 							onChange={(value: boolean) => set[DOTTEDNAME_ACRE](value)}
 							defaultSelected={values[DOTTEDNAME_ACRE] as boolean}
-							label="Activer l'ACRE dans la simulation"
 							invertLabel
-						/>
+							light
+						>
+							<Trans>Activer l'ACRE dans la simulation</Trans>
+						</Switch>
 					</FlexCentered>
 
 					{values[DOTTEDNAME_ACRE] && (
@@ -102,7 +104,7 @@ const ModifierOptions = () => {
 								à l'ACRE sont plus restrictives pour les auto-entrepreneurs.
 							</Body>
 							<FlexCentered>
-								<SwitchInput
+								<Switch
 									id="activation-acre-ae"
 									onChange={(value: boolean) =>
 										set[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE](value)
@@ -110,9 +112,13 @@ const ModifierOptions = () => {
 									defaultSelected={
 										values[DOTTEDNAME_AUTOENTREPRENEUR_ELIGIBLE_ACRE] as boolean
 									}
-									label="Je suis éligible à l'ACRE pour mon auto-entreprise"
 									invertLabel
-								/>
+									light
+								>
+									<Trans>
+										Je suis éligible à l'ACRE pour mon auto-entreprise
+									</Trans>
+								</Switch>
 							</FlexCentered>
 						</>
 					)}
@@ -183,7 +189,7 @@ const ModifierOptions = () => {
 					/>
 				</H5>
 				<FlexCentered>
-					<SwitchInput
+					<Switch
 						id="versement-liberatoire"
 						onChange={set[DOTTEDNAME_AUTOENTREPRENEUR_VERSEMENT_LIBERATOIRE]}
 						defaultSelected={
@@ -191,9 +197,11 @@ const ModifierOptions = () => {
 								DOTTEDNAME_AUTOENTREPRENEUR_VERSEMENT_LIBERATOIRE
 							] as boolean
 						}
-						label="Activer le versement libératoire dans la simulation."
 						invertLabel
-					/>
+						light
+					>
+						<Trans>Activer le versement libératoire dans la simulation</Trans>
+					</Switch>
 				</FlexCentered>
 			</>
 		</Drawer>

--- a/site/source/pages/statistiques/StatsPage.tsx
+++ b/site/source/pages/statistiques/StatsPage.tsx
@@ -112,7 +112,7 @@ export default function StatPage({ stats }: StatsDetailProps) {
 						/* Need this useless aria-label to silence a React-Aria warning */
 						aria-label=""
 					>
-						Activer le mode accessibilité sur cette section
+						<Trans>Activer le mode accessibilité sur cette section</Trans>
 					</Switch>
 				</Body>
 				<H3>Visites</H3>

--- a/site/source/pages/statistiques/StatsPage.tsx
+++ b/site/source/pages/statistiques/StatsPage.tsx
@@ -106,7 +106,12 @@ export default function StatPage({ stats }: StatsDetailProps) {
 				<H2>Évolution sur plusieurs mois</H2>
 
 				<Body>
-					<Switch defaultSelected={accessibleMode} onChange={setAccessibleMode}>
+					<Switch
+						defaultSelected={accessibleMode}
+						onChange={setAccessibleMode}
+						/* Need this useless aria-label to silence a React-Aria warning */
+						aria-label=""
+					>
 						Activer le mode accessibilité sur cette section
 					</Switch>
 				</Body>

--- a/site/source/pages/statistiques/StatsPage.tsx
+++ b/site/source/pages/statistiques/StatsPage.tsx
@@ -52,18 +52,25 @@ export default function StatPage({ stats }: StatsDetailProps) {
 					<Spacing xl />
 
 					<H1>
-						Statistiques <Emoji emoji="📊" />
+						{t('pages.statistiques.h1', 'Statistiques')} <Emoji emoji="📊" />
 					</H1>
 
 					<Intro>
-						Découvrez nos statistiques d'utilisation mises à jour
-						quotidiennement.
+						{t(
+							'pages.statistiques.intro',
+							'Découvrez nos statistiques d’utilisation mises à jour quotidiennement.'
+						)}
 					</Intro>
 					<Body>
-						Les données recueillies sont anonymisées.{' '}
+						{t(
+							'pages.statistiques.anonymous',
+							'Les données recueillies sont anonymisées.'
+						)}{' '}
 						<PrivacyPolicy label={t('En savoir plus')} />
 					</Body>
-					<h2 className="sr-only">Selection du simulateur</h2>
+					<h2 className="sr-only">
+						{t('pages.statistiques.h2.selection', 'Selection du simulateur')}
+					</h2>
 					<SimulateursChoice
 						onChange={setFilter}
 						value={filter}
@@ -85,14 +92,14 @@ export default function StatPage({ stats }: StatsDetailProps) {
 					questionsRépondues={questionsRépondues}
 					satisfaction={satisfaction}
 				/>
-				<Trans>
+				<Trans i18nKey="pages.statistiques.explanation">
 					<Ul>
 						<Li>
 							Les simulateurs et assistants de ce site ont pour but de{' '}
-							<Strong>répondre à une question</Strong> (par exemple « combien
-							mon entreprise doit-elle payer pour embaucher une personne ? » ou
-							« Quel est le meilleur statut juridique pour débuter mon activité
-							? »
+							<Strong>répondre à une question</Strong> (par exemple
+							«&nbsp;combien mon entreprise doit-elle payer pour embaucher une
+							personne&nbsp;?&nbsp;» ou «&nbsp;Quel est le meilleur statut
+							juridique pour débuter mon activité&nbsp;?&nbsp;»)
 						</Li>
 						<Li>
 							Pour calculer le nombre de questions répondues, nous multiplions
@@ -103,7 +110,9 @@ export default function StatPage({ stats }: StatsDetailProps) {
 				</Trans>
 			</section>
 			<section id="visites-panel">
-				<H2>Évolution sur plusieurs mois</H2>
+				<H2>
+					{t('pages.statistiques.h2.evolution', 'Évolution sur plusieurs mois')}
+				</H2>
 
 				<Body>
 					<Switch
@@ -112,10 +121,13 @@ export default function StatPage({ stats }: StatsDetailProps) {
 						/* Need this useless aria-label to silence a React-Aria warning */
 						aria-label=""
 					>
-						<Trans>Activer le mode accessibilité sur cette section</Trans>
+						{t(
+							'pages.statistiques.a11y-switch',
+							'Activer le mode accessibilité sur cette section'
+						)}
 					</Switch>
 				</Body>
-				<H3>Visites</H3>
+				<H3>{t('pages.statistiques.h3.visits', 'Visites')}</H3>
 				<VisitChart
 					visitesJours={visitesJours}
 					visitesMois={visitesMois}
@@ -127,7 +139,7 @@ export default function StatPage({ stats }: StatsDetailProps) {
 					(satisfaction.at(-2)?.total ?? 0) >= 100 && (
 						<>
 							<Spacing md />
-							<H3>Satisfaction</H3>
+							<H3>{t('pages.statistiques.h3.satisfaction', 'Satisfaction')}</H3>
 							<SatisfactionChart
 								data={satisfaction}
 								accessibleMode={accessibleMode}
@@ -136,7 +148,12 @@ export default function StatPage({ stats }: StatsDetailProps) {
 					)}
 				{filter === '' && (
 					<>
-						<H3>Répartition des visites par simulateurs</H3>
+						<H3>
+							{t(
+								'pages.statistiques.h3.repartition',
+								'Répartition des visites par simulateurs'
+							)}
+						</H3>
 
 						<PagesChart data={repartition} accessibleMode={accessibleMode} />
 					</>

--- a/site/source/utils/index.ts
+++ b/site/source/utils/index.ts
@@ -225,10 +225,6 @@ export async function getIframeOffset(): Promise<number> {
 	})
 }
 
-export const generateUuid = () => {
-	return Math.floor(Math.random() * Date.now()).toString(16)
-}
-
 /**
  * Returns true if x is not null, useful for filtering out nulls from arrays
  * @example [1, null, 2].filter(isNotNull) // [1, 2]

--- a/yarn.lock
+++ b/yarn.lock
@@ -30967,6 +30967,7 @@ __metadata:
     stylis: ^4.3.0
     ts-node: ^10.9.1
     typescript: ^5.2.2
+    uuid: ^11.1.0
     vite: ^4.4.9
     vite-plugin-pwa: ^0.16.5
     vitest: ^0.34.4
@@ -33614,6 +33615,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 840f19758543c4631e58a29439e51b5b669d5f34b4dd2700b6a1d15c5708c7a6e0c3e2c8c4a2eae761a3a7caa7e9884d00c86c02622ba91137bd3deade6b4b4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cette PR est une reprise de la PR https://github.com/betagouv/mon-entreprise/pull/3453 dont elle corrige quelques défauts :

- l'internationalisation n'avait pas été complètement faite
- en corrigeant l'erreur remontée par Wave (présence d'un `label` vide), on n'avait perdu la possibilité de cliquer sur le switch du dark mode (il ne fonctionnait plus qu'au clavier)
- le [WAI Switch Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/switch/) recommandait par ailleurs que le switch, accompagné de son label, aient les mêmes styles au survol et à la prise du focus

Elle traite éqalement l'issue https://github.com/betagouv/mon-entreprise/issues/3501 que j'ai fermé du coup.

---

J'ai par contre renoncé à afficher l'état du switch ("On", "Off", ...) car cela ne me semblait pas pertinent pour les 4-5 utilisations de ce composant `<Switch />`.

![image](https://github.com/user-attachments/assets/444086bf-548c-4b23-93ef-e2963323eddf)

Le wording du label "sr only" du switch du dark mode est sinon désormais "fixe", conformément au WAI Pattern : quelque soit l'état de ce switch, ce label est _"Activer le mode sombre"_.

C'est la vocalisation du `checked` de l'input qui est chargé de donner l'état avec un lecteur d'écran, plutôt qu'un "texte dynamique", peu adapté pour une interface vocalisée.

---

React Aria impose que ce composant Switch est un aria-label, sous peine de remplir la console avec de longs warnings :

![image](https://github.com/user-attachments/assets/b01f7510-94a7-40ab-a75e-ead264cc95ce)

Etant donné que les `<Switch />` auront maintenant toujours un label (éventuellement invisibilisé mais rendu par un lecteur d'écran), ce n'est pas souhaitable de mettre un `aria-label`.

Cela m'a conduit du coup à mettre un dernier commit contenant un hack : https://github.com/betagouv/mon-entreprise/pull/3475/commits/63296a0912de9b0fd2304cb09889d86e699ef2c7

Ce hack fait apparaître un attribut `aria-label` sans valeur dans le HTML, qui est ignoré par VoiceOver (et à mon avis par tous les lecteurs d'écran) :

![image](https://github.com/user-attachments/assets/589c35a9-1962-4587-813d-60d65874ecf7)

Il serait peut-être possible d'éviter ce hack en abandonnant le pattern "label/input" des WCAG pour un des deux autres, mais je ne pense pas que ça vaille le coup de passer plus de temps là-dessus. Nous y avons déjà consacré bcp trop de temps pour juste supprimer une erreur remontée par Wave. 😕

(même si ça a quand même été l'occasion pour moi de rentrer dans la doc de React Aria, ce qui sera utile pour la suite 🙂 )