### PR TITLE
a11y(Simulateurs): lie les inputs et les labels

### DIFF
--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -210,24 +210,28 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 
 		cy.get('@titles').contains('Recettes').should('be.visible')
 		cy.contains('Recettes brutes totales').should('be.visible')
-		cy.get(`#${idPrefix}_recettes_brutes_totales`).should('be.visible')
+		cy.get(`#${idPrefix}_recettes_brutes_totales-input`).should('be.visible')
 		cy.contains('Revenus imposables').should('be.visible')
-		cy.get(`#${idPrefix}_revenus_imposables`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_imposables-input`).should('be.visible')
 		cy.contains('Cotisations sociales obligatoires').should('be.visible')
-		cy.get(`#${idPrefix}_cotisations_sociales_obligatoires`).should(
+		cy.get(`#${idPrefix}_cotisations_sociales_obligatoires-input`).should(
 			'be.visible'
 		)
 
 		cy.get('@titles').contains('Structures de soins').should('be.visible')
 		cy.contains('Honoraires tirés d’actes conventionnés').should('be.visible')
-		cy.get(`#${idPrefix}_SNIR___honoraires_remboursables`).should('be.visible')
+		cy.get(`#${idPrefix}_SNIR___honoraires_remboursables-input`).should(
+			'be.visible'
+		)
 		cy.contains('Dépassements d’honoraires').should('be.visible')
-		cy.get(`#${idPrefix}_SNIR___dépassements_honoraires`).should('be.visible')
+		cy.get(`#${idPrefix}_SNIR___dépassements_honoraires-input`).should(
+			'be.visible'
+		)
 
 		cy.contains(
 			'Avez-vous des recettes issues d’une activité en structure de soins ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${structureDeSoins}`).should('be.visible')
+		cy.get(`#${idPrefix}_${structureDeSoins}-input`).should('be.visible')
 
 		cy.get('@titles')
 			.contains('Déductions et exonérations')
@@ -235,7 +239,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Bénéficiez-vous de déductions et/ou de revenus exonérés fiscalement ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${exonerations}`).should('be.visible')
+		cy.get(`#${idPrefix}_${exonerations}-input`).should('be.visible')
 
 		cy.get('@titles')
 			.contains('Autres revenus non salariés')
@@ -243,19 +247,21 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Avez-vous des revenus non salariés autres que ceux relevant du régime micro-BNC ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC-input`).should('be.visible')
 
 		cy.get('@titles').contains('Actes conventionnés').should('be.visible')
 		cy.contains(
 			'Avez-vous effectué uniquement des actes conventionnés ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_actes_conventionnés_uniquement`).should('be.visible')
+		cy.get(`#${idPrefix}_actes_conventionnés_uniquement-input`).should(
+			'be.visible'
+		)
 
 		cy.get('@titles').contains('Revenus de remplacement').should('be.visible')
 		cy.contains(
 			'Avez-vous perçu des indemnités de la Caf, de la CPAM ou de votre caisse de retraite ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_revenus_de_remplacement`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement-input`).should('be.visible')
 	})
 
 	it('devrait effacer les réponses en cliquant sur réinitialiser', function () {
@@ -296,15 +302,17 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('Impôt sur les sociétés').click()
 
 		cy.contains('Recettes brutes totales').should('be.visible')
-		cy.get(`#${idPrefix}_recettes_brutes_totales`).should('be.visible')
+		cy.get(`#${idPrefix}_recettes_brutes_totales-input`).should('be.visible')
 		cy.contains('Revenus des associés et gérants').should('be.visible')
-		cy.get(`#${idPrefix}_revenus_des_associés_et_gérants`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_des_associés_et_gérants-input`).should(
+			'be.visible'
+		)
 		cy.contains('Dividendes').should('be.visible')
-		cy.get(`#${idPrefix}_dividendes`).should('be.visible')
+		cy.get(`#${idPrefix}_dividendes-input`).should('be.visible')
 		cy.contains('Frais réels hors intérêt d’emprunts').should('be.visible')
-		cy.get(`#${idPrefix}_frais_réels`).should('be.visible')
+		cy.get(`#${idPrefix}_frais_réels-input`).should('be.visible')
 		cy.contains('Cotisations sociales obligatoires').should('be.visible')
-		cy.get(`#${idPrefix}_cotisations_sociales_obligatoires`).should(
+		cy.get(`#${idPrefix}_cotisations_sociales_obligatoires-input`).should(
 			'be.visible'
 		)
 
@@ -351,7 +359,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Avez-vous des revenus non salariés autres que ceux relevant des BNC ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_BNC`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_BNC-input`).should('be.visible')
 		cy.contains(
 			'Avez-vous des revenus non salariés autres que ceux relevant de l’impôt sur les sociétés ?'
 		).should('not.exist')
@@ -369,7 +377,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Avez-vous des revenus non salariés autres que ceux relevant de l’impôt sur les sociétés ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_IS`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_IS-input`).should('be.visible')
 	})
 
 	it('ne devrait pas montrer les résultats avant que les champs soient remplis', function () {
@@ -609,7 +617,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('Chirurgien/chirurgienne-dentiste').click()
 
 		cy.get(`#${idPrefix}_SNIR___taux_urssaf-title`).should('be.visible')
-		cy.get(`#${idPrefix}_SNIR___taux_urssaf`).should('be.visible')
+		cy.get(`#${idPrefix}_SNIR___taux_urssaf-input`).should('be.visible')
 
 		cy.contains(
 			'Avez-vous des recettes issues d’une activité en structure de soins ?'
@@ -676,13 +684,15 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get(`#${idPrefix}_SNIR___honoraires_tarifs_opposables-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_SNIR___honoraires_tarifs_opposables`).should(
+		cy.get(`#${idPrefix}_SNIR___honoraires_tarifs_opposables-input`).should(
 			'be.visible'
 		)
 		cy.get(`#${idPrefix}_SNIR___honoraires_hors_forfaits-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_SNIR___honoraires_hors_forfaits`).should('be.visible')
+		cy.get(`#${idPrefix}_SNIR___honoraires_hors_forfaits-input`).should(
+			'be.visible'
+		)
 	})
 
 	it('devrait montrer des résultats différents aux médecins', function () {
@@ -736,7 +746,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('Avez-vous effectué uniquement des actes conventionnés ?')
 			.as('questionLabel')
 			.should('be.visible')
-		cy.get(`#${idPrefix}_actes_conventionnés_uniquement`)
+		cy.get(`#${idPrefix}_actes_conventionnés_uniquement-label`)
 			.as('questionInput')
 			.should('be.visible')
 
@@ -751,13 +761,15 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('micro-fiscal').click()
 
 		// "oui" à structure de soins et "non" à autres revenus
-		cy.get(`#${idPrefix}_${structureDeSoins}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${structureDeSoins}-input`).contains('Oui').click()
 
 		cy.get('@questionLabel').should('not.exist')
 		cy.get('@questionInput').should('not.exist')
 
 		// "oui" à structure de soins et "oui" à autres revenus
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC-input`)
+			.contains('Oui')
+			.click()
 
 		cy.get('@questionLabel').should('not.exist')
 		cy.get('@questionInput').should('not.exist')
@@ -783,12 +795,14 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		)
 		cy.get(`#${idPrefix}_${structureDeSoins}___recettes`).should('not.exist')
 
-		cy.get(`#${idPrefix}_${structureDeSoins}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${structureDeSoins}-input`).contains('Oui').click()
 
 		cy.get(`#${idPrefix}_${structureDeSoins}___recettes-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_${structureDeSoins}___recettes`).should('be.visible')
+		cy.get(`#${idPrefix}_${structureDeSoins}___recettes-input`).should(
+			'be.visible'
+		)
 		cy.contains(
 			'Dont revenus nets de l’activité réalisée dans des structures de soins'
 		).should('be.visible')
@@ -821,20 +835,20 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 			'not.exist'
 		)
 
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.contains('Revenus exonérés').should('be.visible')
-		cy.get(`#${idPrefix}_${exonerations}___revenus_exonérés`).should(
+		cy.get(`#${idPrefix}_${exonerations}___revenus_exonérés-input`).should(
 			'be.visible'
 		)
 		cy.contains('Plus-values à court terme exonérées').should('be.visible')
-		cy.get(`#${idPrefix}_${exonerations}___plus-values_à_court_terme`).should(
-			'be.visible'
-		)
+		cy.get(
+			`#${idPrefix}_${exonerations}___plus-values_à_court_terme-input`
+		).should('be.visible')
 		cy.contains(
 			'Montant des chèques vacances déduits du revenu imposable'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${exonerations}___chèques_vacances`).should(
+		cy.get(`#${idPrefix}_${exonerations}___chèques_vacances-input`).should(
 			'be.visible'
 		)
 		cy.get(`#${idPrefix}_${exonerations}___chèques_vacances-label`).should(
@@ -854,7 +868,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.contains('Exonération zone déficitaire en offre de soins').should(
 			'not.exist'
@@ -886,13 +900,13 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.get(
 			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-title`
 		).should('be.visible')
 		cy.get(
-			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins`
+			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-input`
 		).should('be.visible')
 		cy.get(
 			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-label`
@@ -924,7 +938,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.contains('Exonération zone déficitaire en offre de soins').should(
 			'not.exist'
@@ -956,13 +970,13 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.get(
 			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-title`
 		).should('be.visible')
 		cy.get(
-			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins`
+			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-input`
 		).should('be.visible')
 		cy.get(
 			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-label`
@@ -973,7 +987,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Déduction du groupe III et déduction complémentaire 3%'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${exonerations}___déduction_groupe_III`).should(
+		cy.get(`#${idPrefix}_${exonerations}___déduction_groupe_III-input`).should(
 			'be.visible'
 		)
 		cy.contains('Médecin secteur 1 - déduction complémentaire 3%').should(
@@ -993,7 +1007,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.contains('Exonération zone déficitaire en offre de soins').should(
 			'not.exist'
@@ -1025,13 +1039,13 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_${exonerations}`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${exonerations}-input`).contains('Oui').click()
 
 		cy.get(
 			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-title`
 		).should('be.visible')
 		cy.get(
-			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins`
+			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-input`
 		).should('be.visible')
 		cy.get(
 			`#${idPrefix}_${exonerations}___zone_déficitaire_en_offre_de_soins-label`
@@ -1083,26 +1097,28 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('Bénéfice/déficit agricole').should('not.exist')
 		cy.get(`#${idPrefix}_${autresRevenus}_agricole`).should('not.exist')
 
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC-input`)
+			.contains('Oui')
+			.click()
 
 		cy.contains('Plus-values nettes à court terme').should('be.visible')
 		cy.get(
-			`#${idPrefix}_${autresRevenus}_plus-values_nettes_à_court_terme`
+			`#${idPrefix}_${autresRevenus}_plus-values_nettes_à_court_terme-input`
 		).should('be.visible')
 		cy.contains('Micro-BIC : chiffre d’affaires vente de marchandises').should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_marchandises`).should(
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_marchandises-input`).should(
 			'be.visible'
 		)
 		cy.contains('Micro-BIC : chiffre d’affaires prestation de service').should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_service`).should(
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_service-input`).should(
 			'be.visible'
 		)
 		cy.contains('Micro-BA : chiffre d’affaires agricole').should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BA`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BA-input`).should('be.visible')
 	})
 
 	it('devrait montrer uniquement les champs des autres revenus non salariés relevant du régime micro-fiscal lorsque le régime micro-fiscal est sélectionné', function () {
@@ -1121,7 +1137,9 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		).should('not.exist')
 		cy.get(`#${idPrefix}_${autresRevenus}_IS`).should('not.exist')
 
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BNC-input`)
+			.contains('Oui')
+			.click()
 
 		// Champs absents
 		cy.contains('Bénéfice/déficit BIC').should('not.exist')
@@ -1140,7 +1158,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Avez-vous des revenus non salariés autres que ceux relevant des BNC ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_BNC`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_BNC-input`).should('be.visible')
 
 		// Questions absentes
 		cy.contains(
@@ -1152,7 +1170,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		).should('not.exist')
 		cy.get(`#${idPrefix}_${autresRevenus}_IS`).should('not.exist')
 
-		cy.get(`#${idPrefix}_${autresRevenus}_BNC`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${autresRevenus}_BNC-input`).contains('Oui').click()
 
 		// Champs présents
 		cy.contains('Bénéfice/déficit BIC').should('be.visible')
@@ -1191,7 +1209,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains(
 			'Avez-vous des revenus non salariés autres que ceux relevant de l’impôt sur les sociétés ?'
 		).should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_IS`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_IS-input`).should('be.visible')
 
 		// Questions absentes
 		cy.contains(
@@ -1203,7 +1221,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		).should('not.exist')
 		cy.get(`#${idPrefix}_${autresRevenus}_BNC`).should('not.exist')
 
-		cy.get(`#${idPrefix}_${autresRevenus}_IS`).contains('Oui').click()
+		cy.get(`#${idPrefix}_${autresRevenus}_IS-input`).contains('Oui').click()
 
 		// Champs présents
 		cy.contains('Bénéfice/déficit BIC').should('be.visible')
@@ -1211,19 +1229,19 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('Micro-BIC : chiffre d’affaires vente de marchandises').should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_marchandises`).should(
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_marchandises-input`).should(
 			'be.visible'
 		)
 		cy.contains('Micro-BIC : chiffre d’affaires prestation de service').should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_service`).should(
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BIC_service-input`).should(
 			'be.visible'
 		)
 		cy.contains('Bénéfice/déficit agricole').should('be.visible')
 		cy.get(`#${idPrefix}_${autresRevenus}_agricole`).should('be.visible')
 		cy.contains('Micro-BA : chiffre d’affaires agricole').should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_micro-BA`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_micro-BA-input`).should('be.visible')
 
 		// Champ absent
 		cy.contains('Plus-values nettes à court terme').should('not.exist')
@@ -1255,7 +1273,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 			'not.exist'
 		)
 
-		cy.get(`#${idPrefix}_revenus_de_remplacement`).contains('Oui').click()
+		cy.get(`#${idPrefix}_revenus_de_remplacement-input`).contains('Oui').click()
 
 		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-title`).should(
 			'be.visible'
@@ -1281,7 +1299,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('input[type="text"]').each(($input) => {
 			cy.wrap($input).type('{selectall}100')
 		})
-		cy.get(`#${idPrefix}_revenus_de_remplacement`).contains('Oui').click()
+		cy.get(`#${idPrefix}_revenus_de_remplacement-input`).contains('Oui').click()
 
 		cy.contains(
 			'Montant des indemnités journalières versées par la CPAM'

--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -775,7 +775,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get('@questionInput').should('not.exist')
 
 		// "non" à structure de soins et "oui" à autres revenus
-		cy.get(`#${idPrefix}_${structureDeSoins}`).contains('Non').click()
+		cy.get(`#${idPrefix}_${structureDeSoins}-input`).contains('Non').click()
 
 		cy.get('@questionLabel').should('not.exist')
 		cy.get('@questionInput').should('not.exist')

--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -746,7 +746,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.contains('Avez-vous effectué uniquement des actes conventionnés ?')
 			.as('questionLabel')
 			.should('be.visible')
-		cy.get(`#${idPrefix}_actes_conventionnés_uniquement-label`)
+		cy.get(`#${idPrefix}_actes_conventionnés_uniquement-input`)
 			.as('questionInput')
 			.should('be.visible')
 

--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -1225,7 +1225,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 
 		// Champs présents
 		cy.contains('Bénéfice/déficit BIC').should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_BIC`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_BIC-input`).should('be.visible')
 		cy.contains('Micro-BIC : chiffre d’affaires vente de marchandises').should(
 			'be.visible'
 		)
@@ -1375,7 +1375,9 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement__-input`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement__AJPA-input`).should(
+			'be.visible'
+		)
 		cy.get(
 			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-title`
 		).should('be.visible')

--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -1174,9 +1174,9 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 
 		// Champs présents
 		cy.contains('Bénéfice/déficit BIC').should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_BIC`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_BIC-input`).should('be.visible')
 		cy.contains('Bénéfice/déficit agricole').should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_agricole`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_agricole-input`).should('be.visible')
 
 		// Champs absents
 		cy.contains('Plus-values nettes à court terme').should('not.exist')
@@ -1278,7 +1278,9 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-input`).should(
+			'be.visible'
+		)
 		cy.get('h3')
 			.contains('Montant des revenus de remplacement')
 			.should('be.visible')
@@ -1324,11 +1326,15 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get(`#${idPrefix}_revenus_de_remplacement___IJ-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement___IJ`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement___IJ-input`).should(
+			'be.visible'
+		)
 		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-input`).should(
+			'be.visible'
+		)
 		cy.get(
 			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-title`
 		).should('be.visible')
@@ -1363,11 +1369,13 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get(`#${idPrefix}_revenus_de_remplacement___IJ-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement___IJ`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement___IJ-input`).should(
+			'be.visible'
+		)
 		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA`).should('be.visible')
+		cy.get(`#${idPrefix}_revenus_de_remplacement__-input`).should('be.visible')
 		cy.get(
 			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-title`
 		).should('be.visible')

--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -1239,7 +1239,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 			'be.visible'
 		)
 		cy.contains('Bénéfice/déficit agricole').should('be.visible')
-		cy.get(`#${idPrefix}_${autresRevenus}_agricole`).should('be.visible')
+		cy.get(`#${idPrefix}_${autresRevenus}_agricole-input`).should('be.visible')
 		cy.contains('Micro-BA : chiffre d’affaires agricole').should('be.visible')
 		cy.get(`#${idPrefix}_${autresRevenus}_micro-BA-input`).should('be.visible')
 
@@ -1375,7 +1375,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-title`).should(
 			'be.visible'
 		)
-		cy.get(`#${idPrefix}_revenus_de_remplacement__AJPA-input`).should(
+		cy.get(`#${idPrefix}_revenus_de_remplacement___AJPA-input`).should(
 			'be.visible'
 		)
 		cy.get(

--- a/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/declaration-revenus-pamc.ts
@@ -1339,7 +1339,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-title`
 		).should('be.visible')
 		cy.get(
-			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire`
+			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-input`
 		).should('be.visible')
 		cy.get('h3')
 			.contains('Montant des revenus de remplacement')
@@ -1380,7 +1380,7 @@ describe(`L'assistant à la déclaration de revenu pour PAMC`, function () {
 			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-title`
 		).should('be.visible')
 		cy.get(
-			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire`
+			`#${idPrefix}_revenus_de_remplacement___indemnités_incapacité_temporaire-input`
 		).should('be.visible')
 		cy.get('h3')
 			.contains('Montant des revenus de remplacement')

--- a/site/cypress/integration/mon-entreprise/assistants/détermination-charges-sociales.ts
+++ b/site/cypress/integration/mon-entreprise/assistants/détermination-charges-sociales.ts
@@ -12,10 +12,10 @@ describe(`Assistant charges sociales`, function () {
 		cy.contains('Impôt sur le revenu').click()
 		cy.contains('Comptabilité de trésorerie').click()
 		cy.get(
-			'#déclaration_charge_sociales___cotisations_payées___cotisations_sociales'
+			'#déclaration_charge_sociales___cotisations_payées___cotisations_sociales-input'
 		).type('12000')
 		cy.get(
-			'#déclaration_charge_sociales___cotisations_payées___CSG_déductible_et_CFP'
+			'#déclaration_charge_sociales___cotisations_payées___CSG_déductible_et_CFP-input'
 		).type('1000')
 
 		cy.contains('Montants à reporter dans votre déclaration de revenus')

--- a/site/cypress/integration/mon-entreprise/english/prerender.ts
+++ b/site/cypress/integration/mon-entreprise/english/prerender.ts
@@ -63,10 +63,12 @@ describe('Test prerender', function () {
 					cy.contains('Montant annuel')
 
 					cy.contains("Chiffre d'affaires")
-					cy.get('input[id="entreprise___chiffre_d\'affaires"]').should('exist')
+					cy.get('input[id="entreprise___chiffre_d\'affaires-input"]').should(
+						'exist'
+					)
 
 					cy.contains('Charges')
-					cy.get('input[id="entreprise___charges"]').should('exist')
+					cy.get('input[id="entreprise___charges-input"]').should('exist')
 
 					cy.get('input[id="dirigeant___rémunération___net"]').should('exist')
 

--- a/site/cypress/integration/mon-entreprise/english/prerender.ts
+++ b/site/cypress/integration/mon-entreprise/english/prerender.ts
@@ -3,12 +3,12 @@ import { fr } from '../../../support/utils'
 type cyType = typeof cy
 type Obj = Record<string, { test: (cy: cyType) => unknown; path: string }[]>
 
-const coutTotalSelector = 'input[id="salarié___coût_total_employeur"]'
-const salaireBrutSelector = 'input[id="salarié___contrat___salaire_brut"]'
+const coutTotalSelector = 'input[id="salarié___coût_total_employeur-input"]'
+const salaireBrutSelector = 'input[id="salarié___contrat___salaire_brut-input"]'
 const salaireNetSelector =
-	'input[id="salarié___rémunération___net___à_payer_avant_impôt"]'
+	'input[id="salarié___rémunération___net___à_payer_avant_impôt-input"]'
 const salaireNetApresImpot =
-	'input[id="salarié___rémunération___net___payé_après_impôt"]'
+	'input[id="salarié___rémunération___net___payé_après_impôt-input"]'
 
 describe('Test prerender', function () {
 	const testSimuSalaire = (cy: cyType) => {

--- a/site/cypress/integration/mon-entreprise/english/prerender.ts
+++ b/site/cypress/integration/mon-entreprise/english/prerender.ts
@@ -70,11 +70,13 @@ describe('Test prerender', function () {
 					cy.contains('Charges')
 					cy.get('input[id="entreprise___charges-input"]').should('exist')
 
-					cy.get('input[id="dirigeant___rémunération___net"]').should('exist')
+					cy.get('input[id="dirigeant___rémunération___net-input"]').should(
+						'exist'
+					)
 
 					cy.contains('Revenu après impôt')
 					cy.get(
-						'input[id="dirigeant___rémunération___net___après_impôt"]'
+						'input[id="dirigeant___rémunération___net___après_impôt-input"]'
 					).should('exist')
 				},
 				path: '/simulateurs/indépendant',

--- a/site/cypress/integration/mon-entreprise/partage-simulation.js
+++ b/site/cypress/integration/mon-entreprise/partage-simulation.js
@@ -1,7 +1,7 @@
 const fr = Cypress.env('language') === 'fr'
 
 describe('Partage (simulateur salarié)', function () {
-	const brutInputSelector = '#salarié___contrat___salaire_brut'
+	const brutInputSelector = '#salarié___contrat___salaire_brut-input'
 	const simulatorUrl = '/simulateurs/salaire-brut-net'
 	const searchParams = new URLSearchParams({
 		'salaire-brut': '1539€/mois',

--- a/site/cypress/integration/mon-entreprise/simulateur-location-meuble.ts
+++ b/site/cypress/integration/mon-entreprise/simulateur-location-meuble.ts
@@ -17,14 +17,14 @@ describe('Simulateur de location de meublé', () => {
 
 	it('affiche le formulaire', () => {
 		cy.get(
-			'input#location_de_logement_meublé___courte_durée___recettes'
+			'input#location_de_logement_meublé___courte_durée___recettes-input'
 		).should('be.visible')
 	})
 
 	it('chiffre les cotisations quand on saisi des revenus', () => {
-		cy.get('input#location_de_logement_meublé___courte_durée___recettes').type(
-			'{selectall}25000'
-		)
+		cy.get(
+			'input#location_de_logement_meublé___courte_durée___recettes-input'
+		).type('{selectall}25000')
 
 		cy.get('#location_de_logement_meublé___cotisations-value')
 			.should('be.visible')
@@ -32,9 +32,9 @@ describe('Simulateur de location de meublé', () => {
 	})
 
 	it('ne chiffre rien si on dépasse le plafond de recettes au régime général', () => {
-		cy.get('input#location_de_logement_meublé___courte_durée___recettes').type(
-			'{selectall}78000'
-		)
+		cy.get(
+			'input#location_de_logement_meublé___courte_durée___recettes-input'
+		).type('{selectall}78000')
 
 		cy.get('#location_de_logement_meublé___cotisations-value').should(
 			'not.exist'

--- a/site/cypress/support/simulateur.ts
+++ b/site/cypress/support/simulateur.ts
@@ -1,8 +1,8 @@
 import { checkA11Y } from './utils'
 
 const inputSelector =
-	'div[id="simulator-legend"] input[inputmode="numeric"]:not([id="entreprise___charges"])'
-const chargeInputSelector = 'input[id="entreprise___charges"]'
+	'div[id="simulator-legend"] input[inputmode="numeric"]:not([id="entreprise___charges-input"])'
+const chargeInputSelector = 'input[id="entreprise___charges-input"]'
 const lang = Cypress.env('language') as 'fr' | 'en'
 
 type Simulateur =

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -21,6 +21,7 @@ import RuleLink from '../RuleLink'
 import { Appear } from '../ui/animate'
 import AnimatedTargetValue from '../ui/AnimatedTargetValue'
 import { useEngine } from '../utils/EngineContext'
+import { normalizeRuleName } from '../utils/normalizeRuleName'
 
 type SimulationGoalProps = {
 	dottedName: DottedName
@@ -102,9 +103,7 @@ export function SimulationGoal({
 									}}
 								>
 									<Grid item>
-										<StyledBody
-											id={`${dottedName.replace(/\s|\./g, '_')}-label`}
-										>
+										<StyledBody id={normalizeRuleName.Label(dottedName)}>
 											<Strong>{label || rule.title}</Strong>
 										</StyledBody>
 									</Grid>
@@ -119,14 +118,19 @@ export function SimulationGoal({
 									id={`${dottedName.replace(/\s|\./g, '_')}-label`}
 									dottedName={dottedName}
 								>
-									{label || rule.title}
+									<label
+										htmlFor={normalizeRuleName.Input(dottedName)}
+										style={{ cursor: 'pointer' }}
+									>
+										{label || rule.title}
+									</label>
 								</RuleLink>
 							)}
 
 							{rule.rawNode.résumé && (
 								<StyledSmallBody
 									className={small ? 'sr-only' : ''}
-									id={`${dottedName.replace(/\s|\./g, '_')}-description`}
+									id={normalizeRuleName.Description(dottedName)}
 								>
 									{rule.rawNode.résumé}
 								</StyledSmallBody>
@@ -147,12 +151,7 @@ export function SimulationGoal({
 										  }
 										: undefined
 								}
-								aria-label={engine.getRule(dottedName)?.title}
-								aria-describedby={`${dottedName.replace(
-									/\s|\./g,
-									'_'
-								)}-description`}
-								aria-labelledby="simu-update-explaining"
+								aria-describedby={normalizeRuleName.Description(dottedName)}
 								hideDefaultValue
 								displayedUnit={displayedUnit}
 								dottedName={dottedName}
@@ -168,7 +167,7 @@ export function SimulationGoal({
 						</Grid>
 					) : (
 						<Grid item>
-							<Body id={`${dottedName.replace(/\s|\./g, '_')}-value`}>
+							<Body id={normalizeRuleName.Value(dottedName)}>
 								{formatValue(evaluation, {
 									displayedUnit,
 									precision: round ? 0 : 2,

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -118,12 +118,9 @@ export function SimulationGoal({
 									id={`${dottedName.replace(/\s|\./g, '_')}-label`}
 									dottedName={dottedName}
 								>
-									<label
-										htmlFor={normalizeRuleName.Input(dottedName)}
-										style={{ cursor: 'pointer' }}
-									>
+									<StyledLabel htmlFor={normalizeRuleName.Input(dottedName)}>
 										{label || rule.title}
-									</label>
+									</StyledLabel>
 								</RuleLink>
 							)}
 
@@ -195,7 +192,12 @@ const StyledGoal = styled.div<{ $small: boolean }>`
 const StyledSmallBody = styled(SmallBody)`
 	margin-bottom: 0;
 `
+
 const StyledBody = styled(Body)`
 	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	margin: 0;
+`
+
+const StyledLabel = styled.label`
+	cursor: pointer;
 `

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -50,7 +50,7 @@ export type Choice = ASTNode<'rule'> & {
 	canGiveUp?: boolean
 }
 
-export function MultipleAnswerInput<Names extends string = DottedName>({
+export function MultipleAnswerInput({
 	choices,
 	type = 'radio',
 	autoFocus,
@@ -59,7 +59,7 @@ export function MultipleAnswerInput<Names extends string = DottedName>({
 }: {
 	choices: Choice
 	type?: 'radio' | 'card' | 'toggle' | 'select'
-} & InputProps<Names>) {
+} & InputProps) {
 	const { t } = useTranslation()
 
 	// seront stockées ainsi dans le state :
@@ -263,9 +263,7 @@ const StyledSubRadioGroup = styled.div`
 	margin-top: calc(${({ theme }) => theme.spacings.md} * -1);
 `
 
-export function OuiNonInput<Names extends string = DottedName>(
-	props: InputProps<Names>
-) {
+export function OuiNonInput(props: InputProps) {
 	const { t } = useTranslation()
 
 	// seront stockées ainsi dans le state :
@@ -299,11 +297,7 @@ export function OuiNonInput<Names extends string = DottedName>(
 	)
 }
 
-export function useSelection<Names extends string = DottedName>({
-	value,
-	onChange,
-	missing,
-}: InputProps<Names>) {
+export function useSelection({ value, onChange, missing }: InputProps) {
 	const serializeValue = (nodeValue: Evaluation) =>
 		serializeEvaluation({ nodeValue } as EvaluatedNode)
 

--- a/site/source/components/conversation/MulipleChoicesInput.tsx
+++ b/site/source/components/conversation/MulipleChoicesInput.tsx
@@ -10,7 +10,7 @@ import { ExplicableRule } from './Explicable'
 import { InputProps } from './RuleInput'
 
 export function MultipleChoicesInput<Names extends string = DottedName>(
-	props: Omit<InputProps<Names>, 'onChange'> & {
+	props: Omit<InputProps, 'onChange'> & {
 		choices: Array<RuleNode<Names>>
 		onChange: (value: PublicodesExpression, name: Names) => void
 	}

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -180,7 +180,8 @@ export default function RuleInput({
 		return <SelectAtmp {...commonProps} />
 	}
 
-	if (rule.rawNode.type?.startsWith('date')) {
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+	if ((rule.rawNode.type as string | undefined)?.startsWith('date')) {
 		return (
 			<DateInput
 				{...commonProps}

--- a/site/source/components/utils/normalizeRuleName.tsx
+++ b/site/source/components/utils/normalizeRuleName.tsx
@@ -1,0 +1,16 @@
+import { DottedName } from 'modele-social'
+
+export const normalizeRuleName = (dottedName: DottedName) =>
+	dottedName.replace(/\s|\./g, '_')
+
+normalizeRuleName.Label = (dottedName: DottedName) =>
+	`${normalizeRuleName(dottedName)}-label`
+
+normalizeRuleName.Input = (dottedName: DottedName) =>
+	`${normalizeRuleName(dottedName)}-input`
+
+normalizeRuleName.Value = (dottedName: DottedName) =>
+	`${normalizeRuleName(dottedName)}-value`
+
+normalizeRuleName.Description = (dottedName: DottedName) =>
+	`${normalizeRuleName(dottedName)}-description`


### PR DESCRIPTION
refait #3471 

La PR reprend le code fait lors de la session de mob, en supprimant le lien avec un commit d'Alice.

Le but était de faire que les labels dans les simulateurs soient liés aux inputs.