### PR TITLE
A11y/More relevant aria-label for "modifier mes responses" dialog

### DIFF
--- a/site/source/components/conversation/SeeAnswersButton.tsx
+++ b/site/source/components/conversation/SeeAnswersButton.tsx
@@ -30,6 +30,7 @@ export default function SeeAnswersButton({
 						)}
 					</StyledButton>
 				)}
+				ariaLabel="Modifier mes réponses"
 			>
 				{(close) => <Answers onClose={close}>{children}</Answers>}
 			</PopoverWithTrigger>

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -105,7 +105,7 @@ export function Popover(
 											}
 										}}
 										ref={ref}
-										aria-label={title || ariaLabel}
+										aria-label={ariaLabel || title}
 										data-cy="modal"
 										aria-modal={true}
 									>

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -10,7 +10,6 @@ import {
 import { AriaDialogProps } from '@react-types/dialog'
 import FocusTrap from 'focus-trap-react'
 import React, { RefObject, useRef } from 'react'
-import { useTranslation } from 'react-i18next'
 import { css, keyframes, styled } from 'styled-components'
 
 import { FromBottom } from '@/components/ui/animate'
@@ -26,6 +25,7 @@ export function Popover(
 		AriaDialogProps & {
 			children: React.ReactNode
 			title?: string
+			ariaLabel?: string
 			small?: boolean
 			contentRef?: RefObject<HTMLDivElement>
 			onClose?: () => void
@@ -34,9 +34,7 @@ export function Popover(
 			disableOverflowAuto?: boolean
 		}
 ) {
-	const { title, children, small, contentRef } = props
-
-	const { t } = useTranslation()
+	const { title, ariaLabel, children, small, contentRef } = props
 
 	// Handle interacting outside the dialog and pressing
 	// the Escape key to close the modal.
@@ -107,7 +105,7 @@ export function Popover(
 											}
 										}}
 										ref={ref}
-										aria-label={title || t('Boite de dialogue')}
+										aria-label={title || ariaLabel}
 										data-cy="modal"
 										aria-modal={true}
 									>

--- a/site/source/design-system/popover/PopoverWithTrigger.tsx
+++ b/site/source/design-system/popover/PopoverWithTrigger.tsx
@@ -21,6 +21,7 @@ export type PopoverWithTriggerProps = {
 	) => ReactElement<typeof Button> | ReactElement<typeof Link>
 	children: React.ReactNode | ((close: () => void) => React.ReactNode)
 	title?: string
+	ariaLabel?: string
 	small?: boolean
 	contentRef?: RefObject<HTMLDivElement>
 	disableOverflowAuto?: boolean
@@ -29,6 +30,7 @@ export type PopoverWithTriggerProps = {
 export function PopoverWithTrigger({
 	children,
 	title,
+	ariaLabel,
 	trigger,
 	small,
 	contentRef,
@@ -68,6 +70,7 @@ export function PopoverWithTrigger({
 						{...overlayProps}
 						disableOverflowAuto={disableOverflowAuto}
 						title={title}
+						ariaLabel={ariaLabel}
 						onClose={() => {
 							state.close()
 						}}


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur de revenus pour salarié :

> L'aria-label de la modale "Modifier mes réponses" n'est pas pertinent il indique "Boite de dialogue"

![image](https://github.com/user-attachments/assets/edf574dd-b5de-4e86-80b4-9ded8c45c9be)