### PR TITLE
A11y/Structurer en liste les lignes de la modale "Modifier mes réponses"

### DIFF
--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -14,6 +14,7 @@ import PopoverConfirm from '@/design-system/popover/PopoverConfirm'
 import { Strong } from '@/design-system/typography'
 import { H2, H3 } from '@/design-system/typography/heading'
 import { Link } from '@/design-system/typography/link'
+import { Ul } from '@/design-system/typography/list'
 import { Body, Intro } from '@/design-system/typography/paragraphs'
 import { useCurrentSimulatorData } from '@/hooks/useCurrentSimulatorData'
 import { useNextQuestions } from '@/hooks/useNextQuestion'
@@ -246,11 +247,11 @@ function StepsTable({
 	const { t } = useTranslation()
 
 	return (
-		<>
+		<Ul>
 			{rules
 				.filter((rule) => !('nodeValue' in rule) || rule.nodeValue !== null)
 				.map((rule) => (
-					<StyledAnswerList container key={rule.dottedName}>
+					<StyledAnswerLine as="li" container key={rule.dottedName}>
 						<Grid item xs>
 							{rule.title}
 							<ExplicableRule
@@ -264,9 +265,9 @@ function StepsTable({
 						<StyledAnswer item xs="auto">
 							<AnswerElement {...rule} />
 						</StyledAnswer>
-					</StyledAnswerList>
+					</StyledAnswerLine>
 				))}
-		</>
+		</Ul>
 	)
 }
 
@@ -339,7 +340,8 @@ function AnswerElement(rule: RuleNode) {
 const StyledAnswer = styled(Grid)`
 	text-align: right;
 `
-const StyledAnswerList = styled(Grid)`
+const StyledAnswerLine = styled(Grid)`
+	display: flex;
 	margin: ${({ theme }) => `${theme.spacings.md} 0`};
 	align-items: baseline;
 	justify-content: flex-end;
@@ -349,6 +351,8 @@ const StyledAnswerList = styled(Grid)`
 			? theme.colors.bases.primary[100]
 			: theme.colors.extended.dark[500]};
 	font-family: ${({ theme }) => theme.fonts.main};
+	line-height: 1;
+
 	&:nth-child(2n) {
 		background-color: ${({ theme }) =>
 			theme.darkMode


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 :

> Dans la modale "Modifier mes réponses" le contenu n'est pas sous forme de liste

Les deux listes "Ma situation" et "Prochaines questions" sont restructurées dans une balise `<ul>`.

![image](https://github.com/user-attachments/assets/9412c7d7-df9e-4884-9b5b-235d3d429aad)

![image](https://github.com/user-attachments/assets/f97670f1-1fb8-419e-8193-d59875b86462)

Closes https://github.com/betagouv/mon-entreprise/issues/3680