### PR TITLE
Résultats de la recherche

### DIFF
--- a/site/source/components/search/RulesInfiniteHits/index.tsx
+++ b/site/source/components/search/RulesInfiniteHits/index.tsx
@@ -16,8 +16,6 @@ type THit = AlgoliaHit<{
 }>
 
 const StyledRuleLink = styled(RuleLink)`
-	display: block; // Fix focus outline on chrome
-
 	${SmallBody}, ${Body} {
 		margin: 0;
 		color: inherit;
@@ -33,7 +31,9 @@ const StyledRuleLink = styled(RuleLink)`
 `
 
 const HitContainer = styled.li`
-	display: block;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start
 
 	border-top: 1px solid #eee;
 	padding-top: 0.5rem;
@@ -55,7 +55,7 @@ const Hit = (hit: THit) => {
 				</SmallBody>
 			)}
 
-			<StyledRuleLink dottedName={hit.objectID} aria-label={undefined}>
+			<StyledRuleLink dottedName={hit.objectID} aria-label={hit.ruleName}>
 				<Body as="span" className="hit-ruleName">
 					{hit.ruleName}
 				</Body>


### PR DESCRIPTION
Actions sur la page de Documenation : 

**Retour de l'audit de contrôle :** 
> Nouvelle NC au 27/08/2025 , dans le résultat de recherche les aria-label des liens ne reprennent pas au minimum le contenu visible
 
> Lors de la recherche le mot recherché est indiqué uniquement par la couleur dans le résultat de recherche

Proposition :
- [x] Sortir le breadcrumb du lien
- [ ] ~Supprimer l'aria-label inutile~ (voir le [commentaire](https://github.com/betagouv/mon-entreprise/pull/4084#issuecomment-3654660908))
- [x] Supprimer le surlignage
- [ ] ~Ajouter le terme recherché dans le contenu et pas que dans la recherche~ (voir [commentaire](https://github.com/betagouv/mon-entreprise/issues/3786#issuecomment-3562177843))


Closes #3958 
Closes #3786 
