### PR TITLE
Résultats de recherche en liste non-ordonnée

### DIFF
--- a/site/source/components/search/RulesInfiniteHits/index.tsx
+++ b/site/source/components/search/RulesInfiniteHits/index.tsx
@@ -60,7 +60,7 @@ const Hit = (hit: THit) => {
 	)
 }
 
-const HitList = styled.ol`
+const HitList = styled.ul`
 	display: flex;
 	flex-direction: column;
 	margin: 0;


### PR DESCRIPTION
Dans l'audit était précisé que les résultats de "Documentation des simulateurs" étaient dans des `<ol>`, j'ai remplacé par des `<ul>`.

Il n'y a pas d'ordre donc pas besoin d'ordonner :)

Closes #3858 
Closes #3857 