### PR TITLE
fix(cmg): utilise `useGetPath` pour corriger les liens de navigation

### DIFF
--- a/site/source/pages/assistants/cmg/pages/Accueil.tsx
+++ b/site/source/pages/assistants/cmg/pages/Accueil.tsx
@@ -3,9 +3,11 @@ import { Trans, useTranslation } from 'react-i18next'
 import { TrackPage } from '@/components/ATInternetTracking'
 import Warning from '@/components/ui/WarningBlock'
 import { Body, Button, Strong } from '@/design-system'
+import { useGetPath } from '@/hooks/useGetPath'
 
 export default function Accueil() {
 	const { t } = useTranslation()
+	const getPath = useGetPath()
 
 	return (
 		<>
@@ -32,7 +34,7 @@ export default function Accueil() {
 				</Trans>
 			</Warning>
 
-			<Button size="XS" to="informations-générales">
+			<Button size="XS" to={getPath('assistants.cmg.informations')}>
 				{t('pages.assistants.cmg.démarrer', 'Démarrer une simulation')}
 			</Button>
 		</>

--- a/site/source/pages/assistants/cmg/pages/NonÉligible.tsx
+++ b/site/source/pages/assistants/cmg/pages/NonÉligible.tsx
@@ -6,12 +6,15 @@ import { styled } from 'styled-components'
 import { TrackPage } from '@/components/ATInternetTracking'
 import { useCMG } from '@/contextes/cmg'
 import { Body, Button, FlexCenter, Li, Ul } from '@/design-system'
+import { useGetPath } from '@/hooks/useGetPath'
 
 export default function NonÉligible() {
 	const navigate = useNavigate()
 	const { raisonsInéligibilité, getRaisonsInéligibilitéHumaines, set } =
 		useCMG()
 	const { t } = useTranslation()
+
+	const getPath = useGetPath()
 
 	useEffect(() => {
 		if (!raisonsInéligibilité.length) {
@@ -45,7 +48,12 @@ export default function NonÉligible() {
 			</Ul>
 
 			<ButtonContainer>
-				<Button size="XS" light onClick={set.reset} to="/assistants/cmg">
+				<Button
+					size="XS"
+					light
+					onClick={set.reset}
+					to={getPath('assistants.cmg')}
+				>
 					{t(
 						'pages.assistants.cmg.nouvelle-simulation',
 						'Faire une nouvelle simulation'

--- a/site/source/pages/assistants/cmg/pages/Résultat.tsx
+++ b/site/source/pages/assistants/cmg/pages/Résultat.tsx
@@ -15,6 +15,7 @@ import {
 	Strong,
 } from '@/design-system'
 import { euros, toString as formatMontant } from '@/domaine/Montant'
+import { useGetPath } from '@/hooks/useGetPath'
 
 export default function Résultat() {
 	const navigate = useNavigate()
@@ -27,6 +28,7 @@ export default function Résultat() {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
+	const getPath = useGetPath()
 
 	const amount = formatMontant(O.getOrElse(montantCT, () => euros(0)))
 
@@ -57,7 +59,12 @@ export default function Résultat() {
 			</Trans>
 
 			<ButtonContainer>
-				<Button size="XS" light onClick={set.reset} to="/assistants/cmg">
+				<Button
+					size="XS"
+					light
+					onClick={set.reset}
+					to={getPath('assistants.cmg')}
+				>
 					{t(
 						'pages.assistants.cmg.nouvelle-simulation',
 						'Faire une nouvelle simulation'


### PR DESCRIPTION
- Met à jour les composants Accueil, Résultat et NonÉligible pour utiliser `useGetPath`
- Remplace les chemins absolus par des chemins contextuels pour supporter l'intégration en iframe
 
Closes #3758 