### PR TITLE
A11y/Update charts aria-label in stats page

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -105,13 +105,15 @@ Fermer le module "Donner son avis": Close the "Give your opinion" module
 Fiche de paie: Pay slip
 Fond de la boite de dialogue: Dialog box background
 Frais de transport: Transport costs
-Graphique des principaux simulateurs, présence d’une alternative accessible après l’image: Graphics of the main simulators, with an alternative available after the image.
-Graphique statistiques détaillés de la satisfaction, présence d’une alternative accessible après l’image:
-  Detailed statistical graph of satisfaction, presence of an accessible
-  alternative after the image
-Graphique statistiques détaillés du nombre visites par jour, présence d’une alternative accessible après l’image:
-  Graph showing detailed statistics on the number of visits per day, with an
-  alternative accessible after the image
+Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section):
+  Graph detailing the number of visits per simulator (alternative accessible via
+  the switch at the start of the section)
+Graphique détaillant la satisfaction des utilisateurs (alternative accessible avec l'interrupteur en début de section):
+  Graph detailing user satisfaction (alternative accessible with the switch at
+  the beginning of the section)
+Graphique détaillant le nombre de visites (alternative accessible avec l'interrupteur en début de section):
+  Graph detailing number of visits (alternative accessible via the switch at the
+  start of the section)
 Habituellement: Usually
 Impôt: Tax
 Impôt au barème: Tax scale

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -111,15 +111,15 @@ Fermer le module "Donner son avis": Fermer le module "Donner son avis"
 Fiche de paie: Fiche de paie
 Fond de la boite de dialogue: Fond de la boite de dialogue
 Frais de transport: Frais de transport
-Graphique des principaux simulateurs, présence d’une alternative accessible après l’image:
-  Graphique des principaux simulateurs, présence d’une alternative accessible
-  après l’image
-Graphique statistiques détaillés de la satisfaction, présence d’une alternative accessible après l’image:
-  Graphique statistiques détaillés de la satisfaction, présence d’une
-  alternative accessible après l’image
-Graphique statistiques détaillés du nombre visites par jour, présence d’une alternative accessible après l’image:
-  Graphique statistiques détaillés du nombre visites par jour, présence d’une
-  alternative accessible après l’image
+Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section):
+  Graphique détaillant la part des visites par simulateur (alternative
+  accessible avec l'interrupteur en début de section)
+Graphique détaillant la satisfaction des utilisateurs (alternative accessible avec l'interrupteur en début de section):
+  Graphique détaillant la satisfaction des utilisateurs (alternative accessible
+  avec l'interrupteur en début de section)
+Graphique détaillant le nombre de visites (alternative accessible avec l'interrupteur en début de section):
+  Graphique détaillant le nombre de visites (alternative accessible avec
+  l'interrupteur en début de section)
 Habituellement: Habituellement
 Impôt: Impôt
 Impôt au barème: Impôt au barème

--- a/site/source/pages/statistiques/_components/Chart.tsx
+++ b/site/source/pages/statistiques/_components/Chart.tsx
@@ -101,7 +101,7 @@ export default function VisitsChart({
 					layout={layout}
 					data={flattenData}
 					aria-label={t(
-						'Graphique statistiques détaillés du nombre visites par jour, présence d’une alternative accessible après l’image'
+						"Graphique détaillant le nombre de visites (alternative accessible avec l'interrupteur en début de section)"
 					)}
 					role="img"
 				>

--- a/site/source/pages/statistiques/_components/PagesCharts.tsx
+++ b/site/source/pages/statistiques/_components/PagesCharts.tsx
@@ -93,7 +93,7 @@ export default function PagesChart({
 						data={flattenedData}
 						syncId={sync ? '1' : undefined}
 						aria-label={t(
-							'Graphique des principaux simulateurs, présence d’une alternative accessible après l’image'
+							"Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section)"
 						)}
 						role="img"
 					>

--- a/site/source/pages/statistiques/_components/SatisfactionChart.tsx
+++ b/site/source/pages/statistiques/_components/SatisfactionChart.tsx
@@ -111,7 +111,7 @@ export default function SatisfactionChart({
 					<BarChartWithRole
 						data={flattenData}
 						aria-label={t(
-							'Graphique statistiques détaillés de la satisfaction, présence d’une alternative accessible après l’image'
+							"Graphique détaillant la satisfaction des utilisateurs (alternative accessible avec l'interrupteur en début de section)"
 						)}
 						role="img"
 					>


### PR DESCRIPTION
Sur la page `/statistiques`, avec la mise en place d'un Switch avant les graphiques, pour pouvoir les remplacer par des tableaux, les `aria-label` des graphiques mentionnant une _"une alternative accessible **après** l’image"_ induisent l'utilisateur en erreur :

![image](https://github.com/user-attachments/assets/9675530d-af6f-4fe3-a1e6-7b90dbe522c3)

Cette PR actualise juste ces `aria-label` pour guider plus correctement les utilisateurs de lecteur d'écran.