### PR TITLE
Rajoute un role et modifie l'aria-label pour la navigation des nouveautés 

### DIFF
--- a/site/source/pages/nouveautés/index.tsx
+++ b/site/source/pages/nouveautés/index.tsx
@@ -108,7 +108,10 @@ export default function Nouveautés() {
 						</Select>
 					</MobileGridItem>
 					<DesktopGridItem item lg={3}>
-						<Sidebar aria-label="Navigation lettres d'actualités" role="navigation">
+						<Sidebar
+							aria-label="Navigation lettres d'actualités"
+							role="navigation"
+						>
 							<StyledUl>
 								{data.map(({ name }, index) => (
 									<li key={name}>


### PR DESCRIPTION
Lors de l'audit initial le retour suivant a été fait : 
>   Le role navigation qui est sur le conteneur de liste de gauche de posséde pas d'aria-label

Et lors de l'audit de contrôle, il y avait la précision : 
>  Ko au 29/08/2025, a discuter sur la pertinence de l'aria-label

J'ai donc modifié l'`aria-label` et rajouté le `role="navigation"`.

Closes #3971 
