### PR TITLE
fix(cmg): Lorsque l’on renseigne la déclaration pour une AMA, impossible de cocher les enfants gardés sur avril et mai

### DIFF
--- a/site/source/contextes/cmg/domaine/Mois.ts
+++ b/site/source/contextes/cmg/domaine/Mois.ts
@@ -1,0 +1,1 @@
+export type Mois = 'mars' | 'avril' | 'mai'

--- a/site/source/contextes/cmg/index.ts
+++ b/site/source/contextes/cmg/index.ts
@@ -9,6 +9,7 @@ export {
 export { CMGProvider } from './hooks/CMGContext'
 export { useCMG } from './hooks/useCMG'
 export type { Enfant, EnfantValide } from './domaine/enfant'
+export type { Mois } from './domaine/Mois'
 export {
 	estEnfantsÀChargeValide,
 	estEnfantGardable,

--- a/site/source/pages/assistants/cmg/components/AMA/AMAInput.tsx
+++ b/site/source/pages/assistants/cmg/components/AMA/AMAInput.tsx
@@ -1,3 +1,6 @@
+import { pipe } from 'effect'
+import * as A from 'effect/Array'
+import * as R from 'effect/Record'
 import { useTranslation } from 'react-i18next'
 import { css, styled } from 'styled-components'
 
@@ -40,22 +43,26 @@ export default function AMAInput({
 			</TitreContainer>
 			<InputsContainer>
 				<AideSaisieAMA />
-				{Object.keys(salariée).map((month) => (
-					<DéclarationAMAInput
-						key={month}
-						idSuffix={`${idSuffix}-${month}`}
-						month={month}
-						déclaration={salariée[month as keyof SalariéeAMA<string>]}
-						onChange={(value) =>
-							onChange({
-								...salariée,
-								[month]: value,
-							})
-						}
-						avecAideSaisie={month === 'mars'}
-						avecEspacement={month !== 'mars'}
-					/>
-				))}
+				{pipe(
+					salariée,
+					R.keys,
+					A.map((month) => (
+						<DéclarationAMAInput
+							key={month}
+							idSuffix={`${idSuffix}-${month}`}
+							month={month}
+							déclaration={salariée[month]}
+							onChange={(value) =>
+								onChange({
+									...salariée,
+									[month]: value,
+								})
+							}
+							avecAideSaisie={month === 'mars'}
+							avecEspacement={month !== 'mars'}
+						/>
+					))
+				)}
 			</InputsContainer>
 		</>
 	)

--- a/site/source/pages/assistants/cmg/components/AMA/DéclarationAMAInput.tsx
+++ b/site/source/pages/assistants/cmg/components/AMA/DéclarationAMAInput.tsx
@@ -2,7 +2,7 @@ import * as O from 'effect/Option'
 import { useMemo } from 'react'
 import { css, styled } from 'styled-components'
 
-import { DéclarationDeGardeAMA } from '@/contextes/cmg'
+import { DéclarationDeGardeAMA, Mois } from '@/contextes/cmg'
 import { Montant } from '@/domaine/Montant'
 import { ChangeHandler } from '@/utils/ChangeHandler'
 
@@ -18,7 +18,7 @@ import EnfantsGardésInput from './EnfantsGardésInput'
 
 type Props = {
 	idSuffix: string
-	month: string
+	month: Mois
 	déclaration: O.Option<DéclarationDeGardeAMA<string>>
 	onChange: ChangeHandler<O.Option<DéclarationDeGardeAMA<string>>>
 	avecAideSaisie?: boolean
@@ -96,6 +96,7 @@ export default function DéclarationAMAInput({
 				</DesktopHiddenContainer>
 			)}
 			<EnfantsGardésInput
+				mois={month}
 				enfantsGardés={currentDéclaration.enfantsGardés}
 				onChange={onEnfantsGardésChange}
 			/>

--- a/site/source/pages/assistants/cmg/components/AMA/EnfantsGardésInput.tsx
+++ b/site/source/pages/assistants/cmg/components/AMA/EnfantsGardésInput.tsx
@@ -4,18 +4,23 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
-import { EnfantValide, estEnfantGardable, useCMG } from '@/contextes/cmg'
+import { EnfantValide, estEnfantGardable, Mois, useCMG } from '@/contextes/cmg'
 import { Checkbox } from '@/design-system'
 import { ChangeHandler } from '@/utils/ChangeHandler'
 
 import { Label } from '../styled-components'
 
 type Props = {
+	mois: Mois
 	enfantsGardés: Array<string>
 	onChange: ChangeHandler<Array<string>>
 }
 
-export default function EnfantsGardésInput({ enfantsGardés, onChange }: Props) {
+export default function EnfantsGardésInput({
+	mois,
+	enfantsGardés,
+	onChange,
+}: Props) {
 	const { t } = useTranslation()
 	const { enfants } = useCMG()
 
@@ -49,7 +54,7 @@ export default function EnfantsGardésInput({ enfantsGardés, onChange }: Props)
 				{enfantsGardables.map((enfant, index) => (
 					<Checkbox
 						key={index}
-						id={`checkbox-enfant-${index}`}
+						id={`checkbox-enfant-${index}-${mois}`}
 						label={enfant.prénom.value}
 						isSelected={isEnfantGardé(enfant)}
 						onChange={onCheckboxChange(enfant.prénom.value)}


### PR DESCRIPTION
Le composant `Checkbox` nécessite un id unique pour fonctionner correctement avec le label via `htmlFor`. Dans le fichier `EnfantsGardésInput.tsx`, l'ID généré était `checkbox-enfant-${index}`, ce qui créerait des IDs dupliqués entre les trois mois (mars, avril, mai). Du coup, où que l’on clique, le navigateur considère qu’on a cliqué le premier mois.

- change `EnfantsGardésInput` pour inclure le mois dans les identifiants des checkboxes
- Met à jour `EnfantsGardésInput` pour prendre `mois` en paramètre
- Ajoute le type `Mois` au domaine de contexte CMG
- Remplace `string` par `Mois` pour un typage plus strict

Closes #3756 