### PR TITLE
feat(analytics): ajoute tracking sur le bouton "Modifier mes réponses"

### DIFF
--- a/site/source/components/ATInternetTracking/Tracker.ts
+++ b/site/source/components/ATInternetTracking/Tracker.ts
@@ -20,7 +20,8 @@ type PageHit = {
 	page_chapter2?: string
 	page_chapter3?: string
 }
-type ClickHit = {
+
+export type ClickHit = {
 	click?: string
 	click_chapter1?: string
 	click_chapter2?: string

--- a/site/source/components/ATInternetTracking/index.tsx
+++ b/site/source/components/ATInternetTracking/index.tsx
@@ -4,7 +4,7 @@ import { ATTracker } from './Tracker'
 
 export const TrackingContext = createContext<ATTracker | null>(null)
 
-export function useTracking(): ATTracker | null {
+export function usePianoTracking(): ATTracker | null {
 	return useContext(TrackingContext)
 }
 
@@ -86,7 +86,7 @@ export function TrackPage({
 	children?: React.ReactNode
 } & TrackingChapters) {
 	const { chapter1, chapter2, chapter3 } = useChapters(chapters)
-	const tag = useTracking()
+	const tag = usePianoTracking()
 	useEffect(() => {
 		tag?.sendEvent(
 			'page.display',

--- a/site/source/components/Feedback/Feedback.tsx
+++ b/site/source/components/Feedback/Feedback.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 
-import { useTracking } from '@/components/ATInternetTracking'
+import { usePianoTracking } from '@/components/ATInternetTracking'
 import {
 	Body,
 	Button,
@@ -55,7 +55,7 @@ export function Feedback({
 	const [isNotSatisfied, setIsNotSatisfied] = useState(false)
 	const { t } = useTranslation()
 	const url = useLocation().pathname
-	const tag = useTracking()
+	const tag = usePianoTracking()
 
 	const { absoluteSitePaths } = useSitePaths()
 	const currentPath = useLocation().pathname

--- a/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
+++ b/site/source/components/ShareSimulationBanner/ShareSimulationPopup.tsx
@@ -13,13 +13,13 @@ import {
 	TextField,
 } from '@/design-system'
 
-import { useTracking } from '../ATInternetTracking'
+import { usePianoTracking } from '../ATInternetTracking'
 
 export function ShareSimulationPopup({ url }: { url: string }) {
 	const inputRef = useRef<HTMLInputElement>(null)
 	const { t } = useTranslation()
 	const [linkCopied, setLinkCopied] = useState(false)
-	const tracker = useTracking()
+	const tracker = usePianoTracking()
 
 	const selectInput = () => {
 		inputRef.current?.select()

--- a/site/source/components/ShareSimulationBanner/index.tsx
+++ b/site/source/components/ShareSimulationBanner/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/design-system'
 import { useUrl } from '@/hooks/useUrl'
 
-import { useTracking } from '../ATInternetTracking'
+import { usePianoTracking } from '../ATInternetTracking'
 import { ConseillersEntreprisesButton } from '../ConseillersEntreprisesButton'
 import { ShareSimulationPopup } from './ShareSimulationPopup'
 
@@ -31,7 +31,7 @@ export default function ShareOrSaveSimulationBanner({
 	customSimulationbutton?: CustomSimulationButton
 }) {
 	const { t } = useTranslation()
-	const tracker = useTracking()
+	const tracker = usePianoTracking()
 	const shareAPIAvailable = !!window?.navigator?.share
 	const url = useUrl()
 	const startSharing = async () => {

--- a/site/source/components/conversation/SeeAnswersButton.tsx
+++ b/site/source/components/conversation/SeeAnswersButton.tsx
@@ -22,7 +22,14 @@ export default function SeeAnswersButton({
 		<>
 			<PopoverWithTrigger
 				trigger={(buttonProps) => (
-					<StyledButton {...buttonProps} aria-haspopup="dialog">
+					<StyledButton
+						{...buttonProps}
+						aria-haspopup="dialog"
+						tracking={{
+							feature: 'modifier_reponses',
+							action: 'ouvre',
+						}}
+					>
 						{label ?? (
 							<>
 								<EditIcon /> <Trans>Modifier mes réponses</Trans>

--- a/site/source/components/layout/Footer/PrivacyPolicy.tsx
+++ b/site/source/components/layout/Footer/PrivacyPolicy.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/design-system'
 
 import * as safeLocalStorage from '../../../storage/safeLocalStorage'
-import { TrackPage, useTracking } from '../../ATInternetTracking'
+import { TrackPage, usePianoTracking } from '../../ATInternetTracking'
 
 const StyledTable = styled.table`
 	&,
@@ -40,7 +40,7 @@ export default function PrivacyPolicy({
 	label?: string
 	noUnderline?: boolean
 }) {
-	const tracker = useTracking()
+	const tracker = usePianoTracking()
 	const [valueChanged, setValueChanged] = useState(false)
 	const { t } = useTranslation()
 

--- a/site/source/hooks/useTracking.ts
+++ b/site/source/hooks/useTracking.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+
+import { usePianoTracking } from '@/components/ATInternetTracking'
+import { usePlausibleTracking } from '@/hooks/usePlausibleTracking'
+
+export type ClickTracking = {
+	feature: string
+	action: string
+	simulateur?: string
+}
+
+export function useTracking() {
+	const pianoTracker = usePianoTracking()
+	const plausibleTracker = usePlausibleTracking()
+
+	const trackClick = useCallback(
+		({ feature, action, simulateur }: ClickTracking) => {
+			pianoTracker?.sendEvent('click.action', {
+				click_chapter1: feature,
+				click: action,
+			})
+			plausibleTracker.track('click', {
+				feature,
+				action,
+				...(simulateur && { simulateur }),
+			})
+		},
+		[pianoTracker, plausibleTracker]
+	)
+
+	return { trackClick }
+}


### PR DESCRIPTION
- Ajoute une prop `tracking` au composant Button du design-system
- Crée un hook unifié `useTracking` qui encapsule Piano et Plausible
- Renomme `useTracking` en `usePianoTracking` pour clarifier
- Le tracking accepte { feature, action, simulateur? }