### PR TITLE
Modifie le niveau de titre de cartes de la page simulateurs

### DIFF
--- a/site/source/components/SimulateurCard.tsx
+++ b/site/source/components/SimulateurCard.tsx
@@ -8,6 +8,7 @@ type SimulateurCardProps = MergedSimulatorDataValues & {
 	small?: boolean
 	fromGérer?: boolean
 	role?: string
+	titleLevel?: 'h3' | 'h4'
 }
 
 export function SimulateurCard({
@@ -22,9 +23,12 @@ export function SimulateurCard({
 	small = false,
 	fromGérer = false,
 	role,
+	titleLevel = 'h3',
 }: SimulateurCardProps) {
 	const isIframe = useIsEmbedded()
 	const { t } = useTranslation()
+
+	const TitleTag = titleLevel
 
 	const ctaLabel =
 		pathId.startsWith('assistants') || pathId.startsWith('gérer')
@@ -55,14 +59,14 @@ export function SimulateurCard({
 			) : (
 				<Card
 					title={
-						<>
+						<TitleTag>
 							{shortName}
 							{beta && (
 								<Chip type="info" icon={<Emoji emoji="🚧" />}>
 									Bêta
 								</Chip>
 							)}
-						</>
+						</TitleTag>
 					}
 					icon={<Emoji emoji={icône} />}
 					ctaLabel={ctaLabel}

--- a/site/source/pages/simulateurs-et-assistants/index.tsx
+++ b/site/source/pages/simulateurs-et-assistants/index.tsx
@@ -161,10 +161,12 @@ export default function SimulateursEtAssistants() {
 					<SimulateurCard
 						{...simulators['déclaration-charges-sociales-indépendant']}
 						role="listitem"
+						titleLevel="h4"
 					/>
 					<SimulateurCard
 						{...simulators['déclaration-revenus-pamc']}
 						role="listitem"
+						titleLevel="h4"
 					/>
 				</Grid>
 


### PR DESCRIPTION
**Retour :**
Les titres enfants de la section "Assistants à la déclaration de revenus des indépendants" possède le même niveau que le titre parent

J'ai donc ajouté la possibilité de spécifier si le titre est de niveau 3 ou 4.
Ce code a été réalisé avec l'aide de Claude, je suis preneur de critique ;)

Closes #3679
