### PR TITLE
fix(impôts-société): Le montant se met en `NaN` dès qu’on saisi quelque chose

### DIFF
--- a/modele-social/règles/entreprise/imposition.publicodes
+++ b/modele-social/règles/entreprise/imposition.publicodes
@@ -241,6 +241,7 @@ entreprise . imposition . IS . résultat imposable:
   titre: Résultat de l’exercice
   résumé: Imposable à l’impôt sur les sociétés
   valeur: résultat fiscal
+  unité: €/an
 
 entreprise . imposition . IS . information sur le report de déficit:
   type: notification


### PR DESCRIPTION
- Définit l'unité à €/an pour le résultat fiscal

Closes #3740