### PR TITLE
Remplace les boutons de langues par un lien par langue

### DIFF
--- a/site/cypress/integration/mon-entreprise/english/navigation.ts
+++ b/site/cypress/integration/mon-entreprise/english/navigation.ts
@@ -9,7 +9,9 @@ describe('General navigation', function () {
 				? encodeURI('/assistants/choix-du-statut')
 				: '/assistants/choice-of-status'
 		)
-		cy.contains('Switch to the English version').click()
+		cy.contains(
+			fr ? 'Switch to the English version' : 'Passer à la version française'
+		).click()
 		cy.url().should(
 			'include',
 			fr

--- a/site/cypress/integration/mon-entreprise/english/navigation.ts
+++ b/site/cypress/integration/mon-entreprise/english/navigation.ts
@@ -9,9 +9,7 @@ describe('General navigation', function () {
 				? encodeURI('/assistants/choix-du-statut')
 				: '/assistants/choice-of-status'
 		)
-		cy.get(
-			fr ? '[data-test-id=en-switch-button]' : '[data-test-id=fr-switch-button]'
-		).click()
+		cy.contains('Switch to the English version').click()
 		cy.url().should(
 			'include',
 			fr

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -181,57 +181,6 @@ export default function Footer() {
 														: t('Passer à la version française')}
 												</Link>
 											</StyledLi>
-
-											// <StyledLi key={altLang}>
-											// 	<Grid container spacing={2} role="list">
-											// 		<Grid item role="listitem">
-											// 			<StyledButton
-											// 				openInSameWindow
-											// 				href={altHref}
-											// 				isDisabled={isFrenchMode}
-											// 				aria-label={
-											// 					isFrenchMode
-											// 						? t('Version française du site activée.')
-											// 						: t('Passer à la version française du site')
-											// 				}
-											// 				title={
-											// 					isFrenchMode
-											// 						? t('Version française du site activée.')
-											// 						: t('Passer à la version française du site')
-											// 				}
-											// 				lang="fr"
-											// 				data-test-id="fr-switch-button"
-											// 			>
-											// 				FR <Emoji emoji="🇫🇷" />
-											// 			</StyledButton>
-											// 		</Grid>
-											// 		<Grid item role="listitem">
-											// 			<StyledButton
-											// 				href={altHref}
-											// 				openInSameWindow
-											// 				lang="en"
-											// 				isDisabled={!isFrenchMode}
-											// 				aria-label={
-											// 					!isFrenchMode
-											// 						? t('English version of the website enabled.')
-											// 						: t(
-											// 								'Switch to the english version of the website'
-											// 						  )
-											// 				}
-											// 				title={
-											// 					!isFrenchMode
-											// 						? t('English version of the website enabled.')
-											// 						: t(
-											// 								'Switch to the english version of the website'
-											// 						  )
-											// 				}
-											// 				data-test-id="en-switch-button"
-											// 			>
-											// 				EN <Emoji emoji="🇬🇧" />
-											// 			</StyledButton>
-											// 		</Grid>
-											// 	</Grid>
-											// </StyledLi>
 										)}
 									</ul>
 								</nav>

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -177,8 +177,8 @@ export default function Footer() {
 													lang={isFrenchMode ? 'en' : 'fr'}
 												>
 													{isFrenchMode
-														? t('Switch to the english version')
-														: t('Passer à la version française')}
+														? 'Switch to the English version'
+														: 'Passer à la version française'}
 												</Link>
 											</StyledLi>
 										)}

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -1,17 +1,16 @@
 import { Helmet } from 'react-helmet-async'
 import { Trans, useTranslation } from 'react-i18next'
 import { generatePath, matchPath, useLocation } from 'react-router-dom'
-import { css, styled } from 'styled-components'
+import { styled } from 'styled-components'
 
 import Contact from '@/components/Contact'
 import FeedbackButton from '@/components/Feedback'
 import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
-import { Button } from '@/design-system/buttons'
 import { Emoji } from '@/design-system/emoji'
 import { FooterContainer } from '@/design-system/footer'
 import { FooterColumn } from '@/design-system/footer/column'
 import { GithubIcon } from '@/design-system/icons'
-import { Container, Grid } from '@/design-system/layout'
+import { Container } from '@/design-system/layout'
 import { Link } from '@/design-system/typography/link'
 import { Body } from '@/design-system/typography/paragraphs'
 import { alternatePathname, useSitePaths } from '@/sitePaths'
