### PR TITLE
fix(pam): application de la CURPS si création au 1er janvier

### DIFF
--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 ### Corrections
 - Correction de la formule du calcul de la contribution additionnelle pour les PAMC
+- Correction du montant de la CURPS pour les activités démarrées au 1er janvier
 
 ## 6.0.0
 ### Breaking changes

--- a/modele-social/règles/dirigeant/professions-libérales/PAMC.publicodes
+++ b/modele-social/règles/dirigeant/professions-libérales/PAMC.publicodes
@@ -86,7 +86,7 @@ dirigeant . indépendant . PL . PAMC . CURPS:
   acronyme: CURPS
   applicable si:
     toutes ces conditions:
-      - entreprise . date de création < période . début d'année
+      - entreprise . date de création <= période . début d'année
       - revenu professionnel > 0
   non applicable si:
     une de ces conditions:


### PR DESCRIPTION
Pour les professions médicales (PAM), la CURPS doit être rajoutée si l'entreprise démarre au 1er janvier #3466 