### PR TITLE
Mise à jour du SMIC pour la cotisation maladie et les allocations familiales

### DIFF
--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Mise à jour des niveaux de rémunération pour les taux réduits de cotisations maladie et familiales
 - Mise à jour du plafond d’exonération de cotisations sociales pour les apprentis
 - Mise à jour de l’exonération de CSG-CRDS pour les apprentis
+- Mise à jour du SMIC pour la cotisation maladie et les allocations familiales
 
 ### Dépréciations
 - `dirigeant . auto-entrepreneur . affiliation CIPAV` : utiliser `dirigeant . auto-entrepreneur . Cipav` à la place

--- a/modele-social/règles/salarié/cotisations.publicodes
+++ b/modele-social/règles/salarié/cotisations.publicodes
@@ -321,7 +321,11 @@ salarié . cotisations . allocations familiales:
                 - sinon: 3.5
             - valeur: SMIC
               contexte:
-                date: 31/12/2023
+                date:
+                  variations:
+                    - si: date >= 01/2025
+                      alors: 01/01/2025
+                    - sinon: 31/12/2023
             - temps de travail . effectif . quotité
       références:
         Code de la sécurité sociale - Article L241-6-1: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051285453
@@ -747,7 +751,11 @@ salarié . cotisations . maladie:
                     - sinon: 2.5
                 - valeur: SMIC
                   contexte:
-                    date: 31/12/2023
+                    date:
+                      variations:
+                        - si: date >= 01/2025
+                          alors: 01/01/2025
+                        - sinon: 31/12/2023
                 - temps de travail . effectif . quotité
           références:
             Code de la sécurité sociale - Article L241-2-1: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048684728

--- a/site/test/regressions/__snapshots__/salarié.test.ts.snap
+++ b/site/test/regressions/__snapshots__/salarié.test.ts.snap
@@ -79,7 +79,7 @@ salarié . rémunération . net . à payer avant impôt: 2404"
 exports[`calculate simulations-salarié > activité partielle 5`] = `
 "salarié . contrat . salaire brut: 4000
 salarié . contrat . salaire brut . équivalent temps plein: null
-salarié . coût total employeur: 2770
+salarié . coût total employeur: 2738
 salarié . rémunération . net . payé après impôt: 2471
 salarié . rémunération . net . à payer avant impôt: 2680"
 `;
@@ -725,7 +725,7 @@ Notifications affichées : salarié . contrat . salaire brut . contrôle salaire
 exports[`calculate simulations-salarié > impôt sur le revenu 6`] = `
 "salarié . contrat . salaire brut: 3000
 salarié . contrat . salaire brut . équivalent temps plein: null
-salarié . coût total employeur: 4256
+salarié . coût total employeur: 4076
 salarié . rémunération . net . payé après impôt: 2549
 salarié . rémunération . net . à payer avant impôt: 2626"
 `;
@@ -801,7 +801,7 @@ salarié . rémunération . net . à payer avant impôt: 2353"
 exports[`calculate simulations-salarié > lodeom 4`] = `
 "salarié . contrat . salaire brut: 4000
 salarié . contrat . salaire brut . équivalent temps plein: null
-salarié . coût total employeur: 5677
+salarié . coût total employeur: 5437
 salarié . rémunération . net . payé après impôt: 2816
 salarié . rémunération . net . à payer avant impôt: 3140"
 `;
@@ -843,7 +843,7 @@ salarié . rémunération . net . à payer avant impôt: 2353"
 exports[`calculate simulations-salarié > lodeom compétitivité renforcée 4`] = `
 "salarié . contrat . salaire brut: 4000
 salarié . contrat . salaire brut . équivalent temps plein: null
-salarié . coût total employeur: 4739
+salarié . coût total employeur: 4647
 salarié . rémunération . net . payé après impôt: 2816
 salarié . rémunération . net . à payer avant impôt: 3140"
 `;
@@ -885,7 +885,7 @@ salarié . rémunération . net . à payer avant impôt: 2353"
 exports[`calculate simulations-salarié > lodeom innovation et croissance 4`] = `
 "salarié . contrat . salaire brut: 4000
 salarié . contrat . salaire brut . équivalent temps plein: null
-salarié . coût total employeur: 4515
+salarié . coût total employeur: 4458
 salarié . rémunération . net . payé après impôt: 2816
 salarié . rémunération . net . à payer avant impôt: 3140"
 `;
@@ -1093,7 +1093,7 @@ salarié . rémunération . net . à payer avant impôt: 2353"
 exports[`calculate simulations-salarié > échelle de salaires 11`] = `
 "salarié . contrat . salaire brut: 4000
 salarié . contrat . salaire brut . équivalent temps plein: null
-salarié . coût total employeur: 5677
+salarié . coût total employeur: 5437
 salarié . rémunération . net . payé après impôt: 2816
 salarié . rémunération . net . à payer avant impôt: 3140"
 `;


### PR DESCRIPTION
Suite à la publication du décret https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051430146, le SMIC de référence est celui du 01/01/2025 pour la cotisation maladie et les allocations familiales.