### PR TITLE
Change le niveau du titre de la modal de recherche principale

### DIFF
--- a/site/source/design-system/popover/Popover.tsx
+++ b/site/source/design-system/popover/Popover.tsx
@@ -18,7 +18,7 @@ import { wrapperDebounceEvents } from '@/utils'
 import { FocusStyle } from '../global-style'
 import { useIFrameOffset } from '../hooks'
 import { Container, Grid } from '../layout'
-import { H2 } from '../typography/heading'
+import { H1 } from '../typography/heading'
 
 export function Popover(
 	props: OverlayProps &
@@ -134,7 +134,7 @@ export function Popover(
 											ref={contentRef}
 											$disableOverflowAuto={props.disableOverflowAuto ?? false}
 										>
-											{title && <H2 {...titleProps}>{title}</H2>}
+											{title && <H1 {...titleProps}>{title}</H1>}
 											{children}
 										</PopoverContent>
 									</PopoverContainer>


### PR DESCRIPTION
Retour de l'audit de contrôle
> Les titres dans la modal de recherche sont bien sous forme de titres html mais ils possèdent un niveau identique à celui du parent

Pour faire suite à #3855 je pensais que c'était dans la recherche d'entreprises mais c'est ok là.
Il s'agit bien de la modale de recherche général, j'ai donc passé le texte "Recherche sur le site" en `h1` à la place de `h2`. Les titres "Simulateurs" et "Documentation des simulateurs" sont en `h2`

Closes #3963 
