### PR TITLE
Simplifie les aria-label des liens du composant CasParticuliers

### DIFF
--- a/site/source/pages/integration/components/CasParticuliers.tsx
+++ b/site/source/pages/integration/components/CasParticuliers.tsx
@@ -192,7 +192,7 @@ export function CasParticuliers() {
 							La documentation{' '}
 							<Link
 								href="https://www.ameli.fr/entreprise/votre-entreprise/cotisation-atmp"
-								aria-label="Cotisations AT/MP"
+								aria-label="Cotisations AT/MP, nouvelle fenêtre"
 							>
 								Cotisations AT/MP
 							</Link>{' '}


### PR DESCRIPTION
Dans les deux audits d'accessibilité il y a eu le retour : 
```   
* Dans la partie "Le versement mobilité" l'aria-label du lien "établissement . commune . taux versement mobilité" ne reprend pas le contenu visible
* Dans la partie "Le taux collectif AT/MP" l'aria-label du lien "établissement . taux ATMP . taux collectif" ne reprend pas le contenu visible. Idem pour le lien "Cotisations AT/MP"
```

Résolution : 
J'ai changé le contenu par celui du lien, sans valeur ajouté.

Closes #3657