### PR TITLE
A11y/Replace unnecessary role="list" and role="listitem" by simplest <ul> and <li>

### DIFF
--- a/site/source/components/Feedback/FeedbackRating.tsx
+++ b/site/source/components/Feedback/FeedbackRating.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 
-import { Emoji } from '@/design-system'
+import { Emoji, Li } from '@/design-system'
 
 export type FeedbackT = 'mauvais' | 'moyen' | 'bien' | 'très bien'
 
@@ -10,49 +10,54 @@ const FeedbackRating = ({
 	submitFeedback: (feedbackValue: FeedbackT) => void
 }) => {
 	return (
-		<div
+		<EmojisList
 			style={{
 				display: 'flex',
 				flexWrap: 'wrap',
 				justifyContent: 'center',
 			}}
-			role="list"
 		>
-			<div role="listitem">
+			<Li>
 				<EmojiButton
 					onClick={() => submitFeedback('mauvais')}
 					aria-label="Pas satisfait, envoyer cette réponse"
 				>
 					<Emoji emoji="🙁" />
 				</EmojiButton>
-			</div>
-			<div role="listitem">
+			</Li>
+			<Li>
 				<EmojiButton
 					onClick={() => submitFeedback('moyen')}
 					aria-label="Moyennement satisfait, envoyer cette réponse"
 				>
 					<Emoji emoji="😐" />
 				</EmojiButton>
-			</div>
-			<div role="listitem">
+			</Li>
+			<Li>
 				<EmojiButton
 					onClick={() => submitFeedback('bien')}
 					aria-label="Plutôt satisfait, envoyer cette réponse"
 				>
 					<Emoji emoji="🙂" />
 				</EmojiButton>
-			</div>
-			<div role="listitem">
+			</Li>
+			<Li>
 				<EmojiButton
 					onClick={() => submitFeedback('très bien')}
 					aria-label="Très satisfait, envoyer cette réponse"
 				>
 					<Emoji emoji="😀" />
 				</EmojiButton>
-			</div>
-		</div>
+			</Li>
+		</EmojisList>
 	)
 }
