### PR TITLE
A11y / Simplify <InfoButton /> aria-label

### DIFF
--- a/site/source/components/conversation/RadioChoices.tsx
+++ b/site/source/components/conversation/RadioChoices.tsx
@@ -94,7 +94,7 @@ export function RadioChoices<Names extends string = DottedName>({
 											<ExplicableRule
 												light
 												dottedName={node.dottedName as DottedName}
-												aria-label={t("Plus d'informations sur {{ title }}", {
+												aria-label={t('Info sur {{ title }}', {
 													title: node.title,
 												})}
 											/>

--- a/site/source/design-system/InfoButton.tsx
+++ b/site/source/design-system/InfoButton.tsx
@@ -12,7 +12,6 @@ export interface InfoButtonProps {
 	children?: ReactNode
 	className?: string
 	onClick?: () => void
-	'aria-label'?: string
 }
 
 export function InfoButton({
@@ -23,7 +22,6 @@ export function InfoButton({
 	children,
 	className,
 	onClick,
-	'aria-label': ariaLabel,
 }: InfoButtonProps) {
 	const { t } = useTranslation()
 
@@ -39,12 +37,9 @@ export function InfoButton({
 			bigPopover={bigPopover}
 			className={className || 'print-hidden'}
 			aria-haspopup="dialog"
-			aria-label={
-				ariaLabel ??
-				t("Plus d'infos sur {{ title }}", {
-					title,
-				})
-			}
+			aria-label={t('Info sur {{ title }}', {
+				title,
+			})}
 			onClick={onClick}
 		>
 			{description && typeof description === 'string' ? (

--- a/site/source/design-system/molecules/field/choix/ChoixMultiple.tsx
+++ b/site/source/design-system/molecules/field/choix/ChoixMultiple.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from 'react'
-import { useTranslation } from 'react-i18next'
 
 import { Emoji } from '../../../emoji'
 import { InfoButton } from '../../../InfoButton'
@@ -62,8 +61,6 @@ type CheckBoxOptionProps = {
 }
 
 function CheckBoxOption({ option, onChange }: CheckBoxOptionProps) {
-	const { t } = useTranslation()
-
 	return (
 		<>
 			<Checkbox
@@ -78,9 +75,6 @@ function CheckBoxOption({ option, onChange }: CheckBoxOptionProps) {
 					light
 					title={option.label}
 					description={option.description}
-					aria-label={t("Plus d'informations sur {{ title }}", {
-						title: option.label,
-					})}
 				/>
 			)}
 			<br />


### PR DESCRIPTION
Cette PR repasse sur un problème d'accessibilité traité dans [#3659](https://github.com/betagouv/mon-entreprise/issues/3659), mais qui n'a pas été validé lors de l'audit de contrôle :

> Les aria-label des boutons "Info" ne reprennent pas le contenu visible

J'ai donc remplacé les formulations _"Plus d'informations sur..."_ par _"Info sur..."_.

J'en ai profité pour :

- retirer la prop `aria-label` dans `<InfoButton />`, qui était dispensable
- simplifier de la même façon l'aria-label _"Plus d'informations sur..."_ présent dans `<RadioChoices />`