### PR TITLE
fix(a11y): remet les boutons radios visibles et dans le simulateur

### DIFF
--- a/site/source/components/PeriodSwitch.tsx
+++ b/site/source/components/PeriodSwitch.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
+import styled from 'styled-components'
 
 import { Grid, Radio, TitreObjectif, ToggleGroup } from '@/design-system'
 import { updateUnit } from '@/store/actions/actions'
@@ -54,7 +55,7 @@ export default function PeriodSwitch({ periods }: Props) {
 			</Grid>
 
 			<Grid item>
-				<ToggleGroup
+				<PeriodSwitchToggleGroup
 					value={currentUnit}
 					onChange={onChange}
 					aria-label={t("Mode d'affichage")}
@@ -67,8 +68,15 @@ export default function PeriodSwitch({ periods }: Props) {
 							<Radio value={unit}>{label}</Radio>
 						</span>
 					))}
-				</ToggleGroup>
+				</PeriodSwitchToggleGroup>
 			</Grid>
 		</Grid>
 	)
 }
+
+const PeriodSwitchToggleGroup = styled(ToggleGroup)`
+	input + span {
+		background: none !important;
+		border: none !important;
+	}
+`

--- a/site/source/components/PeriodSwitch.tsx
+++ b/site/source/components/PeriodSwitch.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Radio, ToggleGroup } from '@/design-system'
+import { Grid, Radio, TitreObjectif, ToggleGroup } from '@/design-system'
 import { updateUnit } from '@/store/actions/actions'
 import { targetUnitSelector } from '@/store/selectors/simulationSelectors'
 
@@ -38,23 +38,37 @@ export default function PeriodSwitch({ periods }: Props) {
 	)
 
 	return (
-		<div>
-			<ToggleGroup
-				value={currentUnit}
-				onChange={onChange}
-				mode="tab"
-				hideRadio
-				aria-label={t("Mode d'affichage")}
-			>
-				{periodsValue.map(({ label, unit }) => (
-					<span
-						key={unit}
-						className={currentUnit !== unit ? 'print-hidden' : ''}
-					>
-						<Radio value={unit}>{label}</Radio>
-					</span>
-				))}
-			</ToggleGroup>
-		</div>
+		<Grid
+			container
+			style={{
+				alignItems: 'baseline',
+				justifyContent: 'space-between',
+			}}
+			spacing={2}
+			as="fieldset"
+		>
+			<Grid item md="auto" sm={9} xs={8}>
+				<TitreObjectif noWrap={true}>
+					<legend>Période de calcul</legend>
+				</TitreObjectif>
+			</Grid>
+
+			<Grid item>
+				<ToggleGroup
+					value={currentUnit}
+					onChange={onChange}
+					aria-label={t("Mode d'affichage")}
+				>
+					{periodsValue.map(({ label, unit }) => (
+						<span
+							key={unit}
+							className={currentUnit !== unit ? 'print-hidden' : ''}
+						>
+							<Radio value={unit}>{label}</Radio>
+						</span>
+					))}
+				</ToggleGroup>
+			</Grid>
+		</Grid>
 	)
 }

