### PR TITLE
Remove unused props in current <Radio /> component

### DIFF
--- a/site/source/design-system/molecules/field/Radio/Radio.tsx
+++ b/site/source/design-system/molecules/field/Radio/Radio.tsx
@@ -13,8 +13,6 @@ type RadioProps = AriaRadioProps & {
 	className?: string
 	role?: string
 	visibleRadioAs?: string | React.ComponentType
-	emoji?: string
-	infoButton?: React.ReactNode
 	defaultSelected?: boolean
 }
 
@@ -28,8 +26,6 @@ export function Radio(props: RadioProps) {
 		id,
 		'aria-label': ariaLabel,
 		'aria-labelledby': ariaLabelledby,
-		emoji,
-		infoButton,
 		visibleRadioAs,
 		defaultSelected,
 	} = props
@@ -44,8 +40,6 @@ export function Radio(props: RadioProps) {
 			id={id}
 			aria-label={ariaLabel}
 			aria-labelledby={ariaLabelledby}
-			emoji={emoji}
-			infoButton={infoButton}
 			visibleRadioAs={visibleRadioAs}
 			defaultSelected={defaultSelected}
 		>


### PR DESCRIPTION
Cette mini-PR supprime juste les deux props `emoji` et `infoButton` du composant `<Radio />` qui n'ont plus l'air d'être exploitées.

**Remarque :** Je les ai repérées en préparant la refacto de ce composant, mais il va être en fait surtout avantageux de juste le remplacer par le composant `<Radio />` de React Aria, sur lequel il n'y aura qu'à reconstruire le CSS.
Ca me conforte dans l'idée que passer par les composants de React Aria, plutôt que ses hooks, va beaucoup réduire la quantité de code et sa complexité.