### PR TITLE
A11y/Add a visible label to "Votre lien de partage" URL

### DIFF
--- a/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
+++ b/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { styled } from 'styled-components'
 
 import {
 	Body,
@@ -41,14 +42,11 @@ export function ShareSimulationPopup({ url }: { url: string }) {
 				</Trans>
 			</Intro>
 
+			<UrlLabel as="label">{t('URL de votre simulation')}</UrlLabel>
+
 			<Grid container spacing={3}>
 				<Grid item xs={12} sm>
-					<TextField
-						inputRef={inputRef}
-						onFocus={selectInput}
-						value={url}
-						aria-label="URL de votre simulation"
-					/>
+					<TextField inputRef={inputRef} onFocus={selectInput} value={url} />
 				</Grid>
 
 				{navigator.clipboard ? (
@@ -107,3 +105,8 @@ export function ShareSimulationPopup({ url }: { url: string }) {
 		</>
 	)
 }
+
+const UrlLabel = styled(SmallBody)`
+	position: relative;
+	top: -${({ theme }) => theme.spacings.xs};
+`

--- a/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
+++ b/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
@@ -42,11 +42,18 @@ export function ShareSimulationPopup({ url }: { url: string }) {
 				</Trans>
 			</Intro>
 
-			<UrlLabel as="label">{t('URL de votre simulation')}</UrlLabel>
+			<UrlLabel as="label" htmlFor="simulation-share-url">
+				{t('URL de votre simulation')}
+			</UrlLabel>
 
 			<Grid container spacing={3}>
 				<Grid item xs={12} sm>
-					<TextField inputRef={inputRef} onFocus={selectInput} value={url} />
+					<TextField
+						id="simulation-share-url"
+						inputRef={inputRef}
+						onFocus={selectInput}
+						value={url}
+					/>
 				</Grid>
 
 				{navigator.clipboard ? (

--- a/site/source/design-system/molecules/field/TextField.tsx
+++ b/site/source/design-system/molecules/field/TextField.tsx
@@ -11,6 +11,7 @@ const LABEL_HEIGHT = '1rem'
 type TextFieldProps = AriaTextFieldOptions<'input'> & {
 	inputRef?: RefObject<HTMLInputElement>
 	small?: boolean
+	id?: string
 	role?: string
 }
 
@@ -33,6 +34,7 @@ export default function TextField(props: TextFieldProps) {
 						'errorMessage'
 					) as HTMLAttributes<HTMLInputElement>)}
 					{...(inputProps as HTMLAttributes<HTMLInputElement>)}
+					{...(props.id && { id: props.id })}
 					role={props.role}
 					placeholder={
 						(inputProps as HTMLAttributes<HTMLInputElement>).placeholder ??

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -240,6 +240,7 @@ Tout plier: Fold everything
 Tout réinitialiser: Reset all
 Trimestre: Quarter
 Type: Type
+URL de votre simulation: URL of your simulation
 Un avis sur cette page ?: What do you think of this page?
 Urssaf, voir le site urssaf:
   fr, nouvelle fenêtre: Urssaf, see the urssaf.fr website, new window

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -253,6 +253,7 @@ Tout plier: Tout plier
 Tout réinitialiser: Tout réinitialiser
 Trimestre: Trimestre
 Type: Type
+URL de votre simulation: URL de votre simulation
 Un avis sur cette page ?: Un avis sur cette page ?
 Urssaf, voir le site urssaf:
   fr, nouvelle fenêtre: Urssaf, voir le site urssaf.fr, nouvelle fenêtre


### PR DESCRIPTION
Cette PR traite traite la remontée suivante de l'audit 2025 concernant le simulateur salarié :

> Dans la modale "Votre lien de partage" l'étiquette n'est pas visible

La capture ci-dessous montre la correction :

<img width="944" height="729" alt="image" src="https://github.com/user-attachments/assets/8cbdc5fe-3633-48d9-9b40-b4d30665d0ce" />