### PR TITLE
[CMG] Navigation

### DIFF
--- a/site/source/contextes/cmg/domaine/situation.ts
+++ b/site/source/contextes/cmg/domaine/situation.ts
@@ -36,10 +36,7 @@ export interface SituationCMGValide extends SituationCMG {
 export const estSituationCMGValide = (
 	situation: SituationCMG
 ): situation is SituationCMGValide =>
-	O.isSome(situation.aPerçuCMG) &&
-	O.isSome(situation.plusDe2MoisDeDéclaration) &&
-	O.isSome(situation.parentIsolé) &&
-	O.isSome(situation.ressources) &&
+	estInformationsValides(situation) &&
 	estEnfantsÀChargeValide(situation.enfantsÀCharge) &&
 	estModesDeGardeValide(situation.modesDeGarde)
 
@@ -59,6 +56,12 @@ export const initialSituationCMG: SituationCMG = {
 		AMA: [],
 	},
 }
+
+export const estInformationsValides = (situation: SituationCMG): boolean =>
+	O.isSome(situation.aPerçuCMG) &&
+	O.isSome(situation.plusDe2MoisDeDéclaration) &&
+	O.isSome(situation.parentIsolé) &&
+	O.isSome(situation.ressources)
 
 export const estModesDeGardeValide = (
 	modesDeGarde: SituationCMG['modesDeGarde']

--- a/site/source/contextes/cmg/index.ts
+++ b/site/source/contextes/cmg/index.ts
@@ -8,4 +8,7 @@ export type {
 	DéclarationDeGardeGED,
 } from './domaine/déclaration-de-garde'
 export type { RaisonInéligibilité } from './domaine/éligibilité'
-export { estModesDeGardeValide } from './domaine/situation'
+export {
+	estInformationsValides,
+	estModesDeGardeValide,
+} from './domaine/situation'

--- a/site/source/pages/assistants/cmg/pages/Déclarations.tsx
+++ b/site/source/pages/assistants/cmg/pages/Déclarations.tsx
@@ -1,5 +1,9 @@
+import { useNavigate } from 'react-router-dom'
+
 import { TrackPage } from '@/components/ATInternetTracking'
 import {
+	estEnfantsÀChargeValide,
+	estInformationsValides,
 	estModesDeGardeValide,
 	RaisonInéligibilité,
 	useCMG,
@@ -8,24 +12,31 @@ import {
 import AMA from '../components/AMA/AMA'
 import GED from '../components/GED/GED'
 import Navigation from '../components/Navigation'
-import NonÉligible from './NonÉligible'
 
 export default function Déclarations() {
+	const navigate = useNavigate()
 	const { raisonsInéligibilité, situation } = useCMG()
+
+	if (
+		!estInformationsValides(situation) ||
+		!estEnfantsÀChargeValide(situation.enfantsÀCharge)
+	) {
+		navigate('/assistants/cmg')
+	}
+
 	const raisonsInéligibilitéValables: Array<RaisonInéligibilité> = [
 		'ressources',
 		'enfants-à-charge',
 	]
-
-	const isSuivantDisabled = !estModesDeGardeValide(situation.modesDeGarde)
-
 	if (
 		raisonsInéligibilitéValables.some((raison) =>
 			raisonsInéligibilité.includes(raison)
 		)
 	) {
-		return <NonÉligible précédent="enfants" />
+		navigate('/assistants/cmg/inéligible', { state: { précédent: 'enfants' } })
 	}
+
+	const isSuivantDisabled = !estModesDeGardeValide(situation.modesDeGarde)
 
 	return (
 		<>

--- a/site/source/pages/assistants/cmg/pages/Enfants.tsx
+++ b/site/source/pages/assistants/cmg/pages/Enfants.tsx
@@ -1,11 +1,13 @@
 import * as A from 'effect/Array'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 
 import { TrackPage } from '@/components/ATInternetTracking'
 import {
 	Enfant,
 	estEnfantsÀChargeValide,
+	estInformationsValides,
 	RaisonInéligibilité,
 	useCMG,
 } from '@/contextes/cmg'
@@ -15,15 +17,29 @@ import EnfantInput from '../components/enfants/EnfantInput'
 import QuestionsAeeH from '../components/enfants/QuestionsAeeH'
 import Navigation from '../components/Navigation'
 import { Question } from '../components/styled-components'
-import NonÉligible from './NonÉligible'
 
 export default function Enfants() {
+	const navigate = useNavigate()
 	const { t } = useTranslation()
 	const { raisonsInéligibilité, situation, enfants, set } = useCMG()
+
+	if (!estInformationsValides(situation)) {
+		navigate('/assistants/cmg')
+	}
+
 	const raisonsInéligibilitéValables: Array<RaisonInéligibilité> = [
 		'CMG-perçu',
 		'déclarations',
 	]
+	if (
+		raisonsInéligibilitéValables.some((raison) =>
+			raisonsInéligibilité.includes(raison)
+		)
+	) {
+		navigate('/assistants/cmg/inéligible', {
+			state: { précédent: 'informations' },
+		})
+	}
 
 	useEffect(() => {
 		if (!enfants.length) {
@@ -40,16 +56,7 @@ export default function Enfants() {
 	}
 
 	const isAddButtonDisabled = enfants.length > 18
-
 	const isSuivantDisabled = !estEnfantsÀChargeValide(situation.enfantsÀCharge)
-
-	if (
-		raisonsInéligibilitéValables.some((raison) =>
-			raisonsInéligibilité.includes(raison)
-		)
-	) {
-		return <NonÉligible précédent="informations" />
-	}
 
 	return (
 		<>

--- a/site/source/pages/assistants/cmg/pages/InformationsGénérales.tsx
+++ b/site/source/pages/assistants/cmg/pages/InformationsGénérales.tsx
@@ -1,7 +1,5 @@
-import * as O from 'effect/Option'
-
 import { TrackPage } from '@/components/ATInternetTracking'
-import { useCMG } from '@/contextes/cmg'
+import { estInformationsValides, useCMG } from '@/contextes/cmg'
 
 import QuestionCMGPerçu from '../components/informations-générales/QuestionCMGPerçu'
 import QuestionNombreMoisDéclarationsSuffisant from '../components/informations-générales/QuestionNombreMoisDéclarationsSuffisant'
@@ -11,11 +9,7 @@ import Navigation from '../components/Navigation'
 
 export default function InformationsGénérales() {
 	const { situation } = useCMG()
-	const isSuivantDisabled =
-		O.isNone(situation.aPerçuCMG) ||
-		O.isNone(situation.plusDe2MoisDeDéclaration) ||
-		O.isNone(situation.parentIsolé) ||
-		O.isNone(situation.ressources)
+	const isSuivantDisabled = !estInformationsValides(situation)
 
 	return (
 		<>

--- a/site/source/pages/assistants/cmg/pages/NonÉligible.tsx
+++ b/site/source/pages/assistants/cmg/pages/NonÉligible.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { TrackPage } from '@/components/ATInternetTracking'
 import { useCMG } from '@/contextes/cmg'
@@ -12,11 +13,13 @@ type Props = {
 }
 
 export default function NonÉligible({ précédent }: Props) {
+	const navigate = useNavigate()
+	const location = useLocation()
 	const { raisonsInéligibilité, getRaisonsInéligibilitéHumaines } = useCMG()
 	const { t } = useTranslation()
 
 	if (!raisonsInéligibilité.length) {
-		return
+		navigate('/assistants/cmg')
 	}
 
 	return (
@@ -42,7 +45,9 @@ export default function NonÉligible({ précédent }: Props) {
 				)}
 			</Ul>
 
-			<Navigation précédent={précédent} />
+			<Navigation
+				précédent={précédent || (location.state as Props).précédent}
+			/>
 		</>
 	)
 }

--- a/site/source/pages/assistants/cmg/pages/Résultat.tsx
+++ b/site/source/pages/assistants/cmg/pages/Résultat.tsx
@@ -1,5 +1,6 @@
 import * as O from 'effect/Option'
 import { Trans } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 
 import { TrackPage } from '@/components/ATInternetTracking'
 import { useCMG } from '@/contextes/cmg'
@@ -7,13 +8,17 @@ import { Body, Message, SmallBody, Strong } from '@/design-system'
 import { toString as formatMontant } from '@/domaine/Montant'
 
 import Navigation from '../components/Navigation'
-import NonÉligible from './NonÉligible'
 
 export default function Résultat() {
+	const navigate = useNavigate()
 	const { montantCT } = useCMG()
 
 	if (!O.isSome(montantCT) || !montantCT.value) {
-		return <NonÉligible précédent="déclarations" />
+		navigate('/assistants/cmg/inéligible', {
+			state: { précédent: 'déclarations' },
+		})
+
+		return
 	}
 
 	const amount = formatMontant(montantCT.value)


### PR DESCRIPTION
- Redirige vers l'accueil de l'assistant en cas d'arrivée en milieu d'assistant (i.e. si j'arrive sur la page `/cmg/enfants` sans être passée par les pages précédentes, je suis redirigée sur `/cmg`)
- Redirection vers la page `/inéligible` plutôt qu'affichage du composant `<NonEligible>` sur `/enfants`