### PR TITLE
A11y/Highlighted word colors contrast in search results

### DIFF
--- a/site/source/components/search/Hightlight.tsx
+++ b/site/source/components/search/Hightlight.tsx
@@ -4,8 +4,8 @@ import { styled } from 'styled-components'
 export const Highlight = styled(ISHighlight)`
 	& .ais-Highlight-highlighted,
 	& .ais-Snippet-highlighted {
-		background-color: rgba(84, 104, 255, 0.1);
-		color: #5468ff;
+		background: #eff1ff;
+		color: #0522ff;
 		font-style: normal;
 	}
 `


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025, concernant la barre de recherche et la page documentation :

> Le mot recherché n'est pas suffisamment contrasté 3,86 au lieu de 4,5

![image](https://github.com/user-attachments/assets/95f38dc6-0269-4ade-a0e7-28ad82706893)

J'ai pu augmenter le contraste autour de 7 sans avoir besoin de beaucoup changer le rendu :

![image](https://github.com/user-attachments/assets/379b8e05-d4b0-48fe-a729-f41e4fb67b6e)

J'ai retiré la couleur avec une transparence car c'est mal de mettre de la transparence quand on n'a pas besoin de transparence. 😛

Par contre, je n'ai pas pu tester en local car les barres de recherche n'y fonctionnent pas. 😕

Closes https://github.com/betagouv/mon-entreprise/issues/3645