### PR TITLE
fix(CSS): aligne l'unité dans les champs numériques

### DIFF
--- a/site/source/design-system/atoms/NumericInput.tsx
+++ b/site/source/design-system/atoms/NumericInput.tsx
@@ -162,6 +162,10 @@ const StyledNumericInputContainer = styled(StyledContainer)`
 
 const StyledNumberInput = styled(StyledInput)`
 	text-align: right;
+
+	& + label + span {
+		padding-top: ${({ theme }) => theme.spacings.md};
+	}
 `
 
 const Unit = styled.span<{ $small?: boolean }>`


### PR DESCRIPTION
Avant
<img width="315" height="69" alt="image" src="https://github.com/user-attachments/assets/d945f78d-337f-4c84-89d2-c354930af2b1" />

Maintenant
<img width="311" height="79" alt="image" src="https://github.com/user-attachments/assets/61de25b9-3118-4de9-b956-b79ff142d89f" />