--- a/site/source/components/PeriodSwitch.tsx
+++ b/site/source/components/PeriodSwitch.tsx
@@ -50,7 +50,7 @@ export default function PeriodSwitch({ periods }: Props) {
 		>
 			<Grid item md="auto" sm={9} xs={8}>
 				<TitreObjectif noWrap={true}>
-					<legend>Période de calcul</legend>
+					<legend>{t('periode-calcul', 'Période de calcul')}</legend>
 				</TitreObjectif>
 			</Grid>
 

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -2084,6 +2084,7 @@ payslip:
     each amount is calculated. This payslip is not a substitute for a real
     payslip. For more information, visit <2>service-public.fr</2>."
   repartition: Breakdown of total expenses
+periode-calcul: Calculation period
 points: points
 pourcentage: percentage
 previousSimulationBanner:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -2208,6 +2208,7 @@ payslip:
     ne peut pas de substituer à une fiche de paie réelle. Pour plus
     d'informations, rendez-vous sur <2>service-public.fr</2>."
   repartition: Répartition du total chargé
+periode-calcul: Période de calcul
 points: points
 pourcentage: pourcentage
 previousSimulationBanner:

--- a/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
+++ b/site/source/pages/simulateurs/artiste-auteur/ArtisteAuteur.tsx
@@ -41,10 +41,8 @@ export default function ArtisteAuteur() {
 						</Body>
 					}
 				/>
-				<SimulationGoals
-					legend="Vos revenus d'artiste auteur"
-					toggles={<PeriodSwitch />}
-				>
+				<SimulationGoals legend="Vos revenus d'artiste auteur">
+					<PeriodSwitch />
 					<SimulationGoal dottedName="artiste-auteur . revenus . traitements et salaires" />
 					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . recettes" />
 					<SimulationGoal dottedName="artiste-auteur . revenus . BNC . frais réels" />

--- a/site/source/pages/simulateurs/auto-entrepreneur/AutoEntrepreneur.tsx
+++ b/site/source/pages/simulateurs/auto-entrepreneur/AutoEntrepreneur.tsx
@@ -53,10 +53,8 @@ export default function AutoEntrepreneur() {
 						</Ul>
 					}
 				/>
-				<SimulationGoals
-					toggles={<PeriodSwitch />}
-					legend="Vos revenus d'auto-entrepreneur"
-				>
+				<SimulationGoals legend="Vos revenus d'auto-entrepreneur">
+					<PeriodSwitch />
 					<ChiffreAffairesActivitéMixte dottedName="dirigeant . auto-entrepreneur . chiffre d'affaires" />
 					<SimulationGoal
 						small

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Comparateur.tsx
@@ -29,9 +29,9 @@ function Comparateur({ namedEngines }: { namedEngines: EngineComparison }) {
 				id="simulation-comparateur"
 			>
 				<SimulationGoals
-					toggles={<PeriodSwitch />}
 					legend={'Estimations sur votre rémunération brute et vos charges'}
 				>
+					<PeriodSwitch />
 					<SimulationGoal
 						dottedName="entreprise . chiffre d'affaires"
 						isInfoMode

--- a/site/source/pages/simulateurs/indépendant/Goals.tsx
+++ b/site/source/pages/simulateurs/indépendant/Goals.tsx
@@ -4,13 +4,14 @@ import PeriodSwitch from '@/components/PeriodSwitch'
 import { SimulationGoal, SimulationGoals } from '@/components/Simulation'
 
 export const IndépendantSimulationGoals = ({
-	toggles = <PeriodSwitch />,
+	toggles,
 	legend,
 }: {
 	toggles?: React.ReactNode
 	legend: string
 }) => (
 	<SimulationGoals toggles={toggles} legend={legend}>
+		<PeriodSwitch />
 		<Condition expression="entreprise . imposition = 'IR'">
 			<Condition expression="entreprise . imposition . régime . micro-entreprise = non">
 				<SimulationGoal

--- a/site/source/pages/simulateurs/indépendant/Indépendant.tsx
+++ b/site/source/pages/simulateurs/indépendant/Indépendant.tsx
@@ -3,7 +3,6 @@ import { Trans } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 
 import RuleInput from '@/components/conversation/RuleInput'
-import PeriodSwitch from '@/components/PeriodSwitch'
 import SimulateurWarning from '@/components/SimulateurWarning'
 import Simulation from '@/components/Simulation'
 import { YearSelectionBanner } from '@/components/Simulation/YearSelectionBanner'
@@ -52,7 +51,6 @@ export default function IndépendantSimulation() {
 									)
 								}}
 							/>
-							<PeriodSwitch />
 						</>
 					}
 				/>

--- a/site/source/pages/simulateurs/lodeom/Goals.tsx
+++ b/site/source/pages/simulateurs/lodeom/Goals.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { WhenApplicable } from '@/components/EngineValue/WhenApplicable'
+import PeriodSwitch from '@/components/PeriodSwitch'
 import RéductionBasique from '@/components/RéductionDeCotisations/RéductionBasique'
 import RéductionMoisParMois from '@/components/RéductionDeCotisations/RéductionMoisParMois'
 import { SimulationGoals } from '@/components/Simulation'
