### PR TITLE
fix(cmg): navigation instable en iframe

### DIFF
--- a/site/source/hooks/useGetPath.ts
+++ b/site/source/hooks/useGetPath.ts
@@ -1,0 +1,67 @@
+import { useSitePaths } from '../sitePaths'
+import { useCurrentSimulatorData } from './useCurrentSimulatorData'
+import { useIsEmbedded } from './useIsEmbedded'
+
+type NestedKeyOf<ObjectType extends object> = {
+	[Key in keyof ObjectType & (string | number)]: ObjectType[Key] extends object
+		? `${Key}` | `${Key}.${NestedKeyOf<ObjectType[Key]>}`
+		: `${Key}`
+}[keyof ObjectType & (string | number)]
+
+type SitePathsNode =
+	| string
+	| { index?: string; [key: string]: SitePathsNode | undefined }
+
+const trouveLeChemin = (
+	objetAExplorer: SitePathsNode,
+	chemin: string[]
+): string => {
+	if (chemin.length === 0) {
+		return typeof objetAExplorer === 'string'
+			? objetAExplorer
+			: objetAExplorer.index || ''
+	}
+
+	if (typeof objetAExplorer === 'string') {
+		throw new Error(
+			`Navigation invalide: tentative de navigation dans une string`
+		)
+	}
+
+	const [head, ...tail] = chemin
+	const nextObj = objetAExplorer[head]
+
+	if (!nextObj) {
+		throw new Error(`Chemin invalide: ${head}`)
+	}
+
+	return trouveLeChemin(nextObj, tail)
+}
+
+export const useGetPath = () => {
+	const { relativeSitePaths, absoluteSitePaths } = useSitePaths()
+	const isEmbedded = useIsEmbedded()
+	const { currentSimulatorData } = useCurrentSimulatorData()
+
+	return (sitePath: NestedKeyOf<typeof relativeSitePaths>): string => {
+		if (!currentSimulatorData) {
+			throw new Error(
+				'useGetPath doit être utilisé dans un contexte de simulateur/assistant'
+			)
+		}
+
+		const cheminComplet = trouveLeChemin(absoluteSitePaths, sitePath.split('.'))
+
+		const cheminDeBaseDeLAssistant = trouveLeChemin(
+			absoluteSitePaths,
+			currentSimulatorData.pathId.split('.')
+		)
+
+		return isEmbedded && currentSimulatorData.iframePath
+			? cheminComplet.replace(
+					cheminDeBaseDeLAssistant,
+					`/iframes/${currentSimulatorData.iframePath}`
+			  )
+			: cheminComplet
+	}
+}

--- a/site/source/pages/assistants/cmg/components/Navigation.tsx
+++ b/site/source/pages/assistants/cmg/components/Navigation.tsx
@@ -3,11 +3,14 @@ import { styled } from 'styled-components'
 
 import { useCMG } from '@/contextes/cmg'
 import { Button, FlexCenter } from '@/design-system'
-import { RelativeSitePaths, useSitePaths } from '@/sitePaths'
+import { useGetPath } from '@/hooks/useGetPath'
+import { RelativeSitePaths } from '@/sitePaths'
+
+type CMGPage = keyof RelativeSitePaths['assistants']['cmg']
 
 type Props = {
-	précédent?: keyof RelativeSitePaths['assistants']['cmg']
-	suivant?: keyof RelativeSitePaths['assistants']['cmg']
+	précédent?: CMGPage
+	suivant?: CMGPage
 	isSuivantDisabled?: boolean
 }
 
@@ -16,15 +19,17 @@ export default function Navigation({
 	suivant,
 	isSuivantDisabled,
 }: Props) {
-	const { absoluteSitePaths } = useSitePaths()
-	const cmgPaths = absoluteSitePaths.assistants.cmg
 	const { submit } = useCMG()
 	const { t } = useTranslation()
+	const getPath = useGetPath()
+
+	const getCMGPath = (page: CMGPage) =>
+		getPath(`assistants.cmg.${page}` as const)
 
 	return (
 		<Container>
 			{précédent && (
-				<Button size="XS" light to={cmgPaths[précédent]}>
+				<Button size="XS" light to={getCMGPath(précédent)}>
 					{t('Précédent')}
 				</Button>
 			)}
@@ -32,7 +37,7 @@ export default function Navigation({
 				<Button
 					size="XS"
 					onClick={submit}
-					to={cmgPaths[suivant]}
+					to={getCMGPath(suivant)}
 					isDisabled={isSuivantDisabled}
 				>
 					{t('Suivant')}


### PR DESCRIPTION
Résout un problème de persistance des données lors de la navigation entre les pages de l'assistant CMG quand utilisé en iframe. Les données saisies sur la première page étaient perdues à la première navigation.

**Cause racine :** Le composant Navigation utilisait des liens absolus (/assistants/cmg/*) même en contexte iframe (/iframes/cmg/*), provoquant un remontage complet de SimulateurOrAssistantPage et donc de CMGProvider à la première navigation.

**Solution :**
- Créé le hook useGetPath() pour générer des URLs contextuelles
- Navigation.tsx utilise maintenant ce hook au lieu des liens absolus
- Le hook détecte automatiquement si on est en iframe ou en accès direct

Closes #3754 