### PR TITLE
Corrige les balises uniquement pour des fins de présentation dans le simulateur salarié

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -2002,8 +2002,8 @@ pages:
         recruitment subsidies</2> which are not all taken into account by our
         simulator. You can find them on <6>the official
         portal</6>.</8><9><0>Talk to an advisor about your recruitment
-        project</0><1>You would like to :<1><0>be advised on the hiring aids
-        available for your recruitment project</0><1>Find out about
+        project</0><1><0>You would like to :</0><1><0>be advised on the hiring
+        aids available for your recruitment project</0><1>Find out about
         apprenticeships, professionalization contracts, \"emplois francs\" in
         priority neighborhoods, <2>VTE</2>, etc.</1><2>Find
         candidates</2><3>Recruiting a disabled person</3></1><2>Fast, simple

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -2119,11 +2119,11 @@ pages:
         <2>aides différées</2> à l'embauche qui ne sont pas toutes prises en
         compte par notre simulateur, vous pouvez les retrouver sur <6>le portail
         officiel</6>.</8><9><0>Échanger avec un conseiller pour votre projet de
-        recrutement</0><1>Vous souhaitez :<1><0>Être conseillé(e) sur les aides
-        à l'embauche mobilisables pour votre recrutement</0><1>Vous informer sur
-        l'apprentissage, le contrat de professionnalisation, les emplois francs
-        en quartiers prioritaires, le <2>VTE</2>...</1><2>Trouver des
-        candidats</2><3>Recruter une personne en situation de
+        recrutement</0><1><0>Vous souhaitez :</0><1><0>Être conseillé(e) sur les
+        aides à l'embauche mobilisables pour votre recrutement</0><1>Vous
+        informer sur l'apprentissage, le contrat de professionnalisation, les
+        emplois francs en quartiers prioritaires, le <2>VTE</2>...</1><2>Trouver
+        des candidats</2><3>Recruter une personne en situation de
         handicap</3></1><2>Service public simple et rapide : vous êtes
         rappelé(e) par le conseiller qui peut vous aider.</2></1><2>Partenaires
         mobilisés : France Travail, Apec, Cap Emploi, missions

--- a/site/source/pages/simulateurs/salarié/Salarié.tsx
+++ b/site/source/pages/simulateurs/salarié/Salarié.tsx
@@ -207,7 +207,7 @@ export const SeoExplanations = () => {
 			<div className="print-hidden">
 				<H2>Échanger avec un conseiller pour votre projet de recrutement</H2>
 				<Body as="div">
-					Vous souhaitez :
+					<p>Vous souhaitez :</p>
 					<Ul>
 						<Li>
 							Être conseillé(e) sur les aides à l'embauche mobilisables pour


### PR DESCRIPTION
- dans la partie "Échanger avec un conseiller pour votre projet de recrutement", le texte introductif à la liste n'avait pas de balise, j'y ai ajouté un `<p>`
- Dans la partie "Fiche de paie" le contenu sous la même forme que le nombre d'heures par mois n'est pas entre des balises 

Closes #3678 