### PR TITLE
A11y/Remove useless <div> with role='presentation' in <ObjectifSaisissableDeSimulation />

### DIFF
--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -1,5 +1,5 @@
 import { Option } from 'effect'
-import React, { useState } from 'react'
+import React from 'react'
 import { styled } from 'styled-components'
 
 import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
@@ -34,21 +34,8 @@ export function ObjectifSaisissableDeSimulation({
 	rendreChampSaisie,
 	small = false,
 	appear = true,
-	onFocus,
-	onBlur,
 }: ObjectifSaisissableDeSimulationProps) {
 	const initialRender = useInitialRender()
-	const [isFocused, setFocused] = useState(false)
-
-	const handleFocus = () => {
-		setFocused(true)
-		onFocus?.()
-	}
-
-	const handleBlur = () => {
-		setFocused(false)
-		onBlur?.()
-	}
 
 	const montantAnimation = Option.isSome(valeur) ? valeur.value : undefined
 
@@ -89,12 +76,10 @@ export function ObjectifSaisissableDeSimulation({
 					</Grid>
 					<LectureGuide />
 					<Grid item md={small ? 2 : 3} sm={small ? 3 : 4} xs={4}>
-						{!isFocused && !small && montantAnimation !== undefined && (
+						{!small && montantAnimation !== undefined && (
 							<AnimatedTargetValue value={montantAnimation} />
 						)}
-						<div onFocus={handleFocus} onBlur={handleBlur} role="presentation">
-							{rendreChampSaisie()}
-						</div>
+						{rendreChampSaisie()}
 					</Grid>
 				</Grid>
 			</StyledGoal>


### PR DESCRIPTION
Je viens de remarquer que les champs initiaux du simulateur salarié avaient leur `<input />` à l'intérieur d'une `<div>` avec un `role="presentation"` :

<img width="827" height="394" alt="image" src="https://github.com/user-attachments/assets/a7572007-9e82-41b8-99b2-64fded0586e9" />

On a ajouté à cette `<div>` des event handlers pour la prise et la perte du focus.

---

A priori, le `role="presentation` retire la sémantique de cette `<div>` (qui n'en a pas) et de ses descendants.

Les cas où l'utilisation de ce `role` est justifiée sont rares (par exemple un `<table role="presentation">` utilisé, "à l'ancienne", pour avoir un grille à styler).

Cependant, en testant avec VoiceOver, on peut tout de même accéder au clavier et interagir avec les `<input >`, avec une vocalisation correcte.

Mais, en démontant, cette `<div role="presentation">`, le comportement au clavier et avec VoiceOver m'a semblé identique.

Je propose donc de démonter cette `<div>` :
- pour retirer du code apparemment inutile
- car il est possible que ce `role="presentation` pose problème avec d'autres lecteurs d'écran (ils semblent ne pas traiter ce `role` de manière uniforme selon [MDN](https://developer.mozilla.org/fr/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role#effets_possibles_sur_les_agents_utilisateurs_et_les_technologies_dassistance))

---

@JalilArfaoui J'aimerai que tu regardes la PR car tu apparais comme le dernier à avoir modifier le code que je propose de retirer ici, au cas où tu aurais vu le pourquoi de cette `<div>`.

@newick Pourrais-tu vérifier toi aussi que la navigation au clavier et le rendu au lecteur d'écran sont identiques sur cette branche branche et sur `main` ?