### PR TITLE
FIX : Impossible de saisir une décimale en sélectionnant toute la zone de saisie d'un input

### DIFF
--- a/site/source/components/RéductionDeCotisations/MonthOptions.tsx
+++ b/site/source/components/RéductionDeCotisations/MonthOptions.tsx
@@ -180,6 +180,7 @@ export default function MonthOptions({
 							unité="Euro"
 							onChange={(m) => onRémunérationETPChange(m?.valeur)}
 							aria-labelledby={`rémunération-etp-label`}
+							avecCentimes
 						/>
 					</NumberFieldContainer>
 				</GridItemInput>
@@ -217,6 +218,7 @@ export default function MonthOptions({
 							unité="Euro"
 							onChange={(m) => onRémunérationPrimesChange(m?.valeur)}
 							aria-labelledby={`rémunération-primes-label`}
+							avecCentimes
 						/>
 					</NumberFieldContainer>
 				</GridItemInput>
@@ -248,6 +250,7 @@ export default function MonthOptions({
 							unité="Euro"
 							onChange={(m) => onRémunérationHeuresSupChange(m?.valeur)}
 							aria-labelledby={`rémunération-heures-sup-label`}
+							avecCentimes
 						/>
 					</NumberFieldContainer>
 				</GridItemInput>

--- a/site/source/components/RéductionDeCotisations/RéductionMois.tsx
+++ b/site/source/components/RéductionDeCotisations/RéductionMois.tsx
@@ -70,7 +70,7 @@ export default function RéductionMois({
 					: undefined
 			}
 			unité="Euro"
-			avecCentimes={false}
+			avecCentimes
 		/>
 	)
 

--- a/site/source/components/RéductionDeCotisations/RéductionMois.tsx
+++ b/site/source/components/RéductionDeCotisations/RéductionMois.tsx
@@ -6,23 +6,21 @@ import { styled } from 'styled-components'
 import Montant from '@/components/RéductionDeCotisations/Montant'
 import MonthOptions from '@/components/RéductionDeCotisations/MonthOptions'
 import RuleLink from '@/components/RuleLink'
-import { useEngine } from '@/components/utils/EngineContext'
 import {
 	Body,
 	Button,
 	Grid,
-	MontantField,
 	RotatingChevronIcon,
 	Spacing,
 } from '@/design-system'
-import { euros } from '@/domaine/Montant'
 import {
 	MonthState,
 	Options,
 	RéductionDottedName,
 	réductionGénéraleDottedName,
-	rémunérationBruteDottedName,
 } from '@/utils/réductionDeCotisations'
+
+import RémunérationInput from './RémunérationInput'
 
 type Props = {
 	dottedName: RéductionDottedName
@@ -52,27 +50,7 @@ export default function RéductionMois({
 	const { t, i18n } = useTranslation()
 	const language = i18n.language
 	const displayedUnit = '€'
-	const engine = useEngine()
 	const [isOptionVisible, setOptionVisible] = useState(false)
-
-	const RémunérationInput = () => (
-		<MontantField
-			id={`${rémunérationBruteDottedName.replace(/\s|\./g, '_')}-${monthName}`}
-			aria={{
-				label: `${engine.getRule(rémunérationBruteDottedName)
-					?.title} (${monthName})`,
-				labelledby: 'simu-update-explaining',
-			}}
-			onChange={(montant) => onRémunérationChange(index, montant?.valeur ?? 0)}
-			value={
-				data.rémunérationBrute !== undefined
-					? euros(data.rémunérationBrute)
-					: undefined
-			}
-			unité="Euro"
-			avecCentimes
-		/>
-	)
 
 	const OptionsButton = () => {
 		return (
@@ -131,7 +109,12 @@ export default function RéductionMois({
 					<RuleLink dottedName="salarié . rémunération . brut" />
 				</Grid>
 				<Grid item xs={5} sm={5}>
-					<RémunérationInput />
+					<RémunérationInput
+						index={index}
+						monthName={monthName}
+						rémunérationBrute={data.rémunérationBrute}
+						onRémunérationChange={onRémunérationChange}
+					/>
 				</Grid>
 			</GridContainer>
 
@@ -185,7 +168,12 @@ export default function RéductionMois({
 			<tr>
 				<th scope="row">{monthName}</th>
 				<td>
-					<RémunérationInput />
+					<RémunérationInput
+						index={index}
+						monthName={monthName}
+						rémunérationBrute={data.rémunérationBrute}
+						onRémunérationChange={onRémunérationChange}
+					/>
 				</td>
 				<td>
 					<MontantRéduction />

--- a/site/source/components/RéductionDeCotisations/RéductionMoisParMois.tsx
+++ b/site/source/components/RéductionDeCotisations/RéductionMoisParMois.tsx
@@ -109,15 +109,8 @@ export default function RéductionMoisParMois({
 										monthName={monthName}
 										data={data[monthIndex]}
 										index={monthIndex}
-										onRémunérationChange={(
-											monthIndex: number,
-											rémunérationBrute: number
-										) => {
-											onRémunérationChange(monthIndex, rémunérationBrute)
-										}}
-										onOptionsChange={(monthIndex: number, options: Options) => {
-											onOptionsChange(monthIndex, options)
-										}}
+										onRémunérationChange={onRémunérationChange}
+										onOptionsChange={onOptionsChange}
 										warningCondition={warningCondition}
 										warningTooltip={warningTooltip}
 										withRépartitionAndRégularisation={
@@ -202,15 +195,8 @@ export default function RéductionMoisParMois({
 								monthName={monthName}
 								data={data[monthIndex]}
 								index={monthIndex}
-								onRémunérationChange={(
-									monthIndex: number,
-									rémunérationBrute: number
-								) => {
-									onRémunérationChange(monthIndex, rémunérationBrute)
-								}}
-								onOptionsChange={(monthIndex: number, options: Options) => {
-									onOptionsChange(monthIndex, options)
-								}}
+								onRémunérationChange={onRémunérationChange}
+								onOptionsChange={onOptionsChange}
 								warningCondition={warningCondition}
 								warningTooltip={warningTooltip}
 								withRépartitionAndRégularisation={

--- a/site/source/components/RéductionDeCotisations/RémunérationInput.tsx
+++ b/site/source/components/RéductionDeCotisations/RémunérationInput.tsx
@@ -1,0 +1,38 @@
+import { MontantField } from '@/design-system'
+import { euros } from '@/domaine/Montant'
+import { rémunérationBruteDottedName } from '@/utils/réductionDeCotisations'
+
+import { useEngine } from '../utils/EngineContext'
+
+type Props = {
+	index: number
+	monthName: string
+	rémunérationBrute: number
+	onRémunérationChange: (monthIndex: number, rémunérationBrute: number) => void
+}
+
+export default function RémunérationInput({
+	index,
+	monthName,
+	rémunérationBrute,
+	onRémunérationChange,
+}: Props) {
+	const engine = useEngine()
+
+	return (
+		<MontantField
+			id={`${rémunérationBruteDottedName.replace(/\s|\./g, '_')}-${monthName}`}
+			aria={{
+				label: `${engine.getRule(rémunérationBruteDottedName)
+					?.title} (${monthName})`,
+				labelledby: 'simu-update-explaining',
+			}}
+			onChange={(montant) => onRémunérationChange(index, montant?.valeur ?? 0)}
+			value={
+				rémunérationBrute !== undefined ? euros(rémunérationBrute) : undefined
+			}
+			unité="Euro"
+			avecCentimes
+		/>
+	)
+}

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -323,6 +323,7 @@ export default function RuleInput({
 					labelledby: accessibilityProps['aria-labelledby'],
 					label: accessibilityProps['aria-label'] ?? rule.title,
 				}}
+				avecCentimes={!!accessibilityProps.formatOptions?.maximumFractionDigits}
 			/>
 		)
 	}

--- a/site/source/design-system/atoms/NumericInput.tsx
+++ b/site/source/design-system/atoms/NumericInput.tsx
@@ -336,7 +336,7 @@ function useSimpleNumberFieldState(
 
 			if (
 				// Handle case for partially formatted input while typing decimal numbers
-				inputValue.match(/[\d][,.]([\d]*[0]+)?[^\d]*$/) ||
+				inputValue.match(/[\d€][,.]([\d]*[0]+)?[^\d]*$/) ||
 				// Handle case for 000015
 				inputValue.match(/^[^\d]*0([0]+|[\d\s,.]+)[^\d]*$/)
 			) {

--- a/site/source/design-system/atoms/NumericInput.tsx
+++ b/site/source/design-system/atoms/NumericInput.tsx
@@ -178,6 +178,7 @@ function useKeepCursorPositionOnUpdate(
 	const [value, setValue] = useState<string | undefined>()
 	const [rerenderSwitch, toggle] = useState(false)
 	const { onChange: inputOnChange, onKeyDown: inputOnKeyDown } = inputProps
+
 	const onChange = useCallback(
 		(e: ChangeEvent<HTMLInputElement>) => {
 			const input = e.target
@@ -190,6 +191,7 @@ function useKeepCursorPositionOnUpdate(
 		},
 		[inputOnChange, rerenderSwitch]
 	)
+
 	const onKeyDown = useCallback(
 		(e: KeyboardEvent<HTMLInputElement>) => {
 			inputOnKeyDown?.(e)
@@ -215,6 +217,7 @@ function useKeepCursorPositionOnUpdate(
 		},
 		[inputOnKeyDown, rerenderSwitch]
 	)
+
 	useEffect(() => {
 		const input = inputRef.current
 		if (!input || selection === null) {

--- a/site/source/design-system/atoms/NumericInput.tsx
+++ b/site/source/design-system/atoms/NumericInput.tsx
@@ -5,9 +5,11 @@ import { NumberFieldState } from '@react-stately/numberfield'
 import { AriaNumberFieldProps } from '@react-types/numberfield'
 import {
 	ChangeEvent,
+	ChangeEventHandler,
 	HTMLAttributes,
 	InputHTMLAttributes,
 	KeyboardEvent,
+	KeyboardEventHandler,
 	RefObject,
 	useCallback,
 	useEffect,
@@ -84,24 +86,12 @@ export const NumericInput = (props: NumericInputProps) => {
 		state as NumberFieldState,
 		ref
 	)
-	const inputWithCursorHandlingProps = useKeepCursorPositionOnUpdate(
-		inputProps,
+	const { onChange, onKeyDown } = useKeepCursorPositionOnUpdate(
+		inputProps.onChange,
+		inputProps.onKeyDown,
+		props.onSubmit,
 		ref
 	)
-
-	// Handle Enter key for onSubmit
-	const handleKeyDown = useCallback(
-		(e: KeyboardEvent<HTMLInputElement>) => {
-			inputWithCursorHandlingProps.onKeyDown?.(e)
-			if (e.key === 'Enter' && props.onSubmit) {
-				e.preventDefault()
-				props.onSubmit('enter')
-			}
-		},
-		[inputWithCursorHandlingProps.onKeyDown, props.onSubmit]
-	)
-
-	delete inputWithCursorHandlingProps.autoCorrect
 
 	return (
 		<StyledNumericInputContainer>
@@ -125,8 +115,9 @@ export const NumericInput = (props: NumericInputProps) => {
 						'suggestions',
 						'onSubmit'
 					) as HTMLAttributes<HTMLInputElement>)}
-					{...inputWithCursorHandlingProps}
-					onKeyDown={handleKeyDown}
+					{...omit(inputProps, 'autoCorrect')}
+					onChange={onChange}
+					onKeyDown={onKeyDown}
 					placeholder={
 						props.placeholder != null
 							? state.formatter.format(props.placeholder)
@@ -171,13 +162,14 @@ const StyledNumberInput = styled(StyledInput)`
 `
 
 function useKeepCursorPositionOnUpdate(
-	inputProps: InputHTMLAttributes<HTMLInputElement>,
+	inputOnChange: ChangeEventHandler<HTMLInputElement> | undefined,
+	inputOnKeyDown: KeyboardEventHandler<HTMLInputElement> | undefined,
+	inputOnSubmit: ((source?: string) => void) | undefined,
 	inputRef: RefObject<HTMLInputElement>
 ): InputHTMLAttributes<HTMLInputElement> {
 	const [selection, setSelection] = useState<null | number>(null)
 	const [value, setValue] = useState<string | undefined>()
 	const [rerenderSwitch, toggle] = useState(false)
-	const { onChange: inputOnChange, onKeyDown: inputOnKeyDown } = inputProps
 
 	const onChange = useCallback(
 		(e: ChangeEvent<HTMLInputElement>) => {
@@ -197,25 +189,26 @@ function useKeepCursorPositionOnUpdate(
 			inputOnKeyDown?.(e)
 			const input = e.target as HTMLInputElement | undefined
 			if (
-				!(
-					e.key === 'Backspace' &&
-					input?.value
-						?.slice((input.selectionStart ?? 0) - 1, input.selectionStart ?? 0)
-						.match(/[\s]/)
-				)
+				e.key === 'Backspace' &&
+				input?.value
+					?.slice((input.selectionStart ?? 0) - 1, input.selectionStart ?? 0)
+					.match(/[\s]/)
 			) {
-				return
-			}
-			setSelection(
-				Math.max(
-					0,
-					(input.selectionStart ?? 0) - 2,
-					(input.selectionEnd ?? 0) - 2
+				setSelection(
+					Math.max(
+						0,
+						(input.selectionStart ?? 0) - 2,
+						(input.selectionEnd ?? 0) - 2
+					)
 				)
-			)
-			toggle(!rerenderSwitch)
+				toggle(!rerenderSwitch)
+			}
+			if (e.key === 'Enter' && inputOnSubmit) {
+				e.preventDefault()
+				inputOnSubmit('enter')
+			}
 		},
-		[inputOnKeyDown, rerenderSwitch]
+		[inputOnKeyDown, inputOnSubmit, rerenderSwitch]
 	)
 
 	useEffect(() => {
@@ -232,7 +225,7 @@ function useKeepCursorPositionOnUpdate(
 		input.selectionEnd = Math.max(adjustedSelection, 0)
 	}, [inputRef, selection, value, rerenderSwitch])
 
-	return { ...inputProps, onChange, onKeyDown }
+	return { onChange, onKeyDown } satisfies InputHTMLAttributes<HTMLInputElement>
 }
 
 /*

--- a/site/source/design-system/molecules/field/QuantitéField.tsx
+++ b/site/source/design-system/molecules/field/QuantitéField.tsx
@@ -66,7 +66,7 @@ export const QuantitéField = <U extends string = string>({
 		handleChange(quantité<U>(valeurFinale, unité))
 	}
 
-	const formatOptions =
+	const formatOptions = (
 		unité === '%'
 			? {
 					style: 'percent',
@@ -76,6 +76,7 @@ export const QuantitéField = <U extends string = string>({
 					style: 'decimal',
 					maximumFractionDigits: 0,
 			  }
+	) satisfies Intl.NumberFormatOptions
 
 	// Pour les pourcentages, le format 'percent' multiplie par 100,
 	// donc nous devons diviser notre valeur stockée en % par 100

--- a/site/source/pages/assistants/cmg/components/déclaration/CMGPerçuInput.tsx
+++ b/site/source/pages/assistants/cmg/components/déclaration/CMGPerçuInput.tsx
@@ -27,7 +27,7 @@ export default function CMGPerçuInput({ idSuffix, valeur, onChange }: Props) {
 			<MontantField
 				value={O.getOrUndefined(valeur)}
 				unité="Euro"
-				avecCentimes={true}
+				avecCentimes
 				onChange={(montant) => onChange(O.fromNullable(montant))}
 				aria-labelledby={`CMG-perçu-label-${idSuffix}`}
 			/>

--- a/site/source/pages/assistants/cmg/components/déclaration/RémunérationInput.tsx
+++ b/site/source/pages/assistants/cmg/components/déclaration/RémunérationInput.tsx
@@ -31,7 +31,7 @@ export default function RémunérationInput({
 			<MontantField
 				value={O.getOrUndefined(valeur)}
 				unité="Euro"
-				avecCentimes={true}
+				avecCentimes
 				onChange={(montant) => onChange(O.fromNullable(montant))}
 				aria-labelledby={`rémunération-label-${idSuffix}`}
 			/>


### PR DESCRIPTION
Closes #3183 (doublon #3741)

- Permet de saisir des décimales lorsqu'on place le curseur après le '€' dans un champ de type montant

Mais zossi :
- Remet les centimes dans les champs RGCP/Lodeom
- Simplifie le code de `NumericInput`
- Corrige une erreur de type dans `QuantitéFiled`