### PR TITLE
Change la couleur du texte sur Choix du statut

### DIFF
--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -189,7 +189,7 @@ const DetailsRowCards = ({
 }
 
 const StyledSmall = styled.small`
-	color: ${({ theme }) => theme.colors.extended.grey[700]};
+	color: ${({ theme }) => theme.colors.extended.grey[800]};
 	font-weight: normal;
 	font-size: 80%;
 `


### PR DESCRIPTION
Actuellement dans les accordions de fin de simulation le texte "Le montant demandé n'est pas calculable..." est trop clair (contraste de 4,45 pour 4,5).
<img width="1212" height="384" alt="image" src="https://github.com/user-attachments/assets/05515f95-ecc1-4136-bba9-6714c066c1b7" />

La PR le passe donc le contraste à 7,76 et rend le texte + lisible.

@logic-fabric je me pose la question de le mettre au même niveau que le texte courant, je veux bien ton avis.

Closes #3957 