### PR TITLE
Reorder Design System in Storybook as in /design-system

### DIFF
--- a/site/source/design-system/InfoButton.stories.tsx
+++ b/site/source/design-system/InfoButton.stories.tsx
@@ -10,7 +10,6 @@ const RouterDecorator = (Story: StoryFn) => (
 )
 
 const meta = {
-	title: 'Design System/Buttons/InfoButton',
 	component: InfoButton,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/card/StatusCard.stories.tsx
+++ b/site/source/design-system/card/StatusCard.stories.tsx
@@ -8,7 +8,6 @@ import { DesignSystemThemeProvider } from '../root'
 import { StatusCard } from './StatusCard'
 
 const meta: Meta<typeof StatusCard> = {
-	title: 'Design System/Card/StatusCard',
 	component: StatusCard,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/documentation/AccordeonDocumentation/AccordeonDocumentation.stories.tsx
+++ b/site/source/design-system/documentation/AccordeonDocumentation/AccordeonDocumentation.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { AccordeonDocumentation } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/AccordeonDocumentation',
 	component: AccordeonDocumentation,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/BoutonMinimaliste/BoutonMinimaliste.stories.tsx
+++ b/site/source/design-system/documentation/BoutonMinimaliste/BoutonMinimaliste.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { BoutonMinimaliste } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/BoutonMinimaliste',
 	component: BoutonMinimaliste,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/Callout.stories.tsx
+++ b/site/source/design-system/documentation/Callout.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Callout } from './Callout'
 
 const meta = {
-	title: 'Design System/Documentation/Callout',
 	component: Callout,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/DocumentationPage.stories.tsx
+++ b/site/source/design-system/documentation/DocumentationPage.stories.tsx
@@ -5,7 +5,6 @@ import { MemoryRouter } from 'react-router-dom'
 import { DocumentationPage } from './DocumentationPage'
 
 const meta = {
-	title: 'Design System/Documentation/DocumentationPage',
 	component: DocumentationPage,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/ExemplePratique/ExemplePratique.stories.tsx
+++ b/site/source/design-system/documentation/ExemplePratique/ExemplePratique.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ExemplePratique } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/ExemplePratique',
 	component: ExemplePratique,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/Liseré/Liseré.stories.tsx
+++ b/site/source/design-system/documentation/Liseré/Liseré.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Liseré } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/Liseré',
 	component: Liseré,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/Tableau/TableauSeuils.stories.tsx
+++ b/site/source/design-system/documentation/Tableau/TableauSeuils.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Tableau } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/Tableau',
 	component: Tableau,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/Valeur/Valeur.stories.tsx
+++ b/site/source/design-system/documentation/Valeur/Valeur.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Valeur } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/Valeur',
 	component: Valeur,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/documentation/ValeurImportante/ValeurImportante.stories.tsx
