### PR TITLE
A11y / Simplify <Progress /> to remove useless ARIA attributes

### DIFF
--- a/site/source/components/ui/Progress.tsx
+++ b/site/source/components/ui/Progress.tsx
@@ -1,4 +1,3 @@
-import { useProgressBar } from '@react-aria/progress'
 import { useTranslation } from 'react-i18next'
 import { styled } from 'styled-components'
 
@@ -6,47 +5,25 @@ import { Body } from '@/design-system'
 
 type ProgressProps = {
 	progress: number
-	minValue?: number
 	maxValue?: number
-	step?: number
 }
 
-export default function Progress({
-	progress,
-	minValue = 0,
-	maxValue = 1,
-}: ProgressProps) {
+export default function Progress({ progress, maxValue = 1 }: ProgressProps) {
 	const { t } = useTranslation()
-	const propsBar = {
-		showValueLabel: false,
-		label: 'Questions répondues pour améliorer la précision de la simulation',
-		minValue,
-		maxValue,
-		value: progress,
-	}
 
-	const { progressBarProps, labelProps } = useProgressBar(propsBar)
 	const total = Math.min(progress, maxValue).toString()
 
 	return (
 		<div style={{ position: 'relative' }}>
-			<ProgressContainer {...progressBarProps}>
-				<ProgressBar
-					style={{ width: `${(progress * 100) / (maxValue || 1)}%` }}
-				/>
-			</ProgressContainer>
+			<ProgressBar style={{ width: `${(progress * 100) / maxValue}%` }} />
 
-			<StyledBody {...labelProps} role="alert">
+			<StyledBody role="alert">
 				{t('Étape {{ total }} sur {{ maxValue }}', { total, maxValue })}
 			</StyledBody>
 		</div>
 	)
 }
 
-const ProgressContainer = styled.div`
-	width: 100%;
-	background-color: ${({ theme }) => theme.colors.bases.primary[100]};
-`
 const ProgressBar = styled.div`
 	width: 0;
 	transition: width 0.5s;


### PR DESCRIPTION
Cette PR traite la partie manquante de la remontée suivante de l'audit 2025 :

> L'information du changement d'étape n'est pas vocalisé (contenu en aria-hidden)

Si la PR https://github.com/betagouv/mon-entreprise/pull/4132 le changement d'étape, j'avais oublié de masquer aux TA le trait visualisant la progression, portant de nombreux attributs ARIA devenant inutiles :

<img width="493" height="63" alt="image" src="https://github.com/user-attachments/assets/411bba68-88b2-448f-9b6e-11c01e500b63" />

Cette PR simplifie donc ce "trait" pour qu'il ne soit plus qu'un élément graphique.

Closes https://github.com/betagouv/mon-entreprise/issues/3962