### PR TITLE
Corrige les aria-label des boutons 'infos' dans les simulateurs

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -163,7 +163,6 @@ Passer: Pass
 Personnalisez l'intégration: Customize integration
 Plan du site: Site map
 Plus d'informations sur {{ title }}: More information on {{ title }}
-Plus d'infos sur {{ title }}: More info on {{ title }}
 Plus de 50 salariés: More than 50 employees
 Pour en savoir plus, rendez-vous sur le site <2>aquoiserventlescotisations:
   urssaf:

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -171,7 +171,6 @@ Passer: Passer
 Personnalisez l'intégration: Personnalisez l'intégration
 Plan du site: Plan du site
 Plus d'informations sur {{ title }}: Plus d'informations sur {{ title }}
-Plus d'infos sur {{ title }}: Plus d'infos sur {{ title }}
 Plus de 50 salariés: Plus de 50 salariés
 Pour en savoir plus, rendez-vous sur le site <2>aquoiserventlescotisations:
   urssaf:


### PR DESCRIPTION
Dans l'audit de contrôle était précisé 

> Les aria-label des boutons "Info" ne reprennent pas le contenu visible

Jusqu'à maintenant il était indiqué "Plus d'informations sur". 
Il faut que le mot "info" soit présent dans l'`aria-label`, j'ai donc harmonisé avec la PR #3702 pour ne garde que "Info sur".

Closes #3960