### PR TITLE
Corrige la pagination des statistiques

### DIFF
--- a/site/source/pages/statistiques/DemandesUtilisateurs.tsx
+++ b/site/source/pages/statistiques/DemandesUtilisateurs.tsx
@@ -73,7 +73,7 @@ function Pagination({ title, items }: PaginationProps) {
 					<Issue key={`issue-${item.number}`} {...item} />
 				))}
 			</Ul>
-			<nav aria-label={`Navigation pour ${title}`} role='navigation'>
+			<nav aria-label={`Navigation pour ${title}`} role="navigation">
 				<Pager>
 					{[...Array(Math.ceil(items.length / 10)).keys()].map((i) => (
 						<li key={i}>


### PR DESCRIPTION
Retour présent dans les 2 audits : 
> Les balises nav des éléments de pagination ne possèdent pas de landmark ni d'aria-label

Il y avait déjà un `aria-label`, je l'ai donc modifié et rajouté le `role="navigation"`.

Closes #3970
