### PR TITLE
A11y/Info buttons aria-label must contain visible label

### DIFF
--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -255,7 +255,7 @@ function StepsTable({
 						<Grid item xs>
 							{rule.title}
 							<ExplicableRule
-								aria-label={t(`Plus d'informations sur {{ title }}`, {
+								aria-label={t(`Info sur {{ title }}`, {
 									title: rule.title,
 								})}
 								light

--- a/site/source/components/conversation/ChoicesInput.tsx
+++ b/site/source/components/conversation/ChoicesInput.tsx
@@ -232,7 +232,7 @@ function RadioChoices<Names extends string = DottedName>({
 								<ExplicableRule
 									light
 									dottedName={node.dottedName as DottedName}
-									aria-label={t("Plus d'informations sur {{ title }}", {
+									aria-label={t('Info sur {{ title }}', {
 										title: node.title,
 									})}
 								/>

--- a/site/source/components/conversation/Explicable.tsx
+++ b/site/source/components/conversation/Explicable.tsx
@@ -40,7 +40,7 @@ export function ExplicableRule<Names extends string = DottedName>({
 			bigPopover={bigPopover}
 			className="print-hidden"
 			aria-haspopup="dialog"
-			aria-label={`Plus d'informations sur ${rule.title}`}
+			aria-label={`Info sur ${rule.title}`}
 			{...props}
 		>
 			<Markdown>{rule.rawNode.description}</Markdown>

--- a/site/source/components/conversation/MulipleChoicesInput.tsx
+++ b/site/source/components/conversation/MulipleChoicesInput.tsx
@@ -65,7 +65,7 @@ function CheckBoxRule({ node, engine, onChange }: CheckBoxRuleProps) {
 			<ExplicableRule
 				light
 				dottedName={node.dottedName as DottedName}
-				aria-label={t("Plus d'informations sur {{ title }}", {
+				aria-label={t('Info sur {{ title }}', {
 					title: node.title,
 				})}
 			/>

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -112,6 +112,7 @@ Impôt: Tax
 Impôt au barème: Tax scale
 Impôt sur le revenu: Income tax
 Impôts: Taxes
+Info sur {{ title }}: Info on {{ title }}
 Insérer dans le champ la valeur du {{text}}: Insert the value of the {{text}}
 Intégrer le module Web: Integrating the Web module
 Intégrer nos simulateurs: Integrate our simulators
@@ -170,7 +171,6 @@ Passer: Pass
 Passer, passer la question sans répondre: Pass, pass the question without answering
 Personnalisez l'intégration: Customize integration
 Plan du site: Site map
-Plus d'informations sur {{ title }}: More information on {{ title }}
 Plus de 50 salariés: More than 50 employees
 Pour en savoir plus, rendez-vous sur le site <2>aquoiserventlescotisations:
   urssaf:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -117,6 +117,7 @@ Impôt: Impôt
 Impôt au barème: Impôt au barème
 Impôt sur le revenu: Impôt sur le revenu
 Impôts: Impôts
+Info sur {{ title }}: Info sur {{ title }}
 Insérer dans le champ la valeur du {{text}}: Insérer dans le champ la valeur du {{text}}
 Intégrer le module Web: Intégrer le module Web
 Intégrer nos simulateurs: Intégrer nos simulateurs
@@ -178,7 +179,6 @@ Passer: Passer
 Passer, passer la question sans répondre: Passer, passer la question sans répondre
 Personnalisez l'intégration: Personnalisez l'intégration
 Plan du site: Plan du site
-Plus d'informations sur {{ title }}: Plus d'informations sur {{ title }}
 Plus de 50 salariés: Plus de 50 salariés
 Pour en savoir plus, rendez-vous sur le site <2>aquoiserventlescotisations:
   urssaf:


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur de revenus pour salarié :

> Les aria-label des boutons "Info" ne reprennent pas le contenu visible

![image](https://github.com/user-attachments/assets/f67789e5-6887-4894-bdd6-6f25d29e3b93)