@@ -60,6 +61,24 @@ export default function LodeomSimulationGoals({
 	).nodeValue as string
 
 	const withRépartition = currentZone === 'zone un'
+
+	const periods = [
+		{
+			label: t('pages.simulateurs.lodeom.tab.month', 'Exonération mensuelle'),
+			unit: '€/mois',
+		},
+		{
+			label: t('pages.simulateurs.lodeom.tab.year', 'Exonération annuelle'),
+			unit: '€/an',
+		},
+		{
+			label: t(
+				'pages.simulateurs.lodeom.tab.month-by-month',
+				'Exonération mois par mois'
+			),
+			unit: '€',
+		},
+	]
 
 	const initializeLodeomMoisParMoisData = useCallback(() => {
 		const data = getInitialRéductionMoisParMois(
@@ -141,6 +160,7 @@ export default function LodeomSimulationGoals({
 					</Message>
 				)}
 			</WhenApplicable>
+			{currentBarème && <PeriodSwitch periods={periods} />}
 			{currentBarème &&
 				(monthByMonth ? (
 					<RéductionMoisParMois

--- a/site/source/pages/simulateurs/lodeom/Lodeom.tsx
+++ b/site/source/pages/simulateurs/lodeom/Lodeom.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
-import PeriodSwitch from '@/components/PeriodSwitch'
 import EffectifSwitch from '@/components/RéductionDeCotisations/EffectifSwitch'
 import RégularisationSwitch from '@/components/RéductionDeCotisations/RégularisationSwitch'
 import SimulateurWarning from '@/components/SimulateurWarning'
@@ -18,23 +17,6 @@ import LodeomSimulationGoals from './Goals'
 export default function LodeomSimulation() {
 	const currentZone = useZoneLodeom()
 	const { t } = useTranslation()
-	const periods = [
-		{
-			label: t('pages.simulateurs.lodeom.tab.month', 'Exonération mensuelle'),
-			unit: '€/mois',
-		},
-		{
-			label: t('pages.simulateurs.lodeom.tab.year', 'Exonération annuelle'),
-			unit: '€/an',
-		},
-		{
-			label: t(
-				'pages.simulateurs.lodeom.tab.month-by-month',
-				'Exonération mois par mois'
-			),
-			unit: '€',
-		},
-	]
 
 	const [régularisationMethod, setRégularisationMethod] =
 		useState<RégularisationMethod>('progressive')
@@ -71,7 +53,6 @@ export default function LodeomSimulation() {
 									<EffectifSwitch />
 								</>
 							)}
-							<PeriodSwitch periods={periods} />
 						</>
 					}
 					régularisationMethod={

--- a/site/source/pages/simulateurs/reduction-generale/Goals.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/Goals.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
+import PeriodSwitch from '@/components/PeriodSwitch'
 import RéductionBasique from '@/components/RéductionDeCotisations/RéductionBasique'
 import RéductionMoisParMois from '@/components/RéductionDeCotisations/RéductionMoisParMois'
 import { SimulationGoals } from '@/components/Simulation'
@@ -47,6 +48,29 @@ export default function RéductionGénéraleSimulationGoals({
 	const currentUnit = useSelector(targetUnitSelector)
 	const monthByMonth = currentUnit === '€'
 
+	const periods = [
+		{
+			label: t(
+				'pages.simulateurs.réduction-générale.tab.month',
+				'Réduction mensuelle'
+			),
+			unit: '€/mois',
+		},
+		{
+			label: t(
+				'pages.simulateurs.réduction-générale.tab.year',
+				'Réduction annuelle'
+			),
+			unit: '€/an',
+		},
+		{
+			label: t(
+				'pages.simulateurs.réduction-générale.tab.month-by-month',
+				'Réduction mois par mois'
+			),
+			unit: '€',
+		},
+	]
 	const initializeRéductionGénéraleMoisParMoisData = useCallback(() => {
 		const data = getInitialRéductionMoisParMois(
 			réductionGénéraleDottedName,
@@ -113,6 +137,7 @@ export default function RéductionGénéraleSimulationGoals({
 
 	return (
 		<SimulationGoals toggles={toggles} legend={legend}>
+			<PeriodSwitch periods={periods} />
 			{monthByMonth ? (
 				<RéductionMoisParMois
 					dottedName={réductionGénéraleDottedName}

--- a/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
+++ b/site/source/pages/simulateurs/reduction-generale/RéductionGénérale.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
-import PeriodSwitch from '@/components/PeriodSwitch'
 import EffectifSwitch from '@/components/RéductionDeCotisations/EffectifSwitch'
 import RégularisationSwitch from '@/components/RéductionDeCotisations/RégularisationSwitch'
 import SimulateurWarning from '@/components/SimulateurWarning'
@@ -15,29 +14,6 @@ import RéductionGénéraleSimulationGoals from './Goals'
 
 export default function RéductionGénéraleSimulation() {
 	const { t } = useTranslation()
-	const periods = [
-		{
-			label: t(
-				'pages.simulateurs.réduction-générale.tab.month',
-				'Réduction mensuelle'
-			),
-			unit: '€/mois',
-		},
-		{
-			label: t(
-				'pages.simulateurs.réduction-générale.tab.year',
-				'Réduction annuelle'
-			),
-			unit: '€/an',
-		},
-		{
-			label: t(
-				'pages.simulateurs.réduction-générale.tab.month-by-month',
-				'Réduction mois par mois'
-			),
-			unit: '€',
-		},
-	]
 
 	const [régularisationMethod, setRégularisationMethod] =
 		useState<RégularisationMethod>('progressive')
@@ -74,7 +50,6 @@ export default function RéductionGénéraleSimulation() {
 							/>
 							<EffectifSwitch />
 							<CongésPayésSwitch />
-							<PeriodSwitch periods={periods} />
 						</>
 					}
 					régularisationMethod={régularisationMethod}

--- a/site/source/pages/simulateurs/salarié/Salarié.tsx
+++ b/site/source/pages/simulateurs/salarié/Salarié.tsx
@@ -249,10 +249,8 @@ export const SeoExplanations = () => {
 
 function SalariéSimulationGoals() {
 	return (
-		<SimulationGoals
-			toggles={<PeriodSwitch />}
-			legend="Rémunération du salarié"
-		>
+		<SimulationGoals legend="Rémunération du salarié">
+			<PeriodSwitch />
 			<SimulationGoal dottedName="salarié . coût total employeur" />
 			<AidesGlimpse />
 

--- a/site/source/pages/simulateurs/sasu/SASU.tsx
+++ b/site/source/pages/simulateurs/sasu/SASU.tsx
@@ -30,10 +30,8 @@ export function SASUSimulation() {
 						</Body>
 					}
 				/>
-				<SimulationGoals
-					toggles={<PeriodSwitch />}
-					legend="Vos revenus de dirigeant de SAS(U)"
-				>
+				<SimulationGoals legend="Vos revenus de dirigeant de SAS(U)">
+					<PeriodSwitch />
 					<SimulationGoal dottedName="dirigeant . rémunération . totale" />
 					<SimulationGoal
 						editable


### PR DESCRIPTION
Impacte le switch de période des simulateurs : 
- [x] réaffiche les boutons radios
- [x] met le groupe dans la partie Simulateur
- [x] rajoute un `<legend>` au `<fieldset>`
- [x] change le style
- [ ] ~fait que le montant s'affiche "€/mois" ou "€/an" et pas seulement "€"~ (fera lieu d'une prochaine PR, vu avec @liliced )

Bloquant : 
- [x] http://localhost:3000/mon-entreprise/simulateurs/lodeom voir comment on traite ce cas
- [x] http://localhost:3000/mon-entreprise/simulateurs/r%C3%A9duction-g%C3%A9n%C3%A9rale voir comment on traite ce cas

Closes #3490 
Closes #3644