### PR TITLE
A11y/Refactor <SelectCommune /> following ARIA APG Combobox pattern

### DIFF
--- a/site/source/components/conversation/select/SelectCommune.tsx
+++ b/site/source/components/conversation/select/SelectCommune.tsx
@@ -120,6 +120,7 @@ export default function Select({
 					e.preventDefault()
 					break
 				case 'Escape':
+				case 'Tab':
 					setName('')
 					setSearchResults(null)
 					break

--- a/site/source/components/conversation/select/SelectCommune.tsx
+++ b/site/source/components/conversation/select/SelectCommune.tsx
@@ -135,18 +135,24 @@ export default function Select({
 	return (
 		<Container>
 			<TextField
-				/* role="combobox" // FIXME: Need to use a proper combobox component here */
-				errorMessage={noResult && <Trans>Cette commune n'existe pas</Trans>}
+				role="combobox"
 				id={id}
-				autoFocus={autoFocus}
-				aria-autocomplete="list"
-				onBlur={submitFocusedElem}
-				aria-readonly="true"
-				onKeyDown={handleKeyDown}
 				label={t('Commune ou code postal')}
 				value={name}
-				onChange={handleChange}
+				autoFocus={autoFocus}
 				autoComplete="off"
+				aria-controls="liste-commune"
+				aria-expanded={!!searchResults}
+				aria-activedescendant={
+					searchResults && searchResults.length > 0
+						? `commune-${focusedElem}`
+						: undefined
+				}
+				aria-autocomplete="list"
+				onBlur={submitFocusedElem}
+				onKeyDown={handleKeyDown}
+				onChange={handleChange}
+				errorMessage={noResult && <Trans>Cette commune n'existe pas</Trans>}
 			/>
 
 			{!!searchResults && (

--- a/site/source/components/conversation/select/SelectCommune.tsx
+++ b/site/source/components/conversation/select/SelectCommune.tsx
@@ -150,13 +150,25 @@ export default function Select({
 			/>
 
 			{!!searchResults && (
-				<OptionList role="listbox" aria-expanded="true" id="liste-commune">
+				<OptionList
+					role="listbox"
+					id="liste-commune"
+					tabIndex={0}
+					aria-label={t('Communes et code postaux correspondants')}
+					aria-activedescendant={`commune-${focusedElem}`}
+				>
 					{searchResults.map((result, i) => {
 						const nom = formatCommune(result)
 
 						return (
 							<Option
 								as="li"
+								role="option"
+								id={`commune-${i}`}
+								aria-selected={i === focusedElem}
+								focused={i === focusedElem}
+								key={nom}
+								data-role="commune-option"
 								onMouseDown={
 									// Prevent input blur and focus elem selection
 									(e: React.MouseEvent) => e.preventDefault()
@@ -164,10 +176,6 @@ export default function Select({
 								onClick={() => {
 									void handleSubmit(result)
 								}}
-								role="option"
-								focused={i === focusedElem}
-								data-role="commune-option"
-								key={nom}
 								onFocus={() => setFocusedElem(i)}
 							>
 								{nom}

--- a/site/source/components/conversation/select/SelectCommune.tsx
+++ b/site/source/components/conversation/select/SelectCommune.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEvent, useCallback, useMemo, useState } from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { css, styled } from 'styled-components'
 
 import {
@@ -152,7 +152,7 @@ export default function Select({
 				onBlur={submitFocusedElem}
 				onKeyDown={handleKeyDown}
 				onChange={handleChange}
-				errorMessage={noResult && <Trans>Cette commune n'existe pas</Trans>}
+				errorMessage={noResult && t('Cette commune n’existe pas')}
 			/>
 
 			{!!searchResults && (

--- a/site/source/design-system/molecules/field/TextField.tsx
+++ b/site/source/design-system/molecules/field/TextField.tsx
@@ -11,6 +11,7 @@ const LABEL_HEIGHT = '1rem'
 type TextFieldProps = AriaTextFieldOptions<'input'> & {
 	inputRef?: RefObject<HTMLInputElement>
 	small?: boolean
+	role?: string
 }
 
 export default function TextField(props: TextFieldProps) {
@@ -32,6 +33,7 @@ export default function TextField(props: TextFieldProps) {
 						'errorMessage'
 					) as HTMLAttributes<HTMLInputElement>)}
 					{...(inputProps as HTMLAttributes<HTMLInputElement>)}
+					role={props.role}
 					placeholder={
 						(inputProps as HTMLAttributes<HTMLInputElement>).placeholder ??
 						undefined

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -48,7 +48,7 @@ Bonjour, je suis boulanger et je n'ai pas trouvé en cherchant "pain" ou "vienno
 Budget: Budget
 Bénéfice: Profit
 Cacher le message: Hide message
-Cette commune n'existe pas: This commune does not exist
+Cette commune n’existe pas: This commune does not exist
 Cette opération n'est pas réversible.: This operation is not reversible.
 Charger plus de résultats: Load more results
 Charges: Charges
@@ -59,6 +59,7 @@ Comment ça marche ? Voir la page explicative sur la page du dépôt github, nou
   How does it work? See the explanatory page on the github repository page, new
   window
 Commune ou code postal: Town or zip code
+Communes et code postaux correspondants: Corresponding towns and postcodes
 Confirmer: Confirm
 Cotisations: Contributions
 Cotisations sociales: Social security contributions

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -52,7 +52,7 @@ Bonjour, je suis boulanger et je n'ai pas trouvé en cherchant "pain" ou "vienno
 Budget: Budget
 Bénéfice: Bénéfice
 Cacher le message: Cacher le message
-Cette commune n'existe pas: Cette commune n'existe pas
+Cette commune n’existe pas: Cette commune n’existe pas
 Cette opération n'est pas réversible.: Cette opération n'est pas réversible.
 Charger plus de résultats: Charger plus de résultats
 Charges: Charges
@@ -63,6 +63,7 @@ Comment ça marche ? Voir la page explicative sur la page du dépôt github, nou
   Comment ça marche ? Voir la page explicative sur la page du dépôt github,
   nouvelle fenêtre
 Commune ou code postal: Commune ou code postal
+Communes et code postaux correspondants: Communes et code postaux correspondants
 Confirmer: Confirmer
 Cotisations: Cotisations
 Cotisations sociales: Cotisations sociales


### PR DESCRIPTION
Traite la remontée suivante de l'audit 2025, concernant le Simulateur de revenus pour salarié :

> Le champ d'autocompletion "Dans quelle commune l'établissement est-il implanté ?" ne respecte pas un motif de conception accessible

![image](https://github.com/user-attachments/assets/bbe8b150-16de-4de4-80e5-8ab5f8aa96b1)

---

Un premier commit aligne la liste déroulante avec le [pattern ARIA APG Listbox](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/).
Le second commit aligne l'ensemble du champ avec le [pattern ARIA APG Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).

Les interactions au clavier attendues étaient déjà en place. Il s'agissait surtout de rectifier quelques attributs ARIA.