### PR TITLE
Propose une solution pour que le type='info' n'apparaisse pas dans l'HTML

### DIFF
--- a/site/source/components/ui/WarningBlock.tsx
+++ b/site/source/components/ui/WarningBlock.tsx
@@ -22,7 +22,7 @@ export default function Warning({ localStorageKey, children }: WarningProps) {
 
 	return (
 		<>
-			<Message type="info" icon>
+			<Message type={'info'} icon>
 				<div className="print-hidden">
 					<Intro as="h2">
 						<Trans i18nKey="simulateurs.warning.titre">


### PR DESCRIPTION
La solution la plus simple que j'ai trouvé c'est de rajouter des `{ }`.
Dites moi si c'est ok et je corrige partout.

Fix #3482 