### PR TITLE
A11y/Display non available status in a separate list

### DIFF
--- a/site/source/pages/assistants/choix-du-statut/_components/StatutsPossibles.tsx
+++ b/site/source/pages/assistants/choix-du-statut/_components/StatutsPossibles.tsx
@@ -7,32 +7,45 @@ import { StatutTag, StatutType } from '@/components/StatutTag'
 import { useEngine } from '@/components/utils/EngineContext'
 import { H5, Li, Message, Ul } from '@/design-system'
 
+const STATUTS = [
+	'entreprise . catégorie juridique . EI . EI',
+	'entreprise . catégorie juridique . EI . auto-entrepreneur',
+	'entreprise . catégorie juridique . SARL . EURL',
+	'entreprise . catégorie juridique . SARL . SARL',
+	'entreprise . catégorie juridique . SAS . SAS',
+	'entreprise . catégorie juridique . SAS . SASU',
+	'entreprise . catégorie juridique . SELARL . SELARL',
+	'entreprise . catégorie juridique . SELARL . SELARLU',
+	'entreprise . catégorie juridique . SELAS . SELAS',
+	'entreprise . catégorie juridique . SELAS . SELASU',
+	'entreprise . catégorie juridique . association',
+] as DottedName[]
+
 export default function StatutsPossibles() {
 	const engine = useEngine()
-	const statuts = [
-		'entreprise . catégorie juridique . EI . EI',
-		'entreprise . catégorie juridique . EI . auto-entrepreneur',
-		'entreprise . catégorie juridique . SARL . EURL',
-		'entreprise . catégorie juridique . SARL . SARL',
-		'entreprise . catégorie juridique . SAS . SAS',
-		'entreprise . catégorie juridique . SAS . SASU',
-		'entreprise . catégorie juridique . SELARL . SELARL',
-		'entreprise . catégorie juridique . SELARL . SELARLU',
-		'entreprise . catégorie juridique . SELAS . SELAS',
-		'entreprise . catégorie juridique . SELAS . SELASU',
-		'entreprise . catégorie juridique . association',
-	].sort(
-		(a, b) =>
-			(engine.evaluate({ '=': [a, 'non'] }).nodeValue ? 1 : -1) -
-			(engine.evaluate({ '=': [b, 'non'] }).nodeValue ? 1 : -1)
-	) as DottedName[]
+
+	const nonAvailableStatus = STATUTS.filter(
+		(statut) => engine.evaluate({ '=': [statut, 'non'] }).nodeValue
+	)
+
+	const availableStatus = STATUTS.filter(
+		(statut) => !nonAvailableStatus.includes(statut)
+	)
 
 	return (
 		<StyledMessage>
-			<H5 as="h2"> Statuts disponibles</H5>
+			<H5 as="h2">Statuts disponibles</H5>
 
 			<StyledUl $noMarker as={FlipMove} typeName="ul">
-				{statuts.map((statut) => (
+				{availableStatus.map((statut) => (
+					<Statut key={statut} statut={statut} />
+				))}
+			</StyledUl>
+
+			<H5 as="h2">Statuts non disponibles</H5>
+
+			<StyledUl $noMarker as={FlipMove} typeName="ul">
+				{nonAvailableStatus.map((statut) => (
 					<Statut key={statut} statut={statut} />
 				))}
 			</StyledUl>


### PR DESCRIPTION
Cette concerne la remontée suivante de l'audit 2025 concernant le choix d'un statut juridique :

> Dans la partie "Statuts disponibles" l'indication des status non disponible est indiquée uniquement par la forme

![image](https://github.com/user-attachments/assets/2312379c-e59b-41d4-97f2-b5705adda59a)

Je propose dans cette PR d'ajouter un titre intermédiaire "Statuts non disponibles" pour simplement séparer les statuts en deux listes distinctes :

![image](https://github.com/user-attachments/assets/ea998b7b-8a4d-41ca-8d1d-1efa6a0502e4)

Closes https://github.com/betagouv/mon-entreprise/issues/3665