### PR TITLE
A11y / Vocalize question when info button takes focus in <Questions />

### DIFF
--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -116,6 +116,10 @@ export function Questions<S extends Situation>({
 		.replaceAll(' . ', '_')
 		.replaceAll(' ', '-')
 
+	const questionCouranteLabel =
+		QuestionCourante?._tag === 'QuestionPublicodes' ?
+		evaluateQuestion(engine, engine.getRule(QuestionCourante.id)) : undefined
+
 	return (
 		nombreDeQuestions > 0 && (
 			<>
@@ -168,11 +172,8 @@ export function Questions<S extends Situation>({
 							{shouldBeWrappedByFieldset ? (
 								<fieldset>
 									<H3 as="legend">
-										{evaluateQuestion(
-											engine,
-											engine.getRule(QuestionCourante.id)
-										)}
-										<ExplicableRule light dottedName={QuestionCourante.id} />
+										{questionCouranteLabel}
+										<ExplicableRule light dottedName={QuestionCourante.id} ariaDescribedBy={questionCouranteLabel}/>
 									</H3>
 									<RuleInput
 										dottedName={QuestionCourante.id}
@@ -186,11 +187,8 @@ export function Questions<S extends Situation>({
 							) : (
 								<>
 									<H3 as="label" htmlFor={questionCouranteHtmlForId}>
-										{evaluateQuestion(
-											engine,
-											engine.getRule(QuestionCourante.id)
-										)}
-										<ExplicableRule light dottedName={QuestionCourante.id} />
+										{questionCouranteLabel}
+										<ExplicableRule light dottedName={QuestionCourante.id} ariaDescribedBy={questionCouranteLabel} />
 									</H3>
 									<RuleInput
 										id={questionCouranteHtmlForId}

--- a/site/source/components/conversation/Explicable.tsx
+++ b/site/source/components/conversation/Explicable.tsx
@@ -12,12 +12,14 @@ export function ExplicableRule<Names extends string = DottedName>({
 	light,
 	bigPopover,
 	title,
+	ariaDescribedBy,
 	...props
 }: {
 	dottedName: Names
 	light?: boolean
 	bigPopover?: boolean
 	title?: string
+	ariaDescribedBy?: string
 }) {
 	const engine = useEngine()
 	const rule = engine.getRule(dottedName as DottedName)
@@ -38,6 +40,7 @@ export function ExplicableRule<Names extends string = DottedName>({
 			className="print-hidden"
 			aria-haspopup="dialog"
 			aria-label={`Info sur ${rule.title}`}
+			aria-describedby={ariaDescribedBy}
 			{...props}
 		>
 			<Markdown>{rule.rawNode.description}</Markdown>


### PR DESCRIPTION
Cette PR traite la remontée suivante de l'audit 2025, concernant le simulateur salarié :

> Le changement de contexte dans la partie de réponse n'est pas correctement géré, quand une question possède un bouton "info" le focus de l'utilisateur est dirigé sur celui sans qu'il n'est connaissance de la question.

<img width="454" height="113" alt="image" src="https://github.com/user-attachments/assets/1e760cce-3d34-4e0d-8eb6-c899823c9b64" />

---

Le problème ici est que, si on navigue en tabulant, le focus n'est jamais donné à la question. Il va l'être pour le bouton "info" ou l'input (qui s'occupera de vocaliser la question grâce à la connexion `htmlFor / id`).
Le bouton "info" sera alors vocalisé AVANT la question pour laquelle il propose un complément d'informations.

L'idée ici est de vocaliser la question en arrivant sur le bouton "info" en lui ajoutant un `aria-describedby` qui la vocalisera à la suite de son `aria-label`.