### PR TITLE
A11y/Progress in form steps is no more aria-hidden

### DIFF
--- a/site/source/components/ui/Progress.tsx
+++ b/site/source/components/ui/Progress.tsx
@@ -29,18 +29,13 @@ export default function Progress({
 	const total = Math.min(progress, maxValue).toString()
 
 	return (
-		<div
-			aria-live="polite"
-			style={{
-				position: 'relative',
-			}}
-		>
+		<div style={{ position: 'relative' }}>
 			<ProgressContainer {...progressBarProps}>
 				<ProgressBar
 					style={{ width: `${(progress * 100) / (maxValue || 1)}%` }}
 				/>
 			</ProgressContainer>
-			<StyledBody {...labelProps} aria-hidden>
+			<StyledBody {...labelProps}>
 				{t('Étape {{ total }} sur {{ maxValue }}', { total, maxValue })}
 			</StyledBody>
 		</div>


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur de revenus pour salarié :

> L'information du changement d'étape n'est pas vocalisé (contenu en aria-hidden)

![image](https://github.com/user-attachments/assets/957d9429-c42b-4d94-a156-ba95d2c46352)