### PR TITLE
Transforme du texte en label

### DIFF
--- a/site/source/design-system/markdown/Markdown.tsx
+++ b/site/source/design-system/markdown/Markdown.tsx
@@ -26,17 +26,20 @@ export type MarkdownProps = React.ComponentProps<typeof MarkdownToJsx> & {
 	components?: MarkdownToJSX.Overrides
 	renderers?: Record<string, unknown>
 	as?: string
+	htmlFor?: string
 }
 
 export function Markdown({
 	children,
 	components = {},
 	as,
+	htmlFor,
 	...otherProps
 }: MarkdownProps) {
 	return (
 		<MarkdownToJsx
 			as={as}
+			htmlFor={htmlFor}
 			options={{
 				forceBlock: true,
 				...otherProps.options,

--- a/site/source/pages/assistants/components/Fields.tsx
+++ b/site/source/pages/assistants/components/Fields.tsx
@@ -9,6 +9,7 @@ import { ExplicableRule } from '@/components/conversation/Explicable'
 import RuleInput from '@/components/conversation/RuleInput'
 import { FadeIn } from '@/components/ui/animate'
 import { useEngine } from '@/components/utils/EngineContext'
+import { normalizeRuleName } from '@/components/utils/normalizeRuleName'
 import { H3, Intro, Markdown, SmallBody, Spacing } from '@/design-system'
 import { ValeurPublicodes } from '@/domaine/engine/PublicodesAdapter'
 import { useNextQuestions } from '@/hooks/useNextQuestion'
@@ -116,7 +117,13 @@ export function SimpleField(props: SimpleFieldProps) {
 	return (
 		<FadeIn>
 			<StyledQuestion id={labelId}>
-				<Markdown components={markdownComponents}>{displayedLabel}</Markdown>
+				<Markdown
+					as="label"
+					htmlFor={normalizeRuleName.Input(dottedName)}
+					components={markdownComponents}
+				>
+					{displayedLabel}
+				</Markdown>
 				{required && <RedIntro aria-hidden>&nbsp;*</RedIntro>}
 				<ExplicableRule dottedName={dottedName} />
 			</StyledQuestion>


### PR DESCRIPTION
Dans les audits est remonté : 
>  L'intitulé du champ dans la partie "Quel est votre résultat fiscal au titre de l’année 2024 ?" n'est pas visible

En effet jusqu'à présent il ne s'agissait pas de `<label>`.
<img width="917" height="327" alt="image" src="https://github.com/user-attachments/assets/26021e15-005f-465c-ac58-b760cfe0f19d" />

La PR propose donc de remplacer du texte en `label`.

Actuellement le `htmlFor` ne transparait pas, @logic-fabric tu pourrais mater ?

Closes #3968