### PR TITLE
Corrige l'affichage des informations de l'entreprise sélectionnée

### DIFF
--- a/site/source/components/entreprise/EntrepriseDetails.tsx
+++ b/site/source/components/entreprise/EntrepriseDetails.tsx
@@ -1,5 +1,5 @@
 import { ComponentType, ReactNode } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { styled } from 'styled-components'
 
@@ -15,9 +15,11 @@ export default function EntrepriseDetails({
 	small = false,
 	headingTag = 'h3',
 }: Props) {
-	const { t } = useTranslation()
 	const companyDetails = useSelector(companyDetailsSelector)
 	const BodyComponent = small ? BodyWithoutMargin : Body
+
+	const DateDeCréation = () => <Strong>{companyDetails.dateDeCréation}</Strong>
+	const Commune = () => <Strong>{companyDetails.commune}</Strong>
 
 	return (
 		<>
@@ -29,14 +31,9 @@ export default function EntrepriseDetails({
 				{`${companyDetails.nom} ${companyDetails.siren}`}
 			</TitleComponent>
 			<BodyComponent>
-				{t(
-					'entreprise.détails',
-					'Entreprise créée le {{ date }} et domiciliée à {{ commune }}.',
-					{
-						date: <Strong>{companyDetails.dateDeCréation}</Strong>,
-						commune: <Strong>{companyDetails.commune}</Strong>,
-					}
-				)}
+				<Trans i18nKey="entreprise.détails">
+					Entreprise créée le <DateDeCréation /> et domiciliée à <Commune />.
+				</Trans>
 			</BodyComponent>
 		</>
 	)

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -473,7 +473,7 @@ design-system:
     year: Year
 décembre: December
 entreprise:
-  détails: Company created on {{ date }} and domiciled at {{ commune }}.
+  détails: Company created on <1> &lt;/1> and domiciled at <3></3>.
 error:
   back: Back to home page
   body0: <0>If you would like to help us correct this problem, please describe the

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -498,7 +498,7 @@ design-system:
     year: Année
 décembre: décembre
 entreprise:
-  détails: Entreprise créée le {{ date }} et domiciliée à {{ commune }}.
+  détails: Entreprise créée le <1></1> et domiciliée à <3></3>.
 error:
   back: Retourner à la page d'accueil
   body0: "<0>Si vous souhaitez nous aider à corriger ce problème, vous pouvez


### PR DESCRIPTION
Sur https://4160--mon-entreprise.netlify.app/, lorsqu'on sélectionne son entreprise (sur la page d'accueil ou dans un simulateur), 
le bloc de détails affiche "Entreprise créée le [object Object] et domiciliée à [object Object]."
<img width="695" height="117" alt="image" src="https://github.com/user-attachments/assets/516a20d9-d133-4bb3-9213-f80645448c1d" />

Cette PR corrige ce problème.