### PR TITLE
A11y/Boutons "crayons" dans la modale "Modifier mes réponses

### DIFF
--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -288,6 +288,9 @@ function AnswerElement(rule: RuleNode) {
 		: parentDottedName && engine.getRule(parentDottedName).rawNode.API
 		? parentDottedName
 		: undefined
+	const ariaLabel = t('update-rule', 'Modifier {{title}}', {
+		title: rule.title,
+	})
 
 	const handleChange = useCallback(
 		(value: ValeurPublicodes | undefined) => {
@@ -301,14 +304,15 @@ function AnswerElement(rule: RuleNode) {
 		<PopoverWithTrigger
 			small
 			disableOverflowAuto // disable overflow auto for SelectCommune autocomplete to not be hidden
-			ariaLabel={`Modifier ${rule.title}`}
+			ariaLabel={ariaLabel}
 			trigger={(buttonProps) => (
 				<>
 					<Value expression={rule.dottedName} linkToRule={false} />
 					<StyledButton
 						{...buttonProps}
 						aria-haspopup="dialog"
-						aria-label={`Modifier ${rule.title}`}
+						aria-label={ariaLabel}
+						title={ariaLabel}
 					>
 						<span className="print-hidden">
 							<Emoji emoji="✏" />
@@ -355,7 +359,7 @@ const StyledAnswerLine = styled(Grid)`
 	justify-content: flex-end;
 	gap: ${({ theme }) => theme.spacings.sm};
 	min-height: 2.8rem;
-	padding: 0.25rem 0.5rem;
+	padding: ${({ theme }) => `${theme.spacings.xxs} ${theme.spacings.xs}`};
 	color: ${({ theme }) =>
 		theme.darkMode
 			? theme.colors.bases.primary[100]
@@ -374,8 +378,8 @@ const StyledAnswerLine = styled(Grid)`
 `
 
 const StyledButton = styled(Link)`
-	margin: 0 -0.5rem 0 0.5rem;
-	padding: 0.5rem 1rem;
+	margin: 0 -0.5rem 0 1rem;
+	padding: 0.75rem;
 
 	&:hover,
 	&:focus {

--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -303,8 +303,8 @@ function AnswerElement(rule: RuleNode) {
 			disableOverflowAuto // disable overflow auto for SelectCommune autocomplete to not be hidden
 			trigger={(buttonProps) => (
 				<>
-					<Value expression={rule.dottedName} linkToRule={false} />{' '}
-					<Link
+					<Value expression={rule.dottedName} linkToRule={false} />
+					<StyledButton
 						{...buttonProps}
 						aria-haspopup="dialog"
 						aria-label={t(`Modifier ${rule.title}`)}
@@ -312,7 +312,7 @@ function AnswerElement(rule: RuleNode) {
 						<span className="print-hidden">
 							<Emoji emoji="✏" />
 						</span>
-					</Link>
+					</StyledButton>
 				</>
 			)}
 		>
@@ -350,10 +350,11 @@ const StyledAnswer = styled(Grid)`
 `
 const StyledAnswerLine = styled(Grid)`
 	display: flex;
-	margin: ${({ theme }) => `${theme.spacings.md} 0`};
-	align-items: baseline;
+	align-items: center;
 	justify-content: flex-end;
 	gap: ${({ theme }) => theme.spacings.sm};
+	min-height: 2.8rem;
+	padding: 0.25rem 0.5rem;
 	color: ${({ theme }) =>
 		theme.darkMode
 			? theme.colors.bases.primary[100]
@@ -368,12 +369,18 @@ const StyledAnswerLine = styled(Grid)`
 				: theme.colors.bases.primary[100]};
 		color: ${({ theme }) => theme.colors.bases.primary[800]};
 		color-adjust: exact !important;
-		outline: solid
-			${({ theme }) =>
-				`calc(${theme.spacings.md} / 2) ${
-					theme.darkMode
-						? theme.colors.extended.dark[500]
-						: theme.colors.bases.primary[100]
-				}`};
+	}
+`
+
+const StyledButton = styled(Link)`
+	margin: 0 -0.5rem 0 0.5rem;
+	padding: 0.5rem 1rem;
+
+	&:hover,
+	&:focus {
+		outline: 3px solid
+			hsl(var(--COLOR_HUE), calc(var(--COLOR_SATURATION) - 34%), 33%);
+		outline-offset: 2px;
+		box-shadow: 0 0 0 2px #ffffff;
 	}
 `

--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -280,6 +280,7 @@ function StepsTable({
 function AnswerElement(rule: RuleNode) {
 	const dispatch = useDispatch()
 	const engine = useEngine()
+	const { t } = useTranslation()
 
 	const parentDottedName = utils.ruleParent(rule.dottedName) as DottedName
 	const questionDottedName = rule.rawNode.question
@@ -301,12 +302,18 @@ function AnswerElement(rule: RuleNode) {
 			small
 			disableOverflowAuto // disable overflow auto for SelectCommune autocomplete to not be hidden
 			trigger={(buttonProps) => (
-				<Link {...buttonProps} aria-haspopup="dialog" aria-label="Modifier">
+				<>
 					<Value expression={rule.dottedName} linkToRule={false} />{' '}
-					<span className="print-hidden">
-						<Emoji emoji="✏" />
-					</span>
-				</Link>
+					<Link
+						{...buttonProps}
+						aria-haspopup="dialog"
+						aria-label={t(`Modifier ${rule.title}`)}
+					>
+						<span className="print-hidden">
+							<Emoji emoji="✏" />
+						</span>
+					</Link>
+				</>
 			)}
 		>
 			{(onClose) => (

--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -301,13 +301,14 @@ function AnswerElement(rule: RuleNode) {
 		<PopoverWithTrigger
 			small
 			disableOverflowAuto // disable overflow auto for SelectCommune autocomplete to not be hidden
+			ariaLabel={`Modifier ${rule.title}`}
 			trigger={(buttonProps) => (
 				<>
 					<Value expression={rule.dottedName} linkToRule={false} />
 					<StyledButton
 						{...buttonProps}
 						aria-haspopup="dialog"
-						aria-label={t(`Modifier ${rule.title}`)}
+						aria-label={`Modifier ${rule.title}`}
 					>
 						<span className="print-hidden">
 							<Emoji emoji="✏" />

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -267,4 +267,8 @@ const PopoverContent = styled.div<{ $disableOverflowAuto: boolean }>`
 	${({ $disableOverflowAuto }) =>
 		$disableOverflowAuto ? '' : 'overflow: auto;'}
 	padding: 0 ${({ theme }) => theme.spacings.xxl + ' ' + theme.spacings.md};
+
+	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
+		padding: 0 ${({ theme }) => theme.spacings.md + ' ' + theme.spacings.md};
+	}
 `

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -2327,6 +2327,7 @@ termsOfUse:
     and use of the services offered to users.
   title: Terms and conditions of use
 trimestres acquis: quarters acquired
+update-rule: Update {{title}}
 vos retours, accéder aux statistiques d'utilisation: your feedback, access to usage statistics
 warning:
   overwrite:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -2467,6 +2467,7 @@ termsOfUse:
     et utilisatrices.
   title: Conditions générales d'utilisation
 trimestres acquis: trimestres acquis
+update-rule: Modifier {{title}}
 vos retours, accéder aux statistiques d'utilisation: vos retours, accéder aux statistiques d'utilisation
 warning:
   overwrite:


### PR DESCRIPTION
Traite les deux remontées suivantes de l'audit 2025, concernant le Simulateur de revenus pour salarié :

> Dans la modale "Modifier mes réponses" les bouton "crayon" ne sont pas suffisamment pertinent ils ne précisent pas l'élément qui va être modifié

> De plus les modales disponibles après le clique ont des aria-labels non pertinents

![image](https://github.com/user-attachments/assets/df228d62-da49-460d-a3b9-c861e0ca27fb)

Pour pouvoir mettre un `aria-label` sur ces "boutons crayon", j'ai retiré la `<Value>` du bouton, pour ne pas avoir de label visible (qu'il faudrait reprendre dans l'`aria-label`) et pouvoir reprendre le "title" de la règle, plus naturel (et non dynamique).

Le bouton crayon devenant trop petit pour être ergonomique, j'ai modifié quelques styles pour lui donner une surface plus raisonnable de 44 x 44 px :

![image](https://github.com/user-attachments/assets/8ad8715d-dd15-4a88-8898-47d3d5fdaf4e)

Un `title` a sinon été ajouté à ces boutons pour mieux guider les utilisateurs voyants.

J'ai sinon profité de cette PR pour également mettre un `aria-label` à la modale qui s'ouvre lorsqu'on clique sur l'un de ces boutons.
Et pour améliorer le responsive des modales sur smartphone, en réduisant les paddings sur petit écran.