### PR TITLE
A11y/Position of 'Donner son avis' button and dialog when zooming at 400%

### DIFF
--- a/site/source/components/Feedback/index.tsx
+++ b/site/source/components/Feedback/index.tsx
@@ -108,7 +108,7 @@ const StyledButton = styled.button<{
 	$isEmbedded?: boolean
 }>`
 	position: fixed;
-	top: ${({ $isEmbedded }) => ($isEmbedded ? '2rem' : '10.5rem')};
+	top: ${({ $isEmbedded }) => ($isEmbedded ? '2rem' : '20%')};
 	right: 0;
 	width: 3.75rem;
 	height: 3.75rem;
@@ -171,7 +171,7 @@ const StyledButton = styled.button<{
 
 const Section = styled.section<{ $isEmbedded?: boolean }>`
 	position: fixed;
-	top: 10.5rem;
+	top: 20%;
 	${({ $isEmbedded }) => ($isEmbedded ? `top: 2rem;` : '')}
 	right: 0;
 	width: 17.375rem;

--- a/site/source/components/Feedback/index.tsx
+++ b/site/source/components/Feedback/index.tsx
@@ -49,10 +49,7 @@ const FeedbackButton = ({ isEmbedded }: { isEmbedded?: boolean }) => {
 				<FocusTrap>
 					<ForceThemeProvider forceTheme="dark">
 						<CloseButtonContainer>
-							<CloseButton
-								onClick={handleClose}
-								aria-label={t('Fermer le module "Donner son avis"')}
-							>
+							<CloseButton onClick={handleClose} aria-expanded={true}>
 								Fermer
 								<svg
 									role="img"
@@ -96,7 +93,6 @@ const FeedbackButton = ({ isEmbedded }: { isEmbedded?: boolean }) => {
 			aria-label={t('Donner votre avis')}
 			onClick={() => setIsFormOpen(true)}
 			$isEmbedded={isEmbedded}
-			aria-haspopup="dialog"
 			aria-expanded={false}
 		>
 			<Emoji emoji="👋" />


### PR DESCRIPTION
Cette PR traite traite la remontée suivante de l'audit 2025 concernant toutes les pages du site :

> Le bouton "Faire une suggestion" n'est pas visible

Elle concerne les pages lorsqu'on zoome à 400% :

<img width="1564" height="1199" alt="image" src="https://github.com/user-attachments/assets/3a546990-c0e7-454a-bd44-709a983a4f65" />

---

En positionnant le bouton "main qui fait coucou" et la boîte de dialogue avec des `%` plutôt que des `rem`, on rend la position `fixed` indépendante du niveau de zoom (ou de l'agrandissement de la police dans les paramètres du navigateur, qui n'est pas équivalente au zoom car seuls les textes grandissent alors : là le RGAA demande que l'UI résiste avec un agrandissement de seulement 200% des caractères, sans zoom) :

<img width="1564" height="1199" alt="image" src="https://github.com/user-attachments/assets/0fbd10a9-3d5e-4681-a247-b3b089e4cb76" />

---

**Remarque :** L'audit de 2023 notait que le focus pouvait s'échapper de la boîte de dialogue mais pas celui de 2025.

En fait, il semblerait qu'un composant `dialog` n'ait besoin de ce "focus trap" que s'il apparaît comme une modale (un overaly bloque l'accès à l'arrière-plan).

Le pattern APG est d'ailleurs ["Dialog(Modal")](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) et pas juste "Dialog".

Le code plaçant ce bouton dans le footer avec un attribut `aria-expanded`, on peut en fait considérer ce composant pour les lecteurs d'écran comme un accordéon ([Disclosure (Show/Hide) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/)) plutôt qu'une boîte de dialogue.

Cela fait sens qu'il soit rendu comme tel par lecteur d'écran. Son apparence pour les voyants n'a pas besoin d'être celle d'un accordéon.

Le fait que le focus puisse sortir (ou retourner) dans la "boîte de dialogue dépliée" fait sens pour les lecteurs d'écran.

---

Un deuxième commit améliore (et allège) l'emploi d'ARIA sur ce composant `<FeedbackButton />`.

Closes https://github.com/betagouv/mon-entreprise/issues/3666