### PR TITLE
Change la couleur de texte de description lors du choix de statut pour une association

### DIFF
--- a/site/source/design-system/molecules/field/Radio/RadioCard.tsx
+++ b/site/source/design-system/molecules/field/Radio/RadioCard.tsx
@@ -55,7 +55,7 @@ export function RadioCard({
 					{label} {emoji && <Emoji emoji={emoji} />}
 				</Body>
 
-				{description && <SmallBody $grey>{description}</SmallBody>}
+				{description && <SmallBody>{description}</SmallBody>}
 			</div>
 		</StyledRadioCardSkeleton>
 	)


### PR DESCRIPTION
Lors de l'audit de contrôle 2026, il a été remonté qu'il y avait un contraste qui faisait défaut dans la page proposant de faire une association.

Il s'agit de la description lors que la radio est cochée (ou au survol).
<img width="654" height="288" alt="image" src="https://github.com/user-attachments/assets/3949adee-38ba-418d-93a9-7925d6a85cab" />

J'ai donc remis le texte en couleur normale.
<img width="643" height="279" alt="image" src="https://github.com/user-attachments/assets/d2102670-e733-455d-a183-353a3245e572" />

Closes #4254 