### PR TITLE
fix(tracking): restaure le tracking "simulation commencée"

### DIFF
--- a/site/source/components/Simulation/index.tsx
+++ b/site/source/components/Simulation/index.tsx
@@ -99,6 +99,7 @@ export default function Simulation<S extends Situation = Situation>({
 	return (
 		<>
 			{!isFirstStepCompleted && <TrackPage name="accueil" />}
+			{isFirstStepCompleted && <TrackPage name="simulation commencée" />}
 
 			<SimulationContainer fullWidth={fullWidth} id={id}>
 				<PrintExportRecover />


### PR DESCRIPTION
Le tracking "simulation commencée" a été supprimé par erreur lors du refactoring de l'architecture des questions (commit 17e324501 du 9 mai 2025).

Impact : chute de 94% des statistiques de simulations commencées depuis juin 2025
- Mai : 431k simulations trackées
- Juillet : 12k simulations trackées (principalement CMG avec tracking explicite)

La correction ajoute le tracking dans Simulation/index.tsx quand isFirstStepCompleted devient true, restaurant ainsi le comportement précédent.

Fixes #3816