### PR TITLE
A11y/EntrepriseSelection disclosure follows ARIA APG pattern

### DIFF
--- a/site/source/components/Simulation/EntrepriseSelection.tsx
+++ b/site/source/components/Simulation/EntrepriseSelection.tsx
@@ -41,8 +41,13 @@ export default function EntrepriseSelection() {
 
 					<LectureGuide />
 
-					<Grid item onClick={() => setSearchVisible(!isSearchVisible)}>
-						<ValueBody>
+					<Grid item>
+						<DisclosureButton
+							as="button"
+							onClick={() => setSearchVisible(!isSearchVisible)}
+							aria-expanded={isSearchVisible}
+							aria-controls="entreprise-search-panel"
+						>
 							{companySIREN ? (
 								<>
 									<Value expression="entreprise . nom" linkToRule={false} />
@@ -51,7 +56,6 @@ export default function EntrepriseSelection() {
 							) : (
 								<>
 									<span
-										role="button"
 										aria-label={t(
 											"Rechercher, afficher le champ de recherche d'entreprise."
 										)}
@@ -61,16 +65,18 @@ export default function EntrepriseSelection() {
 									<SearchIcon aria-hidden />
 								</>
 							)}
-						</ValueBody>
+						</DisclosureButton>
 					</Grid>
 				</Grid>
 				<WrongSimulateurWarning />
 			</EntrepriseRecap>
-			{isSearchVisible && (
-				<Appear>
-					<EntrepriseInput onSubmit={() => setSearchVisible(false)} />
-				</Appear>
-			)}
+			<div aria-controls="entreprise-search-panel">
+				{isSearchVisible && (
+					<Appear>
+						<EntrepriseInput onSubmit={() => setSearchVisible(false)} />
+					</Appear>
+				)}
+			</div>
 		</Container>
 	)
 }
@@ -131,8 +137,7 @@ const TitleBody = styled(Body)`
 	font-weight: bold;
 `
 
-const ValueBody = styled(Body)`
-	cursor: pointer;
+const DisclosureButton = styled(Body)`
 	color: ${({ theme }) =>
 		theme.darkMode
 			? theme.colors.extended.grey[100]
@@ -140,6 +145,9 @@ const ValueBody = styled(Body)`
 	display: flex;
 	align-items: center;
 	gap: ${({ theme }) => theme.spacings.xs};
+	border: none;
+	background: transparent;
+	cursor: pointer;
 `
 
 const IconStyle = css`

--- a/site/source/components/Simulation/EntrepriseSelection.tsx
+++ b/site/source/components/Simulation/EntrepriseSelection.tsx
@@ -22,7 +22,7 @@ const { Body } = typography
 export default function EntrepriseSelection() {
 	const { t } = useTranslation()
 	const companySIREN = useEngine().evaluate('entreprise . SIREN').nodeValue
-	const [isSearchVisible, setSearchVisible] = useState(false)
+	const [isSearchVisible, setIsSearchVisible] = useState(false)
 
 	return (
 		<Container>
@@ -44,7 +44,7 @@ export default function EntrepriseSelection() {
 					<Grid item>
 						<DisclosureButton
 							as="button"
-							onClick={() => setSearchVisible(!isSearchVisible)}
+							onClick={() => setIsSearchVisible(!isSearchVisible)}
 							aria-expanded={isSearchVisible}
 							aria-controls="entreprise-search-panel"
 						>
@@ -73,7 +73,7 @@ export default function EntrepriseSelection() {
 			<div aria-controls="entreprise-search-panel">
 				{isSearchVisible && (
 					<Appear>
-						<EntrepriseInput onSubmit={() => setSearchVisible(false)} />
+						<EntrepriseInput onSubmit={() => setIsSearchVisible(false)} />
 					</Appear>
 				)}
 			</div>


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur de revenus pour salarié :

> Le composant qui permet d'afficher le champ de recherche ne respecte pas le motif de conception disclosure

![image](https://github.com/user-attachments/assets/2862afbf-01d0-4568-b2d6-6d470659326d)