### PR TITLE
fix(cessation-activité): précise que la rémunération inclut cotisations et contributions

### DIFF
--- a/modele-social/règles/dirigeant/dirigeant.publicodes
+++ b/modele-social/règles/dirigeant/dirigeant.publicodes
@@ -38,7 +38,7 @@ dirigeant . rémunération . totale:
     C’est ce que l’entreprise dépense en tout pour la rémunération du dirigeant. Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer. On peut aussi considérer que c’est la valeur monétaire du travail du dirigeant.
   titre global: Rémunération totale dirigeant
   unité: €/an
-  résumé: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé: Total payé par l'entreprise pour la rémunération du dirigeant, cotisations et contributions incluses
   variations:
     - si: assimilé salarié
       alors:

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -4647,8 +4647,10 @@ dirigeant . rémunération . totale:
     dirigeant.
   question.en: '[automatic] What is the total amount you expect to earn in compensation?'
   question.fr: Quel montant total pensez-vous dégager pour votre rémunération ?
-  résumé.en: '[automatic] Total paid by the company for executive compensation'
-  résumé.fr: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé.en: "[automatic] Total paid by the company for the executive's
+    remuneration, including contributions"
+  résumé.fr: Total payé par l'entreprise pour la rémunération du dirigeant,
+    cotisations et contributions incluses
   titre.en: '[automatic] Total compensation'
   titre.fr: Rémunération totale
 durée légale du travail:


### PR DESCRIPTION
Clarification du texte affiché sous le champ "Rémunération totale pour l'année de cessation" dans le simulateur de cessation d'activité pour IS.

Closes #3989