### PR TITLE
[Auto-entrepreneur] Bug quand on rentre un chiffre d'affaires en activité mixte

### DIFF
--- a/site/source/components/ChiffreAffairesActivitéMixte.tsx
+++ b/site/source/components/ChiffreAffairesActivitéMixte.tsx
@@ -6,7 +6,7 @@ import * as R from 'effect/Record'
 import { DottedName } from 'modele-social'
 import { useCallback } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { styled } from 'styled-components'
 
 import { Switch } from '@/design-system'
@@ -16,6 +16,7 @@ import {
 } from '@/domaine/engine/PublicodesAdapter'
 import * as M from '@/domaine/Montant'
 import { batchUpdateSituation } from '@/store/actions/actions'
+import { targetUnitSelector } from '@/store/selectors/simulationSelectors'
 
 import { ExplicableRule } from './conversation/Explicable'
 import { Condition } from './EngineValue/Condition'
@@ -90,22 +91,40 @@ export default function ChiffreAffairesActivitéMixte({
 function useAdjustProportions(CADottedName: DottedName) {
 	const engine = useEngine()
 	const dispatch = useDispatch()
+	const currentUnit = useSelector(targetUnitSelector)
 
 	return useCallback(
 		(name: DottedName, valeur?: ValeurPublicodes) => {
-			const nouvelleValeurPour = (règleCA: DottedName): O.Option<M.Montant> =>
-				règleCA === name
-					? O.fromNullable((valeur as M.Montant | undefined) || M.eurosParAn(0))
-					: (pipe(
-							engine.evaluate(règleCA),
-							PublicodesAdapter.decode
-					  ) as O.Option<M.Montant>)
+			const defaultValue =
+				currentUnit === '€/an' ? M.eurosParAn(0) : M.eurosParMois(0)
+			const convertisseur = (m: ValeurPublicodes) =>
+				currentUnit === '€/an'
+					? M.toEurosParAn(m as M.Montant)
+					: M.toEurosParMois(m as M.Montant)
+
+			const nouvelleValeurPour = (règleCA: DottedName): O.Option<M.Montant> => {
+				const nouvelleValeur =
+					règleCA === name
+						? pipe(
+								(valeur as M.Montant | undefined) || defaultValue,
+								convertisseur,
+								O.fromNullable
+						  )
+						: pipe(
+								engine.evaluate(règleCA),
+								PublicodesAdapter.decode,
+								O.map(convertisseur)
+						  )
+
+				return nouvelleValeur
+			}
 
 			const nouveauCA = pipe(
 				Object.values(proportions),
 				A.map(nouvelleValeurPour),
 				A.getSomes,
-				M.somme
+				M.somme,
+				E.getOrElse(() => defaultValue)
 			)
 
 			const nouvellesProportions = pipe(
@@ -133,7 +152,7 @@ function useAdjustProportions(CADottedName: DottedName) {
 
 			dispatch(batchUpdateSituation(situation))
 		},
-		[CADottedName, engine, dispatch]
+		[CADottedName, dispatch, currentUnit, engine]
 	)
 }
 

--- a/site/source/domaine/Montant.test.ts
+++ b/site/source/domaine/Montant.test.ts
@@ -19,6 +19,8 @@ import {
 	moins,
 	Montant,
 	plus,
+	somme,
+	SommeImpossible,
 	toString,
 } from './Montant'
 
@@ -74,6 +76,26 @@ describe('Montant', () => {
 			const resultat = fois(montant, 2)
 			expect(Equal.equals(resultat, euros(200))).toBe(true)
 			expect(resultat.unité).toBe('Euro')
+		})
+
+		it('somme correctement plusieurs montants de même unité', () => {
+			const montants = [eurosParAn(100), eurosParAn(200), eurosParAn(300)]
+			const resultatEither = somme(montants)
+			expect(Either.isRight(resultatEither)).toBe(true)
+			if (Either.isRight(resultatEither)) {
+				expect(Equal.equals(resultatEither.right, eurosParAn(600))).toBe(true)
+				expect(resultatEither.right.unité).toBe('EuroParAn')
+			}
+		})
+
+		it("retourne une erreur lors d'une somme de montants d'unités différentes", () => {
+			const montants = [eurosParAn(100), eurosParMois(200), eurosParAn(300)]
+			const resultatEither = somme(montants)
+			expect(Either.isLeft(resultatEither)).toBe(true)
+			if (Either.isLeft(resultatEither)) {
+				expect(resultatEither.left).toBeInstanceOf(SommeImpossible)
+				expect(resultatEither.left.unités).toStrictEqual(['EuroParAn', 'EuroParMois'])
+			}
 		})
 
 		it('divise correctement un montant par un scalaire non nul', () => {

--- a/site/source/domaine/Montant.ts
+++ b/site/source/domaine/Montant.ts
@@ -1,4 +1,5 @@
-import { Data, Either } from 'effect'
+import { Data, Either, pipe } from 'effect'
+import * as A from 'effect/Array'
 import { dual } from 'effect/Function'
 import { isObject } from 'effect/Predicate'
 
@@ -26,6 +27,9 @@ export class ConversionImpossible extends Data.TaggedError(
 )<{
 	readonly source: UnitéMonétaire
 	readonly cible: UnitéMonétaire
+}> {}
+export class SommeImpossible extends Data.TaggedError('SommeImpossible')<{
+	readonly unités: UnitéMonétaire[]
 }> {}
 
 const Symbole: Record<UnitéMonétaire, string> = {
@@ -192,7 +196,19 @@ export const plus = dual<
 
 export const somme = <T extends UnitéMonétaire>(
 	montants: ReadonlyArray<Montant<T>>
-): Montant<T> => montants.reduce((a, b) => plus(a, b))
+): Either.Either<Montant<T>, SommeImpossible> => {
+	const unités = pipe(
+		montants,
+		A.map((m) => m.unité),
+		A.dedupe
+	)
+
+	if (unités.length > 1) {
+		return Either.left(new SommeImpossible({ unités }))
+	}
+
+	return Either.right(montants.reduce((a, b) => plus(a, b)))
+}
 
 export const moins = dual<
 	<M extends Montant>(b: M) => (a: M) => M,


### PR DESCRIPTION
Closes #3802

- Convertit les CA d'activité mixte à la bonne unité
- Ajoute aussi une erreur dans `Montant.somme` en cas d'unités différentes.
- Ajoute des tests sur `Montant.somme`