### PR TITLE
[Mini-PR] Remove props unused by components using current <DateField />

### DIFF
--- a/site/source/design-system/molecules/field/DateField.stories.tsx
+++ b/site/source/design-system/molecules/field/DateField.stories.tsx
@@ -21,10 +21,6 @@ export default {
 			options: ['date', 'date passé', 'date futur'],
 			defaultValue: 'date',
 		},
-		isRequired: {
-			control: 'boolean',
-			defaultValue: false,
-		},
 		label: {
 			control: 'text',
 			defaultValue: 'Date de naissance',
@@ -62,12 +58,5 @@ export const WithInitialValue: Story = {
 	args: {
 		defaultSelected: new Date('2000-01-01'),
 		label: 'Avec valeur initiale',
-	},
-}
-
-export const WithRequiredField: Story = {
-	args: {
-		isRequired: true,
-		label: 'Champ obligatoire',
 	},
 }

--- a/site/source/design-system/molecules/field/DateField.tsx
+++ b/site/source/design-system/molecules/field/DateField.tsx
@@ -22,9 +22,7 @@ export interface DateFieldProps {
 	id?: string
 	defaultSelected?: Date
 	onChange?: (value?: Date) => void
-	placeholder?: string
 	label?: string
-	isRequired?: boolean
 	'aria-label'?: string
 	'aria-labelledby'?: string
 	type?: 'date passé' | 'date' | 'date futur'
@@ -32,15 +30,7 @@ export interface DateFieldProps {
 
 export const DateField = (props: DateFieldProps) => {
 	const { aria: ariaProps, rest } = splitAriaProps(props)
-	const {
-		id,
-		defaultSelected,
-		placeholder = 'JJ/MM/AAAA',
-		label,
-		isRequired,
-		onChange,
-		type = 'date',
-	} = rest
+	const { id, defaultSelected, label, onChange, type = 'date' } = rest
 
 	const { t, i18n } = useTranslation()
 	const language = i18n.language as 'fr' | 'en'
@@ -145,8 +135,7 @@ export const DateField = (props: DateFieldProps) => {
 						'design-system.date-picker.label',
 						'Champ de date au format jours/mois/année'
 					)}
-					isRequired={isRequired}
-					placeholder={placeholder}
+					placeholder={language === 'fr' ? 'JJ/MM/AAAA' : 'DD/MM/YYYY'}
 					value={inputValue}
 					onChange={handleInputChange}
 					onBlur={(e) => {


### PR DESCRIPTION
Petite PR de nettoyage du `<DateField />` actuel, en attendant de le remplacer par celui de `react-aria-components`.

Le `<DateField />` actuel n'est apparemment utilisé que par `<DateInput />` et `<DateDeNaissanceInput />` qui, ni l'un ni l'autre, ne passent de prop `placeholder` ou `isRequired`.

Cette PR se contente de les faire disparaître du composant et de Storybook, en internationalisant le placeholder par défaut.