### PR TITLE
Listes structurées pour la page de choix du statut

### DIFF
--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -8,7 +8,7 @@ import { Condition } from '@/components/EngineValue/Condition'
 import Value from '@/components/EngineValue/Value'
 import { WhenNotApplicable } from '@/components/EngineValue/WhenNotApplicable'
 import RuleLink from '@/components/RuleLink'
-import { Body, Grid, HelpIcon, Li, Strong, Ul } from '@/design-system'
+import { Body, Grid, HelpIcon, Strong, Ul } from '@/design-system'
 import { EngineComparison } from '@/pages/simulateurs/comparaison-statuts/EngineComparison'
 
 import { getBestOption, OptionType } from '../utils'
@@ -86,127 +86,115 @@ const DetailsRowCards = ({
 		.filter((arrayOfStatus) => arrayOfStatus.length > 0)
 
 	return (
-		<ResultsWrapper>
-			<Grid container spacing={4} as={Ul}>
-				{groupedOptions.map((sameValueOptions) => {
-					const statusObject = sameValueOptions[0]
+		<Grid container spacing={4} as={Ul}>
+			{groupedOptions.map((sameValueOptions) => {
+				const statusObject = sameValueOptions[0]
 
-					return (
-						<Grid
-							key={statusObject.name}
-							item
-							as={Li}
-							{...getGridSizes(sameValueOptions.length, options.length)}
+				return (
+					<Grid
+						key={statusObject.name}
+						item
+						as="li"
+						{...getGridSizes(sameValueOptions.length, options.length)}
+					>
+						<StatusCard
+							statut={sameValueOptions.map(({ name }) => name)}
+							footerContent={footer?.(statusObject.engine)}
+							isBestOption={
+								sameValueOptions.length !== options.length &&
+								bestOptionValue === statusObject.name
+							}
 						>
-							<StatusCard
-								statut={sameValueOptions.map(({ name }) => name)}
-								footerContent={footer?.(statusObject.engine)}
-								isBestOption={
-									sameValueOptions.length !== options.length &&
-									bestOptionValue === statusObject.name
-								}
-							>
-								<StyledBody as="div">
-									{dottedName && (
-										<WhenNotApplicable
+							<StyledBody as="div">
+								{dottedName && (
+									<WhenNotApplicable
+										dottedName={dottedName}
+										engine={statusObject.engine}
+									>
+										<DisabledLabel>Ne s'applique pas</DisabledLabel>
+										<StyledRuleLink
+											documentationPath={`${statusObject.name as string}`}
 											dottedName={dottedName}
 											engine={statusObject.engine}
 										>
-											<DisabledLabel>Ne s'applique pas</DisabledLabel>
-											<StyledRuleLink
-												documentationPath={`${statusObject.name as string}`}
-												dottedName={dottedName}
-												engine={statusObject.engine}
-											>
-												<HelpIcon />
-											</StyledRuleLink>
-										</WhenNotApplicable>
-									)}
-									{expressionOrDottedName && (
-										<>
-											<Condition
-												expression={{
-													et: [
-														{ 'est défini': expressionOrDottedName },
-														{ 'est applicable': expressionOrDottedName },
-													],
-												}}
-												engine={statusObject.engine}
-											>
-												<StyledDiv>
-													<span>
-														<Value
-															linkToRule={false}
-															expression={expressionOrDottedName}
-															engine={statusObject.engine}
-															precision={0}
-															unit={unit}
-															displayedUnit={displayedUnit}
-														/>
-														{label && ' '}
-														{label && label}
-													</span>
-													{dottedName && (
-														<StyledRuleLink
-															documentationPath={`${statusObject.name}`}
-															dottedName={dottedName}
-															engine={statusObject.engine}
-														>
-															<HelpIcon />
-														</StyledRuleLink>
-													)}
-													{warning?.(statusObject.engine)}
-												</StyledDiv>
-												{evolutionDottedName && (
-													<Precisions>
-														<Value
-															linkToRule={false}
-															expression={evolutionDottedName}
-															engine={statusObject.engine}
-															precision={0}
-															unit={unit}
-														/>{' '}
-														{evolutionLabel}
-													</Precisions>
+											<HelpIcon />
+										</StyledRuleLink>
+									</WhenNotApplicable>
+								)}
+								{expressionOrDottedName && (
+									<>
+										<Condition
+											expression={{
+												et: [
+													{ 'est défini': expressionOrDottedName },
+													{ 'est applicable': expressionOrDottedName },
+												],
+											}}
+											engine={statusObject.engine}
+										>
+											<StyledDiv>
+												<span>
+													<Value
+														linkToRule={false}
+														expression={expressionOrDottedName}
+														engine={statusObject.engine}
+														precision={0}
+														unit={unit}
+														displayedUnit={displayedUnit}
+													/>
+													{label && ' '}
+													{label && label}
+												</span>
+												{dottedName && (
+													<StyledRuleLink
+														documentationPath={`${statusObject.name}`}
+														dottedName={dottedName}
+														engine={statusObject.engine}
+													>
+														<HelpIcon />
+													</StyledRuleLink>
 												)}
-												{!evolutionDottedName && evolutionLabel && (
-													<Precisions>{evolutionLabel}</Precisions>
-												)}
-											</Condition>
-											<Condition
-												expression={{
-													'est non défini': expressionOrDottedName,
-												}}
-												engine={statusObject.engine}
-											>
-												<StyledSmall>
-													<Trans>
-														Le montant demandé n'est{' '}
-														<Strong>pas calculable...</Strong>
-													</Trans>
-												</StyledSmall>
-											</Condition>
-										</>
-									)}
-								</StyledBody>
-							</StatusCard>
-						</Grid>
-					)
-				})}
-			</Grid>
-		</ResultsWrapper>
+												{warning?.(statusObject.engine)}
+											</StyledDiv>
+											{evolutionDottedName && (
+												<Precisions>
+													<Value
+														linkToRule={false}
+														expression={evolutionDottedName}
+														engine={statusObject.engine}
+														precision={0}
+														unit={unit}
+													/>{' '}
+													{evolutionLabel}
+												</Precisions>
+											)}
+											{!evolutionDottedName && evolutionLabel && (
+												<Precisions>{evolutionLabel}</Precisions>
+											)}
+										</Condition>
+										<Condition
+											expression={{
+												'est non défini': expressionOrDottedName,
+											}}
+											engine={statusObject.engine}
+										>
+											<StyledSmall>
+												<Trans>
+													Le montant demandé n'est{' '}
+													<Strong>pas calculable...</Strong>
+												</Trans>
+											</StyledSmall>
+										</Condition>
+									</>
+								)}
+							</StyledBody>
+						</StatusCard>
+					</Grid>
+				)
+			})}
+		</Grid>
 	)
 }
-
-const ResultsWrapper = styled.div`
-	& > ul > li {
-		padding-left: 1rem !important;
-
-		&::before {
-			content: none !important;
-		}
-	}
-`
 
 const StyledSmall = styled.small`
 	color: ${({ theme }) => theme.colors.extended.grey[600]};

--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -8,7 +8,7 @@ import { Condition } from '@/components/EngineValue/Condition'
 import Value from '@/components/EngineValue/Value'
 import { WhenNotApplicable } from '@/components/EngineValue/WhenNotApplicable'
 import RuleLink from '@/components/RuleLink'
-import { Body, Grid, HelpIcon, Strong } from '@/design-system'
+import { Body, Grid, HelpIcon, Li, Strong, Ul } from '@/design-system'
 import { EngineComparison } from '@/pages/simulateurs/comparaison-statuts/EngineComparison'
 
 import { getBestOption, OptionType } from '../utils'
@@ -86,119 +86,134 @@ const DetailsRowCards = ({
 		.filter((arrayOfStatus) => arrayOfStatus.length > 0)
 
 	return (
-		<Grid container spacing={4}>
-			{groupedOptions.map((sameValueOptions) => {
-				const statusObject = sameValueOptions[0]
+		<ResultsWrapper>
+			<Grid container spacing={4} as={Ul}>
+				{groupedOptions.map((sameValueOptions) => {
+					const statusObject = sameValueOptions[0]
 
-				return (
-					<Grid
-						key={statusObject.name}
-						item
-						{...getGridSizes(sameValueOptions.length, options.length)}
-						as="ul"
-					>
-						<StatusCard
-							statut={sameValueOptions.map(({ name }) => name)}
-							footerContent={footer?.(statusObject.engine)}
-							isBestOption={
-								sameValueOptions.length !== options.length &&
-								bestOptionValue === statusObject.name
-							}
+					return (
+						<Grid
+							key={statusObject.name}
+							item
+							as={Li}
+							{...getGridSizes(sameValueOptions.length, options.length)}
 						>
-							<StyledBody as="div">
-								{dottedName && (
-									<WhenNotApplicable
-										dottedName={dottedName}
-										engine={statusObject.engine}
-									>
-										<DisabledLabel>Ne s'applique pas</DisabledLabel>
-										<StyledRuleLink
-											documentationPath={`${statusObject.name as string}`}
+							<StatusCard
+								statut={sameValueOptions.map(({ name }) => name)}
+								footerContent={footer?.(statusObject.engine)}
+								isBestOption={
+									sameValueOptions.length !== options.length &&
+									bestOptionValue === statusObject.name
+								}
+							>
+								<StyledBody as="div">
+									{dottedName && (
+										<WhenNotApplicable
 											dottedName={dottedName}
 											engine={statusObject.engine}
 										>
-											<HelpIcon />
-										</StyledRuleLink>
-									</WhenNotApplicable>
-								)}
-								{expressionOrDottedName && (
-									<>
-										<Condition
-											expression={{
-												et: [
-													{ 'est défini': expressionOrDottedName },
-													{ 'est applicable': expressionOrDottedName },
-												],
-											}}
-											engine={statusObject.engine}
-										>
-											<StyledDiv>
-												<span>
-													<Value
-														linkToRule={false}
-														expression={expressionOrDottedName}
-														engine={statusObject.engine}
-														precision={0}
-														unit={unit}
-														displayedUnit={displayedUnit}
-													/>
-													{label && ' '}
-													{label && label}
-												</span>
-												{dottedName && (
-													<StyledRuleLink
-														documentationPath={`${statusObject.name}`}
-														dottedName={dottedName}
-														engine={statusObject.engine}
-													>
-														<HelpIcon />
-													</StyledRuleLink>
+											<DisabledLabel>Ne s'applique pas</DisabledLabel>
+											<StyledRuleLink
+												documentationPath={`${statusObject.name as string}`}
+												dottedName={dottedName}
+												engine={statusObject.engine}
+											>
+												<HelpIcon />
+											</StyledRuleLink>
+										</WhenNotApplicable>
+									)}
+									{expressionOrDottedName && (
+										<>
+											<Condition
+												expression={{
+													et: [
+														{ 'est défini': expressionOrDottedName },
+														{ 'est applicable': expressionOrDottedName },
+													],
+												}}
+												engine={statusObject.engine}
+											>
+												<StyledDiv>
+													<span>
+														<Value
+															linkToRule={false}
+															expression={expressionOrDottedName}
+															engine={statusObject.engine}
+															precision={0}
+															unit={unit}
+															displayedUnit={displayedUnit}
+														/>
+														{label && ' '}
+														{label && label}
+													</span>
+													{dottedName && (
+														<StyledRuleLink
+															documentationPath={`${statusObject.name}`}
+															dottedName={dottedName}
+															engine={statusObject.engine}
+														>
+															<HelpIcon />
+														</StyledRuleLink>
+													)}
+													{warning?.(statusObject.engine)}
+												</StyledDiv>
+												{evolutionDottedName && (
+													<Precisions>
+														<Value
+															linkToRule={false}
+															expression={evolutionDottedName}
+															engine={statusObject.engine}
+															precision={0}
+															unit={unit}
+														/>{' '}
+														{evolutionLabel}
+													</Precisions>
 												)}
-												{warning?.(statusObject.engine)}
-											</StyledDiv>
-											{evolutionDottedName && (
-												<Precisions>
-													<Value
-														linkToRule={false}
-														expression={evolutionDottedName}
-														engine={statusObject.engine}
-														precision={0}
-														unit={unit}
-													/>{' '}
-													{evolutionLabel}
-												</Precisions>
-											)}
-											{!evolutionDottedName && evolutionLabel && (
-												<Precisions>{evolutionLabel}</Precisions>
-											)}
-										</Condition>
-
-										<Condition
-											expression={{ 'est non défini': expressionOrDottedName }}
-											engine={statusObject.engine}
-										>
-											<StyledSmall>
-												<Trans>
-													Le montant demandé n'est{' '}
-													<Strong>pas calculable...</Strong>
-												</Trans>
-											</StyledSmall>
-										</Condition>
-									</>
-								)}
-							</StyledBody>
-						</StatusCard>
-					</Grid>
-				)
-			})}
-		</Grid>
+												{!evolutionDottedName && evolutionLabel && (
+													<Precisions>{evolutionLabel}</Precisions>
+												)}
+											</Condition>
+											<Condition
+												expression={{
+													'est non défini': expressionOrDottedName,
+												}}
+												engine={statusObject.engine}
+											>
+												<StyledSmall>
+													<Trans>
+														Le montant demandé n'est{' '}
+														<Strong>pas calculable...</Strong>
+													</Trans>
+												</StyledSmall>
+											</Condition>
+										</>
+									)}
+								</StyledBody>
+							</StatusCard>
+						</Grid>
+					)
+				})}
+			</Grid>
+		</ResultsWrapper>
 	)
 }
+
+const ResultsWrapper = styled.div`
+	& > ul > li {
+		padding-left: 1rem !important;
+
+		&::before {
+			content: none !important;
+		}
+	}
+`
+
 const StyledSmall = styled.small`
 	color: ${({ theme }) => theme.colors.extended.grey[600]};
 	font-weight: normal;
 	font-size: 80%;
 `
+
 const StyledRuleLink = styled(RuleLink)`
 	display: inline-flex;
 	margin-left: ${({ theme }) => theme.spacings.xxs};

--- a/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
@@ -4,7 +4,15 @@ import { styled } from 'styled-components'
 import Value from '@/components/EngineValue/Value'
 import { WhenAlreadyDefined } from '@/components/EngineValue/WhenAlreadyDefined'
 import { WhenNotAlreadyDefined } from '@/components/EngineValue/WhenNotAlreadyDefined'
-import { Body, CardContainer, EditIcon, Grid, Link } from '@/design-system'
+import {
+	Body,
+	CardContainer,
+	EditIcon,
+	Grid,
+	Li,
+	Link,
+	Ul,
+} from '@/design-system'
 import { useSitePaths } from '@/sitePaths'
 
 const RevenuEstimé = () => {
@@ -20,8 +28,8 @@ const RevenuEstimé = () => {
 			<Grid container>
 				<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
 					<Grid item xs={12} sm={6} lg={9}>
-						<Grid container role="list">
-							<Grid
+						<Grid container as={Ul}>
+							<GridLi
 								style={{
 									paddingRight: '1.5rem',
 								}}
@@ -29,7 +37,7 @@ const RevenuEstimé = () => {
 								xs={12}
 								sm={6}
 								lg={4}
-								role="listitem"
+								as={Li}
 							>
 								<Label>
 									<Trans>Votre chiffre d'affaires estimé</Trans>
@@ -38,8 +46,8 @@ const RevenuEstimé = () => {
 									linkToRule={false}
 									expression="entreprise . chiffre d'affaires"
 								/>
-							</Grid>
-							<StyledGrid item xs={12} sm={6} lg={6} role="listitem">
+							</GridLi>
+							<StyledGrid item xs={12} sm={6} lg={6} as={Li}>
 								<Label>
 									<Trans>Vos charges estimées</Trans>
 								</Label>
@@ -106,10 +114,19 @@ const StyledGrid = styled(Grid)`
 	border-left: 1px solid ${({ theme }) => theme.colors.extended.grey[400]};
 	padding-left: 1.5rem;
 
+	&::before {
+		content: none !important;
+	}
+
 	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
 		border-left: none;
 		padding-left: 0;
 		margin-top: ${({ theme }) => theme.spacings.md};
+	}
+`
+const GridLi = styled(Grid)`
+	&::before {
+		content: none !important;
 	}
 `
 

--- a/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
@@ -53,7 +53,7 @@ const RevenuEstimé = () => {
 					</WhenAlreadyDefined>
 				</Grid>
 				<WhenNotAlreadyDefined dottedName="entreprise . chiffre d'affaires">
-					<Grid item xs role="listitem">
+					<Grid item xs>
 						<Label>
 							<Trans>Votre rémunération totale estimée</Trans>
 						</Label>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
@@ -18,37 +18,42 @@ const RevenuEstimé = () => {
 			$inert
 		>
 			<Grid container>
-				<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
-					<Grid
-						style={{
-							paddingRight: '1.5rem',
-						}}
-						item
-						xs={12}
-						sm={6}
-						lg={3}
-					>
-						<Label>
-							<Trans>Votre chiffre d'affaires estimé</Trans>
-						</Label>
-						<StyledValue
-							linkToRule={false}
-							expression="entreprise . chiffre d'affaires"
-						/>
-					</Grid>
-					<StyledGrid item xs={12} sm={6} lg={5}>
-						<Label>
-							<Trans>Vos charges estimées</Trans>
-						</Label>
-						<StyledValue
-							linkToRule={false}
-							unit="€/an"
-							expression="entreprise . charges"
-						/>
-					</StyledGrid>
-				</WhenAlreadyDefined>
+				<Grid item xs={12} sm={6} lg={9}>
+					<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
+						<Grid container role="list">
+							<Grid
+								style={{
+									paddingRight: '1.5rem',
+								}}
+								item
+								xs={12}
+								sm={6}
+								lg={4}
+								role="listitem"
+							>
+								<Label>
+									<Trans>Votre chiffre d'affaires estimé</Trans>
+								</Label>
+								<StyledValue
+									linkToRule={false}
+									expression="entreprise . chiffre d'affaires"
+								/>
+							</Grid>
+							<StyledGrid item xs={12} sm={6} lg={6} role="listitem">
+								<Label>
+									<Trans>Vos charges estimées</Trans>
+								</Label>
+								<StyledValue
+									linkToRule={false}
+									unit="€/an"
+									expression="entreprise . charges"
+								/>
+							</StyledGrid>
+						</Grid>
+					</WhenAlreadyDefined>
+				</Grid>
 				<WhenNotAlreadyDefined dottedName="entreprise . chiffre d'affaires">
-					<Grid item xs>
+					<Grid item xs role="listitem">
 						<Label>
 							<Trans>Votre rémunération totale estimée</Trans>
 						</Label>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
@@ -18,8 +18,8 @@ const RevenuEstimé = () => {
 			$inert
 		>
 			<Grid container>
-				<Grid item xs={12} sm={6} lg={9}>
-					<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
+				<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
+					<Grid item xs={12} sm={6} lg={9}>
 						<Grid container role="list">
 							<Grid
 								style={{
@@ -50,8 +50,9 @@ const RevenuEstimé = () => {
 								/>
 							</StyledGrid>
 						</Grid>
-					</WhenAlreadyDefined>
-				</Grid>
+					</Grid>
+				</WhenAlreadyDefined>
+
 				<WhenNotAlreadyDefined dottedName="entreprise . chiffre d'affaires">
 					<Grid item xs>
 						<Label>

--- a/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/RevenuEstimé.tsx
@@ -4,15 +4,7 @@ import { styled } from 'styled-components'
 import Value from '@/components/EngineValue/Value'
 import { WhenAlreadyDefined } from '@/components/EngineValue/WhenAlreadyDefined'
 import { WhenNotAlreadyDefined } from '@/components/EngineValue/WhenNotAlreadyDefined'
-import {
-	Body,
-	CardContainer,
-	EditIcon,
-	Grid,
-	Li,
-	Link,
-	Ul,
-} from '@/design-system'
+import { Body, CardContainer, EditIcon, Grid, Link, Ul } from '@/design-system'
 import { useSitePaths } from '@/sitePaths'
 
 const RevenuEstimé = () => {
@@ -29,7 +21,7 @@ const RevenuEstimé = () => {
 				<WhenAlreadyDefined dottedName="entreprise . chiffre d'affaires">
 					<Grid item xs={12} sm={6} lg={9}>
 						<Grid container as={Ul}>
-							<GridLi
+							<Grid
 								style={{
 									paddingRight: '1.5rem',
 								}}
@@ -37,7 +29,7 @@ const RevenuEstimé = () => {
 								xs={12}
 								sm={6}
 								lg={4}
-								as={Li}
+								as="li"
 							>
 								<Label>
 									<Trans>Votre chiffre d'affaires estimé</Trans>
@@ -46,8 +38,8 @@ const RevenuEstimé = () => {
 									linkToRule={false}
 									expression="entreprise . chiffre d'affaires"
 								/>
-							</GridLi>
-							<StyledGrid item xs={12} sm={6} lg={6} as={Li}>
+							</Grid>
+							<StyledGrid item xs={12} sm={6} lg={6} as="li">
 								<Label>
 									<Trans>Vos charges estimées</Trans>
 								</Label>
@@ -122,11 +114,6 @@ const StyledGrid = styled(Grid)`
 		border-left: none;
 		padding-left: 0;
 		margin-top: ${({ theme }) => theme.spacings.md};
-	}
-`
-const GridLi = styled(Grid)`
-	&::before {
-		content: none !important;
 	}
 `
 

--- a/site/source/pages/simulateurs/comparaison-statuts/components/StatusCard.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/StatusCard.tsx
@@ -19,7 +19,7 @@ const StatusCard = ({
 	isBestOption,
 }: StatutCardType) => {
 	return (
-		<StyledCardContainer $inert as="li">
+		<StyledCardContainer $inert>
 			<CardBody>
 				<Grid container spacing={1}>
 					{status.map((statusString) => (

--- a/site/source/pages/simulateurs/comparaison-statuts/components/StatutChoice.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/StatutChoice.tsx
@@ -1,7 +1,6 @@
 import { DottedName } from 'modele-social'
 import Engine from 'publicodes'
 import { Trans, useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { ExplicableRule } from '@/components/conversation/Explicable'
 import { StatutType, TAG_DATA } from '@/components/StatutTag'
@@ -22,38 +21,24 @@ const StatutChoice = ({
 	const gridSizes = getGridSizes(1, namedEngines.length)
 
 	return (
-		<StatusChoiceWrapper>
+		<div>
 			<Spacing lg />
 			<Grid container spacing={4} as={Ul}>
-				<Grid item {...gridSizes} as={Li}>
+				<Grid item {...gridSizes} as="li">
 					<StatutBloc {...namedEngines[0]} hideCTA={hideCTA} />
 				</Grid>
-				<Grid item {...gridSizes} as={Li}>
+				<Grid item {...gridSizes} as="li">
 					<StatutBloc {...namedEngines[1]} hideCTA={hideCTA} />
 				</Grid>
-				<Grid item {...gridSizes} as={Li}>
+				<Grid item {...gridSizes} as="li">
 					{namedEngines[2] && (
 						<StatutBloc {...namedEngines[2]} hideCTA={hideCTA} />
 					)}
 				</Grid>
 			</Grid>
-		</StatusChoiceWrapper>
+		</div>
 	)
 }
-
-const StatusChoiceWrapper = styled.div`
-	& > ul > li {
-		padding-left: 1rem !important;
-
-		&:empty {
-			display: none;
-		}
-
-		&::before {
-			content: none !important;
-		}
-	}
-`
 
 function StatutBloc({
 	engine,

--- a/site/source/pages/simulateurs/comparaison-statuts/components/StatutChoice.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/StatutChoice.tsx
@@ -1,6 +1,7 @@
 import { DottedName } from 'modele-social'
 import Engine from 'publicodes'
 import { Trans, useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 
 import { ExplicableRule } from '@/components/conversation/Explicable'
 import { StatutType, TAG_DATA } from '@/components/StatutTag'
@@ -21,24 +22,38 @@ const StatutChoice = ({
 	const gridSizes = getGridSizes(1, namedEngines.length)
 
 	return (
-		<div>
+		<StatusChoiceWrapper>
 			<Spacing lg />
-			<Grid container spacing={4}>
-				<Grid item {...gridSizes}>
+			<Grid container spacing={4} as={Ul}>
+				<Grid item {...gridSizes} as={Li}>
 					<StatutBloc {...namedEngines[0]} hideCTA={hideCTA} />
 				</Grid>
-				<Grid item {...gridSizes}>
+				<Grid item {...gridSizes} as={Li}>
 					<StatutBloc {...namedEngines[1]} hideCTA={hideCTA} />
 				</Grid>
-				<Grid item {...gridSizes}>
+				<Grid item {...gridSizes} as={Li}>
 					{namedEngines[2] && (
 						<StatutBloc {...namedEngines[2]} hideCTA={hideCTA} />
 					)}
 				</Grid>
 			</Grid>
-		</div>
+		</StatusChoiceWrapper>
 	)
 }
+
+const StatusChoiceWrapper = styled.div`
+	& > ul > li {
+		padding-left: 1rem !important;
+
+		&:empty {
+			display: none;
+		}
+
+		&::before {
+			content: none !important;
+		}
+	}
+`
 
 function StatutBloc({
 	engine,


### PR DESCRIPTION
Retour de l'audit 2025 :
>  le contenu "Votre chiffre d'affaires estimé 10 000 €/an" et "Vos charges estimées 10 000 €/an" n'est pas sous forme de liste
-> ~rajoute un `role=list` au parent, et `role=listitem` aux enfants où c'est nécessaire~ remplacé par des `<ul>` et `<li>`.

> Dans les accordéons le contenu est dans deux liste distinct alors qu'une seule liste est nécessaire
-> corrigé

closes #3862