### PR TITLE
A11Y/Add role='status' to <Notifications /> container to make it an ARIA live region

### DIFF
--- a/site/source/components/Notifications.tsx
+++ b/site/source/components/Notifications.tsx
@@ -63,6 +63,7 @@ export default function Notifications() {
 
 	return (
 		<div
+			role="status"
 			style={{
 				marginTop: '1rem',
 			}}


### PR DESCRIPTION
Cette PR traite **(en théorie)** la remontée suivante de l'audit 2025, concernant le simulateur salarié :

> Les messages sous les boutons "Précédent/Suivant" disponibles en cas d'action dans le formulaire de réponse aux question ne sont pas restitués aux TA

**En théorie car** cette remontée doit concerner la `<Notifications />` suivante, qui n'apparaît plus pour une raison qui m'échappe (je n'arrive pas à voir à quel moment elle a été retirée) :

<img width="820" height="99" alt="image" src="https://github.com/user-attachments/assets/3452db4d-b4c1-4a0b-b1a0-72b6428b28ea" />

Cette notification apparaissait dès qu'on saisissait par exemple 50 000 € en étant en "Montant mensuel".

---

@JalilArfaoui @liliced Le problème est que cette notification, sous le formulaire, n'était pas vocalisée au moment de la saisie. Un utilisateur avec un lecteur d'écran se retrouvait à la découvrir un peu tard pour qu'elle soit comprise.

La solution consiste à faire du container de cette notification une "live region", en lui donnant un `role` qui peut être `"alert"`, `"status"` ou `"log"` :

- `role="alert"` interrompt immédiatement la vocalisation en cours pour énoncer la notification (pour un message d'erreur typiquement)
- `role="status"` laisse le lecteur d'écran "finir sa phrase" avant que la notification ne soit vocalisée (pour un warning comme ici par exemple)
- `role="log"` lui sert surtout pour les processus "à étapes" qu'il est moins pressant de vocaliser

### Deux choses à savoir concernant les live regions

#### Éviter d'utiliser `aria-live` et `aria-atomic`

En principe, chacun de ces rôles est équivalent à combinaison de valeurs `aria-live / aria-atomic`.
Dans la pratique, les tests montrent que ces attributs ne fonctionnent pas correctement pour de nombreux couplages OS / navigateur / lecteur d'écran.

C'est un des meilleurs exemples de différences d'implémentation d'ARIA selon les navigateurs et technologies d'assistance.

On peut le voir dans le "Can I Use de l'accessibilité" qu'est https://a11ysupport.io/.

Il est donc préférable de ne pas utiliser l'option `aria-live / aria-atomic` et de privilégier l'usage des rôles `alert / status / log`.

#### Ne pas ajouter la live region dynamiquement

Les live regions fonctionnent généralement bien lorsque la live region est présente dans le DOM avant qu'on ne lui injecte un contenu à annoncer.

Si on ajoute dynamiquement ce container, au moment d'injecter le contenu à annoncer, la restitution est très aléatoire selon les combos OS / navigateur / lecteur d'écran.

### Pour aller plus loin

La [série d'articles sur les live regions d'Access42](https://access42.net/tag/utiliser-live-regions-aria/) fait bien le tour du sujet.

J'ai en gros résumé ici les deux premiers article, mais le 3ème, ["Live regions ARIA : bonnes et mauvaises pratiques"](https://access42.net/quand-utiliser-live-regions-aria/) permet de savoir quand une live region est pertinente et quand il ne fait pas en mettre.

Closes https://github.com/betagouv/mon-entreprise/issues/3673