### PR TITLE
feat(économie-collaborative): améliore la mise en avant visuelle des régimes non applicables

### DIFF
--- a/site/source/design-system/card/StatusCard.stories.tsx
+++ b/site/source/design-system/card/StatusCard.stories.tsx
@@ -133,3 +133,17 @@ export const PlusieursÉtiquettes: Story = {
 		</StatusCard>
 	),
 }
+
+export const OptionNonApplicable: Story = {
+	render: () => (
+		<StatusCard nonApplicable>
+			<StatusCard.Étiquette>
+				<Tag color="tertiary">AE</Tag>
+			</StatusCard.Étiquette>
+			<StatusCard.Titre>Auto-entrepreneur</StatusCard.Titre>
+			<StatusCard.ValeurSecondaire>
+				Non applicable avec vos recettes actuelles
+			</StatusCard.ValeurSecondaire>
+		</StatusCard>
+	),
+}

--- a/site/source/design-system/card/StatusCard.test.tsx
+++ b/site/source/design-system/card/StatusCard.test.tsx
@@ -141,4 +141,26 @@ describe('StatusCard', () => {
 		expect(valeurSecondaireIndex).toBeLessThan(complementIndex)
 		expect(complementIndex).toBeLessThan(actionIndex)
 	})
+
+	it('affiche une icône pour les options non applicables', () => {
+		renderWithTheme(
+			<StatusCard nonApplicable>
+				<StatusCard.Titre>Option non applicable</StatusCard.Titre>
+			</StatusCard>
+		)
+
+		expect(screen.getByTitle('Option non applicable.')).toBeInTheDocument()
+	})
+
+	it("n'affiche pas l'icône si l'option est applicable", () => {
+		renderWithTheme(
+			<StatusCard nonApplicable={false}>
+				<StatusCard.Titre>Option applicable</StatusCard.Titre>
+			</StatusCard>
+		)
+
+		expect(
+			screen.queryByTitle('Option non applicable.')
+		).not.toBeInTheDocument()
+	})
 })

--- a/site/source/design-system/card/StatusCard.tsx
+++ b/site/source/design-system/card/StatusCard.tsx
@@ -14,10 +14,15 @@ import { CardContainer } from './Card'
 
 type StatusCardProps = {
 	isBestOption?: boolean
+	nonApplicable?: boolean
 	children: ReactNode
 }
 
-export const StatusCard = ({ children, isBestOption }: StatusCardProps) => {
+export const StatusCard = ({
+	children,
+	isBestOption,
+	nonApplicable,
+}: StatusCardProps) => {
 	const { t } = useTranslation()
 
 	const étiquettes = findChildrenByType(children, StatusCard.Étiquette)
@@ -32,7 +37,7 @@ export const StatusCard = ({ children, isBestOption }: StatusCardProps) => {
 	const hasContent = titre || valeurSecondaire
 
 	return (
-		<StyledCardContainer $inert>
+		<StyledCardContainer $inert $nonApplicable={nonApplicable}>
 			<CardBody>
 				{étiquettes.length > 0 && (
 					<Grid container spacing={1}>
@@ -47,14 +52,24 @@ export const StatusCard = ({ children, isBestOption }: StatusCardProps) => {
 				)}
 			</CardBody>
 			{isBestOption && (
-				<AbsoluteSpan
+				<AbsoluteSpanTop
 					title={t(
 						'pages.simulateurs.comparaison-statuts.meilleure-option',
 						'Option la plus avantageuse.'
 					)}
 				>
 					<StyledEmoji emoji="🥇" />
-				</AbsoluteSpan>
+				</AbsoluteSpanTop>
+			)}
+			{nonApplicable && (
+				<AbsoluteSpanWithMargin
+					title={t(
+						'pages.simulateurs.comparaison-statuts.option-non-applicable',
+						'Option non applicable.'
+					)}
+				>
+					<StyledDisabledEmoji emoji="🚫" />
+				</AbsoluteSpanWithMargin>
 			)}
 			{(complément || actions.length > 0) && (
 				<CardFooter>
@@ -99,18 +114,55 @@ StatusCard.ValeurSecondaire = StatusCardValeurSecondaire
 StatusCard.Complément = StatusCardComplément
 StatusCard.Action = StatusCardAction
 
-const StyledCardContainer = styled(CardContainer)`
+const StyledCardContainer = styled(CardContainer)<{
+	$nonApplicable?: boolean
+}>`
 	position: relative;
 	align-items: flex-start;
 	padding: 0;
+
+	${({ $nonApplicable, theme }) =>
+		$nonApplicable &&
+		`
+		opacity: 0.6;
+		background-color: ${
+			theme.darkMode
+				? theme.colors.extended.dark[700]
+				: theme.colors.extended.grey[200]
+		} !important;
+		border-color: ${theme.colors.extended.grey[400]};
+		filter: grayscale(30%);
+
+		&:hover {
+			background-color: ${
+				theme.darkMode
+					? theme.colors.extended.dark[700]
+					: theme.colors.extended.grey[200]
+			} !important;
+			box-shadow: ${
+				theme.darkMode ? theme.elevationsDarkMode[2] : theme.elevations[2]
+			};
+		}
+	`}
 `
 
-const AbsoluteSpan = styled.span`
+const AbsoluteSpanTop = styled.span`
 	position: absolute;
 	top: 0;
 	right: 1.5rem;
 `
+
+const AbsoluteSpanWithMargin = styled.span`
+	position: absolute;
+	top: 0.5rem;
+	right: 1.5rem;
+`
+
 const StyledEmoji = styled(Emoji)`
+	font-size: 1.5rem;
+`
+
+const StyledDisabledEmoji = styled(Emoji)`
 	font-size: 1.5rem;
 `
 

--- a/site/source/pages/simulateurs/location-de-meublé/components/ComparateurRégimesCards.tsx
+++ b/site/source/pages/simulateurs/location-de-meublé/components/ComparateurRégimesCards.tsx
@@ -113,7 +113,10 @@ const RégimeCard = ({
 	}
 
 	return (
-		<StatusCard isBestOption={estMeilleurRégime}>
+		<StatusCard
+			isBestOption={estMeilleurRégime}
+			nonApplicable={!résultat.applicable}
+		>
 			<StatusCard.Étiquette>
 				<RégimeTag régime={résultat.régime} />
 			</StatusCard.Étiquette>


### PR DESCRIPTION
- Ajoute une prop `nonApplicable` au composant StatusCard du design-system
- Applique des styles visuels distinctifs aux cartes non applicables
- Ajoute une icône 🚫 pour signaler visuellement les options non applicables
- Met à jour ComparateurRégimesCards pour utiliser la nouvelle prop

Closes #4070