### PR TITLE
UI/Fix text superposition in Questions.tsx

### DIFF
--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -69,11 +69,11 @@ export function Questions<S extends Situation>({
 				<div className="print-hidden">
 					{(nombreDeQuestions === 0 ||
 						nombreDeQuestionsRépondues < nombreDeQuestions) && (
-						<Notice>
+						<Body>
 							<Trans i18nKey="simulateurs.précision.défaut">
 								Améliorez votre simulation en répondant aux questions :
 							</Trans>
-						</Notice>
+						</Body>
 					)}
 				</div>
 				{finished && (
@@ -148,10 +148,6 @@ const QuestionsContainer = styled.div`
 			? theme.colors.extended.grey[700]
 			: theme.colors.extended.grey[100]};
 	box-shadow: ${({ theme }) => theme.elevations[2]};
-`
-
-const Notice = styled(Body)`
-	margin-bottom: -1rem;
 `
 
 const QuestionTitle = styled.h3`


### PR DESCRIPTION
Cette PR fixe une superposition de texte dans les questions associées à un simulateur.
Superposition constatée sur le simulateur auto-entrepreneur :

![image](https://github.com/user-attachments/assets/7e6435c1-5616-4b0d-a169-534479e2ff72)