### PR TITLE
A11y / Supposed better support of step vocalization

### DIFF
--- a/site/source/components/ui/Progress.tsx
+++ b/site/source/components/ui/Progress.tsx
@@ -17,7 +17,7 @@ export default function Progress({ progress, maxValue = 1 }: ProgressProps) {
 		<div style={{ position: 'relative' }}>
 			<ProgressBar style={{ width: `${(progress * 100) / maxValue}%` }} />
 
-			<StyledBody role="alert">
+			<StyledBody role="status">
 				{t('Étape {{ total }} sur {{ maxValue }}', { total, maxValue })}
 			</StyledBody>
 		</div>


### PR DESCRIPTION
Cette PR est censée finir de résoudre le problème suivant remonté dans l'audit de contrôle 2026 :

> L'information du changement d'étape n'est pas vocalisée

Cette vocalisation était assurée par un `role="alert"` mais le retour des experts de l'Urssaf indique :

> L’auditrice a utilisé Firefox et NVDA pour constater que le changement d’étape n’était pas vocalisé, et ceci même si le code semble valide. C’est donc très étrange.
Toutefois, comme cette configuration fait partie de la base de référence, nous devons trouver une solution.
Après investigation, cela fonctionne correctement avec Safari et VoiceOver, Chrome et NVDA ou JAWS, mais pas avec Firefox (Windows) et NVDA ou JAWS. Par ailleurs, des exemples simples avec role="alert" fonctionnent correctement avec Firefox. Serait-ce lié à React ?
Quoi qu’il en soit, remplacer role="alert" par role="status" corrige le problème.
De plus, ce role est plus adapté à un notre cas, car ce n’est pas une erreur mais le résultat d’une action

Cette PR remplace donc le rôle `alert` par `status`.

---

J'ai des doutes sur la pertinence de cette modification, compte tenu des indications de support des deux rôles sur https://a11ysupport.io :

<img width="1166" height="273" alt="image" src="https://github.com/user-attachments/assets/13f15d60-55e3-4d44-97b5-5be44067ca8a" />

<img width="1187" height="292" alt="image" src="https://github.com/user-attachments/assets/c56a2bc0-4d21-4ee0-b303-3ff91af4a35a" />

On peut y voir que le rôle `alert` serait mieux supporté que `status` par le combo NVDA/Firefox que l'auditrice aurait utilisé.
Il s'agit probablement d'une régression de NVDA et je ne pense pas qu'il faille en tenir compte.

L'UX me semblait par ailleurs plus satisfaisante, vu le nombre d'étapes, avec le rôle `alert` que `status`.

---

Sinon, concernant la base de référence mentionné par l'expert correspond aux combos lecteur d'écran/OS avec lesquels on doit faire un audit RGAA : https://accessibilite.numerique.gouv.fr/methode/environnement-de-test/

Une base de référence d'une grande pertinence actuellement, Chrome n'y figurant pas...
Alors même qu'une récente [étude de WebAIM](https://webaim.org/projects/screenreadersurvey10/) montre que c'est le plus utilisé avec un lecteur d'écran :

<img width="797" height="366" alt="image" src="https://github.com/user-attachments/assets/1fa1afb2-1681-48ca-ac80-fd54d6e86165" />