### PR TITLE
A11y/Structurer en liste les boutons 'Aller à la question'

### DIFF
--- a/site/source/components/QuickLinks.tsx
+++ b/site/source/components/QuickLinks.tsx
@@ -35,20 +35,27 @@ export default function QuickLinks() {
 	}
 
 	return (
-		<StyledLinks>
-			<span>Aller à la question : </span>
-			{links.map(({ label, dottedName }) => (
-				<StyledLink
-					key={dottedName}
-					$underline={dottedName === currentQuestion}
-					onPress={() => dispatch(vaÀLaQuestion(dottedName))}
-					aria-label={t('{{question}}, aller à la question : {{question}}', {
-						question: label,
-					})}
-				>
-					{label}
-				</StyledLink>
-			))}
+		<StyledLinks as="div">
+			<p>Aller à la question : </p>
+
+			<StyledList>
+				{links.map(({ label, dottedName }) => (
+					<li key={dottedName}>
+						<StyledLink
+							$underline={dottedName === currentQuestion}
+							onPress={() => dispatch(vaÀLaQuestion(dottedName))}
+							aria-label={t(
+								'{{question}}, aller à la question : {{question}}',
+								{
+									question: label,
+								}
+							)}
+						>
+							{label}
+						</StyledLink>
+					</li>
+				))}
+			</StyledList>
 		</StyledLinks>
 	)
 }
@@ -57,6 +64,14 @@ const StyledLinks = styled(SmallBody)`
 	display: inline-flex;
 	flex-wrap: wrap;
 	gap: ${({ theme }) => theme.spacings.sm};
+`
+
+const StyledList = styled.ul`
+	display: flex;
+	gap: 12px;
+	margin: 1em 0;
+	padding: 0;
+	list-style: none;
 `
 
 const StyledLink = styled(Link)<{ $underline: boolean }>`


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 :

> Les boutons après "Aller à la question" ne sont pas sous forme de liste

![image](https://github.com/user-attachments/assets/254b2575-7aca-4063-a1f5-4a1ef2ccb548)

La structure HTML est changée pour organiser ces boutons dans une `<ul>` mais les styles existants sont conservés.