### PR TITLE
fix(a11y): met les titres entre h3 et non div

### DIFF
--- a/site/source/components/entreprise/EntrepriseSearchDetails.tsx
+++ b/site/source/components/entreprise/EntrepriseSearchDetails.tsx
@@ -30,7 +30,7 @@ export default function EntrepriseSearchDetails({
 	return (
 		<CompanyContainer>
 			<H4
-				as="div"
+				as="h3"
 				style={{
 					margin: '0',
 				}}


### PR DESCRIPTION
<img width="776" height="153" alt="image" src="https://github.com/user-attachments/assets/0a1f68e4-de35-41cd-b46f-368458e4403c" />

Les titres étaient entourés par des `<div>`, j'ai remplacé par des `<h3>` car le parent est un `<h2>`.

Closes #3855
