### PR TITLE
feat: #4013 implémente un composant pour le thème light/dark mode en ajoutant l'option "système" (OS/browser) et en fait la valeur par défaut

### DIFF
--- a/site/source/components/layout/Header.tsx
+++ b/site/source/components/layout/Header.tsx
@@ -3,8 +3,7 @@ import { styled } from 'styled-components'
 
 import { Logo } from '@/components/Logo'
 import SearchButton from '@/components/SearchButton'
-import { Container, Emoji, Link, Switch } from '@/design-system'
-import { useDarkMode } from '@/hooks/useDarkMode'
+import { Container, Link } from '@/design-system'
 import { useGetFullURL } from '@/hooks/useGetFullURL'
 import { useSitePaths } from '@/sitePaths'
 
@@ -12,6 +11,7 @@ import { Appear } from '../ui/animate'
 import BrowserOnly from '../utils/BrowserOnly'
 import { Menu } from './Menu'
 import NewsBannerWrapper from './NewsBanner'
+import ThemeSwitcher from './ThemeSwitcher'
 
 export default function Header() {
 	const { absoluteSitePaths } = useSitePaths()
@@ -20,7 +20,7 @@ export default function Header() {
 
 	const { i18n, t } = useTranslation()
 
-	const [darkMode, setDarkMode] = useDarkMode()
+
 
 	return (
 		<>
@@ -74,20 +74,7 @@ export default function Header() {
 							}}
 							className="print-hidden"
 						>
-							<Emoji emoji="☀️" aria-hidden />
-							<Switch
-								isSelected={darkMode}
-								onChange={setDarkMode}
-								srOnlyLabel
-								/* Need this useless aria-label to silence a React-Aria warning */
-								aria-label=""
-							>
-								{t(
-									'header.dark-mode-switch.activate-dark-mode',
-									'Activer le mode sombre'
-								)}
-							</Switch>
-							<Emoji emoji="🌙" aria-hidden />
+							<ThemeSwitcher />
 						</div>
 
 						{i18n.language === 'fr' && <SearchButton />}

--- a/site/source/components/layout/ThemeSwitcher.tsx
+++ b/site/source/components/layout/ThemeSwitcher.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Emoji } from '@/design-system'
+import { useTheme } from '@/hooks/useDarkMode'
+
+export default function ThemeSwitcher() {
+    const { theme, setTheme } = useTheme()
+    const [isOpen, setIsOpen] = useState(false)
+    const dropdownRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                dropdownRef.current &&
+                !dropdownRef.current.contains(event.target as Node)
+            ) {
+                setIsOpen(false)
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside)
+        return () => document.removeEventListener('mousedown', handleClickOutside)
+    }, [])
+
+    return (
+        <Container ref={dropdownRef}>
+            <ToggleButton
+                onClick={() => setIsOpen(!isOpen)}
+                title="Changer de thème"
+                aria-label="Changer de thème"
+                $isOpen={isOpen}
+            >
+                <EmojiWrapper>
+                    <Emoji emoji="🔦" />
+                </EmojiWrapper>
+            </ToggleButton>
+
+            {isOpen && (
+                <Dropdown>
+                    <Option
+                        onClick={() => {
+                            setTheme('light')
+                            setIsOpen(false)
+                        }}
+                        $isSelected={theme === 'light'}
+                    >
+                        <OptionContent>
+                            <Emoji emoji="☀️" />
+                            <span>Clair</span>
+                        </OptionContent>
+                        {theme === 'light' && <Emoji emoji="☑️" />}
+                    </Option>
+
+                    <Option
+                        onClick={() => {
+                            setTheme('dark')
+                            setIsOpen(false)
+                        }}
+                        $isSelected={theme === 'dark'}
+                    >
+                        <OptionContent>
+                            <Emoji emoji="🌙" />
+                            <span>Sombre</span>
+                        </OptionContent>
+                        {theme === 'dark' && <Emoji emoji="☑️" />}
+                    </Option>
+
+                    <Option
+                        onClick={() => {
+                            setTheme('system')
+                            setIsOpen(false)
+                        }}
+                        $isSelected={theme === 'system'}
+                    >
+                        <OptionContent>
+                            <Emoji emoji="💻" />
+                            <span>Système</span>
+                        </OptionContent>
+                        {theme === 'system' && <Emoji emoji="☑️" />}
+                    </Option>
+                </Dropdown>
+            )}
+        </Container>
+    )
+}
+
+const Container = styled.div`
+	position: relative;
+	display: flex;
+	align-items: center;
+`
+
+const ToggleButton = styled.button<{ $isOpen: boolean }>`
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0.5rem;
+	border-radius: 0.5rem;
+	transition: background-color 0.2s;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background-color: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.dark[500]
+				: theme.colors.bases.primary[100]};
+	}
+
+	${({ $isOpen, theme }) =>
+		$isOpen &&
+		css`
+			background-color: ${theme.darkMode
+				? theme.colors.extended.dark[500]
+				: theme.colors.bases.primary[100]};
+		`}
+`
+
+const EmojiWrapper = styled.div`
+	transform: rotate(90deg);
+	font-size: 1.25rem;
+	line-height: 1;
+`
+
+const Dropdown = styled.div`
+	position: absolute;
+	top: 100%;
+	right: 0;
+	margin-top: 0.5rem;
+	width: 10rem;
+	background-color: ${({ theme }) =>
+		theme.darkMode
+			? theme.colors.extended.dark[700]
+			: theme.colors.bases.primary[100]};
+	border-radius: 0.5rem;
+	box-shadow:
+		0 4px 6px -1px rgba(0, 0, 0, 0.1),
+		0 2px 4px -1px rgba(0, 0, 0, 0.06);
+	padding: 0.25rem;
+	z-index: 50;
+	border: 1px solid
+		${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.dark[500]
+				: theme.colors.bases.primary[200]};
+`
+
+const Option = styled.button<{ $isSelected: boolean }>`
+	display: flex;
+	width: 100%;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem;
+	border-radius: 0.25rem;
+	border: none;
+	background: none;
+	cursor: pointer;
+	font-size: 0.875rem;
+	color: ${({ theme }) =>
+		theme.darkMode
+			? theme.colors.extended.grey[100]
+			: theme.colors.extended.grey[800]};
+	transition: background-color 0.2s;
+
+	&:hover {
+		background-color: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.dark[600]
+				: theme.colors.bases.primary[200]};
+	}
+
+	${({ $isSelected, theme }) =>
+		$isSelected &&
+		css`
+			background-color: ${theme.darkMode
+				? theme.colors.extended.dark[600]
+				: theme.colors.bases.primary[200]};
+			font-weight: bold;
+		`}
+`
+
+const OptionContent = styled.div`
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+`