@@ -170,56 +169,69 @@ export default function Footer() {
 											</Link>
 										</StyledLi>
 										{altHref && (
-											<StyledLi key={altLang}>
-												<Grid container spacing={2} role="list">
-													<Grid item role="listitem">
-														<StyledButton
-															openInSameWindow
-															href={altHref}
-															isDisabled={isFrenchMode}
-															aria-label={
-																isFrenchMode
-																	? t('Version française du site activée.')
-																	: t('Passer à la version française du site')
-															}
-															title={
-																isFrenchMode
-																	? t('Version française du site activée.')
-																	: t('Passer à la version française du site')
-															}
-															lang="fr"
-															data-test-id="fr-switch-button"
-														>
-															FR <Emoji emoji="🇫🇷" />
-														</StyledButton>
-													</Grid>
-													<Grid item role="listitem">
-														<StyledButton
-															href={altHref}
-															openInSameWindow
-															lang="en"
-															isDisabled={!isFrenchMode}
-															aria-label={
-																!isFrenchMode
-																	? t('English version of the website enabled.')
-																	: t(
-																			'Switch to the english version of the website'
-																	  )
-															}
-															title={
-																!isFrenchMode
-																	? t('English version of the website enabled.')
-																	: t(
-																			'Switch to the english version of the website'
-																	  )
-															}
-															data-test-id="en-switch-button"
-														>
-															EN <Emoji emoji="🇬🇧" />
-														</StyledButton>
-													</Grid>
-												</Grid>
+											<StyledLi>
+												<Link
+													href={altHref}
+													noUnderline
+													openInSameWindow
+													lang={isFrenchMode ? 'en' : 'fr'}
+												>
+													{isFrenchMode
+														? t('Switch to the english version')
+														: t('Passer à la version française')}
+												</Link>
 											</StyledLi>
+
+											// <StyledLi key={altLang}>
+											// 	<Grid container spacing={2} role="list">
+											// 		<Grid item role="listitem">
+											// 			<StyledButton
+											// 				openInSameWindow
+											// 				href={altHref}
+											// 				isDisabled={isFrenchMode}
+											// 				aria-label={
+											// 					isFrenchMode
+											// 						? t('Version française du site activée.')
+											// 						: t('Passer à la version française du site')
+											// 				}
+											// 				title={
+											// 					isFrenchMode
+											// 						? t('Version française du site activée.')
+											// 						: t('Passer à la version française du site')
+											// 				}
+											// 				lang="fr"
+											// 				data-test-id="fr-switch-button"
+											// 			>
+											// 				FR <Emoji emoji="🇫🇷" />
+											// 			</StyledButton>
+											// 		</Grid>
+											// 		<Grid item role="listitem">
+											// 			<StyledButton
+											// 				href={altHref}
+											// 				openInSameWindow
+											// 				lang="en"
+											// 				isDisabled={!isFrenchMode}
+											// 				aria-label={
+											// 					!isFrenchMode
+											// 						? t('English version of the website enabled.')
+											// 						: t(
+											// 								'Switch to the english version of the website'
+											// 						  )
+											// 				}
+											// 				title={
+											// 					!isFrenchMode
+											// 						? t('English version of the website enabled.')
+											// 						: t(
+											// 								'Switch to the english version of the website'
+											// 						  )
+											// 				}
+											// 				data-test-id="en-switch-button"
+											// 			>
+											// 				EN <Emoji emoji="🇬🇧" />
+											// 			</StyledButton>
+											// 		</Grid>
+											// 	</Grid>
+											// </StyledLi>
 										)}
 									</ul>
 								</nav>
@@ -266,19 +278,6 @@ export default function Footer() {
 		</>
 	)
 }
-
-const StyledButton = styled(Button)`
-	padding: 10px 16px 10px 16px;
-	border-radius: 4px;
-
-	${({ isDisabled }) =>
-		isDisabled &&
-		css`
-			background-color: ${({ theme }) =>
-				theme.colors.bases.primary[300]}!important;
-			opacity: 1;
-		`}
-`
 
 const StyledLi = styled.li`
 	margin-top: ${({ theme }) => theme.spacings.sm};

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -173,7 +173,7 @@ Page d'accueil: Home page
 "Par exemple : coiffure, boulangerie ou restauration": "For example: hairdressing, bakery or catering"
 Passer: Pass
 Passer le contenu principal et aller directement au pied de page: Skip the main content and go directly to the footer
-Passer à la version française du site: Switch to the French version of the site
+Passer à la version française: Passer à la version française
 Passer, passer la question sans répondre: Pass, pass the question without answering
 Personnalisez l'intégration: Customize integration
 Plan du site: Site map
@@ -236,7 +236,7 @@ Suivant: Next
 Suivant, enregistrer et passer à l'étape suivante: Next, save and go to the next step
 Suivant, passer à la question suivante: Next, move on to the next question
 Suivant, voir le résultat: Next, see the result
-Switch to the english version of the website: Switch to the english version of the website
+Switch to the english version: Switch to the english version
 Tableau indiquant la satisfaction des utilisateurs en {{percentOrVotes}} sur le site mon-entreprise par mois.:
   Table showing user satisfaction with {{percentOrVotes}} on the mon-entreprise
   site, by month.

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -184,7 +184,7 @@ Page d'accueil: Page d'accueil
 "Par exemple : coiffure, boulangerie ou restauration": "Par exemple : coiffure, boulangerie ou restauration"
 Passer: Passer
 Passer le contenu principal et aller directement au pied de page: Passer le contenu principal et aller directement au pied de page
-Passer à la version française du site: Passer à la version française du site
+Passer à la version française: Passer à la version française
 Passer, passer la question sans répondre: Passer, passer la question sans répondre
 Personnalisez l'intégration: Personnalisez l'intégration
 Plan du site: Plan du site
@@ -252,7 +252,7 @@ Suivant: Suivant
 Suivant, enregistrer et passer à l'étape suivante: Suivant, enregistrer et passer à l'étape suivante
 Suivant, passer à la question suivante: Suivant, passer à la question suivante
 Suivant, voir le résultat: Suivant, voir le résultat
-Switch to the english version of the website: Switch to the english version of the website
+Switch to the english version: Switch to the english version
 Tableau indiquant la satisfaction des utilisateurs en {{percentOrVotes}} sur le site mon-entreprise par mois.:
   Tableau indiquant la satisfaction des utilisateurs en {{percentOrVotes}} sur
   le site mon-entreprise par mois.


### PR DESCRIPTION
Actuellement le changement de langue dans le footer se fait avec des liens qui ressemblent à des boutons.

Cela crée des soucis de non conformités expliquées dans #3500.
Je pense que ça correspond aussi au retour de l'audit #3510 

Closes #3500, closes #3510