### PR TITLE
Corrige les roles button et link non pertinents

### DIFF
--- a/site/cypress/integration/mon-entreprise/recherche.ts
+++ b/site/cypress/integration/mon-entreprise/recherche.ts
@@ -5,7 +5,7 @@ describe('Recherche globales', { testIsolation: false }, function () {
 		return
 	}
 
-	it('should display the search results when the magnifying glass is clicked', function () {
+	it('should display results when an input is written', function () {
 		cy.visit('/')
 
 		cy.contains('Rechercher').click()
@@ -17,10 +17,8 @@ describe('Recherche globales', { testIsolation: false }, function () {
 		// eslint-disable-next-line cypress/unsafe-to-chain-command
 		cy.get('input[type=search]').should('be.focused')
 
-		cy.contains('Simulateurs')
-			.next()
-			.find('[role="button"]')
-			.should('have.length', 6)
+		cy.contains('Simulateurs').next().find('li').should('have.length', 6)
+
 		cy.contains('Documentation des simulateurs')
 			.next()
 			.find('li')
@@ -29,17 +27,15 @@ describe('Recherche globales', { testIsolation: false }, function () {
 		// eslint-disable-next-line cypress/unsafe-to-chain-command
 		cy.focused().type('avocat')
 
-		cy.contains('Simulateurs')
-			.next()
-			.find('[role="button"]')
-			.should('have.length', 1)
+		cy.contains('Simulateurs').next().find('li').should('have.length', 1)
+
 		cy.contains('Documentation des simulateurs')
 			.next()
 			.find('li')
 			.should('have.length.of.at.least', 1)
 	})
 
-	it('should be RGAA compliant', function () {
+	it('should check minimal accessibility tests', function () {
 		checkA11Y()
 	})
 })

--- a/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
+++ b/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
@@ -62,7 +62,6 @@ export function ShareSimulationPopup({ url }: { url: string }) {
 								)
 								setLinkCopied(true)
 							}}
-							role={linkCopied ? 'status' : ''}
 						>
 							{linkCopied ? (
 								<>✅ {t('shareSimulation.button.copied', 'Copié')}</>

--- a/site/source/components/SimulateurCard.tsx
+++ b/site/source/components/SimulateurCard.tsx
@@ -26,6 +26,7 @@ export function SimulateurCard({
 	beta,
 	small = false,
 	fromGérer = false,
+	role,
 }: SimulateurCardProps) {
 	const isIframe = useIsEmbedded()
 	const { t } = useTranslation()
@@ -36,56 +37,50 @@ export function SimulateurCard({
 			: t('pages.simulateurs.home.cta.simulateur', 'Lancer le simulateur')
 
 	return (
-		<>
+		<Grid item xs={12} sm={6} md={6} lg={4} role={role}>
 			{small ? (
-				<Grid item xs={12} sm={6} md={6} lg={4}>
-					<SmallCard
-						icon={<Emoji emoji={icône} />}
-						to={{
-							pathname:
-								(isIframe && `/iframes/${encodeURI(iframePath ?? '')}`) || path,
-						}}
-						state={fromGérer ? { fromGérer: true } : { fromSimulateurs: true }}
-						title={
-							<span>
-								{shortName} {tooltip && <InfoBulle>{tooltip}</InfoBulle>}
-								{beta && (
-									<Chip type="info" icon={<Emoji emoji="🚧" />}>
-										Bêta
-									</Chip>
-								)}
-							</span>
-						}
-						role="link"
-					/>
-				</Grid>
+				<SmallCard
+					icon={<Emoji emoji={icône} />}
+					to={{
+						pathname:
+							(isIframe && `/iframes/${encodeURI(iframePath ?? '')}`) || path,
+					}}
+					state={fromGérer ? { fromGérer: true } : { fromSimulateurs: true }}
+					title={
+						<span>
+							{shortName} {tooltip && <InfoBulle>{tooltip}</InfoBulle>}
+							{beta && (
+								<Chip type="info" icon={<Emoji emoji="🚧" />}>
+									Bêta
+								</Chip>
+							)}
+						</span>
+					}
+				/>
 			) : (
-				<Grid item xs={12} sm={6} md={6} lg={4}>
-					<Card
-						title={
-							<>
-								{shortName}
-								{beta && (
-									<Chip type="info" icon={<Emoji emoji="🚧" />}>
-										Bêta
-									</Chip>
-								)}
-							</>
-						}
-						icon={<Emoji emoji={icône} />}
-						ctaLabel={ctaLabel}
-						aria-label={`${shortName}, ${ctaLabel}`}
-						to={{
-							pathname:
-								(isIframe && `/iframes/${encodeURI(iframePath ?? '')}`) || path,
-						}}
-						state={fromGérer ? { fromGérer: true } : { fromSimulateurs: true }}
-						role="link"
-					>
-						{meta?.description}
-					</Card>
-				</Grid>
+				<Card
+					title={
+						<>
+							{shortName}
+							{beta && (
+								<Chip type="info" icon={<Emoji emoji="🚧" />}>
+									Bêta
+								</Chip>
+							)}
+						</>
+					}
+					icon={<Emoji emoji={icône} />}
+					ctaLabel={ctaLabel}
+					aria-label={`${shortName}, ${ctaLabel}`}
+					to={{
+						pathname:
+							(isIframe && `/iframes/${encodeURI(iframePath ?? '')}`) || path,
+					}}
+					state={fromGérer ? { fromGérer: true } : { fromSimulateurs: true }}
+				>
+					{meta?.description}
+				</Card>
 			)}
-		</>
+		</Grid>
 	)
 }

--- a/site/source/components/Simulation/PreviousSimulationBanner.tsx
+++ b/site/source/components/Simulation/PreviousSimulationBanner.tsx
@@ -25,7 +25,6 @@ export default function PreviousSimulationBanner() {
 				aria-label={t(
 					'Retrouver ma précédente simulation, charger les données de ma précédente simulation.'
 				)}
-				role="button"
 			>
 				<Trans i18nKey="previousSimulationBanner.retrieveButton">
 					Retrouver ma précédente simulation

--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -295,12 +295,7 @@ function AnswerElement(rule: RuleNode) {
 			small
 			disableOverflowAuto // disable overflow auto for SelectCommune autocomplete to not be hidden
 			trigger={(buttonProps) => (
-				<Link
-					{...buttonProps}
-					role="button"
-					aria-haspopup="dialog"
-					aria-label="Modifier"
-				>
+				<Link {...buttonProps} aria-haspopup="dialog" aria-label="Modifier">
 					<Value expression={rule.dottedName} linkToRule={false} />{' '}
 					<span className="print-hidden">
 						<Emoji emoji="✏" />

--- a/site/source/components/conversation/InputSuggestions.tsx
+++ b/site/source/components/conversation/InputSuggestions.tsx
@@ -41,7 +41,6 @@ export default function InputSuggestions({
 							}
 						}}
 						type="button" // To avoid submitting the form
-						role="button"
 						aria-label={t('Insérer dans le champ la valeur du {{text}}', {
 							text,
 						})}

--- a/site/source/components/ui/WarningBlock.tsx
+++ b/site/source/components/ui/WarningBlock.tsx
@@ -30,7 +30,6 @@ export default function Warning({ localStorageKey, children }: WarningProps) {
 						</Trans>{' '}
 						{folded && (
 							<Link
-								role="button"
 								onPress={() => fold(false)}
 								aria-expanded={false}
 								aria-label={t(

--- a/site/source/design-system/buttons/Button.tsx
+++ b/site/source/design-system/buttons/Button.tsx
@@ -17,7 +17,6 @@ type ButtonProps = GenericButtonOrNavLinkProps & {
 	children: React.ReactNode
 	size?: Size
 	light?: boolean
-	role?: string
 	lang?: string
 	underline?: boolean
 }
@@ -29,7 +28,7 @@ export const Button = forwardRef(function Button(
 		color = 'primary' as const,
 		underline,
 		isDisabled,
-		role,
+
 		lang,
 		...ariaButtonProps
 	}: ButtonProps,
@@ -40,7 +39,7 @@ export const Button = forwardRef(function Button(
 		forwardedRef
 	)
 
-	// Omit isDisabled and openInSameWindow from props casue it's not a valid HTML attribute
+	// Omit isDisabled and openInSameWindow from props cause it's not a valid HTML attribute
 	const props = omit(
 		buttonOrLinkProps as Record<string, unknown>,
 		'isDisabled',
@@ -56,7 +55,6 @@ export const Button = forwardRef(function Button(
 			$color={color}
 			disabled={isDisabled}
 			$underline={underline}
-			role={role}
 			lang={lang}
 		/>
 	)

--- a/site/source/design-system/card/Article.tsx
+++ b/site/source/design-system/card/Article.tsx
@@ -37,18 +37,22 @@ export function Article({
 		...ariaButtonProps,
 	})
 
+	// Remove role to avoid contradiction with final HTML tag
+	const elementPropsWithoutRole = Object.fromEntries(
+		Object.entries({
+			...ariaButtonProps,
+			...buttonProps,
+			...linkProps,
+		}).filter(([key]) => key !== 'role')
+	)
+
 	return (
 		<StyledArticle>
 			<StyledHeader as={titleProps.as}>
 				{titleProps.children} {icon}
 			</StyledHeader>
 			<Content>{children}</Content>
-			<StyledBody
-				{...ariaButtonProps}
-				{...buttonProps}
-				{...linkProps}
-				as={elementType}
-			>
+			<StyledBody {...elementPropsWithoutRole} as={elementType}>
 				{ctaLabel}
 				{linkProps.target === '_blank' && <NewWindowLinkIcon />}
 				<StyledChevron aria-hidden />

--- a/site/source/design-system/card/Card.tsx
+++ b/site/source/design-system/card/Card.tsx
@@ -44,7 +44,6 @@ export function Card(props: CardProps) {
 		compact = false,
 		ctaLabel,
 		icon,
-		role,
 		tabIndex,
 		title,
 		...ariaButtonProps
@@ -86,7 +85,6 @@ export function Card(props: CardProps) {
 					$light
 					$color="primary"
 					{...buttonOrLinkProps}
-					role={role || buttonOrLinkProps?.role}
 					tabIndex={undefined}
 				>
 					{ctaLabel}

--- a/site/source/design-system/card/SmallCard.tsx
+++ b/site/source/design-system/card/SmallCard.tsx
@@ -16,9 +16,8 @@ export function SmallCard({
 	icon,
 	children,
 	title,
-	role,
 	...ariaButtonProps
-}: GenericCardProps & { icon: React.ReactNode; role?: string }) {
+}: GenericCardProps & { icon: React.ReactNode }) {
 	const elementType: 'a' | 'div' | typeof Link =
 		'href' in ariaButtonProps ? 'a' : 'to' in ariaButtonProps ? Link : 'div'
 
@@ -27,14 +26,17 @@ export function SmallCard({
 	const titleProps = getTitleProps(title, 'h4')
 	const linkProps = useExternalLinkProps(ariaButtonProps)
 
+	// Remove role to avoid contradiction with final HTML tag
+	const elementPropsWithoutRole = Object.fromEntries(
+		Object.entries({
+			...ariaButtonProps,
+			...buttonProps,
+			...linkProps,
+		}).filter(([key]) => key !== 'role')
+	)
+
 	return (
-		<Container
-			{...ariaButtonProps}
-			{...buttonProps}
-			{...linkProps}
-			role={role || buttonProps?.role}
-			as={elementType}
-		>
+		<Container {...elementPropsWithoutRole} as={elementType}>
 			<IconPlaceholder>{icon}</IconPlaceholder>
 			<Content>
 				<H6

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -209,6 +209,11 @@ export function useButtonOrLink(
 		)
 	)
 
+	// Remove role to avoid contradiction with final HTML tag
+	const buttonPropsWithoutRole = Object.fromEntries(
+		Object.entries(buttonProps).filter(([key]) => key !== 'role')
+	)
+
 	// Rename style if it is a function, see CustomNavLink
 	const styleProps =
 		'to' in props && typeof props.style === 'function'
@@ -223,7 +228,7 @@ export function useButtonOrLink(
 
 	const buttonOrLinkProps = {
 		...initialProps,
-		...buttonProps,
+		...buttonPropsWithoutRole,
 		...useExternalLinkProps(props),
 		...classNameProps,
 		...styleProps,

--- a/site/source/design-system/typography/link.tsx
+++ b/site/source/design-system/typography/link.tsx
@@ -77,13 +77,12 @@ export const Link = React.forwardRef<
 			  }
 	}
 >(function Link(props, forwardedRef) {
-	const { isDisabled, role, noUnderline, type, ...ariaButtonProps } = props
+	const { isDisabled, noUnderline, type, ...ariaButtonProps } = props
 	const buttonOrLinkProps = useButtonOrLink(ariaButtonProps, forwardedRef)
 
 	return (
 		<StyledLink
 			{...buttonOrLinkProps}
-			role={role || (props.href || props.to ? undefined : 'button')}
 			type={type}
 			$isDisabled={isDisabled}
 			$noUnderline={noUnderline}
@@ -170,7 +169,6 @@ export type GenericButtonOrNavLinkProps = (
 	| AriaButtonProps<'button'>
 ) & {
 	openInSameWindow?: true
-	role?: string
 }
 
 export function useButtonOrLink(

--- a/site/source/pages/404.tsx
+++ b/site/source/pages/404.tsx
@@ -31,7 +31,7 @@ export default function Page404() {
 				}
 				picture={image}
 			>
-				<Button size="XL" role="link" to={'/'}>
+				<Button size="XL" to={'/'}>
 					<Trans i18nKey="404.action">Revenir en lieu sûr</Trans>
 				</Button>
 			</PageHeader>

--- a/site/source/pages/_landing/SearchOrCreate.tsx
+++ b/site/source/pages/_landing/SearchOrCreate.tsx
@@ -43,7 +43,6 @@ export default function SearchOrCreate() {
 						<Spacing md />
 						<AnswerGroup role="list">
 							<Button
-								role="link"
 								to={generatePath(
 									absoluteSitePaths.assistants['pour-mon-entreprise']
 										.entreprise,

--- a/site/source/pages/integration/Iframe.tsx
+++ b/site/source/pages/integration/Iframe.tsx
@@ -422,7 +422,6 @@ function IntegrationCode({
 					}
 					color={copied ? 'secondary' : 'primary'}
 					onPress={copyCodeToClipboard}
-					role={copied ? 'status' : undefined}
 				>
 					<Emoji emoji={copied ? '✔️' : '📑'} />
 				</Button>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -753,27 +753,6 @@ const Détails = ({
 const StyledH4 = styled(H4)`
 	color: ${({ theme }) => theme.colors.bases.primary[600]};
 `
-// TODO : décommenter une fois l'implémentation du calcul des coûts de créations
-// ajouté à modèle-social
-/*
-const StyledRuleLink = styled(RuleLink)`
-	display: inline-flex;
-	margin-left: ${({ theme }) => theme.spacings.xxs};
-	&:hover {
-		opacity: 0.8;
-	}
-`
-const Precisions = styled.span`
-	display: block;
-	font-family: ${({ theme }) => theme.fonts.main};
-	font-weight: normal;
-	font-size: 1rem;
-	color: ${({ theme }) => theme.colors.extended.grey[700]};
-	margin: 0;
-	margin-top: 0.5rem;
-	width: 100%;
-`
-*/
 
 const StyledDiv = styled.div`
 	display: flex;


### PR DESCRIPTION
Plusieurs éléments `<a>` et `<button>`sont rendus avec des attributs ARIA `role="link"` ou `role="button"`. C'est au mieux redondant mais surtout contradictoire par endroit.

Ces attributs apparaissent avec l'usage de hooks comme `useButton` et `useLink` de `react-aria`, souvent dans des versions "customisées".

Beaucoup d'éléments se voient appliqués les props générés par ces hooks (dont un `role` parfois), pas forcément de manière pertinente.
Un composant ne devrait pas avoir besoin des caractéristiques d'un bouton en plus de celles d'un lien.

Mais il est difficile de démêler les choses vu leur intrication et la complexité de ces composants "Bouton ou Lien ça dépend du contexte". Difficile et risqué vu l'omniprésence de ces composants.

---

Cette PR se contente donc de :
- retirer toute prop `role` des composants destinés à être rendus comme un `<a>` ou un `<button>` (la balise suffit, le rôle n'apporte rien, et je n'ai pas vu de cas où c'était une autre balise qui était rendu, même si le code le prévoit)
- filtrer les props amenés par les hooks pour en retirer `role` sans risquer de retirer une autre prop qui serait utile mais difficile à identifier

Dans l'idéal, il faudrait remettre à plat ces composants "Bouton ou Lien ça dépend du contexte", mais cela représenterait un chantier trop chronophage pour valoir le coup.

Il s'agit surtout ici de résoudre plusieurs remontées à ce sujet dans l'audit 2025.

**Remarques :**

Cette PR :
- retire également un bout de code commenté qui date, trouvé en parcourant les fichiers
- fait une modif dans `SimulateurCard` pour qu'un `role="listitem"` puisse être rendu, ce qui devrait corriger une autre remontée de l'audit 2025

Closes #3582 
Closes #3505 
