### PR TITLE
fix(salarié): remet la règle emploi franc . éligible

### DIFF
--- a/api/source/test-e2e/__snapshots__/index.test.ts.snap
+++ b/api/source/test-e2e/__snapshots__/index.test.ts.snap
@@ -436,7 +436,7 @@ exports[`e2e test mon-entreprise api > Test evaluate brut => net + super brut 2`
         "salarié . cotisations . exonérations . zones lodeom",
         "salarié . cotisations . prévoyances . santé . montant",
         "salarié . cotisations . prévoyances . santé . taux employeur",
-        "salarié . coût total employeur . aides . emploi franc",
+        "salarié . coût total employeur . aides . emploi franc . éligible",
         "salarié . régimes spécifiques . DFS",
         "salarié . régimes spécifiques . alsace moselle",
         "salarié . régimes spécifiques . taux réduits",

--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Corrections
+- Remet la règle `salarié . coût total employeur . aides . emploi franc . éligible` qui avait été supprimée dans la version précédente
+
 ## 10.0.1
 
 ### Mises à jour

--- a/modele-social/règles/salarié/aides-employeur.publicodes
+++ b/modele-social/règles/salarié/aides-employeur.publicodes
@@ -60,6 +60,8 @@ salarié . coût total employeur . aides . emploi franc:
       - toutes ces conditions:
           - contrat . CDD
           - contrat . CDD . durée >= 6
+
+salarié . coût total employeur . aides . emploi franc . éligible:
   question: Cette embauche est-elle éligible à l'aide emploi-franc ?
   description: |
     Conditions :
@@ -78,6 +80,7 @@ salarié . coût total employeur . aides . emploi franc . montant:
     - *embauche en CDD d'au moins 6 mois* : 2 500€/an pendant 2 ans, soit 5 000€ au maximum
 
     [🗺 Vérifier l'éligibilité d'une adresse](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
+  applicable si: éligible
   formule:
     produit:
       - variations:

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -13156,24 +13156,6 @@ salarié . coût total employeur . aides . embauche . senior professionnalisatio
   titre.en: '[automatic] senior professionalization'
   titre.fr: senior professionnalisation
 salarié . coût total employeur . aides . emploi franc:
-  description.en: >
-    [automatic] Conditions :
-
-    - The employee recruited is a jobseeker registered with France Travail and resides in a priority urban district (QPV) [check district eligibility](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
-
-    - The employer is up to date with its contributions and has not made any redundancies for the position filled in the 6 months prior to recruitment.
-
-    - The employee recruited must not have been part of the company's workforce in the 6 months prior to recruitment.
-  description.fr: >
-    Conditions :
-
-    - Le salarié recruté est un demandeur d'emploi inscrit à France Travail et réside dans un quartier prioritaire de la ville (QPV) [vérifier l'éligibilité d'un quartier](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
-
-    - L'employeur est à jour de ses cotisations et n'a pas procédé à un licenciement économique pour le poste pourvu dans les 6 mois précédents le recrutement
-
-    - Le salarié recruté ne doit pas avoir appartenu à l'effectif de l'entreprise dans les 6 mois précédent l'embauche
-  question.en: '[automatic] Is this recruitment eligible for the "emploi-franc" scheme?'
-  question.fr: Cette embauche est-elle éligible à l'aide emploi-franc ?
   titre.en: '[automatic] free employment'
   titre.fr: emploi franc
 salarié . coût total employeur . aides . emploi franc . montant:
@@ -13209,6 +13191,27 @@ salarié . coût total employeur . aides . emploi franc . montant:
     [🗺 Vérifier l'éligibilité d'une adresse](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
   titre.en: '[automatic] amount'
   titre.fr: montant
+salarié . coût total employeur . aides . emploi franc . éligible:
+  description.en: >
+    [automatic] Conditions :
+
+    - The employee recruited is a jobseeker registered with France Travail and resides in a priority urban district (QPV) [check district eligibility](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
+
+    - The employer is up to date with its contributions and has not made any redundancies for the position filled in the 6 months prior to recruitment.
+
+    - The employee recruited must not have been part of the company's workforce in the 6 months prior to recruitment.
+  description.fr: >
+    Conditions :
+
+    - Le salarié recruté est un demandeur d'emploi inscrit à France Travail et réside dans un quartier prioritaire de la ville (QPV) [vérifier l'éligibilité d'un quartier](https://sig.ville.gouv.fr/recherche-adresses-qp-polville)
+
+    - L'employeur est à jour de ses cotisations et n'a pas procédé à un licenciement économique pour le poste pourvu dans les 6 mois précédents le recrutement
+
+    - Le salarié recruté ne doit pas avoir appartenu à l'effectif de l'entreprise dans les 6 mois précédent l'embauche
+  question.en: '[automatic] Is this recruitment eligible for the "emploi-franc" scheme?'
+  question.fr: Cette embauche est-elle éligible à l'aide emploi-franc ?
+  titre.en: '[automatic] eligible'
+  titre.fr: éligible
 salarié . mois incomplet:
   description.en: >
     [automatic] Management of incomplete months (absence, hiring, departure,

--- a/site/source/pages/simulateurs/salarié/simulationConfig.ts
+++ b/site/source/pages/simulateurs/salarié/simulationConfig.ts
@@ -20,7 +20,8 @@ export const configSalarié: SimulationConfig = {
 			},
 			{
 				label: 'Emploi franc',
-				dottedName: 'salarié . coût total employeur . aides . emploi franc',
+				dottedName:
+					'salarié . coût total employeur . aides . emploi franc . éligible',
 			},
 			{
 				label: 'Cadre',

--- a/site/test/regressions/salarié.yaml
+++ b/site/test/regressions/salarié.yaml
@@ -100,12 +100,12 @@ aides:
     salarié . régimes spécifiques . impatriés: oui
   # emploi franc
   - salarié . contrat . salaire brut: 2000 €/mois
-    salarié . coût total employeur . aides . emploi franc: oui
+    salarié . coût total employeur . aides . emploi franc . éligible: oui
     salarié . contrat . date d'embauche: 01/09/2020
   - salarié . contrat: "'CDD'"
     salarié . contrat . salaire brut: 2000 €/mois
     salarié . contrat . CDD . durée: 6 mois
-    salarié . coût total employeur . aides . emploi franc: oui
+    salarié . coût total employeur . aides . emploi franc . éligible: oui
     salarié . contrat . date d'embauche: 01/09/2020
 
 temps partiel:


### PR DESCRIPTION
[ Erreur syntaxique ]
➡️  Dans la règle "$EVALUATION"
✖️  La référence "salarié . coût total employeur . aides . emploi franc . éligible" est introuvable.

Closes #4217 
