### PR TITLE
Rend explicite les liens de la page AE

### DIFF
--- a/site/source/components/EngineValue/Value.tsx
+++ b/site/source/components/EngineValue/Value.tsx
@@ -51,11 +51,11 @@ export default function Value<Names extends string>({
 			<RuleLink
 				dottedName={dottedName}
 				documentationPath={documentationPath}
-				aria-label={
-					t('Voir la documentation du calcul de') +
-					' ' +
-					value.replace(/(\d)\s+(\d)/g, '$1$2')
-				}
+				aria-label={t(
+					'composants.engine-value.voir-la-documentation',
+					'Voir la documentation du calcul de {{valeur}}',
+					{ valeur: value.replace(/(\d)\s+(\d)/g, '$1$2') }
+				)}
 			>
 				<StyledValue {...props} key={value} $flashOnChange={flashOnChange}>
 					{value}
@@ -77,7 +77,7 @@ const flash = keyframes`
     background-color: white;
 		opacity: 0.8;
   }
-	
+
 		to {
 			background-color: transparent;
 		}

--- a/site/source/components/StackedBarChart.tsx
+++ b/site/source/components/StackedBarChart.tsx
@@ -201,6 +201,7 @@ export default function StackedRulesChart({
 	data,
 	precision = 0.1,
 }: StackedRulesChartProps) {
+	const { t } = useTranslation().i18n
 	const engine = useEngine()
 	const targetUnit = useSelector(targetUnitSelector)
 
@@ -214,7 +215,11 @@ export default function StackedRulesChart({
 				legend: (
 					<RuleLink
 						dottedName={dottedName}
-						aria-label={`Voir les détails du calcul de ${title}`}
+						aria-label={t(
+							'composants.engine-value.voir-les-details-du-calcul',
+							'Voir les détails du calcul de {{title}}',
+							{ title }
+						)}
 					>
 						{title}
 					</RuleLink>

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -248,7 +248,6 @@ Utiliser avec un tableur: Using a spreadsheet
 Utiliser les calculs des simulateurs dans votre application: Use simulator calculations in your application
 Veuillez entrer un message avant de soumettre le formulaire.: Please enter a message before submitting the form.
 Veuillez renseigner votre adresse email.: Please enter your email address.
-Voir la documentation du calcul de: See the documentation for the calculation of
 Voir la fiche Urssaf: See the Urssaf sheet
 Voir la fiche de paie: View pay slip
 Voir les autres simulateurs: See other simulators
@@ -437,6 +436,10 @@ components:
       share:
         checkbox: I'd like to share my latest simulation with you to help you respond
           better.
+composants:
+  engine-value:
+    voir-la-documentation: See the documentation for the calculation of {{valeur}}
+    voir-les-details-du-calcul: See details of the calculation of {{title}}
 contact:
   email: "<0>You can contact us via our returns module using the 👋 button at the
     top right of your screen or directly by e-mail at the following address:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -261,7 +261,6 @@ Utiliser avec un tableur: Utiliser avec un tableur
 Utiliser les calculs des simulateurs dans votre application: Utiliser les calculs des simulateurs dans votre application
 Veuillez entrer un message avant de soumettre le formulaire.: Veuillez entrer un message avant de soumettre le formulaire.
 Veuillez renseigner votre adresse email.: Veuillez renseigner votre adresse email.
-Voir la documentation du calcul de: Voir la documentation du calcul de
 Voir la fiche Urssaf: Voir la fiche Urssaf
 Voir la fiche de paie: Voir la fiche de paie
 Voir les autres simulateurs: Voir les autres simulateurs
@@ -461,6 +460,10 @@ components:
       share:
         checkbox: Je souhaite partager ma dernière simulation pour vous aider à mieux me
           répondre.
+composants:
+  engine-value:
+    voir-la-documentation: Voir la documentation du calcul de {{valeur}}
+    voir-les-details-du-calcul: Voir les détails du calcul de {{title}}
 contact:
   email: "<0>Vous pouvez nous contacter via notre module de retours via le boutton
     👋 en haut à droite de votre ecran ou directement par mail à l'adresse


### PR DESCRIPTION
- [x] L'aria-label du lien "Revenu (incluant les dépenses liées à l'activité)" ne reprend pas au minimum l'intitulé visible du lien
- [x] Dans la partie "L’Urssaf recouvre les cotisations servant au financement de la sécurité sociale (assurance maladie, allocations familiales, dépendance et retraite )." l'aria-label du lien ne reprend pas au minimum l'intitulé visible
- [x] Dans la partie "Retraite : droits acquis sur l'année" les aria-label des liens ne reprennent pas au minimum l'intitulé visible

Closes #3656 