### PR TITLE
fix(a11y): <BarStackLegend /> refactored as a <ul>

### DIFF
--- a/site/source/components/StackedBarChart.tsx
+++ b/site/source/components/StackedBarChart.tsx
@@ -31,12 +31,14 @@ const BarItem = styled.div`
 	}
 `
 
-const BarStackLegend = styled.div`
+const BarStackLegend = styled.ul`
 	font-family: ${({ theme }) => theme.fonts.main};
 	display: flex;
-	margin-top: 10px;
+	margin: 10px 0 0;
+	padding: 0;
 	flex-direction: column;
 	justify-content: space-between;
+	list-style: none;
 
 	@media (min-width: 800px) {
 		flex-direction: row;
@@ -44,7 +46,7 @@ const BarStackLegend = styled.div`
 	}
 `
 
-const BarStackLegendItem = styled.div`
+const BarStackLegendItem = styled.li`
 	font-family: ${({ theme }) => theme.fonts.main};
 	background-color: inherit;
 	strong {


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025 concernant le simulateur AE :

> Les pourcentages dans la partie "Répartition du chiffre d'affaires" ne sont pas sous forme de liste

<img width="1210" height="173" alt="image" src="https://github.com/user-attachments/assets/a2763f6c-d50f-4808-96f5-2666e67c6f39" />

Closes https://github.com/betagouv/mon-entreprise/issues/3861