+++ b/site/source/design-system/documentation/ValeurImportante/ValeurImportante.stories.tsx
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ValeurImportante } from './index'
 
 const meta = {
-	title: 'Design System/Documentation/ValeurImportante',
 	component: ValeurImportante,
 	parameters: {
 		layout: 'padded',

--- a/site/source/design-system/molecules/field/Checkbox.stories.tsx
+++ b/site/source/design-system/molecules/field/Checkbox.stories.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react'
 import { Checkbox } from './Checkbox'
 
 export default {
-	title: 'Design System/Field/Checkbox',
 	component: Checkbox,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/field/ChoiceGroup/CardChoiceGroup.stories.tsx
+++ b/site/source/design-system/molecules/field/ChoiceGroup/CardChoiceGroup.stories.tsx
@@ -78,7 +78,6 @@ const optionsWithSubOptions = [
 ]
 
 const meta = {
-	title: 'Design System/Field/ChoiceGroup/CardChoiceGroup',
 	component: CardChoiceGroup,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/molecules/field/ChoiceGroup/RadioChoiceGroup.stories.tsx
+++ b/site/source/design-system/molecules/field/ChoiceGroup/RadioChoiceGroup.stories.tsx
@@ -57,7 +57,6 @@ const optionsWithDisabled = [
 ]
 
 const meta = {
-	title: 'Design System/Field/ChoiceGroup/RadioChoiceGroup',
 	component: RadioChoiceGroup,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/molecules/field/ChoiceGroup/SelectChoiceGroup.stories.tsx
+++ b/site/source/design-system/molecules/field/ChoiceGroup/SelectChoiceGroup.stories.tsx
@@ -42,7 +42,6 @@ const optionsWithSubOptions = [
 ]
 
 const meta = {
-	title: 'Design System/Field/ChoiceGroup/SelectChoiceGroup',
 	component: SelectChoiceGroup,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/molecules/field/ChoiceGroup/ToggleChoiceGroup.stories.tsx
+++ b/site/source/design-system/molecules/field/ChoiceGroup/ToggleChoiceGroup.stories.tsx
@@ -22,7 +22,6 @@ const options = [
 ]
 
 const meta = {
-	title: 'Design System/Field/ChoiceGroup/ToggleChoiceGroup',
 	component: ToggleChoiceGroup,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/molecules/field/DateField.stories.tsx
+++ b/site/source/design-system/molecules/field/DateField.stories.tsx
@@ -5,7 +5,6 @@ import { Spacing } from '../../layout'
 import { DateField } from './DateField'
 
 export default {
-	title: 'Design System/Field/DateField',
 	component: DateField,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/field/MontantField.stories.tsx
+++ b/site/source/design-system/molecules/field/MontantField.stories.tsx
@@ -8,7 +8,6 @@ import { UnitéMonétaire } from '@/domaine/Unités'
 import { MontantField } from './MontantField'
 
 export default {
-	title: 'Design System/Field/MontantField',
 	component: MontantField,
 	parameters: {
 		docs: {

--- a/site/source/design-system/molecules/field/NumberField.stories.tsx
+++ b/site/source/design-system/molecules/field/NumberField.stories.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react'
 import { NumberField } from './NumberField'
 
 export default {
-	title: 'Design System/Field/NumberField',
 	component: NumberField,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/field/QuantitéField.stories.tsx
+++ b/site/source/design-system/molecules/field/QuantitéField.stories.tsx
@@ -8,7 +8,6 @@ import { UnitéQuantité } from '@/domaine/Unités'
 import { QuantitéField } from './QuantitéField'
 
 export default {
-	title: 'Design System/Field/QuantitéField',
 	component: QuantitéField,
 	parameters: {
 		docs: {

--- a/site/source/design-system/molecules/field/Radio/RadioCard.stories.tsx
+++ b/site/source/design-system/molecules/field/Radio/RadioCard.stories.tsx
@@ -5,7 +5,6 @@ import { RadioCard } from './RadioCard'
 import { RadioCardGroup } from './RadioCardGroup'
 
 export default {
-	title: 'Design System/Field/Radio/RadioCard',
 	component: RadioCard,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/field/TextField.stories.tsx
+++ b/site/source/design-system/molecules/field/TextField.stories.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react'
 import TextField from './TextField'
 
 export default {
-	title: 'Design System/Field/TextField',
 	component: TextField,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/field/choix/ChoixMultiple.stories.tsx
+++ b/site/source/design-system/molecules/field/choix/ChoixMultiple.stories.tsx
@@ -10,7 +10,6 @@ const RouterDecorator = (Story: StoryFn) => (
 )
 
 const meta = {
-	title: 'Design System/Field/Choix/ChoixMultiple',
 	component: ChoixMultiple,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/molecules/field/choix/ChoixUnique.stories.tsx
+++ b/site/source/design-system/molecules/field/choix/ChoixUnique.stories.tsx
@@ -10,7 +10,6 @@ const RouterDecorator = (Story: StoryFn) => (
 )
 
 const meta = {
-	title: 'Design System/Field/Choix/ChoixUnique',
 	component: ChoixUnique,
 	parameters: {
 		layout: 'centered',

--- a/site/source/design-system/molecules/fields/CheckboxField/CheckboxField.stories.tsx
+++ b/site/source/design-system/molecules/fields/CheckboxField/CheckboxField.stories.tsx
@@ -13,7 +13,6 @@ const CHECKBOX_OPTION_WITH_DESCRIPTION = {
 }
 
 export default {
-	title: 'Design System/molecules/fields/CheckboxField',
 	component: CheckboxField,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/fields/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/site/source/design-system/molecules/fields/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -35,7 +35,6 @@ const CHECKBOX_OPTIONS_WITH_DESCRIPTIONS = [
 ]
 
 export default {
-	title: 'Design System/molecules/fields/CheckboxGroup',
 	component: CheckboxGroup,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/fields/DateFieldWithPicker/DateFieldWithPicker.stories.tsx
+++ b/site/source/design-system/molecules/fields/DateFieldWithPicker/DateFieldWithPicker.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryObj } from '@storybook/react'
 import { DateFieldWithPicker } from './DateFieldWithPicker'
 
 export default {
-	title: 'Design System/molecules/fields/DateFieldWithPicker',
 	component: DateFieldWithPicker,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/fields/NumberField/NumberField.stories.tsx
+++ b/site/source/design-system/molecules/fields/NumberField/NumberField.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryObj } from '@storybook/react'
 import { NumberField } from './NumberField'
 
 export default {
-	title: 'Design System/molecules/fields/NumberField',
 	component: NumberField,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/fields/Radiogroup/RadioGroup.stories.tsx
+++ b/site/source/design-system/molecules/fields/Radiogroup/RadioGroup.stories.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { RadioGroup, type RadioOption } from './RadioGroup'
 
 export default {
-	title: 'Design System/molecules/fields/RadioGroup',
 	component: RadioGroup,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/molecules/fields/TextField/TextField.stories.tsx
+++ b/site/source/design-system/molecules/fields/TextField/TextField.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryObj } from '@storybook/react'
 import { TextField } from './TextField'
 
 export default {
-	title: 'Design System/molecules/fields/TextField',
 	component: TextField,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/suggestions/InputSuggestions.stories.tsx
+++ b/site/source/design-system/suggestions/InputSuggestions.stories.tsx
@@ -7,7 +7,6 @@ import { Montant, montant } from '@/domaine/Montant'
 import { InputSuggestions } from './InputSuggestions'
 
 export default {
-	title: 'Design System/Suggestions/InputSuggestions',
 	component: InputSuggestions,
 	decorators: [
 		(Story) => (

--- a/site/source/design-system/switch/index.stories.tsx
+++ b/site/source/design-system/switch/index.stories.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react'
 import { Switch } from './'
 
 const meta: Meta<typeof Switch> = {
-	title: 'Design System/Switch',
 	component: Switch,
 	parameters: {
 		layout: 'centered',


### PR DESCRIPTION
Cette PR réaligne la structure du Design System dans Storybook avec celle du dossier `/design-system`.

Compte tenu des évolutions dans l'organisation des composants (introduction des dossiers `/atoms` et `/molecules`, ajout de nouveaux composants dans `/molecules/fields` ayant parfois le même nom que des composants existants), l'organisation du Storybook n'était plus cohérente avec celle du code.

À ce stade du "chantier" de remise en ordre de `/design-system`, il me semble plus simple que le Storybook reflète l'organisation actuelle des composants dans le code.
Vouloir les organiser dans Storybook comme un "design system bien rangé" me paraît compliqué, surtout difficile à maintenir et pas vraiment pratique actuellement pour s'y retrouver en tant que développeur.

Cette PR supprime donc les attributs `title` dans les stories, ce qui aligne par défaut les arborescences dans le code et dans Storybook.