+
+const EmojisList = styled.ul`
+	margin: 0;
+	padding: 0;
+	list-style: none;
+`
 
 const EmojiButton = styled.button`
 	font-size: 1.5rem;

--- a/site/source/components/MoreInfosOnUs.tsx
+++ b/site/source/components/MoreInfosOnUs.tsx
@@ -8,6 +8,7 @@ import {
 	H2,
 	SmallCard,
 	Spacing,
+	Ul,
 } from '@/design-system'
 import { useSitePaths } from '@/sitePaths'
 
@@ -23,9 +24,9 @@ export default function MoreInfosOnUs() {
 	return (
 		<>
 			<H2>Plus d'informations sur mon-entreprise</H2>
-			<Grid container spacing={2} role="list">
+			<Grid as={Ul} container spacing={2}>
 				{!pathname.startsWith(absoluteSitePaths.nouveautés.index) && (
-					<Grid item xs={12} sm={6} md={4} role="listitem">
+					<Grid as="li" item xs={12} sm={6} md={4}>
 						<SmallCard
 							icon={<Emoji emoji={'✨'} />}
 							title={<h3>Les nouveautés</h3>}
@@ -36,7 +37,7 @@ export default function MoreInfosOnUs() {
 					</Grid>
 				)}
 				{!pathname.startsWith(absoluteSitePaths.stats) && (
-					<Grid item xs={12} sm={6} md={4} role="listitem">
+					<Grid as="li" item xs={12} sm={6} md={4}>
 						<SmallCard
 							icon={<Emoji emoji="📊" />}
 							to={absoluteSitePaths.stats}
@@ -47,7 +48,7 @@ export default function MoreInfosOnUs() {
 					</Grid>
 				)}
 				{!pathname.startsWith(absoluteSitePaths.budget) && (
-					<Grid item xs={12} sm={6} md={4} role="listitem">
+					<Grid as="li" item xs={12} sm={6} md={4}>
 						<SmallCard
 							icon={<Emoji emoji="💶" />}
 							to={absoluteSitePaths.budget}
@@ -57,7 +58,7 @@ export default function MoreInfosOnUs() {
 						</SmallCard>
 					</Grid>
 				)}
-				<Grid item xs={12} sm={6} md={4} role="listitem">
+				<Grid as="li" item xs={12} sm={6} md={4}>
 					<SmallCard
 						icon={<GithubIcon style={{ width: '2rem', height: '2rem' }} />}
 						href="https://github.com/betagouv/mon-entreprise"

--- a/site/source/components/ShareSimulationBanner/index.tsx
+++ b/site/source/components/ShareSimulationBanner/index.tsx
@@ -14,10 +14,6 @@ import { useTracking } from '../ATInternetTracking'
 import { ConseillersEntreprisesButton } from '../ConseillersEntreprisesButton'
 import { ShareSimulationPopup } from './ShareSimulationPopup'
 
-const ButtonLabel = styled.span`
-	margin-left: 1rem;
-`
-
 export interface CustomSimulationButton {
 	href: string
 	title: string
@@ -66,13 +62,13 @@ export default function ShareOrSaveSimulationBanner({
 		<>
 			<Spacing lg />
 			<Grid
+				as={LinksList}
 				container
 				className=" print-hidden"
 				spacing={4}
 				style={{
 					justifyContent: 'center',
 				}}
-				role="list"
 			>
 				{customSimulationbutton && (
 					<Grid item xs={12} sm="auto" role="listitem">
@@ -83,7 +79,7 @@ export default function ShareOrSaveSimulationBanner({
 				)}
 
 				{share && (
-					<Grid item xs={12} sm="auto" role="listitem">
+					<Grid as="li" item xs={12} sm="auto">
 						<PopoverWithTrigger
 							title={t('shareSimulation.modal.title', 'Votre lien de partage')}
 							trigger={(buttonProps) => (
@@ -121,7 +117,7 @@ export default function ShareOrSaveSimulationBanner({
 				)}
 
 				{print && typeof window.print === 'function' && (
-					<Grid item xs={12} sm="auto" role="listitem">
+					<Grid as="li" item xs={12} sm="auto">
 						<Button
 							light
 							size="XS"
@@ -139,7 +135,7 @@ export default function ShareOrSaveSimulationBanner({
 				)}
 
 				{conseillersEntreprises && (
-					<Grid item xs={12} sm="auto" role="listitem">
+					<Grid as="li" item xs={12} sm="auto">
 						<ConseillersEntreprisesButton variant="recrutement" />
 					</Grid>
 				)}
@@ -147,3 +143,11 @@ export default function ShareOrSaveSimulationBanner({
 		</>
 	)
 }
+
+const ButtonLabel = styled.span`
+	margin-left: 1rem;
+`
+
+const LinksList = styled.ul`
+	list-style: none;
+`

--- a/site/source/pages/integration/Iframe.tsx
+++ b/site/source/pages/integration/Iframe.tsx
@@ -23,6 +23,7 @@ import {
 	Select,
 	Spacing,
 	TextField,
+	Ul,
 } from '@/design-system'
 import useSimulatorsData, { SimulatorData } from '@/hooks/useSimulatorsData'
 
@@ -246,8 +247,8 @@ export default function Integration() {
 				<H2>
 					<Trans>Liste des intégrations</Trans>
 				</H2>
-				<Grid role="list" container id="integrationList" spacing={2}>
-					<Grid role="listitem" item xs={12} md={6} xl={4}>
+				<Grid as={Ul} container id="integrationList" spacing={2}>
+					<Grid as="li" item xs={12} md={6} xl={4}>
 						<Article
 							title="Urssaf"
 							href="https://www.urssaf.fr/portail/home/utile-et-pratique/estimateur-de-cotisations-2019.html?ut=estimateurs"
@@ -257,7 +258,7 @@ export default function Integration() {
 							<Logo src={urssafLogo} alt="Logo urssaf.fr" />
 						</Article>
 					</Grid>
-					<Grid role="listitem" item xs={12} md={6} xl={4}>
+					<Grid as="li" item xs={12} md={6} xl={4}>
 						<Article
 							title="CCI de France"
 							href="http://les-aides.fr/embauche"
@@ -267,7 +268,7 @@ export default function Integration() {
 							<Logo src={cciLogo} alt="Logo Les-aides.fr" />
 						</Article>
 					</Grid>
-					<Grid role="listitem" item xs={12} md={6} xl={4}>
+					<Grid as="li" item xs={12} md={6} xl={4}>
 						<Article
 							title="Code du travail numérique"
 							href="https://code.travail.gouv.fr/outils/simulateur-embauche"
@@ -277,7 +278,7 @@ export default function Integration() {
 							<Logo src={minTraLogo} alt="Logo Ministère du travail" />
 						</Article>
 					</Grid>
-					<Grid role="listitem" item xs={12} md={6} xl={4}>
+					<Grid as="li" item xs={12} md={6} xl={4}>
 						<Article
 							title="France Travail"
 							href="https://entreprise.francetravail.fr/cout-salarie/"
@@ -287,7 +288,7 @@ export default function Integration() {
 							<Logo src={poleEmploiLogo} alt="" />
 						</Article>
 					</Grid>
-					<Grid role="listitem" item xs={12} md={6} xl={4}>
+					<Grid as="li" item xs={12} md={6} xl={4}>
 						<Article
 							title="Une idée&nbsp;?"
 							href="mailto:contact@mon-entreprise.beta.gouv.fr?subject=Proposition de réutilisation"

--- a/site/source/pages/simulateurs/NextSteps.tsx
+++ b/site/source/pages/simulateurs/NextSteps.tsx
@@ -3,7 +3,7 @@ import { Trans } from 'react-i18next'
 
 import { WhenAlreadyDefined } from '@/components/EngineValue/WhenAlreadyDefined'
 import { useEngine } from '@/components/utils/EngineContext'
-import { Grid, H2, Spacing } from '@/design-system'
+import { Grid, H2, Spacing, Ul } from '@/design-system'
 import { MergedSimulatorDataValues } from '@/hooks/useCurrentSimulatorData'
 import { IframeIntegrationCard } from '@/pages/simulateurs/cards/IframeIntegrationCard'
 import { SimulatorRessourceCard } from '@/pages/simulateurs/cards/SimulatorRessourceCard'
@@ -41,7 +41,7 @@ export default function NextSteps({
 			<H2>
 				<Trans i18nKey="common.useful-resources">Ressources utiles</Trans>
 			</H2>
-			<Grid container spacing={3} role="list">
+			<Grid as={Ul} container spacing={3}>
 				<WhenAlreadyDefined dottedName="entreprise . SIREN">
 					<GridItem>
 						<AnnuaireEntreprises />
@@ -81,7 +81,7 @@ type GridItemProps = {
 	children: ReactNode
 }
 const GridItem = ({ children }: GridItemProps) => (
-	<Grid item xs={12} sm={6} lg={4} role="listitem">
+	<Grid as="li" item xs={12} sm={6} lg={4}>
 		{children}
 	</Grid>
 )

--- a/site/source/pages/statistiques/_components/LastMonthIndicators.tsx
+++ b/site/source/pages/statistiques/_components/LastMonthIndicators.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { Emoji, Grid, Message, typography } from '@/design-system'
+import { Emoji, Grid, Message, typography, Ul } from '@/design-system'
 
 import { useStatistiques } from '../useStatistiques'
 import {
@@ -42,8 +42,8 @@ export function MainIndicators({
 	return (
 		<>
 			<H2>Notre impact en {formatMonth(lastMonth.date, language)}</H2>
-			<Grid container spacing={4} role="list">
-				<Grid item xs={12} md={6} role="listitem">
+			<Grid as={Ul} container spacing={4}>
+				<Grid as="li" item xs={12} md={6}>
 					<Message border={false} icon={<Emoji emoji="🛎️" />}>
 						<Intro>
 							<Strong>
@@ -62,7 +62,7 @@ export function MainIndicators({
 					</Message>
 				</Grid>
 				{satisfactionLastMonth && (
-					<Grid item xs={12} md={6} role="listitem">
+					<Grid as="li" item xs={12} md={6}>
 						<Message
 							border={false}
 							type={messageTypeSatisfaction(satisfactionLastMonth.moyenne)}

--- a/site/source/pages/statistiques/_components/LastYearIndicator.tsx
+++ b/site/source/pages/statistiques/_components/LastYearIndicator.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { Body, Emoji, Grid, H2, Intro, Message, Strong } from '@/design-system'
+import { Emoji, Grid, H2, Intro, Message, Strong, Ul } from '@/design-system'
 
 import { QuestionRépondues, Satisfaction, Visites } from '../types'
 import {
@@ -59,8 +59,8 @@ export function LastYearIndicator({
 	return (
 		<>
 			<H2>Retour sur l'année {lastYear.date.slice(0, 4)}</H2>
-			<Grid container columnSpacing={4} role="list">
-				<Grid item xs={12} sm={6} md={4} role="listitem">
+			<Grid as={Ul} container columnSpacing={4}>
+				<Grid as="li" item xs={12} sm={6} md={4}>
 					<Message border={false} icon={<Emoji emoji="🛎️" />}>
 						<Intro>
 							<Strong>
@@ -70,7 +70,8 @@ export function LastYearIndicator({
 						</Intro>
 					</Message>
 				</Grid>
-				<Grid item xs={12} sm={6} md={4} role="listitem">
+
+				<Grid as="li" item xs={12} sm={6} md={4}>
 					<Message
 						border={false}
 						icon={<Emoji emoji={emojiSatisfaction(satisfactionRate)} />}
@@ -82,7 +83,7 @@ export function LastYearIndicator({
 					</Message>
 				</Grid>
 
-				<Grid item xs={12} sm={6} md={4} role="listitem">
+				<Grid as="li" item xs={12} sm={6} md={4}>
 					<Message border={false} icon={<Emoji emoji="🏇" />}>
 						<Intro>
 							<Strong>{conversionRate}</Strong> taux de conversion
@@ -90,15 +91,16 @@ export function LastYearIndicator({
 					</Message>
 				</Grid>
 
-				<Grid item xs={12} sm={6} md={4} role="listitem">
+				<Grid as="li" item xs={12} sm={6} md={4}>
 					<Message border={false} icon={<Emoji emoji="📈" />}>
-						<Body>
+						<Intro>
 							<Strong>{formatIndicator(visitesLastYear, language)}</Strong>{' '}
 							visites
-						</Body>
+						</Intro>
 					</Message>
 				</Grid>
-				<Grid item xs={12} sm={6} md={4} role="listitem">
+
+				<Grid as="li" item xs={12} sm={6} md={4}>
 					<Message
 						border={false}
 						icon={<Emoji emoji="👋" />}
@@ -110,12 +112,12 @@ export function LastYearIndicator({
 								: 'primary'
 						}
 					>
-						<Body>
+						<Intro>
 							<Strong>
 								{formatIndicator(cumulSatisfaction.total, language)}
 							</Strong>{' '}
 							avis collectés
-						</Body>
+						</Intro>
 					</Message>
 				</Grid>
 			</Grid>


### PR DESCRIPTION
Cette PR traite des remontées de l'audit 2025 pointant des listes construites avec `role="list"` et `role="listitem"` plutôt que `<ul>` et `<li>`.

Même si l'usage de `role` ne devraient pas invalider le critère 9.3 du RGAA (le test 9.3.1 considère que c'est une façon de faire acceptable), l'un des principes fondamentaux d'ARIA est de se passer d'ARIA lorsque du HTML permet de faire la même chose.
(c'est cependant un peu plus sémantique puisque `role="list"`ne distingue pas les `<ul>` des `<ol>`)

Cette PR fait cependant cette refacto uniquement sur les cas où il n'y avait pas besoin de faire des modifications trop importantes.