### PR TITLE
Transmet l'information de la page courante de la pagination

### DIFF
--- a/site/source/pages/statistiques/DemandesUtilisateurs.tsx
+++ b/site/source/pages/statistiques/DemandesUtilisateurs.tsx
@@ -85,9 +85,11 @@ function Pagination({ title, items }: PaginationProps) {
 									search: currentSearch,
 								}}
 								state={{ ...state, [title]: i }}
-								aria-label={`${title}, Page ${i + 1}`}
+								aria-label={`${title}, Page ${i + 1}${
+									currentPage === i ? ', page actuelle' : ''
+								}`}
 								currentPage={currentPage === i}
-								aria-current={currentPage === i ? 'page' : undefined}
+								aria-current={currentPage === i}
 							>
 								{i + 1}
 							</PagerButton>

--- a/site/source/pages/statistiques/DemandesUtilisateurs.tsx
+++ b/site/source/pages/statistiques/DemandesUtilisateurs.tsx
@@ -159,14 +159,17 @@ const PagerButton = styled(Button)<PagerButtonProps>`
 		currentPage
 			? `2px solid ${theme.colors.bases.primary[600]}`
 			: `2px solid ${theme.colors.extended.grey[400]}`};
-	background-color: ${({ theme, currentPage }) =>
+
+	${({ theme, currentPage }) =>
 		currentPage &&
 		css`
-			${theme.colors.bases.primary[100]}
-		`};
-	&:hover {
-		background-color: ${({ theme }) => theme.colors.bases.primary[100]};
-	}
+			color: ${theme.colors.extended.grey[100]};
+			background: ${theme.colors.bases.primary[600]};
+
+			&:hover {
+				background: ${theme.colors.bases.primary[600]};
+			}
+		`}
 `
 
 const Pager = styled.ol`


### PR DESCRIPTION
Actuellement la page active de la pagination n'est affichée que par la couleur.

J'ai corrigé le retour qui dit "tous les liens possèdent un aria-current=page".

@logic-fabric je pensais qu'on pouvait enlever le lien sur la page courante, t'en penses quoi ? 
Ça enlève le border et donc pas que de la couleur.
Si ça te va, je veux bien que tu regardes pour la partie technique.

Closes #3643 