### PR TITLE
A11y / Better vocalization of the following question in <Questions />

### DIFF
--- a/site/source/components/Simulation/Questions.tsx
+++ b/site/source/components/Simulation/Questions.tsx
@@ -168,8 +168,6 @@ export function Questions<S extends Situation>({
 						)}
 					</div>
 
-					<div ref={focusAnchorForA11yRef} tabIndex={-1}></div>
-
 					{finished && (
 						<VousAvezComplétéCetteSimulation
 							customEndMessages={customEndMessages}
@@ -212,46 +210,49 @@ export function Questions<S extends Situation>({
 
 					{!finished && QuestionCourante?._tag === 'QuestionPublicodes' && (
 						<FromTop key={`publicodes-question-${QuestionCourante.id}`}>
-							{shouldBeWrappedByFieldset ? (
-								<fieldset>
-									<H3 as="legend">
-										{questionCouranteLabel}
-										<ExplicableRule
-											light
+							<div ref={focusAnchorForA11yRef} tabIndex={-1} role="status">
+								{shouldBeWrappedByFieldset ? (
+									<fieldset>
+										<H3 as="legend">
+											{questionCouranteLabel}
+											<ExplicableRule
+												light
+												dottedName={QuestionCourante.id}
+												ariaDescribedBy={questionCouranteLabel}
+											/>
+										</H3>
+										<RuleInput
 											dottedName={QuestionCourante.id}
-											ariaDescribedBy={questionCouranteLabel}
+											onChange={(value, name) =>
+												handlePublicodesQuestionResponse(name, value)
+											}
+											key={QuestionCourante.id}
+											onSubmit={handleGoToNext}
 										/>
-									</H3>
-									<RuleInput
-										dottedName={QuestionCourante.id}
-										onChange={(value, name) =>
-											handlePublicodesQuestionResponse(name, value)
-										}
-										key={QuestionCourante.id}
-										onSubmit={handleGoToNext}
-									/>
-								</fieldset>
-							) : (
-								<>
-									<H3 as="label" htmlFor={questionCouranteHtmlForId}>
-										{questionCouranteLabel}
-										<ExplicableRule
-											light
+									</fieldset>
+								) : (
+									<>
+										<H3 as="label" htmlFor={questionCouranteHtmlForId}>
+											{questionCouranteLabel}
+											<ExplicableRule
+												light
+												dottedName={QuestionCourante.id}
+												ariaDescribedBy={questionCouranteLabel}
+											/>
+										</H3>
+										<RuleInput
+											id={questionCouranteHtmlForId}
 											dottedName={QuestionCourante.id}
-											ariaDescribedBy={questionCouranteLabel}
+											onChange={(value, name) =>
+												handlePublicodesQuestionResponse(name, value)
+											}
+											key={QuestionCourante.id}
+											onSubmit={handleGoToNext}
 										/>
-									</H3>
-									<RuleInput
-										id={questionCouranteHtmlForId}
-										dottedName={QuestionCourante.id}
-										onChange={(value, name) =>
-											handlePublicodesQuestionResponse(name, value)
-										}
-										key={QuestionCourante.id}
-										onSubmit={handleGoToNext}
-									/>
-								</>
-							)}
+									</>
+								)}
+							</div>
+
 							<Conversation
 								onPrevious={
 									activeQuestionIndex > 0 ? handleGoToPrevious : undefined


### PR DESCRIPTION
Cette PR apporte une meilleure réponse à la remontée suivante de l'audit de contrôle 2026 :

> L'action sur le bouton après l'indication "Aller à la question" provoque l'affichage de la nouvelle question sans avertir l'utilisateur

Jusqu'à présent, je n'avais pu que repositionner le focus avant la question, sans parvenir à la faire vocaliser dans le même temps.

Je m'y étais en fait mal pris en tentant d'utiliser une live region.

J'avais mis un rôle `status` sur le `<fieldset>` ou sur le container du `<label> / <input>`.
Le problème est que ces éléments sont rendus conditionnellement, selon la valeur de ma verrue `shouldBeWrappedByFieldset`, et donc reconstruits à chaque calcul de ce booléen.

Or les live regions ne fonctionnent pas lorsqu'elles sont placées sur un composant qui vient juste d'être monté : elles lancent la vocalisation lorsque le contenu change et, s'il vient d'apparaître, il ne risque pas d'avoir changé...