### PR TITLE
Propose une nouvelle façon d'afficher les simulateurs

### DIFF
--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -5,7 +5,7 @@ import * as O from 'effect/Option'
 import * as R from 'effect/Record'
 import { DottedName } from 'modele-social'
 import { useCallback } from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { Trans } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { styled } from 'styled-components'
 
@@ -48,7 +48,6 @@ export default function ChiffreAffairesActivitéMixte({
 }) {
 	const adjustProportions = useAdjustProportions(dottedName)
 	const dispatch = useDispatch()
-	const { t } = useTranslation()
 	const clearChiffreAffaireMixte = useCallback(() => {
 		dispatch(
 			batchUpdateSituation(
@@ -62,7 +61,6 @@ export default function ChiffreAffairesActivitéMixte({
 
 	return (
 		<fieldset>
-			<legend className="sr-only">{t("Chiffre d'affaires")}</legend>
 			<SimulationGoal
 				appear={false}
 				onUpdateSituation={clearChiffreAffaireMixte}
@@ -189,10 +187,8 @@ const StyledActivitéMixteContainer = styled.div`
 
 	@media (min-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		text-align: right;
-		margin-top: -1.5rem;
+		// margin-top: -1.5rem;
 		position: relative;
 		z-index: 2;
-		display: flex;
-		align-items: center;
 	}
 `

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -5,7 +5,7 @@ import * as O from 'effect/Option'
 import * as R from 'effect/Record'
 import { DottedName } from 'modele-social'
 import { useCallback } from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { styled } from 'styled-components'
 
@@ -46,6 +46,7 @@ export default function ChiffreAffairesActivitéMixte({
 }: {
 	dottedName: DottedName
 }) {
+	const { t } = useTranslation()
 	const adjustProportions = useAdjustProportions(dottedName)
 	const dispatch = useDispatch()
 	const clearChiffreAffaireMixte = useCallback(() => {
@@ -61,6 +62,7 @@ export default function ChiffreAffairesActivitéMixte({
 
 	return (
 		<fieldset>
+			<legend className="sr-only">{t("Chiffre d'affaires")}</legend>
 			<SimulationGoal
 				appear={false}
 				onUpdateSituation={clearChiffreAffaireMixte}
@@ -202,5 +204,9 @@ const ConditionWrapper = styled.div`
 		& > div > div > div > div {
 			margin-top: 0.75rem;
 		}
+	}
+
+	a {
+		font-size: 1rem;
 	}
 `

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -69,16 +69,18 @@ export default function ChiffreAffairesActivitéMixte({
 			<WhenApplicable dottedName="entreprise . activités . revenus mixtes">
 				<FromTop>
 					<ActivitéMixte />
-					<Condition expression="entreprise . activités . revenus mixtes">
-						{Object.values(proportions).map((chiffreAffaires) => (
-							<SimulationGoal
-								small
-								key={chiffreAffaires}
-								onUpdateSituation={adjustProportions}
-								dottedName={chiffreAffaires}
-							/>
-						))}
-					</Condition>
+					<ConditionWrapper>
+						<Condition expression="entreprise . activités . revenus mixtes">
+							{Object.values(proportions).map((chiffreAffaires) => (
+								<SimulationGoal
+									small
+									key={chiffreAffaires}
+									onUpdateSituation={adjustProportions}
+									dottedName={chiffreAffaires}
+								/>
+							))}
+						</Condition>
+					</ConditionWrapper>
 				</FromTop>
 			</WhenApplicable>
 		</fieldset>
@@ -190,5 +192,16 @@ const StyledActivitéMixteContainer = styled.div`
 		// margin-top: -1.5rem;
 		position: relative;
 		z-index: 2;
+	}
+`
+const ConditionWrapper = styled.div`
+	margin-top: 0.75rem;
+
+	& > div {
+		height: auto !important;
+
+		& > div > div > div > div {
+			margin-top: 0.75rem;
+		}
 	}
 `

--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -189,7 +189,6 @@ const StyledActivitéMixteContainer = styled.div`
 
 	@media (min-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		text-align: right;
-		// margin-top: -1.5rem;
 		position: relative;
 		z-index: 2;
 	}

--- a/site/source/components/RéductionDeCotisations/RéductionBasique.tsx
+++ b/site/source/components/RéductionDeCotisations/RéductionBasique.tsx
@@ -9,7 +9,7 @@ import Répartition from '@/components/RéductionDeCotisations/Répartition'
 import { SimulationGoal } from '@/components/Simulation'
 import { SimulationValue } from '@/components/Simulation/SimulationValue'
 import { useEngine } from '@/components/utils/EngineContext'
-import { Body, Message, SmallBody, Spacing } from '@/design-system'
+import { Intro, Message, Spacing } from '@/design-system'
 import { targetUnitSelector } from '@/store/selectors/simulationSelectors'
 import {
 	getRépartitionBasique,
@@ -54,7 +54,7 @@ export default function RéductionBasique({
 			<ReductionBasiqueConditionWrapper>
 				<Condition expression={warningCondition}>
 					<Message type="info">
-						<Body>{warningMessage}</Body>
+						<Intro>{warningMessage}</Intro>
 					</Message>
 				</Condition>
 			</ReductionBasiqueConditionWrapper>
@@ -77,11 +77,7 @@ export default function RéductionBasique({
 }
 
 const ReductionBasiqueConditionWrapper = styled.div`
-	a,
-	${Body} {
-		font-size: 1.125rem;
-	}
-	${SmallBody} {
-		font-size: 1rem;
+	a {
+		font-size: ${({ theme }) => theme.fontSizes.lg};
 	}
 `

--- a/site/source/components/RéductionDeCotisations/RéductionBasique.tsx
+++ b/site/source/components/RéductionDeCotisations/RéductionBasique.tsx
@@ -2,13 +2,14 @@ import { PublicodesExpression } from 'publicodes'
 import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+import styled from 'styled-components'
 
 import { Condition } from '@/components/EngineValue/Condition'
 import Répartition from '@/components/RéductionDeCotisations/Répartition'
 import { SimulationGoal } from '@/components/Simulation'
 import { SimulationValue } from '@/components/Simulation/SimulationValue'
 import { useEngine } from '@/components/utils/EngineContext'
-import { Body, Message, Spacing } from '@/design-system'
+import { Body, Message, SmallBody, Spacing } from '@/design-system'
 import { targetUnitSelector } from '@/store/selectors/simulationSelectors'
 import {
 	getRépartitionBasique,
@@ -50,24 +51,37 @@ export default function RéductionBasique({
 			/>
 
 			{warnings}
+			<ReductionBasiqueConditionWrapper>
+				<Condition expression={warningCondition}>
+					<Message type="info">
+						<Body>{warningMessage}</Body>
+					</Message>
+				</Condition>
+			</ReductionBasiqueConditionWrapper>
 
-			<Condition expression={warningCondition}>
-				<Message type="info">
-					<Body>{warningMessage}</Body>
-				</Message>
-			</Condition>
-
-			<Condition expression={`${dottedName} >= 0`}>
-				<SimulationValue
-					dottedName={dottedName}
-					isInfoMode={true}
-					round={false}
-				/>
-				<Spacing md />
-				{répartition && (
-					<Répartition dottedName={dottedName} répartition={répartition} />
-				)}
-			</Condition>
+			<ReductionBasiqueConditionWrapper>
+				<Condition expression={`${dottedName} >= 0`}>
+					<SimulationValue
+						dottedName={dottedName}
+						isInfoMode={true}
+						round={false}
+					/>
+					<Spacing md />
+					{répartition && (
+						<Répartition dottedName={dottedName} répartition={répartition} />
+					)}
+				</Condition>
+			</ReductionBasiqueConditionWrapper>
 		</>
 	)
 }
+
+const ReductionBasiqueConditionWrapper = styled.div`
+	a,
+	${Body} {
+		font-size: 1.125rem;
+	}
+	${SmallBody} {
+		font-size: 1rem;
+	}
+`

--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -7,7 +7,6 @@ import { Grid, TitreObjectif, typography } from '@/design-system'
 import { toString as formatMontant, Montant } from '@/domaine/Montant'
 import { useInitialRender } from '@/hooks/useInitialRender'
 
-import LectureGuide from '../LectureGuide'
 import { Appear } from '../ui/animate'
 import AnimatedTargetValue from '../ui/AnimatedTargetValue'
 
@@ -50,7 +49,7 @@ export function ObjectifDeSimulation({
 	return (
 		<Appear unless={!appear || initialRender}>
 			<StyledGoal $small={small}>
-				<Grid
+				<GridCentered
 					container
 					style={{
 						alignItems: 'baseline',
@@ -82,18 +81,28 @@ export function ObjectifDeSimulation({
 							<StyledSmallBody>{messageComplementaire}</StyledSmallBody>
 						)}
 					</Grid>
-					<LectureGuide />
 					<Grid item>
 						{!small && typeof valeur !== 'string' && Option.isSome(valeur) && (
 							<AnimatedTargetValue value={valeur.value} />
 						)}
 						<StyledValue id={`${id}-value`}>{valeurAffichee}</StyledValue>
 					</Grid>
-				</Grid>
+				</GridCentered>
 			</StyledGoal>
 		</Appear>
 	)
 }
+
+const GridCentered = styled(Grid)`
+	display: grid;
+	grid-template-columns: 1.25fr 1fr;
+	gap: 1rem;
+
+	& > div:first-of-type {
+		max-width: 100%;
+		text-align: right;
+	}
+`
 
 const StyledGoal = styled.div<{ $small: boolean }>`
 	position: relative;

--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -10,7 +10,7 @@ import { useInitialRender } from '@/hooks/useInitialRender'
 import { Appear } from '../ui/animate'
 import AnimatedTargetValue from '../ui/AnimatedTargetValue'
 
-const { Body, SmallBody } = typography
+const { Body } = typography
 
 export type ObjectifDeSimulationProps = {
 	id: string
@@ -69,16 +69,16 @@ export function ObjectifDeSimulation({
 						)}
 
 						{description && (
-							<StyledSmallBody
+							<StyledBody
 								className={small ? 'sr-only' : ''}
 								id={`${id}-description`}
 							>
 								{description}
-							</StyledSmallBody>
+							</StyledBody>
 						)}
 
 						{messageComplementaire && (
-							<StyledSmallBody>{messageComplementaire}</StyledSmallBody>
+							<StyledBody>{messageComplementaire}</StyledBody>
 						)}
 					</Grid>
 					<Grid item>
@@ -96,7 +96,7 @@ export function ObjectifDeSimulation({
 const GridCentered = styled(Grid)`
 	display: grid;
 	grid-template-columns: 1.25fr 1fr;
-	gap: 1rem;
+	gap: ${({ theme }) => theme.spacings.md};
 
 	& > div:first-of-type {
 		max-width: 100%;
@@ -114,9 +114,8 @@ const StyledGoal = styled.div<{ $small: boolean }>`
 	}
 `
 
-const StyledSmallBody = styled(SmallBody)`
+const StyledBody = styled(Body)`
 	margin-bottom: 0;
-	font-size: 1rem;
 `
 
 const StyledValue = styled(Body)`

--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -107,6 +107,7 @@ const StyledGoal = styled.div<{ $small: boolean }>`
 
 const StyledSmallBody = styled(SmallBody)`
 	margin-bottom: 0;
+	font-size: 1rem;
 `
 
 const StyledValue = styled(Body)`

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -65,9 +65,9 @@ export function ObjectifSaisissableDeSimulation({
 						</TitreObjectifSaisissable>
 
 						{explication && (
-							<ForceThemeProvider forceTheme="default">
+							<BiggerForceThemeProvider forceTheme="default">
 								{explication}
-							</ForceThemeProvider>
+							</BiggerForceThemeProvider>
 						)}
 
 						{description && (
@@ -83,9 +83,13 @@ export function ObjectifSaisissableDeSimulation({
 						{!isFocused && !small && montantAnimation !== undefined && (
 							<AnimatedTargetValue value={montantAnimation} />
 						)}
-						<div onFocus={handleFocus} onBlur={handleBlur} role="presentation">
+						<LargeInputContainer
+							onFocus={handleFocus}
+							onBlur={handleBlur}
+							role="presentation"
+						>
 							{rendreChampSaisie()}
-						</div>
+						</LargeInputContainer>
 					</Grid>
 				</GridCentered>
 			</StyledGoal>
@@ -95,9 +99,9 @@ export function ObjectifSaisissableDeSimulation({
 
 const GridCentered = styled(Grid)`
 	display: grid;
-	grid-template-columns: 1.5fr 1fr;
+	grid-template-columns: 1.25fr 1fr;
 	gap: 1rem;
-	max-width: 50%;
+	max-width: 75%;
 	margin: 0 auto;
 
 	& > div {
@@ -155,4 +159,16 @@ const StyledGoal = styled.div<{ $small: boolean }>`
 
 const StyledSmallBody = styled(SmallBody)`
 	margin-bottom: 0;
+	font-size: 1rem;
+`
+
+const BiggerForceThemeProvider = styled(ForceThemeProvider)`
+	font-size: 1rem;
+`
+
+const LargeInputContainer = styled.div`
+	input {
+		font-size: 1.125rem;
+		line-height: 1.5;
+	}
 `

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { styled } from 'styled-components'
 
 import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
-import { Grid, SmallBody, TitreObjectifSaisissable } from '@/design-system'
+import { Body, Grid, TitreObjectifSaisissable } from '@/design-system'
 import { Montant } from '@/domaine/Montant'
 import { useInitialRender } from '@/hooks/useInitialRender'
 
@@ -71,12 +71,12 @@ export function ObjectifSaisissableDeSimulation({
 						)}
 
 						{description && (
-							<StyledSmallBody
+							<StyledBody
 								className={small ? 'sr-only' : ''}
 								id={`${id}-description`}
 							>
 								{description}
-							</StyledSmallBody>
+							</StyledBody>
 						)}
 					</Grid>
 					<Grid item>
@@ -100,7 +100,7 @@ export function ObjectifSaisissableDeSimulation({
 const GridCentered = styled(Grid)`
 	display: grid;
 	grid-template-columns: 1.25fr 1fr;
-	gap: 1rem;
+	gap: ${({ theme }) => theme.spacings.md};
 
 	& > div {
 		padding: 0;
@@ -129,7 +129,7 @@ const GridCentered = styled(Grid)`
 
 	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		grid-template-columns: 1fr;
-		gap: 0.5rem;
+		gap: ${({ theme }) => theme.spacings.xs};
 
 		& > div {
 			text-align: left;
@@ -147,9 +147,8 @@ const StyledGoal = styled.div<{ $small: boolean }>`
 	}
 `
 
-const StyledSmallBody = styled(SmallBody)`
+const StyledBody = styled(Body)`
 	margin-bottom: 0;
-	font-size: 1rem;
 `
 
 const BiggerForceThemeProvider = styled(ForceThemeProvider)`
@@ -158,7 +157,7 @@ const BiggerForceThemeProvider = styled(ForceThemeProvider)`
 
 const LargeInputContainer = styled.div`
 	input {
-		font-size: 1.125rem;
+		font-size: ${({ theme }) => theme.fontSizes.lg};
 		line-height: 1.5;
 	}
 `

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -59,7 +59,7 @@ export function ObjectifSaisissableDeSimulation({
 						<TitreObjectifSaisissable
 							id={`${id}-label`}
 							htmlFor={`${id}-input`}
-							noWrap={true}
+							noWrap={false}
 						>
 							{titre}
 						</TitreObjectifSaisissable>
@@ -101,8 +101,6 @@ const GridCentered = styled(Grid)`
 	display: grid;
 	grid-template-columns: 1.25fr 1fr;
 	gap: 1rem;
-	max-width: 75%;
-	margin: 0 auto;
 
 	& > div {
 		padding: 0;
@@ -129,17 +127,8 @@ const GridCentered = styled(Grid)`
 		margin-top: 0;
 	}
 
-	@media (max-width: ${({ theme }) => theme.breakpointsWidth.lg}) {
-		max-width: 75%;
-	}
-
-	@media (max-width: ${({ theme }) => theme.breakpointsWidth.md}) {
-		max-width: 75%;
-	}
-
 	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		grid-template-columns: 1fr;
-		max-width: 100%;
 
 		& > div {
 			text-align: left;

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -129,6 +129,7 @@ const GridCentered = styled(Grid)`
 
 	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		grid-template-columns: 1fr;
+		gap: 0.5rem;
 
 		& > div {
 			text-align: left;

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -7,7 +7,6 @@ import { Grid, SmallBody, TitreObjectifSaisissable } from '@/design-system'
 import { Montant } from '@/domaine/Montant'
 import { useInitialRender } from '@/hooks/useInitialRender'
 
-import LectureGuide from '../LectureGuide'
 import { Appear } from '../ui/animate'
 import AnimatedTargetValue from '../ui/AnimatedTargetValue'
 
@@ -55,15 +54,8 @@ export function ObjectifSaisissableDeSimulation({
 	return (
 		<Appear unless={!appear || initialRender}>
 			<StyledGoal $small={small}>
-				<Grid
-					container
-					style={{
-						alignItems: 'baseline',
-						justifyContent: 'space-between',
-					}}
-					spacing={2}
-				>
-					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
+				<GridCentered container spacing={2}>
+					<Grid item>
 						<TitreObjectifSaisissable
 							id={`${id}-label`}
 							htmlFor={`${id}-input`}
@@ -87,8 +79,7 @@ export function ObjectifSaisissableDeSimulation({
 							</StyledSmallBody>
 						)}
 					</Grid>
-					<LectureGuide />
-					<Grid item md={small ? 2 : 3} sm={small ? 3 : 4} xs={4}>
+					<Grid item>
 						{!isFocused && !small && montantAnimation !== undefined && (
 							<AnimatedTargetValue value={montantAnimation} />
 						)}
@@ -96,11 +87,56 @@ export function ObjectifSaisissableDeSimulation({
 							{rendreChampSaisie()}
 						</div>
 					</Grid>
-				</Grid>
+				</GridCentered>
 			</StyledGoal>
 		</Appear>
 	)
 }
+
+const GridCentered = styled(Grid)`
+	display: grid;
+	grid-template-columns: 1.5fr 1fr;
+	gap: 1rem;
+	max-width: 50%;
+	margin: 0 auto;
+
+	& > div {
+		padding: 0;
+		text-align: right;
+
+		&:nth-child(2) {
+			& [role*='presentation'] > div > div {
+				display: flex;
+				flex-direction: column;
+				gap: 0.5rem;
+
+				p {
+					margin-bottom: 0;
+				}
+
+				span:empty {
+					display: none;
+				}
+			}
+		}
+	}
+
+	p {
+		margin-top: 0;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpointsWidth.lg}) {
+		max-width: 75%;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpointsWidth.md}) {
+		max-width: 75%;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
+		max-width: 100%;
+	}
+`
 
 const StyledGoal = styled.div<{ $small: boolean }>`
 	position: relative;

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -110,7 +110,7 @@ const GridCentered = styled(Grid)`
 			& [role*='presentation'] > div > div {
 				display: flex;
 				flex-direction: column;
-				gap: 0.5rem;
+				gap: ${({ theme }) => theme.spacings.xs};
 
 				p {
 					margin-bottom: 0;

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -134,7 +134,12 @@ const GridCentered = styled(Grid)`
 	}
 
 	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
+		grid-template-columns: 1fr;
 		max-width: 100%;
+
+		& > div {
+			text-align: left;
+		}
 	}
 `
 

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -40,7 +40,7 @@ export function SimulationGoal({
 	round = true,
 	appear = true,
 	editable = true,
-	isTypeBoolean = false, // TODO : remove when type inference works in publicodes
+	isTypeBoolean = false,
 	isInfoMode = false,
 }: SimulationGoalProps) {
 	const dispatch = useDispatch()

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -165,6 +165,8 @@ export function SimulationGoal({
 }
 
 const RuleLinkAccessible = styled(RuleLink)`
+	font-size: 1.125rem;
+
 	&:hover {
 		color: ${({ theme }) => theme.colors.extended.grey[300]};
 	}

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -12,17 +12,11 @@ import { firstStepCompletedSelector } from '@/store/selectors/simulationSelector
 import { LogoWithLink } from '../Logo'
 
 type SimulationGoalsProps = {
-	legend: string
-
 	children: React.ReactNode
 	toggles?: React.ReactNode
 }
 
-export function SimulationGoals({
-	legend,
-	toggles,
-	children,
-}: SimulationGoalsProps) {
+export function SimulationGoals({ toggles, children }: SimulationGoalsProps) {
 	const isFirstStepCompleted = useSelector(firstStepCompletedSelector)
 	const isEmbeded = useIsEmbedded()
 
@@ -38,9 +32,6 @@ export function SimulationGoals({
 					aria-live="polite"
 				>
 					<ForceThemeProvider forceTheme="dark">
-						<div className="sr-only" aria-hidden id="simulator-legend-label">
-							{legend}
-						</div>
 						<Body className="print-hidden" id="simu-update-explaining">
 							<em>
 								<Trans>

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { css, styled } from 'styled-components'
 
 import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
-import { Grid, SmallBody } from '@/design-system'
+import { Body, Grid, SmallBody } from '@/design-system'
 import { WatchInitialRender } from '@/hooks/useInitialRender'
 import { useIsEmbedded } from '@/hooks/useIsEmbedded'
 import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'
@@ -41,7 +41,7 @@ export function SimulationGoals({
 						<div className="sr-only" aria-hidden id="simulator-legend-label">
 							{legend}
 						</div>
-						<SmallBody className="print-hidden" id="simu-update-explaining">
+						<Body className="print-hidden" id="simu-update-explaining">
 							<em>
 								<Trans>
 									Les données de simulations se mettront automatiquement à jour
@@ -54,7 +54,7 @@ export function SimulationGoals({
 									</span>
 								</Trans>
 							</em>
-						</SmallBody>
+						</Body>
 						{children}
 					</ForceThemeProvider>
 				</SimulationGoalsContainer>

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -92,6 +92,14 @@ export const SimulationGoalsContainer = styled.div<{
 	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		border-start-end-radius: ${({ theme }) => theme.box.borderRadius};
 	}
+
+	#simu-update-explaining {
+		text-align: center;
+	}
+
+	& > div:not(.sr-only) {
+		margin-top: 1rem;
+	}
 `
 
 function TopSection({ toggles }: { toggles?: React.ReactNode }) {

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -85,20 +85,29 @@ export const SimulationGoalsContainer = styled.div<{
 	transition: border-radius 0.15s;
 	background: ${({ theme }) => theme.colors.bases.primary[600]};
 
-	@media print {
-		background: initial;
-		padding: 0;
-	}
-	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
-		border-start-end-radius: ${({ theme }) => theme.box.borderRadius};
-	}
-
 	#simu-update-explaining {
 		text-align: center;
 	}
 
 	& > div:not(.sr-only) {
 		margin-top: 1rem;
+	}
+
+	@media print {
+		background: initial;
+		padding: 0;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
+		border-start-end-radius: ${({ theme }) => theme.box.borderRadius};
+
+		#simu-update-explaining {
+			text-align: left;
+		}
+
+		& > div:not(.sr-only) {
+			margin-top: 0.5rem;
+		}
 	}
 `
 

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -81,7 +81,7 @@ export const SimulationGoalsContainer = styled.div<{
 	}
 
 	& > div:not(.sr-only) {
-		margin-top: 1rem;
+		margin-top: ${({ theme }) => theme.spacings.md};
 	}
 
 	& > :is(div, fieldset) {
@@ -106,7 +106,7 @@ export const SimulationGoalsContainer = styled.div<{
 		}
 
 		& > div:not(.sr-only) {
-			margin-top: 0.5rem;
+			margin-top: ${({ theme }) => theme.spacings.xs};
 		}
 	}
 `

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { css, styled } from 'styled-components'
 
 import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
-import { Body, Grid, SmallBody } from '@/design-system'
+import { Body, Grid } from '@/design-system'
 import { WatchInitialRender } from '@/hooks/useInitialRender'
 import { useIsEmbedded } from '@/hooks/useIsEmbedded'
 import { firstStepCompletedSelector } from '@/store/selectors/simulationSelectors'

--- a/site/source/components/Simulation/SimulationGoals.tsx
+++ b/site/source/components/Simulation/SimulationGoals.tsx
@@ -84,6 +84,15 @@ export const SimulationGoalsContainer = styled.div<{
 		margin-top: 1rem;
 	}
 
+	& > :is(div, fieldset) {
+		max-width: 75%;
+		margin-inline: auto;
+
+		@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
+			max-width: 100%;
+		}
+	}
+
 	@media print {
 		background: initial;
 		padding: 0;

--- a/site/source/design-system/suggestions/InputSuggestions.tsx
+++ b/site/source/design-system/suggestions/InputSuggestions.tsx
@@ -79,4 +79,5 @@ export const StyledInputSuggestion = styled(SmallBody)`
 	}
 	gap: ${({ theme }) => theme.spacings.sm};
 	flex-wrap: wrap;
+	font-size: 1rem;
 `

--- a/site/source/design-system/suggestions/InputSuggestions.tsx
+++ b/site/source/design-system/suggestions/InputSuggestions.tsx
@@ -4,7 +4,7 @@ import { styled } from 'styled-components'
 
 import { Spacing } from '../layout'
 import { Link } from '../typography/link'
-import { SmallBody } from '../typography/paragraphs'
+import { Body } from '../typography/paragraphs'
 
 export type InputSuggestionsRecord<T> = Record<string, T>
 
@@ -71,7 +71,7 @@ export function InputSuggestions<T>({
 	)
 }
 
-export const StyledInputSuggestion = styled(SmallBody)`
+export const StyledInputSuggestion = styled(Body)`
 	display: flex;
 	justify-content: flex-end;
 	> * {
@@ -79,5 +79,4 @@ export const StyledInputSuggestion = styled(SmallBody)`
 	}
 	gap: ${({ theme }) => theme.spacings.sm};
 	flex-wrap: wrap;
-	font-size: 1rem;
 `

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -160,7 +160,6 @@ export const baseTheme = {
 
 	fontSizes: {
 		lg: '1.125rem',
-		md: '1rem',
 	},
 
 	box: {

--- a/site/source/design-system/theme.ts
+++ b/site/source/design-system/theme.ts
@@ -158,6 +158,11 @@ export const baseTheme = {
 
 	baseFontSize: '16px',
 
+	fontSizes: {
+		lg: '1.125rem',
+		md: '1rem',
+	},
+
 	box: {
 		borderRadius: '6px',
 		borderWidth: '1px',

--- a/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
+++ b/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
@@ -41,10 +41,7 @@ export default function ArtisteAuteur() {
 						</Body>
 					}
 				/>
-				<SimulationGoals
-					legend="Vos revenus d'artiste auteur"
-					toggles={<PeriodSwitch />}
-				>
+				<SimulationGoals toggles={<PeriodSwitch />}>
 					<SimulationGoal dottedName="artiste-auteur . revenus . traitements et salaires" />
 					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . recettes" />
 					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . frais réels" />

--- a/site/source/pages/simulateurs/auto-entrepreneur/AutoEntrepreneur.tsx
+++ b/site/source/pages/simulateurs/auto-entrepreneur/AutoEntrepreneur.tsx
@@ -53,10 +53,7 @@ export default function AutoEntrepreneur() {
 						</Ul>
 					}
 				/>
-				<SimulationGoals
-					toggles={<PeriodSwitch />}
-					legend="Vos revenus d'auto-entrepreneur"
-				>
+				<SimulationGoals toggles={<PeriodSwitch />}>
 					<ChiffreAffairesActivitéMixte dottedName="dirigeant . auto-entrepreneur . chiffre d'affaires" />
 					<SimulationGoal
 						small

--- a/site/source/pages/simulateurs/cessation-activité/Goals.tsx
+++ b/site/source/pages/simulateurs/cessation-activité/Goals.tsx
@@ -9,10 +9,7 @@ export const CessationActivitéGoals = () => {
 	const { t } = useTranslation()
 
 	return (
-		<SimulationGoals
-			legend="Vos revenus d’activité l’année de cessation"
-			toggles={<CessationActivitéToggles />}
-		>
+		<SimulationGoals toggles={<CessationActivitéToggles />}>
 			<Condition expression="entreprise . imposition = 'IR'">
 				<Condition expression="entreprise . imposition . régime . micro-entreprise = non">
 					<SimulationGoal

--- a/site/source/pages/simulateurs/chômage-partiel/ChômagePartiel.tsx
+++ b/site/source/pages/simulateurs/chômage-partiel/ChômagePartiel.tsx
@@ -65,7 +65,7 @@ export default function ChômagePartiel() {
 					</Ul>
 				}
 			/>
-			<SimulationGoals legend="Salaire brut avant chômage partiel">
+			<SimulationGoals>
 				<SimulationGoal
 					label={t('Salaire brut mensuel')}
 					dottedName="salarié . contrat . salaire brut"

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
@@ -28,10 +28,7 @@ function Comparateur({ namedEngines }: { namedEngines: EngineComparison }) {
 				fullWidth
 				id="simulation-comparateur"
 			>
-				<SimulationGoals
-					toggles={<PeriodSwitch />}
-					legend={'Estimations sur votre rémunération brute et vos charges'}
-				>
+				<SimulationGoals toggles={<PeriodSwitch />}>
 					<SimulationGoal
 						dottedName="entreprise . chiffre d'affaires"
 						isInfoMode

--- a/site/source/pages/simulateurs/cout-creation-entreprise/index.tsx
+++ b/site/source/pages/simulateurs/cout-creation-entreprise/index.tsx
@@ -93,7 +93,7 @@ export default function CoutCreationEntreprise() {
 						</Ul>
 					}
 				/>
-				<SimulationGoals legend="Simulateur du coût de création d'une entreprise">
+				<SimulationGoals>
 					<SimulationGoal
 						displayedUnit="€ HT"
 						dottedName="entreprise . coût formalités . création"

--- a/site/source/pages/simulateurs/dividendes/Dividendes.tsx
+++ b/site/source/pages/simulateurs/dividendes/Dividendes.tsx
@@ -87,10 +87,7 @@ function OptionBarèmeSwitch() {
 }
 
 const DividendesSimulationGoals = () => (
-	<SimulationGoals
-		toggles={<OptionBarèmeSwitch />}
-		legend="Les dividendes de l'entreprise"
-	>
+	<SimulationGoals toggles={<OptionBarèmeSwitch />}>
 		<Condition expression="entreprise . imposition = 'IS'">
 			<SimulationGoal
 				appear={false}

--- a/site/source/pages/simulateurs/impot-societe/index.tsx
+++ b/site/source/pages/simulateurs/impot-societe/index.tsx
@@ -27,8 +27,6 @@ import {
 import { situationSelector } from '@/store/selectors/simulationSelectors'
 
 export default function ISSimulation() {
-	const { t } = useTranslation()
-
 	return (
 		<SimulationContainer>
 			<SimulateurWarning
@@ -45,13 +43,7 @@ export default function ISSimulation() {
 			/>
 			<Notifications />
 
-			<SimulationGoals
-				toggles={<ExerciceDate />}
-				legend={t(
-					'pages.simulateurs.impot-société.légende',
-					'Résultat imposable de l’entreprise'
-				)}
-			>
+			<SimulationGoals toggles={<ExerciceDate />}>
 				<SimulationGoal dottedName="entreprise . imposition . IS . résultat imposable" />
 			</SimulationGoals>
 			<Explanations />

--- a/site/source/pages/simulateurs/indépendant/EntrepriseIndividuelle.tsx
+++ b/site/source/pages/simulateurs/indépendant/EntrepriseIndividuelle.tsx
@@ -11,7 +11,7 @@ export const EntrepriseIndividuelle = () => (
 			afterQuestionsSlot={<YearSelectionBanner />}
 		>
 			<SimulateurWarning simulateur="entreprise-individuelle" />
-			<IndépendantSimulationGoals legend="Vos revenus d'entreprise individuelle" />
+			<IndépendantSimulationGoals />
 		</Simulation>
 	</>
 )

--- a/site/source/pages/simulateurs/indépendant/Goals.tsx
+++ b/site/source/pages/simulateurs/indépendant/Goals.tsx
@@ -5,12 +5,10 @@ import { SimulationGoal, SimulationGoals } from '@/components/Simulation'
 
 export const IndépendantSimulationGoals = ({
 	toggles = <PeriodSwitch />,
-	legend,
 }: {
 	toggles?: React.ReactNode
-	legend: string
 }) => (
-	<SimulationGoals toggles={toggles} legend={legend}>
+	<SimulationGoals toggles={toggles}>
 		<Condition expression="entreprise . imposition = 'IR'">
 			<Condition expression="entreprise . imposition . régime . micro-entreprise = non">
 				<SimulationGoal

--- a/site/source/pages/simulateurs/indépendant/Indépendant.tsx
+++ b/site/source/pages/simulateurs/indépendant/Indépendant.tsx
@@ -36,7 +36,6 @@ export default function IndépendantSimulation() {
 					}
 				/>
 				<IndépendantSimulationGoals
-					legend="Vos revenus d'indépendant"
 					toggles={
 						<>
 							<RuleInput

--- a/site/source/pages/simulateurs/indépendant/IndépendantPLSimulation.tsx
+++ b/site/source/pages/simulateurs/indépendant/IndépendantPLSimulation.tsx
@@ -45,7 +45,7 @@ export const IndépendantPLSimulation = () => {
 						</Ul>
 					}
 				/>
-				<IndépendantSimulationGoals legend="Vos revenus de profession libérale" />
+				<IndépendantSimulationGoals />
 			</Simulation>
 		</>
 	)

--- a/site/source/pages/simulateurs/location-de-meublé/LocationDeMeublé.tsx
+++ b/site/source/pages/simulateurs/location-de-meublé/LocationDeMeublé.tsx
@@ -48,7 +48,7 @@ const LocationDeMeublé = () => {
 				avecQuestionsPublicodes={false}
 			>
 				<SimulateurWarning simulateur="location-de-logement-meublé" />
-				<SimulationGoals legend="Montant de votre loyer net">
+				<SimulationGoals>
 					<ObjectifRecettes />
 					{regimeCotisationChoisi &&
 						Either.match(cotisations, {

--- a/site/source/pages/simulateurs/lodeom/Goals.tsx
+++ b/site/source/pages/simulateurs/lodeom/Goals.tsx
@@ -32,11 +32,9 @@ import WarningSalaireTrans from './components/WarningSalaireTrans'
 
 export default function LodeomSimulationGoals({
 	toggles,
-	legend,
 	régularisationMethod,
 }: {
 	toggles?: React.ReactNode
-	legend: string
 	régularisationMethod?: RégularisationMethod
 }) {
 	const engine = useEngine()
@@ -127,7 +125,7 @@ export default function LodeomSimulationGoals({
 	}
 
 	return (
-		<SimulationGoals toggles={toggles} legend={legend}>
+		<SimulationGoals toggles={toggles}>
 			<Warnings />
 			<WhenApplicable dottedName="salarié . cotisations . exonérations . zones lodeom">
 				{!currentBarème && (

--- a/site/source/pages/simulateurs/lodeom/Lodeom.tsx
+++ b/site/source/pages/simulateurs/lodeom/Lodeom.tsx
@@ -54,10 +54,6 @@ export default function LodeomSimulation() {
 					}
 				/>
 				<LodeomSimulationGoals
-					legend={t(
-						'pages.simulateurs.lodeom.legend',
-						'Rémunération brute du salarié et exonération Lodeom applicable'
-					)}
 					toggles={
 						<>
 							<ZoneSwitch />

--- a/site/source/pages/simulateurs/reduction-generale/Goals.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/Goals.tsx
@@ -29,11 +29,9 @@ import WarningSalaireTrans from './components/WarningSalaireTrans'
 
 export default function RéductionGénéraleSimulationGoals({
 	toggles,
-	legend,
 	régularisationMethod,
 }: {
 	toggles?: React.ReactNode
-	legend: string
 	régularisationMethod: RégularisationMethod
 }) {
 	const engine = useEngine()
@@ -112,7 +110,7 @@ export default function RéductionGénéraleSimulationGoals({
 	}
 
 	return (
-		<SimulationGoals toggles={toggles} legend={legend}>
+		<SimulationGoals toggles={toggles}>
 			{monthByMonth ? (
 				<RéductionMoisParMois
 					dottedName={réductionGénéraleDottedName}

--- a/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
@@ -62,10 +62,6 @@ export default function RéductionGénéraleSimulation() {
 					}
 				/>
 				<RéductionGénéraleSimulationGoals
-					legend={t(
-						'pages.simulateurs.réduction-générale.legend',
-						'Salaire brut du salarié et réduction générale applicable'
-					)}
 					toggles={
 						<>
 							<RégularisationSwitch

--- a/site/source/pages/simulateurs/salarié/Salarié.tsx
+++ b/site/source/pages/simulateurs/salarié/Salarié.tsx
@@ -249,10 +249,7 @@ export const SeoExplanations = () => {
 
 function SalariéSimulationGoals() {
 	return (
-		<SimulationGoals
-			toggles={<PeriodSwitch />}
-			legend="Rémunération du salarié"
-		>
+		<SimulationGoals toggles={<PeriodSwitch />}>
 			<SimulationGoal dottedName="salarié . coût total employeur" />
 			<AidesGlimpse />
 

--- a/site/source/pages/simulateurs/salarié/Salarié.tsx
+++ b/site/source/pages/simulateurs/salarié/Salarié.tsx
@@ -48,13 +48,6 @@ export default function SalariéSimulation() {
 						<Trans i18nKey="simulation-end.hiring.text">
 							Vous pouvez maintenant concrétiser votre projet d'embauche.
 						</Trans>
-						{/* <ButtonContainer>
-							<Button to={absoluteSitePaths.assistants.embaucher}>
-								<Trans i18nKey="simulation-end.cta">
-									Connaître les démarches
-								</Trans>
-							</Button>
-						</ButtonContainer> */}
 					</>
 				}
 				afterQuestionsSlot={

--- a/site/source/pages/simulateurs/sasu/SASU.tsx
+++ b/site/source/pages/simulateurs/sasu/SASU.tsx
@@ -30,10 +30,7 @@ export function SASUSimulation() {
 						</Body>
 					}
 				/>
-				<SimulationGoals
-					toggles={<PeriodSwitch />}
-					legend="Vos revenus de dirigeant de SAS(U)"
-				>
+				<SimulationGoals toggles={<PeriodSwitch />}>
 					<SimulationGoal dottedName="dirigeant . rémunération . totale" />
 					<SimulationGoal
 						editable


### PR DESCRIPTION
Les étiquettes et les champs doivent être accolés. 
Après discussion avec @logic-fabric je propose de centrer le tout.
J'ai aussi revu des espacements.
