### PR TITLE
feat: mise à jour du salaire médian avec les données INSEE 2023

### DIFF
--- a/modele-social/règles/salarié/contrat.publicodes
+++ b/modele-social/règles/salarié/contrat.publicodes
@@ -496,7 +496,7 @@ salarié . contrat . salaire brut:
   unité: €/mois
   plancher: 0 €/mois
   suggestions:
-    salaire médian: 2600 €/mois
+    salaire médian: 2700 €/mois
     SMIC: temps de travail . SMIC
   inversion numérique:
     - coût total employeur


### PR DESCRIPTION
Les dernières données Insee connues donnent un [salaire médian annuel de 25 569 € nets](https://mon-entreprise.urssaf.fr/simulateurs/salaire-brut-net), pour l'année 2023.

Ce salaire de 25 569 €net/an correspond 2 692 €brut/mois (avec mutuelle santé à 0€) [simulation](https://mon-entreprise.urssaf.fr/simulateurs/salaire-brut-net?salaire-net=25569%E2%82%AC%2Fan&salari%C3%A9+.+cotisations+.+pr%C3%A9voyances+.+sant%C3%A9+.+montant=0%E2%82%AC%2Fmois&unite=%E2%82%AC%2Fmois). La PR arrondit a cette valeur 2700€, prenant notamment en compte l'inflation des salaires depuis 2023.  