### PR TITLE
Simplifie les aria-label des liens de StackedBarChart

### DIFF
--- a/site/source/components/StackedBarChart.tsx
+++ b/site/source/components/StackedBarChart.tsx
@@ -203,7 +203,6 @@ export default function StackedRulesChart({
 	data,
 	precision = 0.1,
 }: StackedRulesChartProps) {
-	const { t } = useTranslation().i18n
 	const engine = useEngine()
 	const targetUnit = useSelector(targetUnitSelector)
 
@@ -215,14 +214,7 @@ export default function StackedRulesChart({
 				value: engine.evaluate({ valeur: dottedName, unité: targetUnit })
 					.nodeValue,
 				legend: (
-					<RuleLink
-						dottedName={dottedName}
-						aria-label={t(
-							'composants.engine-value.voir-les-details-du-calcul',
-							'Voir les détails du calcul de {{title}}',
-							{ title }
-						)}
-					>
+					<RuleLink dottedName={dottedName} aria-label={title}>
 						{title}
 					</RuleLink>
 				),


### PR DESCRIPTION
Lors des différents audits d'accessibilités il était remonté que :
```
L'aria-label du lien "Revenu (incluant les dépenses liées à l'activité)" ne reprend pas au minimum l'intitulé visible du lien
```

Résolution : 
Je n'ai mis que le contenu minimal à savoir le contenu du lien à défaut de pouvoir ne pas passer d'`aria-label`.

Closes #3959
