### PR TITLE
[Mini-PR ] Remove now useless aria-label in <RadioChoiceGroup />

### DIFF
--- a/site/source/design-system/molecules/field/ChoiceGroup/RadioChoiceGroup.tsx
+++ b/site/source/design-system/molecules/field/ChoiceGroup/RadioChoiceGroup.tsx
@@ -77,9 +77,6 @@ export default function RadioChoiceGroup({
 								light
 								title={option.label.toString()}
 								description={option.description}
-								aria-label={t("Plus d'informations sur {{ title }}", {
-									title: option.label,
-								})}
 							/>
 						)}
 					</div>
@@ -113,7 +110,6 @@ function RadioGroup(props: RadioGroupProps) {
 	const { children, label, description, isSubRadioGroup } = props
 	const state = useRadioGroupState(props)
 	const { radioGroupProps, labelProps } = useRadioGroup(props, state)
-	const { t } = useTranslation()
 
 	useEffect(() => {
 		if (!props.value) {
@@ -133,14 +129,7 @@ function RadioGroup(props: RadioGroupProps) {
 				<StyledH5 as="p" {...labelProps}>
 					{label}
 					{description && (
-						<InfoButton
-							light
-							title={label}
-							description={description}
-							aria-label={t("Plus d'informations sur {{ title }}", {
-								title: label,
-							})}
-						/>
+						<InfoButton light title={label} description={description} />
 					)}
 				</StyledH5>
 			)}


### PR DESCRIPTION
Avec ma toute récente refacto de `<InfoButton />` (commit https://github.com/betagouv/mon-entreprise/commit/ee6f8918637fcca35fe0c91ff77ec708f9b36a63) dans la PR https://github.com/betagouv/mon-entreprise/pull/4097 construisant un nouveau composant `<RadioGroup />`, certains `aria-label` sont devenus redondants.

Cette mini-PR se contente de les supprimer.