### PR TITLE
A11y/L'appui sur Escape doit fermer une seule modale à la fois

### DIFF
--- a/site/source/components/conversation/AnswerList.tsx
+++ b/site/source/components/conversation/AnswerList.tsx
@@ -208,7 +208,7 @@ export default function AnswerList({
 						style={{
 							textAlign: 'center',
 						}}
-					></div>
+					/>
 					<StepsTable {...{ rules: companyQuestions, onClose }} />
 					<Spacing md />
 					<div className="print-hidden">

--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -99,11 +99,6 @@ export function Popover(
 										{...modalProps}
 										{...overlayProps}
 										$offsetTop={offsetTop}
-										onKeyDown={(e) => {
-											if (props.isDismissable && e.key === 'Escape') {
-												props.onClose?.()
-											}
-										}}
 										ref={ref}
 										aria-label={ariaLabel || title}
 										data-cy="modal"


### PR DESCRIPTION
Cette concerne la remontée suivante de l'audit 2025 concernant le simulateur salarié :

> Dans la modale "Modifier mes reponses" si on ouvre une seconde fenêtre modale et que l'on souhaite la fermer, nous revenons pas sur l'élément déclencheur

![image](https://github.com/user-attachments/assets/6c2b5ee6-c4bd-4dcf-9b6d-6f09d591219e)

Le comportement attendu était présent en cliquant sur "Fermer" mais, en appuyant sur Escape, les deux modales se fermaient ensemble.

Le problème vient de l'ajout d'un event listener qui "court-circuite" le comportement (correct) apporté par le `useOverlay` de React-Aria :

```js
onKeyDown={(e) => {
  if (props.isDismissable && e.key === 'Escape') {
    props.onClose?.()
  }
}}
```

Cet event listener me semble inutile car `props.onClose()` est déjà pris en charge par `useOverlay`. Il lui est passé dans les `...props` (lignes 42-45 de `Popover.tsx`) :

```js
const { overlayProps, underlayProps } = useOverlay(
  { isOpen: true, ...props },
  ref
)
```

Le supprimer rétablit le comportement attendu et ne devrait pas avoir d'effet de bord sur d'autres modales je pense.

Closes https://github.com/betagouv/mon-entreprise/issues/3659