### PR TITLE
Améliore les aria-label des boutons recherche et menu dans le header

### DIFF
--- a/site/source/components/SearchButton.tsx
+++ b/site/source/components/SearchButton.tsx
@@ -23,9 +23,7 @@ export default function SearchButton() {
 					light
 					{...buttonProps}
 					aria-haspopup="dialog"
-					aria-label={t(
-						'Rechercher, ouvrir la boite de dialogue pour entrer vos termes de recherche.'
-					)}
+					aria-label={t('Ouvrir la boite de dialogue pour rechercher')}
 				>
 					<StyledIcon
 						xmlns="http://www.w3.org/2000/svg"

--- a/site/source/components/layout/Menu.tsx
+++ b/site/source/components/layout/Menu.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
 import { Button } from '@/design-system/buttons'
@@ -7,8 +6,6 @@ import { Li, Ul } from '@/design-system/typography/list'
 import { PlanContent } from '@/pages/Plan'
 
 export const Menu = () => {
-	const { t } = useTranslation()
-
 	return (
 		<Drawer
 			trigger={(buttonProps) => (
@@ -25,9 +22,6 @@ export const Menu = () => {
 						// eslint-disable-next-line react/jsx-props-no-spreading
 						{...buttonProps}
 						aria-haspopup="menu"
-						aria-label={t(
-							'Rechercher, ouvrir la boite de dialogue pour entrer vos termes de recherche.'
-						)}
 					>
 						<StyledSVG
 							xmlns="http://www.w3.org/2000/svg"

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -196,7 +196,7 @@ Rechercher: Search
 Rechercher un simulateur ou une règle: Search for a simulator or a rule
 Rechercher une règle dans la documentation: Search for a rule in the documentation
 Rechercher, afficher le champ de recherche d'entreprise.: Search, display the company search field.
-Rechercher, ouvrir la boite de dialogue pour entrer vos termes de recherche.: Search, open the dialog box to enter your search terms.
+Ouvrir la boite de dialogue pour rechercher: Open the dialog box to search
 Remboursements et déductions diverses: Reimbursements and miscellaneous deductions
 Renseigner une adresse e-mail (au format nom@domaine:
   com) pour recevoir une réponse: Enter an e-mail address (in nom@domaine.com format) to receive a reply.


### PR DESCRIPTION
Actuellement 
- le bouton de recherche a un `aria-label` trop long #3515. Je l'ai donc changé et traduis pour le jour où le moteur de recherche sera présent sur la version EN.
- le bouton du menu a comme `aria-label` un doublon de celui du bouton de recherche #3491. J'ai supprimé le aria-label car la valeur "Menu" est un intitulé assez pertinent.

Closes #3515, #3491 