### PR TITLE
A11Y/Add a fallback to always have a for-id link in radio button

### DIFF
--- a/site/source/design-system/field/Radio/Radio.tsx
+++ b/site/source/design-system/field/Radio/Radio.tsx
@@ -29,7 +29,7 @@ export function Radio(props: RadioProps) {
 
 export const RadioSkeleton = (props: RadioProps) => {
 	const { visibleRadioAs, id, ...ariaProps } = props
-	const { children } = ariaProps
+	const { children, value } = ariaProps
 	const state = useContext(RadioContext)
 	if (!state) {
 		throw new Error("Radio can't be instanciated outside a RadioContext")
@@ -39,7 +39,7 @@ export const RadioSkeleton = (props: RadioProps) => {
 	const { inputProps } = useRadio(ariaProps, state, ref)
 
 	return (
-		<Label htmlFor={id} className={props.className}>
+		<Label htmlFor={id || `input-radio-${value}`} className={props.className}>
 			<InputRadio
 				{...inputProps}
 				// Avoid react-aria focus next element (input, button, etc.) on keydown for rgaa
@@ -48,7 +48,7 @@ export const RadioSkeleton = (props: RadioProps) => {
 				tabIndex={undefined}
 				className="sr-only"
 				ref={ref}
-				id={id}
+				id={id || `input-radio-${value}`}
 			/>
 			<VisibleRadio as={visibleRadioAs} $inert={props.isDisabled}>
 				{children}


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur de revenus pour salarié :

> Absence de liaison for/id pour les boutons radio du groupe "Mode d'affichage" (simulateur salarié)

![image](https://github.com/user-attachments/assets/76884f26-fa22-45a5-9de0-4e0ff791967c)

Elle règle également ce problème sur d'autres pages utilisant des boutons radio (choix du statut, statistiques, ...).

Closes https://github.com/betagouv/mon-entreprise/issues/3674
Closes https://github.com/betagouv/mon-entreprise/issues/3668