--- a/site/source/hooks/useDarkMode.ts
+++ b/site/source/hooks/useDarkMode.ts
@@ -1,7 +1,18 @@
 import React from 'react'
 
-import { DarkModeContext } from '@/components/utils/DarkModeContext'
+import {
+	DarkModeContext,
+	ThemeContext,
+} from '@/components/utils/DarkModeContext'
 
 export const useDarkMode = () => {
 	return React.useContext(DarkModeContext)
+}
+
+export const useTheme = () => {
+	const context = React.useContext(ThemeContext)
+	if (context === undefined) {
+		throw new Error('useTheme must be used within a ThemeProvider')
+	}
+	return context
 }


### PR DESCRIPTION
**Ajout du support du thème système (Clair/Sombre/Système)**
Cette PR introduit une option "Système" dans le sélecteur de thème, permettant aux utilisateurs de choisir entre les modes Clair, Sombre et Système (préférence de l'OS ou du navigateur).

**Changements**
- Refactorisation de DarkModeContext : Mise à jour du contexte pour supporter un thème à trois états ('light' | 'dark' | 'system') au lieu d'un simple booléen. Il écoute maintenant correctement les changements de préférence système lorsqu'il est en mode "Système".
- Nouveau composant ThemeSwitcher : Remplacement de l'interrupteur simple dans l'en-tête par un nouveau composant déroulant (inspiré de flashlight-template).
- UI : Utilise un Twemoji lampe de poche (🔦) pour ouvrir un menu avec les options Clair (☀️), Sombre (🌙) et Système (💻).
- Rétrocompatibilité : Le hook existant useDarkMode a été mis à jour pour maintenir la compatibilité avec le reste de l'application.

**Issue liée**
Clos #4013

**Vérification**
- Vérifié que les modes "Clair" et "Sombre" forcent les thèmes respectifs.
- Vérifié que le mode "Système" applique correctement la préférence de l'OS.
- Vérifié que le mode sélectionné est conservé après rechargement.