### PR TITLE
A11y/Better aria-label for Notifications close button

### DIFF
--- a/site/source/components/Notifications.tsx
+++ b/site/source/components/Notifications.tsx
@@ -96,7 +96,7 @@ export default function Notifications() {
 						<Absolute $isMultiline={isMultiline(résumé ?? description ?? '')}>
 							<ExplicableRule dottedName={dottedName} light />
 							<CloseButton
-								aria-label={t('Fermer')}
+								aria-label={t('Cacher le message')}
 								onPress={() => dispatch(hideNotification(dottedName))}
 								color={sévérité === 'avertissement' ? 'tertiary' : 'primary'}
 							/>

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -48,6 +48,7 @@ Bonjour, je suis boulanger et je n'ai pas trouvé en cherchant "pain" ou "vienno
   searched.
 Budget: Budget
 Bénéfice: Profit
+Cacher le message: Hide message
 Cette commune n'existe pas: This commune does not exist
 Cette opération n'est pas réversible.: This operation is not reversible.
 Charger plus de résultats: Load more results

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -52,6 +52,7 @@ Bonjour, je suis boulanger et je n'ai pas trouvé en cherchant "pain" ou "vienno
   "viennoiserie".
 Budget: Budget
 Bénéfice: Bénéfice
+Cacher le message: Cacher le message
 Cette commune n'existe pas: Cette commune n'existe pas
 Cette opération n'est pas réversible.: Cette opération n'est pas réversible.
 Charger plus de résultats: Charger plus de résultats


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur de revenus pour salarié :

> L'intitulé du bouton qui permet de fermer un message sous le formulaire de réponse aux questions n'est pas suffisamment pertinent

Elle améliore en fait l'aria-label du bouton de fermeture de toutes les `<Notifications />`.

![image](https://github.com/user-attachments/assets/a38fddf7-48f1-4b7e-b9e7-6be06dd83d10)