### PR TITLE
chore: reduce GH actions flood

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -240,6 +240,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     container: cypress/browsers:latest
     # We need to specify always() https://github.com/actions/runner/issues/491
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.deploy-preview.result == 'success'
@@ -247,6 +248,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         site: ['fr', 'en']
         browser: [chrome] # Firefox is very slow…
@@ -311,6 +313,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     container: cypress/browsers:latest
     # We need to specify always() https://github.com/actions/runner/issues/491
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.deploy-prod.result == 'success'
@@ -318,6 +321,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         site: ['fr', 'en']
         browser: [chrome] # Firefox is very slow…


### PR DESCRIPTION
Hey! Just wanted to give you a heads up that the e2e jobs are currently using 17 out of our 20 available GitHub runners. Some of these jobs are taking quite a while to complete – we're seeing run times of 3, 4, and even 5+ hours! 😊