### PR TITLE
A11y/Missing required format in <DateDeNaissance /> label

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -828,7 +828,7 @@ pages:
       enfants:
         add-button-label: Add a child
         date-de-naissance:
-          label: Date of birth
+          label: Date of birth in DD/MM/YYYY format
         erreurs:
           AeeH-invalide: There cannot be more children eligible for the AeeH than there
             are dependent children.

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -874,7 +874,7 @@ pages:
       enfants:
         add-button-label: Ajouter un enfant
         date-de-naissance:
-          label: Date de naissance
+          label: Date de naissance au format JJ/MM/AAAA
         erreurs:
           AeeH-invalide: Il ne peut pas y avoir plus d’enfants concernés par l’AeeH que
             d’enfants à charge.

--- a/site/source/pages/assistants/cmg/components/enfants/DateDeNaissanceInput.tsx
+++ b/site/source/pages/assistants/cmg/components/enfants/DateDeNaissanceInput.tsx
@@ -26,7 +26,7 @@ export default function DateDeNaissanceInput({
 			<Label id={htmlForId}>
 				{t(
 					'pages.assistants.cmg.enfants.date-de-naissance.label',
-					'Date de naissance'
+					'Date de naissance au format JJ/MM/AAAA'
 				)}
 			</Label>
 			<DateField


### PR DESCRIPTION
Cette PR traite (partiellement) la remontée suivante de l'audit 2025 :

> Pour le champ date dans le formulaire à étape, il n'y a pas d'indication sur le format à saisir

En effet, elle ne permet pas de s'assurer qu'un champ date généré par `<RuleInput />` aura bien un label contenant le format attendu (JJ/MM/AAAA).

C'est un cas qui devrait être résolu avec le refactoring de `<RuleInput />` et surtout de tous les composants input qu'il peut utiliser.

Seul le cas où `<DateField />` est utilisé dans `<DateDeNaissance />` est résolu ici.

Closes https://github.com/betagouv/mon-entreprise/issues/3845