### PR TITLE
A11y / Remove useless role="radiogroup" inside a <fieldset>

### DIFF
--- a/site/source/design-system/molecules/field/ChoiceGroup/RadioChoiceGroup.tsx
+++ b/site/source/design-system/molecules/field/ChoiceGroup/RadioChoiceGroup.tsx
@@ -101,7 +101,8 @@ type RadioGroupProps = AriaRadioGroupProps & {
 function RadioGroup(props: RadioGroupProps) {
 	const { children, label, description, isSubRadioGroup } = props
 	const state = useRadioGroupState(props)
-	const { radioGroupProps, labelProps } = useRadioGroup(props, state)
+	// Code mysteriously crashes if this hook is removed:
+	useRadioGroup(props, state)
 
 	useEffect(() => {
 		if (!props.value) {
@@ -110,14 +111,9 @@ function RadioGroup(props: RadioGroupProps) {
 	}, [props.value, state])
 
 	return (
-		<div
-			/* eslint-disable-next-line react/jsx-props-no-spreading */
-			{...radioGroupProps}
-			onKeyDown={undefined}
-		>
-			{/* eslint-disable-next-line react/jsx-props-no-spreading */}
+		<>
 			{label && (
-				<StyledH5 as="p" {...labelProps}>
+				<StyledH5 as="p">
 					{label}
 					{description && (
 						<InfoButton light title={label} description={description} />
@@ -130,7 +126,7 @@ function RadioGroup(props: RadioGroupProps) {
 			>
 				<RadioContext.Provider value={state}>{children}</RadioContext.Provider>
 			</RadioGroupContainer>
-		</div>
+		</>
 	)
 }
 


### PR DESCRIPTION
Cette PR prend en compte l'issue de l'audit 2026 demandant de retirer le `role="radiogroup"` sur la `<div>` située dans le `<fieldset>` précédemment ajouté dans `Questions.tsx`.

J'avais en tête que ce `role="radiogroup"` apportait une précision concernant ce `<fieldset>` (balise qui peut contenir autre chose que des boutons radio) mais c'est une erreur de ma part : lorsqu'un `<fieldset>` contient des boutons radio, il semblerait qu'il prenne automatiquement ce rôle `radiogroup`.
Le `role="radiogroup"` dans le `<fieldset>` est alors au mieux inutile, au pire source de confusion lorsqu'on utilise un lecteur d'écran.

L'autre point qui m'incitait à penser que ce `role="radiogroup"` devait être présent, c'est le [pattern APG RadioGroup](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) qui indique qu'il est nécessaire.
Mais, ce que j'ai zappé, c'est que les patterns APG servent à construire des composants corrects avec ARIA lorsqu'on n'utilise pas les balises HTML dédiées.

Mea maxima culpa. 😬

**Remarque :** J'ai du laisser le hook, même si on n'en fait plus rien (ligne 105) :
```js
	useRadioGroup(props, state)
```
Je n'ai pas bien compris pourquoi le code crashait en son absence mais je ne souhaite pas y passer du temps.
J'ai reconstruit le composant `<RadioGroup />`, qui doit le remplacer, avec `react-aria-components` donc ça ne vaut pas le coup de creuser à mon avis.