### PR TITLE
Rend les liens explicites dans la modale info

### DIFF
--- a/site/source/components/References.tsx
+++ b/site/source/components/References.tsx
@@ -90,24 +90,25 @@ function Reference({ href, title }: { href: string; title: string }) {
 						style={{
 							display: 'flex',
 						}}
+						aria-label={title + ', nouvelle fenêtre'}
 					>
 						{capitalise0(title)}
 					</Link>
 				</Grid>
-				<Grid
-					item
-					xs="auto"
-					style={{
-						textAlign: 'right',
-					}}
-				>
-					{domain in referencesImages && (
+				{domain in referencesImages && (
+					<Grid
+						item
+						xs="auto"
+						style={{
+							textAlign: 'right',
+						}}
+					>
 						<StyledImage
 							src={referencesImages[domain as keyof typeof referencesImages]}
 							alt=""
 						/>
-					)}
-				</Grid>
+					</Grid>
+				)}
 			</Grid>
 		</Li>
 	)

--- a/site/source/components/conversation/Explicable.tsx
+++ b/site/source/components/conversation/Explicable.tsx
@@ -45,7 +45,10 @@ export function ExplicableRule<Names extends string = DottedName>({
 		>
 			<Markdown>{rule.rawNode.description}</Markdown>
 
-			<RuleLink dottedName={dottedName as DottedName}>
+			<RuleLink
+				dottedName={dottedName as DottedName}
+				aria-label={`Lire la documentation du calcul de ${rule.title}`}
+			>
 				Lire la documentation
 			</RuleLink>
 

--- a/site/source/components/conversation/Explicable.tsx
+++ b/site/source/components/conversation/Explicable.tsx
@@ -1,4 +1,5 @@
 import { DottedName } from 'modele-social'
+import { useTranslation } from 'react-i18next'
 
 import { References } from '@/components/References'
 import RuleLink from '@/components/RuleLink'
@@ -24,6 +25,7 @@ export function ExplicableRule<Names extends string = DottedName>({
 	const engine = useEngine()
 	const rule = engine.getRule(dottedName as DottedName)
 	const références = useReferences(rule)
+	const { t } = useTranslation()
 
 	if (rule.rawNode.description == null) {
 		return null
@@ -47,7 +49,7 @@ export function ExplicableRule<Names extends string = DottedName>({
 
 			<RuleLink
 				dottedName={dottedName as DottedName}
-				aria-label={`Lire la documentation au sujet de : ${rule.title}`}
+				aria-label={t('Lire la documentation au sujet de :') + ' ' + rule.title}
 			>
 				Lire la documentation
 			</RuleLink>

--- a/site/source/components/conversation/Explicable.tsx
+++ b/site/source/components/conversation/Explicable.tsx
@@ -31,8 +31,6 @@ export function ExplicableRule<Names extends string = DottedName>({
 		return null
 	}
 
-	// TODO montrer les variables de type 'une possibilité'
-
 	return (
 		<HelpButtonWithPopover
 			key={rule.dottedName}
@@ -54,7 +52,7 @@ export function ExplicableRule<Names extends string = DottedName>({
 				Lire la documentation
 			</RuleLink>
 
-			{références && (
+			{références && Object.keys(références).length > 0 && (
 				<>
 					<H3>Liens utiles</H3>
 					<References references={références} />

--- a/site/source/components/conversation/Explicable.tsx
+++ b/site/source/components/conversation/Explicable.tsx
@@ -47,7 +47,7 @@ export function ExplicableRule<Names extends string = DottedName>({
 
 			<RuleLink
 				dottedName={dottedName as DottedName}
-				aria-label={`Lire la documentation du calcul de ${rule.title}`}
+				aria-label={`Lire la documentation au sujet de : ${rule.title}`}
 			>
 				Lire la documentation
 			</RuleLink>

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -128,6 +128,7 @@ Les données de simulations se mettront automatiquement à jour après la modifi
   Simulation data is automatically updated when you modify a field. <2>A panel
   will open to allow you to add details to the simulation, and detailed results
   will be displayed below the form and updated when you modify it.</2>
+"Lire la documentation au sujet de :": "Read the documentation about :"
 Lire la page sur {{ site }}, nouvelle fenêtre.: Read the page on {{ site }}, new window.
 Lire les précisions, ouvrir le message condensé.: Read the details, open the condensed message.
 Liste des intégrations: List of integrations

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -135,6 +135,7 @@ Les données de simulations se mettront automatiquement à jour après la modifi
   d'apporter des précisions à la simulation, des résultats détaillés
   s'afficheront en dessous du formulaire et seront mis à jour quand vous
   modifierez ce dernier.</2>
+"Lire la documentation au sujet de :": "Lire la documentation au sujet de :"
 Lire la page sur {{ site }}, nouvelle fenêtre.: Lire la page sur {{ site }}, nouvelle fenêtre.
 Lire les précisions, ouvrir le message condensé.: Lire les précisions, ouvrir le message condensé.
 Liste des intégrations: Liste des intégrations


### PR DESCRIPTION
- [x] Dans les modales "Info" les aria-labels des liens "Lire la documentation" ne reprennent pas au minimum l'intitulé visible.
- [x] De plus les liens accompagnés d'une image "Flèche" ne précisent pas dans leurs intitulés qu'ils s'ouvrent dans une nouvelle fenêtre

closes #3655 