### PR TITLE
A11y / issue #3482 - Suppression des type="info" apparaissant dans le HTML

### DIFF
--- a/site/source/design-system/chip/index.tsx
+++ b/site/source/design-system/chip/index.tsx
@@ -29,7 +29,7 @@ export function Chip({
 
 	return (
 		<ForceThemeProvider forceTheme="light">
-			<StyledChip className={className} type={type} title={title}>
+			<StyledChip className={className} $type={type} title={title}>
 				{icon && (
 					<StyledIconWrapper type={type}>
 						{typeof icon !== 'boolean' ? (
@@ -65,29 +65,31 @@ const StyledIconWrapper = styled.span<{
 
 const StyledChip = styled.strong<
 	Pick<ChipProps, 'type'> & {
-		type: NonNullable<ChipProps['type']>
+		$type: NonNullable<ChipProps['type']>
 	}
 >`
 	vertical-align: middle;
 	white-space: nowrap;
-	${({ theme, type }) => {
+	${({ theme, $type }) => {
 		const colorSpace: Palette | SmallPalette =
-			type === 'secondary' || type === 'primary'
-				? theme.colors.bases[type]
-				: theme.colors.extended[type]
+			$type === 'secondary' || $type === 'primary'
+				? theme.colors.bases[$type]
+				: theme.colors.extended[$type]
 
 		return css`
 			margin: 0 ${theme.spacings.xxs};
 			border-radius: ${theme.spacings.md};
 			font-family: ${theme.fonts.main};
 			padding: ${theme.spacings.xxs} ${theme.spacings.xs};
-			background-color: ${type === 'error' ? colorSpace[400] : colorSpace[300]};
+			background-color: ${$type === 'error'
+				? colorSpace[400]
+				: colorSpace[300]};
 
 			font-size: ${theme.baseFontSize};
 			text-align: center;
-			color: ${type === 'error'
+			color: ${$type === 'error'
 				? theme.colors.extended.grey[100]
-				: textColorFromType(type, theme)};
+				: textColorFromType($type, theme)};
 		`
 	}}
 `

--- a/site/source/design-system/message/index.tsx
+++ b/site/source/design-system/message/index.tsx
@@ -59,7 +59,7 @@ export function Message({
 				aria-atomic
 			>
 				{icon && (
-					<StyledIconWrapper type={type}>
+					<StyledIconWrapper $type={type}>
 						{typeof icon !== 'boolean' ? (
 							icon
 						) : type === 'success' ? (
@@ -79,14 +79,14 @@ export function Message({
 	)
 }
 const StyledIconWrapper = styled.div<{
-	type: MessageProps['type']
+	$type: MessageProps['type']
 }>`
 	display: flex;
 	position: relative;
 	top: ${({ theme }) => theme.spacings.xxs};
 	width: ${({ theme }) => theme.spacings.xl};
 	svg {
-		fill: ${({ theme, type }) => textColorFromType(type, theme)};
+		fill: ${({ theme, $type }) => textColorFromType($type, theme)};
 	}
 `
 


### PR DESCRIPTION
Certains composants, des `<div>` notamment, étaient rendues avec un attribut `type="info"` invalidant le HTML.

Cette PR renomme la prop `type` par `$type` pour les parties de composant directement construites avec `styled-components` composants concernés :

- `<Message />`
- `<Chip />`

C'est ce que recommandait la doc de `styled-components` à l'époque où je l'ai lu et c'est j'imagine pour éviter de genre de "side effect" (je n'ai pas retrouvé le passage 😕 ).

Concernant `<HelpButtonWithPopover />`, je n'ai pas vu apparaître d'attribut `type="info"` dans l'inspecteur.

C'est cohérent car en regardant son code, aucune des parties de ce composant construites avec `styled-components` n'utilise la prop `type`, contrairement à `<Message />` et `<Chip />`.

**Lien vers l'issue :** https://github.com/betagouv/mon-entreprise/issues/3482