### PR TITLE
Ajoute un caption au tableau de la politique de confidentialité

### DIFF
--- a/site/source/components/layout/Footer/PrivacyPolicy.tsx
+++ b/site/source/components/layout/Footer/PrivacyPolicy.tsx
@@ -140,8 +140,10 @@ export default function PrivacyPolicy({
 			<Body>
 				<StyledTable>
 					<caption className="sr-only">
-						Liste des sous-traitants destinataires des données à caractère
-						personnel
+						{t(
+							'privacyPolicy.recipients.table.caption',
+							'Liste des sous-traitants destinataires des données à caractère personnel'
+						)}
 					</caption>
 					<thead>
 						<tr>

--- a/site/source/components/layout/Footer/PrivacyPolicy.tsx
+++ b/site/source/components/layout/Footer/PrivacyPolicy.tsx
@@ -139,6 +139,10 @@ export default function PrivacyPolicy({
 			</H2>
 			<Body>
 				<StyledTable>
+					<caption className="sr-only">
+						Liste des sous-traitants destinataires des données à caractère
+						personnel
+					</caption>
 					<thead>
 						<tr>
 							<th scope="col">

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -2117,6 +2117,7 @@ privacyPolicy:
     title: Who is responsible for my-company?
   recipients:
     table:
+      caption: List of subcontractors receiving personal data
       country: Destination country
       mailer: Sending e-mails
       processing: Treatment performed

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -2245,6 +2245,7 @@ privacyPolicy:
     title: Qui est responsable de mon-entreprise ?
   recipients:
     table:
+      caption: Liste des sous-traitants destinataires des données à caractère personnel
       country: Pays destinataire
       mailer: Envoi d'e-mails
       processing: Traitement réalisé


### PR DESCRIPTION
Retour de l'audit : 
> Dans la modale "Politique de confidentialité" le titre du tableau "Qui sont les destinataires de vos données ?" n'est pas lié au tableau

La résolution choisie est en ajoutant un `<caption>` destiné aux technologies d'assistance.
Il était aussi possible de rajouter un `aria-labelledby` avec comme `id` le titre au dessus.

closes #3842