### PR TITLE
Modifie les valeurs des cotisations en <p> au lieu de <div>

### DIFF
--- a/site/source/components/BarChart.tsx
+++ b/site/source/components/BarChart.tsx
@@ -62,9 +62,9 @@ function ChartItemBar({
 	)
 }
 
-const Value = styled.div`
+const Value = styled.p`
 	font-weight: bold;
-	margin-left: 1rem;
+	margin: 0 0 0 1rem;
 	font-family: ${({ theme }) => theme.fonts.main};
 `
 


### PR DESCRIPTION
**Retour :**
> Dans la page AE, les chiffres dans la partie "À quoi servent mes cotisations ?" ne sont pas entre des balises 

Il s'agissait de `<div>`, je les ai remplacés par des `<p>`.

Closes #3844