### PR TITLE
Améliore le markup de l'assistant PAM

### DIFF
--- a/site/source/components/Assistant/AssistantGoal.tsx
+++ b/site/source/components/Assistant/AssistantGoal.tsx
@@ -103,10 +103,6 @@ export function AssistantGoal({
 							missing={dottedName in evaluation.missingVariables}
 							onChange={onChange}
 							showSuggestions={false}
-							aria-describedby={`${dottedName.replace(
-								/\s|\./g,
-								'_'
-							)}-description`}
 						/>
 					</Grid>
 				</Grid>

--- a/site/source/components/Assistant/AssistantGoal.tsx
+++ b/site/source/components/Assistant/AssistantGoal.tsx
@@ -7,7 +7,7 @@ import { styled } from 'styled-components'
 
 import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
 import { Grid } from '@/design-system/layout'
-import { Body } from '@/design-system/typography/paragraphs'
+import { baseParagraphStyle } from '@/design-system/typography/paragraphs'
 import { SimpleRuleEvaluation } from '@/domaine/engine/SimpleRuleEvaluation'
 import { useInitialRender } from '@/hooks/useInitialRender'
 import { ajusteLaSituation } from '@/store/actions/actions'
@@ -17,6 +17,7 @@ import RuleInput from '../conversation/RuleInput'
 import LectureGuide from '../LectureGuide'
 import { Appear } from '../ui/animate'
 import { useEngine } from '../utils/EngineContext'
+import { normalizeRuleName } from '../utils/normalizeRuleName'
 
 type SimulationGoalProps = {
 	dottedName: DottedName
@@ -73,8 +74,10 @@ export function AssistantGoal({
 							}}
 						>
 							<Grid item>
-								<StyledBody id={`${dottedName.replace(/\s|\./g, '_')}-title`}>
-									{label || rule.title}
+								<StyledBody>
+									<label htmlFor={normalizeRuleName.Input(dottedName)}>
+										{label || rule.title}
+									</label>
 									{required && (
 										<>
 											<span aria-hidden>&nbsp;*</span>
@@ -100,7 +103,6 @@ export function AssistantGoal({
 							missing={dottedName in evaluation.missingVariables}
 							onChange={onChange}
 							showSuggestions={false}
-							aria-labelledby={`${dottedName.replace(/\s|\./g, '_')}-title`}
 							aria-describedby={`${dottedName.replace(
 								/\s|\./g,
 								'_'
@@ -119,7 +121,8 @@ const StyledGoal = styled.div`
 	margin: ${({ theme }) => theme.spacings.xxs} 0;
 `
 
-const StyledBody = styled(Body)`
+const StyledBody = styled.div`
+	${baseParagraphStyle};
 	margin: 0;
 	font-size: 1.125rem;
 `

--- a/site/source/pages/assistants/components/Fields.tsx
+++ b/site/source/pages/assistants/components/Fields.tsx
@@ -13,7 +13,7 @@ import { useEngine } from '@/components/utils/EngineContext'
 import { Markdown } from '@/components/utils/markdown'
 import { Spacing } from '@/design-system/layout'
 import { H3 } from '@/design-system/typography/heading'
-import { Body, Intro, SmallBody } from '@/design-system/typography/paragraphs'
+import { Intro, SmallBody } from '@/design-system/typography/paragraphs'
 import { useNextQuestions } from '@/hooks/useNextQuestion'
 import { enregistreLaRéponse } from '@/store/actions/actions'
 import {
@@ -132,10 +132,10 @@ export function SimpleField(props: SimpleFieldProps) {
 			<StyledQuestion id={labelId}>
 				<Markdown components={markdownComponents}>{displayedLabel}</Markdown>
 				{required && (
-					<Body>
+					<div>
 						<span aria-hidden>&nbsp;*</span>
 						<span className="sr-only">&nbsp;({t('champ obligatoire')})</span>
-					</Body>
+					</div>
 				)}
 				<ExplicableRule dottedName={dottedName} />
 			</StyledQuestion>


### PR DESCRIPTION
Critère [11.1](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#11.1) "Chaque champ de formulaire a-t-il une étiquette ?"

Actuellement les champs `<input>` ont un `aria-labelledby`. Ça fonctionne mais il est conseillé d'avoir un `<label for>` à la place d'un `<p>`

closes #3511 