### PR TITLE
Proposition de nouveau code pour la fiche de paie

### DIFF
--- a/site/source/components/FicheDePaie/CotisationLine.tsx
+++ b/site/source/components/FicheDePaie/CotisationLine.tsx
@@ -32,21 +32,23 @@ export default function CotisationLine({
 	}
 
 	return (
-		<>
-			<RuleLink dottedName={dottedName} />
-			<span>
+		<tr className="payslip__cotisationLine">
+			<th scope="row">
+				<RuleLink dottedName={dottedName} />
+			</th>
+			<td>
 				{partPatronale?.nodeValue
 					? signePlusOuMoins +
 					  formatValue(partPatronale, { displayedUnit: '€', language })
 					: '–'}
-			</span>
-			<span>
+			</td>
+			<td>
 				{partSalariale?.nodeValue
 					? signePlusOuMoins +
 					  formatValue(partSalariale, { displayedUnit: '€', language })
 					: '–'}
-			</span>
-		</>
+			</td>
+		</tr>
 	)
 }
 

--- a/site/source/components/FicheDePaie/CotisationLine.tsx
+++ b/site/source/components/FicheDePaie/CotisationLine.tsx
@@ -27,10 +27,6 @@ export default function CotisationLine({
 	)
 	const signePlusOuMoins = isExoneration(dottedName) ? '-' : ''
 
-	if (!partPatronale.nodeValue && !partSalariale.nodeValue) {
-		return null
-	}
-
 	return (
 		<tr className="payslip__cotisationLine">
 			<th scope="row">

--- a/site/source/components/FicheDePaie/Cotisations.tsx
+++ b/site/source/components/FicheDePaie/Cotisations.tsx
@@ -10,6 +10,7 @@ import { H3 } from '@/design-system/typography/heading'
 import { ExplicableRule } from '../conversation/Explicable'
 import Value from '../EngineValue/Value'
 import { useEngine } from '../utils/EngineContext'
+import { normalizeRuleName } from '../utils/normalizeRuleName'
 import CotisationLine from './CotisationLine'
 
 function CotisationLines({ cotisations }: { cotisations: Array<DottedName> }) {
@@ -33,11 +34,17 @@ export function Cotisations() {
 
 				return (
 					<Fragment key={section.dottedName}>
-						<table className="payslip__cotisationTable">
-							<caption className="payslip__cotisationTitle">
-								{section.title}
-								<ExplicableRule light dottedName={section.dottedName} />
-							</caption>
+						<h4
+							id={normalizeRuleName(section.dottedName)}
+							className="payslip__cotisationTitle"
+						>
+							{section.title}
+							<ExplicableRule light dottedName={section.dottedName} />
+						</h4>
+						<table
+							className="payslip__cotisationTable"
+							aria-labelledby={normalizeRuleName(section.dottedName)}
+						>
 							<tbody>
 								<tr>
 									<td></td>
@@ -52,11 +59,14 @@ export function Cotisations() {
 			})}
 
 			{/* Total cotisation */}
-			<table className="payslip__cotisationTable">
-				<caption className="payslip__cotisationTitle">
-					<Trans>Total des cotisations et contributions</Trans>
-					<ExplicableRule light dottedName="salarié . cotisations" />
-				</caption>
+			<h4 id="total_cotisation" className="payslip__cotisationTitle">
+				<Trans>Total des cotisations et contributions</Trans>
+				<ExplicableRule light dottedName="salarié . cotisations" />
+			</h4>
+			<table
+				className="payslip__cotisationTable"
+				aria-labelledby="total_cotisation"
+			>
 				<tbody>
 					<tr>
 						<td></td>

--- a/site/source/components/FicheDePaie/Cotisations.tsx
+++ b/site/source/components/FicheDePaie/Cotisations.tsx
@@ -5,18 +5,12 @@ import { Trans } from 'react-i18next'
 
 import './FicheDePaie.css'
 
-import { styled } from 'styled-components'
-
-import { H3, H4 } from '@/design-system/typography/heading'
+import { H3 } from '@/design-system/typography/heading'
 
 import { ExplicableRule } from '../conversation/Explicable'
 import Value from '../EngineValue/Value'
 import { useEngine } from '../utils/EngineContext'
 import CotisationLine from './CotisationLine'
-
-const StyledH3 = styled(H3)`
-	text-align: right;
-`
 
 function CotisationLines({ cotisations }: { cotisations: Array<DottedName> }) {
 	return cotisations.map((cotisation: DottedName) => (
@@ -29,51 +23,68 @@ export function Cotisations() {
 	const cotisationsBySection = getCotisationsBySection(parsedRules)
 
 	return (
-		<div className="payslip__cotisationsSection">
+		<section className="payslip__cotisationsSection">
 			<H3>
 				<Trans>Cotisations sociales</Trans>
 			</H3>
-			<StyledH3>
-				<Trans>employeur</Trans>
-			</StyledH3>
-			<StyledH3>
-				<Trans>salarié</Trans>
-			</StyledH3>
 
 			{cotisationsBySection.map(([sectionDottedName, cotisations]) => {
 				const section = parsedRules[sectionDottedName]
 
 				return (
 					<Fragment key={section.dottedName}>
-						<H4 className="payslip__cotisationTitle">
-							{section.title}
-							<ExplicableRule light dottedName={section.dottedName} />
-						</H4>
-						<CotisationLines cotisations={cotisations} />
+						<table className="payslip__cotisationTable">
+							<caption className="payslip__cotisationTitle">
+								{section.title}
+								<ExplicableRule light dottedName={section.dottedName} />
+							</caption>
+							<tbody>
+								<tr>
+									<td></td>
+									<th scope="col">employeur</th>
+									<th scope="col">salarié</th>
+								</tr>
+								<CotisationLines cotisations={cotisations} />
+							</tbody>
+						</table>
 					</Fragment>
 				)
 			})}
 
 			{/* Total cotisation */}
-			<H4 className="payslip__total">
-				<Trans>Total des cotisations et contributions</Trans>
-				<ExplicableRule light dottedName="salarié . cotisations" />
-			</H4>
-			<div>
-				<Value
-					expression="salarié . cotisations . employeur"
-					displayedUnit="€"
-					className="payslip__total"
-				/>
-			</div>
-			<div>
-				<Value
-					expression="salarié . cotisations . salarié"
-					displayedUnit="€"
-					className="payslip__total"
-				/>
-			</div>
-		</div>
+			<table className="payslip__cotisationTable">
+				<caption className="payslip__cotisationTitle">
+					<Trans>Total des cotisations et contributions</Trans>
+					<ExplicableRule light dottedName="salarié . cotisations" />
+				</caption>
+				<tbody>
+					<tr>
+						<td></td>
+						<th scope="col">employeur</th>
+						<th scope="col">salarié</th>
+					</tr>
+					<tr>
+						<th scope="row">
+							<Trans>Total des cotisations et contributions</Trans>
+						</th>
+						<td>
+							<Value
+								expression="salarié . cotisations . employeur"
+								displayedUnit="€"
+								className="payslip__total"
+							/>
+						</td>
+						<td>
+							<Value
+								expression="salarié . cotisations . salarié"
+								displayedUnit="€"
+								className="payslip__total"
+							/>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
 	)
 }
 

--- a/site/source/components/FicheDePaie/Cotisations.tsx
+++ b/site/source/components/FicheDePaie/Cotisations.tsx
@@ -74,7 +74,7 @@ export function Cotisations() {
 						<th scope="col">salarié</th>
 					</tr>
 					<tr>
-						<th scope="row">
+						<th scope="row" className="payslip__total-th">
 							<Trans>Total des cotisations et contributions</Trans>
 						</th>
 						<td>

--- a/site/source/components/FicheDePaie/FicheDePaie.css
+++ b/site/source/components/FicheDePaie/FicheDePaie.css
@@ -1,22 +1,39 @@
-.payslip__salarySection {
+/* .payslip__salarySection {
 	display: grid;
 	grid-template-columns: auto 8.2em;
 	overflow: visible;
 	grid-gap: 3px 0em;
+} */
+
+.payslip__salaryLine,
+.payslip__payementLine {
+	display: flex;
+	justify-content: space-between;
 }
-.payslip__salaryTitle {
+
+.payslip__salaryLine div {
+	color: hsl(var(--COLOR_HUE), calc(var(--COLOR_SATURATION) - 34%), 33%);
+	font-family: 'Roboto', sans-serif;
+	font-weight: 700;
+	padding: 0;
+}
+
+/* .payslip__salaryTitle {
 	grid-column-end: span 2;
-}
-.payslip__cotisationsSection {
+} */
+
+/* .payslip__cotisationsSection {
 	display: grid;
 	overflow: visible;
 
 	grid-template-columns: auto auto auto;
 	grid-gap: 3px 0em;
-}
+} */
+
 .payslip__container {
 	line-height: 1.5rem;
 }
+
 .payslip__container h3 {
 	border-bottom: 1px solid rgba(0, 0, 0, 0.85);
 	background-color: inherit;
@@ -37,7 +54,6 @@
 
 .payslip__total {
 	font-weight: bold;
-	margin-top: 1.5rem;
 	background-color: transparent !important;
 	color: inherit;
 }
@@ -48,18 +64,21 @@
 	margin-bottom: 0.5rem;
 	margin-top: 0.5rem;
 }
+
 .payslip__container h5:not(:first-of-type) {
 	margin-top: 1.5rem;
 }
+
 .payslip__container *::first-letter {
 	text-transform: capitalize;
 }
 
-.payslip__container span {
+.payslip__container span,
+.payslip__cotisationLine td {
 	display: flex;
-	align-items: flex-end;
-	font-family: 'Courier New', Courier, monospace;
 	justify-content: flex-end;
+	align-items: center;
+	font-family: 'Courier New', Courier, monospace;
 }
 
 .payslip__cotisationsSection a:nth-of-type(2n),
@@ -71,12 +90,14 @@
 	border-top-left-radius: 3px;
 	border-bottom-left-radius: 3px;
 }
-.payslip__cotisationsSection a:nth-of-type(2n) + *,
-.payslip__salarySection a:nth-of-type(2n) + * {
+
+.payslip__salaryLine:nth-of-type(2n),
+.payslip__cotisationLine:nth-of-type(2n)+* {
 	background-color: rgba(255, 255, 255, 0.4);
 	color: inherit;
 }
-.payslip__cotisationsSection a:nth-of-type(2n) + * + * {
+
+.payslip__cotisationsSection a:nth-of-type(2n)+*+* {
 	background-color: rgba(255, 255, 255, 0.4);
 	margin-right: -0.25rem;
 	z-index: 1;
@@ -84,13 +105,63 @@
 	border-bottom-right-radius: 3px;
 	padding-right: 0.25rem;
 }
-.payslip__total + * + * {
+
+.payslip__total+*+* {
 	background-color: transparent !important;
 }
+
 .payslip__cotisationTitle {
 	grid-column-end: span 3;
 }
 
 .payslip__salaireNet {
 	font-weight: bold;
+}
+
+.payslip__cotisationTable {
+	width: 100%
+}
+
+.payslip__cotisationTable:first-of-type .payslip__cotisationTitle {
+	margin-top: 0;
+}
+
+.payslip__container caption {
+	margin: 2rem 0 0;
+	scroll-margin-top: 1rem;
+	font-family: "Montserrat", sans-serif;
+	font-weight: 700;
+	color: hsl(var(--COLOR_HUE), calc(var(--COLOR_SATURATION) - 34%), 33%);
+	font-size: 1rem;
+	line-height: 1.75rem;
+	text-align: left;
+	background-color: transparent;
+}
+
+.payslip__cotisationTable tr {
+	display: grid;
+	grid-template-columns: 3fr 1fr 1fr;
+}
+
+.payslip__cotisationTable [scope="col"],
+
+.payslip__cotisationTable [scope="row"] {
+
+	font-family: 'Roboto', sans-serif;
+	font-weight: 700;
+	font-size: inherit;
+}
+
+.payslip__cotisationTable [scope="row"] {
+	text-align: left;
+	color: inherit;
+}
+
+.payslip__cotisationTable [scope="col"] {
+	color: hsl(var(--COLOR_HUE), calc(var(--COLOR_SATURATION) - 34%), 33%);
+	text-align: right;
+}
+
+.payslip__cotisationLine td {
+	text-align: right;
 }

--- a/site/source/components/FicheDePaie/FicheDePaie.css
+++ b/site/source/components/FicheDePaie/FicheDePaie.css
@@ -132,7 +132,7 @@
 	margin-top: 0;
 }
 
-.payslip__container caption {
+.payslip__container h4 {
 	margin: 2rem 0 0;
 	scroll-margin-top: 1rem;
 	font-family: "Montserrat", sans-serif;

--- a/site/source/components/FicheDePaie/FicheDePaie.css
+++ b/site/source/components/FicheDePaie/FicheDePaie.css
@@ -1,10 +1,3 @@
-/* .payslip__salarySection {
-	display: grid;
-	grid-template-columns: auto 8.2em;
-	overflow: visible;
-	grid-gap: 3px 0em;
-} */
-
 .payslip__salaryLine,
 .payslip__payementLine {
 	display: flex;
@@ -17,18 +10,6 @@
 	font-weight: 700;
 	padding: 0;
 }
-
-/* .payslip__salaryTitle {
-	grid-column-end: span 2;
-} */
-
-/* .payslip__cotisationsSection {
-	display: grid;
-	overflow: visible;
-
-	grid-template-columns: auto auto auto;
-	grid-gap: 3px 0em;
-} */
 
 .payslip__container {
 	line-height: 1.5rem;
@@ -113,6 +94,10 @@
 
 .payslip__total+*+* {
 	background-color: transparent !important;
+}
+
+.payslip__total-th {
+	color: hsl(var(--COLOR_HUE), calc(var(--COLOR_SATURATION) - 34%), 33%);
 }
 
 .payslip__cotisationTitle {

--- a/site/source/components/FicheDePaie/FicheDePaie.css
+++ b/site/source/components/FicheDePaie/FicheDePaie.css
@@ -34,6 +34,11 @@
 	line-height: 1.5rem;
 }
 
+.payslip__container ul {
+	list-style-type: "";
+	padding-left: 0;
+}
+
 .payslip__container h3 {
 	border-bottom: 1px solid rgba(0, 0, 0, 0.85);
 	background-color: inherit;
@@ -119,7 +124,8 @@
 }
 
 .payslip__cotisationTable {
-	width: 100%
+	width: 100%;
+	border-spacing: 0;
 }
 
 .payslip__cotisationTable:first-of-type .payslip__cotisationTitle {

--- a/site/source/components/FicheDePaie/FicheDePaie.tsx
+++ b/site/source/components/FicheDePaie/FicheDePaie.tsx
@@ -10,18 +10,22 @@ import SalaireNet from './SalaireNet'
 export default function FicheDePaie() {
 	return (
 		<StyledContainer className="payslip__container">
-			<div className="payslip__salarySection">
-				<Line
-					rule="salarié . temps de travail"
-					displayedUnit="heures/mois"
-					precision={1}
-				/>
-				<Line
-					rule="salarié . temps de travail . heures supplémentaires"
-					displayedUnit="heures/mois"
-					precision={1}
-				/>
-			</div>
+			<section className="payslip__salarySection">
+				<div className="payslip__salaryLine">
+					<Line
+						rule="salarié . temps de travail"
+						displayedUnit="heures/mois"
+						precision={1}
+					/>
+				</div>
+				<div className="payslip__salaryLine">
+					<Line
+						rule="salarié . temps de travail . heures supplémentaires"
+						displayedUnit="heures/mois"
+						precision={1}
+					/>
+				</div>
+			</section>
 
 			<SalaireBrut />
 			<Cotisations />

--- a/site/source/components/FicheDePaie/FicheDePaie.tsx
+++ b/site/source/components/FicheDePaie/FicheDePaie.tsx
@@ -11,16 +11,18 @@ export default function FicheDePaie() {
 	return (
 		<StyledContainer className="payslip__container">
 			<section className="payslip__salarySection">
-				<Line
-					rule="salarié . temps de travail"
-					displayedUnit="heures/mois"
-					precision={1}
-				/>
-				<Line
-					rule="salarié . temps de travail . heures supplémentaires"
-					displayedUnit="heures/mois"
-					precision={1}
-				/>
+				<ul>
+					<Line
+						rule="salarié . temps de travail"
+						displayedUnit="heures/mois"
+						precision={1}
+					/>
+					<Line
+						rule="salarié . temps de travail . heures supplémentaires"
+						displayedUnit="heures/mois"
+						precision={1}
+					/>
+				</ul>
 			</section>
 
 			<SalaireBrut />

--- a/site/source/components/FicheDePaie/FicheDePaie.tsx
+++ b/site/source/components/FicheDePaie/FicheDePaie.tsx
@@ -11,20 +11,16 @@ export default function FicheDePaie() {
 	return (
 		<StyledContainer className="payslip__container">
 			<section className="payslip__salarySection">
-				<div className="payslip__salaryLine">
-					<Line
-						rule="salarié . temps de travail"
-						displayedUnit="heures/mois"
-						precision={1}
-					/>
-				</div>
-				<div className="payslip__salaryLine">
-					<Line
-						rule="salarié . temps de travail . heures supplémentaires"
-						displayedUnit="heures/mois"
-						precision={1}
-					/>
-				</div>
+				<Line
+					rule="salarié . temps de travail"
+					displayedUnit="heures/mois"
+					precision={1}
+				/>
+				<Line
+					rule="salarié . temps de travail . heures supplémentaires"
+					displayedUnit="heures/mois"
+					precision={1}
+				/>
 			</section>
 
 			<SalaireBrut />

--- a/site/source/components/FicheDePaie/Line.tsx
+++ b/site/source/components/FicheDePaie/Line.tsx
@@ -25,14 +25,16 @@ export default function Line({
 		<WhenApplicable dottedName={rule}>
 			<WhenAlreadyDefined dottedName={rule}>
 				<Condition expression={`${rule} > 0`}>
-					<RuleLink dottedName={rule}>{title}</RuleLink>
-					<Value
-						linkToRule={false}
-						expression={(negative ? '- ' : '') + rule}
-						unit={displayedUnit === '€' ? '€/mois' : displayedUnit}
-						displayedUnit={displayedUnit}
-						{...props}
-					/>
+					<div className="payslip__salaryLine">
+						<RuleLink dottedName={rule}>{title}</RuleLink>
+						<Value
+							linkToRule={false}
+							expression={(negative ? '- ' : '') + rule}
+							unit={displayedUnit === '€' ? '€/mois' : displayedUnit}
+							displayedUnit={displayedUnit}
+							{...props}
+						/>
+					</div>
 				</Condition>
 			</WhenAlreadyDefined>
 		</WhenApplicable>

--- a/site/source/components/FicheDePaie/Line.tsx
+++ b/site/source/components/FicheDePaie/Line.tsx
@@ -25,7 +25,7 @@ export default function Line({
 		<WhenApplicable dottedName={rule}>
 			<WhenAlreadyDefined dottedName={rule}>
 				<Condition expression={`${rule} > 0`}>
-					<div className="payslip__salaryLine">
+					<li className="payslip__salaryLine">
 						<RuleLink dottedName={rule}>{title}</RuleLink>
 						<Value
 							linkToRule={false}
@@ -34,7 +34,7 @@ export default function Line({
 							displayedUnit={displayedUnit}
 							{...props}
 						/>
-					</div>
+					</li>
 				</Condition>
 			</WhenAlreadyDefined>
 		</WhenApplicable>

--- a/site/source/components/FicheDePaie/SalaireBrut.tsx
+++ b/site/source/components/FicheDePaie/SalaireBrut.tsx
@@ -13,18 +13,20 @@ export default function SalaireBrut() {
 			<H3 className="payslip__salaryTitle">
 				<Trans>Salaire brut</Trans>
 			</H3>
-			<Line rule="salarié . contrat . salaire brut" />
-			<Line rule="salarié . rémunération . heures supplémentaires" />
-			<Line rule="salarié . rémunération . heures complémentaires" />
-			<Line rule="salarié . rémunération . primes" />
-			<Line rule="salarié . rémunération . indemnités CDD" />
-			<Line rule="salarié . rémunération . avantages en nature . montant" />
-			<Line rule="salarié . rémunération . frais professionnels" />
-			<Line rule="salarié . activité partielle . retrait absence" />
-			<Line rule="salarié . activité partielle . indemnités" />
-			<Condition expression="salarié . contrat . salaire brut != salarié . rémunération . brut">
-				<Line rule="salarié . rémunération . brut" />
-			</Condition>
+			<ul>
+				<Line rule="salarié . contrat . salaire brut" />
+				<Line rule="salarié . rémunération . heures supplémentaires" />
+				<Line rule="salarié . rémunération . heures complémentaires" />
+				<Line rule="salarié . rémunération . primes" />
+				<Line rule="salarié . rémunération . indemnités CDD" />
+				<Line rule="salarié . rémunération . avantages en nature . montant" />
+				<Line rule="salarié . rémunération . frais professionnels" />
+				<Line rule="salarié . activité partielle . retrait absence" />
+				<Line rule="salarié . activité partielle . indemnités" />
+				<Condition expression="salarié . contrat . salaire brut != salarié . rémunération . brut">
+					<Line rule="salarié . rémunération . brut" />
+				</Condition>
+			</ul>
 		</section>
 	)
 }

--- a/site/source/components/FicheDePaie/SalaireBrut.tsx
+++ b/site/source/components/FicheDePaie/SalaireBrut.tsx
@@ -9,7 +9,7 @@ import './FicheDePaie.css'
 
 export default function SalaireBrut() {
 	return (
-		<div className="payslip__salarySection">
+		<section className="payslip__salarySection">
 			<H3 className="payslip__salaryTitle">
 				<Trans>Salaire brut</Trans>
 			</H3>
@@ -25,6 +25,6 @@ export default function SalaireBrut() {
 			<Condition expression="salarié . contrat . salaire brut != salarié . rémunération . brut">
 				<Line rule="salarié . rémunération . brut" />
 			</Condition>
-		</div>
+		</section>
 	)
 }

--- a/site/source/components/FicheDePaie/SalaireNet.tsx
+++ b/site/source/components/FicheDePaie/SalaireNet.tsx
@@ -13,13 +13,13 @@ import Line from './Line'
 
 function SalaireLine({ rule, title }: { rule: DottedName; title?: string }) {
 	return (
-		<>
+		<div className="payslip__payementLine">
 			<H4>
 				{title}
 				<ExplicableRule light dottedName={rule} />
 			</H4>
 			<Value linkToRule={false} expression={rule} unit="€" displayedUnit="€" />
-		</>
+		</div>
 	)
 }
 
@@ -27,71 +27,80 @@ export default function SalaireNet() {
 	const { t } = useTranslation()
 
 	return (
-		<div className="payslip__salarySection">
+		<section className="payslip__salarySection">
 			<H3 className="payslip__salaryTitle">
 				<Trans>Salaire net</Trans>
 			</H3>
 
-			<SalaireLine
-				rule="salarié . rémunération . montant net social"
-				title={t('Montant net social')}
-			/>
+			<article>
+				<SalaireLine
+					rule="salarié . rémunération . montant net social"
+					title={t('Montant net social')}
+				/>
+			</article>
 
-			<Condition
-				expression={{
-					'une de ces conditions': [
-						'salarié . rémunération . frais professionnels . trajets domicile travail . déductible > 0',
-						'salarié . rémunération . frais professionnels . titres-restaurant', // bool
-						'salarié . rémunération . avantages en nature', // bool
-					],
-				}}
-			>
+			<article>
+				<Condition
+					expression={{
+						'une de ces conditions': [
+							'salarié . rémunération . frais professionnels . trajets domicile travail . déductible > 0',
+							'salarié . rémunération . frais professionnels . titres-restaurant', // bool
+							'salarié . rémunération . avantages en nature', // bool
+						],
+					}}
+				>
+					<H4>
+						<Trans>Remboursements et déductions diverses</Trans>
+					</H4>
+				</Condition>
+
+				<Line
+					rule="salarié . rémunération . frais professionnels . trajets domicile travail . employeur"
+					title={t('Frais de transport')}
+				/>
+				<Line
+					negative
+					rule="salarié . rémunération . frais professionnels . titres-restaurant . salarié"
+					title={t('Titres-restaurant')}
+				/>
+				<Line
+					negative
+					rule="salarié . rémunération . avantages en nature . montant"
+				/>
+			</article>
+
+			<article>
+				<SalaireLine
+					rule="salarié . rémunération . net . à payer avant impôt"
+					title={t('Montant net à payer avant impôt sur le revenu')}
+				/>
+			</article>
+			<article>
 				<H4>
-					<Trans>Remboursements et déductions diverses</Trans>
+					<Trans>Impôt sur le revenu</Trans>
 				</H4>
-				<span />
-			</Condition>
-			<Line
-				rule="salarié . rémunération . frais professionnels . trajets domicile travail . employeur"
-				title={t('Frais de transport')}
-			/>
-			<Line
-				negative
-				rule="salarié . rémunération . frais professionnels . titres-restaurant . salarié"
-				title={t('Titres-restaurant')}
-			/>
-			<Line
-				negative
-				rule="salarié . rémunération . avantages en nature . montant"
-			/>
 
-			<SalaireLine
-				rule="salarié . rémunération . net . à payer avant impôt"
-				title={t('Montant net à payer avant impôt sur le revenu')}
-			/>
+				<Line
+					rule="salarié . rémunération . net . imposable"
+					title={t('Montant net imposable')}
+				/>
+				<Line
+					rule="salarié . rémunération . net . imposable . heures supplémentaires et complémentaires défiscalisées"
+					title={t('Montant net des HC/HS exonérées')}
+				/>
+				<Line
+					negative
+					rule="impôt . montant"
+					title={t('impôt sur le revenu prélevé à la source')}
+				/>
+			</article>
 
-			<H4>
-				<Trans>Impôt sur le revenu</Trans>
-			</H4>
-			<span />
-			<Line
-				rule="salarié . rémunération . net . imposable"
-				title={t('Montant net imposable')}
-			/>
-			<Line
-				rule="salarié . rémunération . net . imposable . heures supplémentaires et complémentaires défiscalisées"
-				title={t('Montant net des HC/HS exonérées')}
-			/>
-			<Line
-				negative
-				rule="impôt . montant"
-				title={t('impôt sur le revenu prélevé à la source')}
-			/>
-
-			<SalaireLine
-				rule="salarié . rémunération . net . payé après impôt"
-				title={t('Montant net à payer')}
-			/>
-		</div>
+			<article>
+				<SalaireLine
+					rule="salarié . rémunération . net . payé après impôt"
+					title={t('Montant net à payer')}
+				/>
+			</article>
+		</section>
 	)
 }

--- a/site/source/components/FicheDePaie/SalaireNet.tsx
+++ b/site/source/components/FicheDePaie/SalaireNet.tsx
@@ -39,36 +39,37 @@ export default function SalaireNet() {
 						title={t('Montant net social')}
 					/>
 				</li>
-
-				<li>
-					<Condition
-						expression={{
-							'une de ces conditions': [
-								'salarié . rémunération . frais professionnels . trajets domicile travail . déductible > 0',
-								'salarié . rémunération . frais professionnels . titres-restaurant', // bool
-								'salarié . rémunération . avantages en nature', // bool
-							],
-						}}
-					>
+				<Condition
+					expression={{
+						'une de ces conditions': [
+							'salarié . rémunération . frais professionnels . trajets domicile travail . déductible > 0',
+							'salarié . rémunération . frais professionnels . titres-restaurant', // bool
+							'salarié . rémunération . avantages en nature', // bool
+						],
+					}}
+				>
+					<li>
 						<H4>
 							<Trans>Remboursements et déductions diverses</Trans>
 						</H4>
-					</Condition>
 
-					<Line
-						rule="salarié . rémunération . frais professionnels . trajets domicile travail . employeur"
-						title={t('Frais de transport')}
-					/>
-					<Line
-						negative
-						rule="salarié . rémunération . frais professionnels . titres-restaurant . salarié"
-						title={t('Titres-restaurant')}
-					/>
-					<Line
-						negative
-						rule="salarié . rémunération . avantages en nature . montant"
-					/>
-				</li>
+						<ul>
+							<Line
+								rule="salarié . rémunération . frais professionnels . trajets domicile travail . employeur"
+								title={t('Frais de transport')}
+							/>
+							<Line
+								negative
+								rule="salarié . rémunération . frais professionnels . titres-restaurant . salarié"
+								title={t('Titres-restaurant')}
+							/>
+							<Line
+								negative
+								rule="salarié . rémunération . avantages en nature . montant"
+							/>
+						</ul>
+					</li>
+				</Condition>
 
 				<li>
 					<SalaireLine
@@ -81,19 +82,21 @@ export default function SalaireNet() {
 						<Trans>Impôt sur le revenu</Trans>
 					</H4>
 
-					<Line
-						rule="salarié . rémunération . net . imposable"
-						title={t('Montant net imposable')}
-					/>
-					<Line
-						rule="salarié . rémunération . net . imposable . heures supplémentaires et complémentaires défiscalisées"
-						title={t('Montant net des HC/HS exonérées')}
-					/>
-					<Line
-						negative
-						rule="impôt . montant"
-						title={t('impôt sur le revenu prélevé à la source')}
-					/>
+					<ul>
+						<Line
+							rule="salarié . rémunération . net . imposable"
+							title={t('Montant net imposable')}
+						/>
+						<Line
+							rule="salarié . rémunération . net . imposable . heures supplémentaires et complémentaires défiscalisées"
+							title={t('Montant net des HC/HS exonérées')}
+						/>
+						<Line
+							negative
+							rule="impôt . montant"
+							title={t('impôt sur le revenu prélevé à la source')}
+						/>
+					</ul>
 				</li>
 
 				<li>

--- a/site/source/components/FicheDePaie/SalaireNet.tsx
+++ b/site/source/components/FicheDePaie/SalaireNet.tsx
@@ -32,75 +32,77 @@ export default function SalaireNet() {
 				<Trans>Salaire net</Trans>
 			</H3>
 
-			<article>
-				<SalaireLine
-					rule="salarié . rémunération . montant net social"
-					title={t('Montant net social')}
-				/>
-			</article>
+			<ul>
+				<li>
+					<SalaireLine
+						rule="salarié . rémunération . montant net social"
+						title={t('Montant net social')}
+					/>
+				</li>
 
-			<article>
-				<Condition
-					expression={{
-						'une de ces conditions': [
-							'salarié . rémunération . frais professionnels . trajets domicile travail . déductible > 0',
-							'salarié . rémunération . frais professionnels . titres-restaurant', // bool
-							'salarié . rémunération . avantages en nature', // bool
-						],
-					}}
-				>
+				<li>
+					<Condition
+						expression={{
+							'une de ces conditions': [
+								'salarié . rémunération . frais professionnels . trajets domicile travail . déductible > 0',
+								'salarié . rémunération . frais professionnels . titres-restaurant', // bool
+								'salarié . rémunération . avantages en nature', // bool
+							],
+						}}
+					>
+						<H4>
+							<Trans>Remboursements et déductions diverses</Trans>
+						</H4>
+					</Condition>
+
+					<Line
+						rule="salarié . rémunération . frais professionnels . trajets domicile travail . employeur"
+						title={t('Frais de transport')}
+					/>
+					<Line
+						negative
+						rule="salarié . rémunération . frais professionnels . titres-restaurant . salarié"
+						title={t('Titres-restaurant')}
+					/>
+					<Line
+						negative
+						rule="salarié . rémunération . avantages en nature . montant"
+					/>
+				</li>
+
+				<li>
+					<SalaireLine
+						rule="salarié . rémunération . net . à payer avant impôt"
+						title={t('Montant net à payer avant impôt sur le revenu')}
+					/>
+				</li>
+				<li>
 					<H4>
-						<Trans>Remboursements et déductions diverses</Trans>
+						<Trans>Impôt sur le revenu</Trans>
 					</H4>
-				</Condition>
 
-				<Line
-					rule="salarié . rémunération . frais professionnels . trajets domicile travail . employeur"
-					title={t('Frais de transport')}
-				/>
-				<Line
-					negative
-					rule="salarié . rémunération . frais professionnels . titres-restaurant . salarié"
-					title={t('Titres-restaurant')}
-				/>
-				<Line
-					negative
-					rule="salarié . rémunération . avantages en nature . montant"
-				/>
-			</article>
+					<Line
+						rule="salarié . rémunération . net . imposable"
+						title={t('Montant net imposable')}
+					/>
+					<Line
+						rule="salarié . rémunération . net . imposable . heures supplémentaires et complémentaires défiscalisées"
+						title={t('Montant net des HC/HS exonérées')}
+					/>
+					<Line
+						negative
+						rule="impôt . montant"
+						title={t('impôt sur le revenu prélevé à la source')}
+					/>
+				</li>
 
-			<article>
-				<SalaireLine
-					rule="salarié . rémunération . net . à payer avant impôt"
-					title={t('Montant net à payer avant impôt sur le revenu')}
-				/>
-			</article>
-			<article>
-				<H4>
-					<Trans>Impôt sur le revenu</Trans>
-				</H4>
-
-				<Line
-					rule="salarié . rémunération . net . imposable"
-					title={t('Montant net imposable')}
-				/>
-				<Line
-					rule="salarié . rémunération . net . imposable . heures supplémentaires et complémentaires défiscalisées"
-					title={t('Montant net des HC/HS exonérées')}
-				/>
-				<Line
-					negative
-					rule="impôt . montant"
-					title={t('impôt sur le revenu prélevé à la source')}
-				/>
-			</article>
-
-			<article>
-				<SalaireLine
-					rule="salarié . rémunération . net . payé après impôt"
-					title={t('Montant net à payer')}
-				/>
-			</article>
+				<li>
+					<SalaireLine
+						rule="salarié . rémunération . net . payé après impôt"
+						title={t('Montant net à payer')}
+					/>
+				</li>
+			</ul>
 		</section>
 	)
 }


### PR DESCRIPTION
La fiche de paie se comporte comme un tableau mais n'en est pas un.

J'ai repris l'affichage en modifiant le code.

Les parties Salaire Brut et Net reste avec un code sans tableau, juste amélioré le rendu.
La partie Cotisations sociales est maintenant un ensemble de plusieurs tableaux qui me paraissent plus simple à lire avec des intitulés qui se répètent mais qui sont plus proche des valeurs.

Closes #3664 