### PR TITLE
A11y/Color contrast in status choice results

### DIFF
--- a/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
@@ -81,7 +81,7 @@ const Label = styled(Body)`
 	color: ${({ theme }) =>
 		theme.darkMode
 			? theme.colors.extended.grey[200]
-			: theme.colors.extended.grey[600]}!important;
+			: theme.colors.extended.grey[700]}!important;
 	font-size: 0.875rem;
 `
 


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025, concernant les résultats d'un Choix de statut :

![image](https://github.com/user-attachments/assets/f9473de5-052e-470b-96d8-aba3e39b975f)

Cette amélioration du contraste semble aussi rendre le choix de couleur plus consistant avec le CSS alentour.

![image](https://github.com/user-attachments/assets/5c48946b-7ab8-4ab5-ad43-24cc541f8f35)

Closes https://github.com/betagouv/mon-entreprise/issues/3646