### PR TITLE
Proposition d'un affichage plus conforme pour la pagination

### DIFF
--- a/site/source/pages/statistiques/DemandesUtilisateurs.tsx
+++ b/site/source/pages/statistiques/DemandesUtilisateurs.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import { css, styled } from 'styled-components'
 
-import { Button, Chip, Emoji, typography } from '@/design-system'
+import { Button, Chip, Emoji, theme, typography } from '@/design-system'
 import { useFetchData } from '@/hooks/useFetchData'
 
 import { StatsStruct } from './types'
@@ -155,50 +155,32 @@ type PagerButtonProps = {
 }
 
 const PagerButton = styled(Button)<PagerButtonProps>`
-	border: ${({ theme, currentPage }) =>
-		currentPage
-			? `2px solid ${theme.colors.bases.primary[600]}`
-			: `2px solid ${theme.colors.extended.grey[400]}`};
+	border: none;
+	text-decoration: underline;
+	text-underline-offset: ${theme.spacings.xxs};
 
 	${({ theme, currentPage }) =>
 		currentPage &&
 		css`
 			color: ${theme.colors.extended.grey[100]};
 			background: ${theme.colors.bases.primary[600]};
+			pointer-events: none;
+			text-decoration: none;
 
 			&:hover {
 				background: ${theme.colors.bases.primary[600]};
 			}
-		`}
+		`};
 `
 
 const Pager = styled.ol`
+	display: flex;
+	gap: ${theme.spacings.xs};
+	justify-content: center;
 	font-family: ${({ theme }) => theme.fonts.main};
-	text-align: center;
-	margin: auto;
 
 	& li {
 		list-style: none;
 		display: inline-block;
-		margin-right: 0.25rem;
-	}
-
-	& li:first-child {
-		button {
-			border-top-left-radius: 0.25rem;
-			border-top-right-radius: 0;
-			border-bottom-left-radius: 0.25rem;
-			border-bottom-right-radius: 0;
-		}
-	}
-
-	& li:last-child {
-		button {
-			border-top-right-radius: 0.25rem;
-			border-bottom-right-radius: 0.25rem;
-			border-top-left-radius: 0;
-			border-bottom-left-radius: 0;
-			margin-right: 0;
-		}
 	}
 `


### PR DESCRIPTION
Avant : 
<img width="527" height="60" alt="image" src="https://github.com/user-attachments/assets/4fb7a4f2-4145-40d4-bea5-184ed7df04c1" />

Après : 
<img width="442" height="56" alt="image" src="https://github.com/user-attachments/assets/e013b0d0-5905-4397-9d17-d0ea07d9c28d" />

Le retour des audits était que "Visuellement le composant actif doit être différentiable par la forme".

J'ai donc supprimé les bordures, mis un soulignement pour les pages inactives.
J'en ai profité pour améliorer le code qui améliore le rendu.
J'ai aussi supprimé la possibilité de cliquer sur la page active ([recommandation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination/accessibilite-de-la-pagination#:~:text=cliquable).

Closes #3955