### PR TITLE
UI/Missing styles for the "no data message" in stats page

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -47,6 +47,7 @@ Attention, vos données sauvegardées seront supprimées de manière définitive
 Aucun: No
 Aucun résultat: No results
 Aucun résultat ne correspond à votre recherche. Essayez avec d'autres mots-clés.: No results matching your search. Try other keywords.
+Aucune donnée disponible.: No data available.
 Avec ACRE: With ACRE
 Avec chômage partiel: With short-time working
 Boite de dialogue: Dialog box

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -52,6 +52,7 @@ Aucun résultat: Aucun résultat
 Aucun résultat ne correspond à votre recherche. Essayez avec d'autres mots-clés.:
   Aucun résultat ne correspond à votre recherche. Essayez avec d'autres
   mots-clés.
+Aucune donnée disponible.: Aucune donnée disponible.
 Avec ACRE: Avec ACRE
 Avec chômage partiel: Avec chômage partiel
 Boite de dialogue: Boite de dialogue

--- a/site/source/pages/statistiques/_components/VisitChart.tsx
+++ b/site/source/pages/statistiques/_components/VisitChart.tsx
@@ -64,7 +64,9 @@ export default function VisitChart({
 					<Chart period={period} data={visites} />
 				)
 			) : (
-				<Message type="info">Aucune donnée disponible.</Message>
+				<Message type="info">
+					<Body>Aucune donnée disponible.</Body>
+				</Message>
 			)}
 		</>
 	)

--- a/site/source/pages/statistiques/_components/VisitChart.tsx
+++ b/site/source/pages/statistiques/_components/VisitChart.tsx
@@ -65,7 +65,7 @@ export default function VisitChart({
 				)
 			) : (
 				<Message type="info">
-					<Body>Aucune donnée disponible.</Body>
+					<Body>{t('Aucune donnée disponible.')}</Body>
 				</Message>
 			)}
 		</>


### PR DESCRIPTION
En parcourant l'audit de 2023, j'ai réalisé qu'il existait plusieurs pages de statistiques navigables avec ce menu déroulant :

![image](https://github.com/user-attachments/assets/50042929-530f-40d3-a218-7e75a7ae311a)

En vérifiant que les `aria-label` que je venais de modifier dans ma PR précédente (https://github.com/betagouv/mon-entreprise/pull/3604) étaient rendus dans tous ces cas, j'ai découvert que le message suivant apparaissait parfois :

![image](https://github.com/user-attachments/assets/d8b34b40-714f-43ec-bd1a-417feabd7329)

Cette PR se contente d'harmoniser le style de ce message avec le reste de l'UI (il manquait juste un composant `<Body />`) et d'internationaliser le message :

![image](https://github.com/user-attachments/assets/6665ec36-af8a-420c-84a5-91b001ed32d7)

---

1. @liliced @JalilArfaoui Au-delà de ce petit souci d'UI, je me demande si l'apparition de ce message n'est pas lié à un "cablage manquant' pour les trois catégories où il apparaît :
- Assistant à la déclaration de revenus des PAMC
- Exonération Lodeom
- Location de logement meublé

2. Se pose sinon la question de l'internationalisation de cette page qui n'est que partielle actuellement.
Je peux peut-être créer une issue à ce sujet ?
(je n'en ai pas repéré une existante à ce sujet) 