### PR TITLE
fix: corrige la gestion des questions "plusieurs possibilités" dans les simulateurs

### DIFF
--- a/site/source/components/conversation/PlusieursPossibilités.tsx
+++ b/site/source/components/conversation/PlusieursPossibilités.tsx
@@ -1,14 +1,16 @@
 import { DottedName } from 'modele-social'
-import Engine, { RuleNode } from 'publicodes'
+import Engine from 'publicodes'
 import { useCallback } from 'react'
 
 import { ChoixMultiple, ChoixOption } from '@/design-system'
 import { ValeurPublicodes } from '@/domaine/engine/PublicodesAdapter'
 
+import { getMultiplePossibilitiesOptions } from './getMultiplePossibilitiesOptions'
+
 interface PlusieursPossibilitésProps {
-	choices: Array<RuleNode<DottedName>>
+	règle: DottedName
 	engine: Engine<DottedName>
-	onChange?: (value: ValeurPublicodes, name: DottedName) => void
+	onChange?: (selectedChoices: DottedName[]) => void
 	value?: ValeurPublicodes
 	id?: string
 	title?: string
@@ -23,12 +25,13 @@ interface PlusieursPossibilitésProps {
 }
 
 export function PlusieursPossibilités({
-	choices,
+	règle,
 	onChange,
 	engine,
 	aria = {},
 	id,
 }: PlusieursPossibilitésProps) {
+	const choices = getMultiplePossibilitiesOptions(engine, règle)
 	const options: ChoixOption[] = choices
 		.map((node) => {
 			const evaluation = engine.evaluate(node)
@@ -45,15 +48,22 @@ export function PlusieursPossibilités({
 
 	const handleChange = useCallback(
 		(id: string, isSelected: boolean) => {
-			choices.forEach((choice) => {
-				const dottedName = choice.dottedName
-				const value =
-					id === dottedName ? isSelected : engine.evaluate(choice).nodeValue
+			if (!onChange) return
 
-				if (onChange) {
-					onChange(value ? 'oui' : 'non', dottedName)
+			const selectedChoices: DottedName[] = []
+			choices.forEach((choice) => {
+				const choiceDottedName = choice.dottedName
+				const isCurrentlySelected =
+					id === choiceDottedName
+						? isSelected
+						: engine.evaluate(choice).nodeValue === true
+
+				if (isCurrentlySelected) {
+					selectedChoices.push(choiceDottedName)
 				}
 			})
+
+			onChange(selectedChoices)
 		},
 		[choices, engine, onChange]
 	)

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -229,16 +229,32 @@ export default function RuleInput({
 		return (
 			<>
 				<PlusieursPossibilités
-					value={value}
-					choices={getMultiplePossibilitiesOptions(engineValue, dottedName)}
-					onChange={onChange}
+					règle={dottedName}
+					onChange={(choixSélectionnés: DottedName[]) => {
+						const toutesLesPossibilités = getMultiplePossibilitiesOptions(
+							engineValue,
+							dottedName
+						)
+						const valeurs = toutesLesPossibilités.reduce<
+							Record<string, OuiNon>
+						>((acc, possibilité) => {
+							const suffixe = possibilité.dottedName.replace(
+								`${dottedName} . `,
+								''
+							)
+
+							return {
+								...acc,
+								[suffixe]: choixSélectionnés.includes(possibilité.dottedName)
+									? 'oui'
+									: 'non',
+							}
+						}, {})
+
+						dispatch(enregistreLesRéponses(dottedName, valeurs))
+					}}
 					engine={engineValue}
 					id={inputId}
-					title={rule.title}
-					description={rule.rawNode.description}
-					/* eslint-disable-next-line jsx-a11y/no-autofocus */
-					autoFocus={accessibilityProps.autoFocus}
-					onSubmit={onSubmit}
 					aria={{
 						labelledby: accessibilityProps['aria-labelledby'],
 						label: accessibilityProps['aria-label'],

--- a/site/source/domaine/useQuestions/estCeQueLaQuestionPublicodesEstRépondue.test.ts
+++ b/site/source/domaine/useQuestions/estCeQueLaQuestionPublicodesEstRépondue.test.ts
@@ -1,0 +1,84 @@
+import règles from 'modele-social'
+import { describe, expect, it } from 'vitest'
+
+import { engineFactory } from '@/components/utils/EngineContext'
+import { QuestionRépondue } from '@/store/reducers/simulation.reducer'
+
+import { estCeQueLaQuestionPublicodesEstRépondue } from './estCeQueLaQuestionPublicodesEstRépondue'
+
+describe('estCeQueLaQuestionPublicodesEstRépondue', () => {
+	const engine = engineFactory(règles)
+
+	describe('pour une question simple', () => {
+		it('retourne true si la question est dans la liste des questions répondues', () => {
+			const questionsRépondues: QuestionRépondue[] = [
+				{ règle: 'entreprise . imposition', applicable: true },
+			]
+			const estRépondue = estCeQueLaQuestionPublicodesEstRépondue(
+				engine,
+				questionsRépondues
+			)
+
+			expect(estRépondue('entreprise . imposition')).toBe(true)
+		})
+
+		it("retourne false si la question n'est pas dans la liste des questions répondues", () => {
+			const questionsRépondues: QuestionRépondue[] = []
+			const estRépondue = estCeQueLaQuestionPublicodesEstRépondue(
+				engine,
+				questionsRépondues
+			)
+
+			expect(estRépondue('entreprise . imposition')).toBe(false)
+		})
+	})
+
+	describe('pour une question "plusieurs possibilités"', () => {
+		it('retourne true si au moins une sous-règle est répondue', () => {
+			const questionsRépondues: QuestionRépondue[] = [
+				{ règle: 'entreprise . activités . artisanale', applicable: true },
+			]
+			const estRépondue = estCeQueLaQuestionPublicodesEstRépondue(
+				engine,
+				questionsRépondues
+			)
+
+			expect(estRépondue('entreprise . activités')).toBe(true)
+		})
+
+		it('retourne true si plusieurs sous-règles sont répondues', () => {
+			const questionsRépondues: QuestionRépondue[] = [
+				{ règle: 'entreprise . activités . artisanale', applicable: true },
+				{ règle: 'entreprise . activités . commerciale', applicable: true },
+			]
+			const estRépondue = estCeQueLaQuestionPublicodesEstRépondue(
+				engine,
+				questionsRépondues
+			)
+
+			expect(estRépondue('entreprise . activités')).toBe(true)
+		})
+
+		it("retourne false si aucune sous-règle n'est répondue", () => {
+			const questionsRépondues: QuestionRépondue[] = []
+			const estRépondue = estCeQueLaQuestionPublicodesEstRépondue(
+				engine,
+				questionsRépondues
+			)
+
+			expect(estRépondue('entreprise . activités')).toBe(false)
+		})
+
+		it('retourne false si des questions non liées sont répondues', () => {
+			const questionsRépondues: QuestionRépondue[] = [
+				{ règle: 'entreprise . imposition', applicable: true },
+			]
+			const estRépondue = estCeQueLaQuestionPublicodesEstRépondue(
+				engine,
+				questionsRépondues
+			)
+
+			expect(estRépondue('entreprise . activités')).toBe(false)
+		})
+	})
+})

--- a/site/source/domaine/useQuestions/estCeQueLaQuestionPublicodesEstRépondue.ts
+++ b/site/source/domaine/useQuestions/estCeQueLaQuestionPublicodesEstRépondue.ts
@@ -1,0 +1,28 @@
+import { DottedName } from 'modele-social'
+import Engine from 'publicodes'
+
+import { QuestionRépondue } from '@/store/reducers/simulation.reducer'
+
+export const estCeQueLaQuestionPublicodesEstRépondue =
+	(engine: Engine<DottedName>, questionsRépondues: QuestionRépondue[]) =>
+	(dottedName: DottedName): boolean => {
+		const estDirectementRépondue = questionsRépondues.some(
+			(q) => q.règle === dottedName
+		)
+		if (estDirectementRépondue) {
+			return true
+		}
+
+		const rule = engine.getRule(dottedName)
+		const plusieursPossibilités = rule.rawNode['plusieurs possibilités']
+		const estPlusieursPossibilités =
+			Array.isArray(plusieursPossibilités) && plusieursPossibilités.length > 0
+
+		if (estPlusieursPossibilités) {
+			return questionsRépondues.some((q) =>
+				q.règle.startsWith(dottedName + ' . ')
+			)
+		}
+
+		return false
+	}


### PR DESCRIPTION
- Unifie l'enregistrement de la règle parente dans questionsRépondues pour les questions de type "plusieurs possibilités"
- Modifie PlusieursPossibilités pour envoyer un seul onChange avec toutes les sélections
- Adapte RuleInput pour utiliser enregistreLesRéponses avec des suffixes pour les sous-règles
- Préserve le comportement de SelectCommune qui utilise aussi enregistreLesRéponses avec préfixe
- Corrige updateSituationMultiple pour gérer correctement les préfixes

Résout le bug de navigation erratique dans le simulateur de coût de création
   (#3764)