### PR TITLE
fix(cessation-activité): précise que la rémunération inclut cotisations et contributions [decoupage]

### DIFF
--- a/modele-as/règles/rémunération.publicodes
+++ b/modele-as/règles/rémunération.publicodes
@@ -3,7 +3,7 @@ assimilé salarié . rémunération:
 
 assimilé salarié . rémunération . totale:
   titre: Rémunération totale
-  résumé: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé: Total payé par l'entreprise pour la rémunération du dirigeant, cotisations et contributions incluses
   question: Quel montant total pensez-vous dégager pour votre rémunération ?
   description: |
     C’est ce que l’entreprise dépense en tout pour la rémunération du dirigeant.

--- a/modele-social/règles/dirigeant/dirigeant.publicodes
+++ b/modele-social/règles/dirigeant/dirigeant.publicodes
@@ -38,7 +38,7 @@ dirigeant . rémunération . totale:
     C’est ce que l’entreprise dépense en tout pour la rémunération du dirigeant. Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer. On peut aussi considérer que c’est la valeur monétaire du travail du dirigeant.
   titre global: Rémunération totale dirigeant
   unité: €/an
-  résumé: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé: Total payé par l'entreprise pour la rémunération du dirigeant, cotisations et contributions incluses
   variations:
     - si: assimilé salarié
       alors:

--- a/modele-ti/règles/indépendant/revenus/rémunération.publicodes
+++ b/modele-ti/règles/indépendant/revenus/rémunération.publicodes
@@ -7,7 +7,7 @@ indépendant . rémunération . totale:
     Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
     On peut aussi considérer que c’est la valeur monétaire du travail du dirigeant.
   titre global: Rémunération totale dirigeant
-  résumé: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé: Total payé par l'entreprise pour la rémunération du dirigeant, cotisations et contributions incluses
   variations:
     - si: entreprise . imposition . IS
       alors:

--- a/site/source/locales/rules-as-en.yaml
+++ b/site/source/locales/rules-as-en.yaml
@@ -1393,8 +1393,10 @@ assimilé salarié . rémunération . totale:
     On peut aussi considérer que c’est la valeur monétaire du travail du dirigeant.
   question.en: '[automatic] How much do you expect to earn in total?'
   question.fr: Quel montant total pensez-vous dégager pour votre rémunération ?
-  résumé.en: '[automatic] Total paid by the company for executive compensation'
-  résumé.fr: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé.en: "[automatic] Total paid by the company for the executive's
+    remuneration, including contributions"
+  résumé.fr: Total payé par l'entreprise pour la rémunération du dirigeant,
+    cotisations et contributions incluses
   titre.en: '[automatic] Total compensation'
   titre.fr: Rémunération totale
 date:

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -4653,8 +4653,10 @@ dirigeant . rémunération . totale:
     dirigeant.
   question.en: '[automatic] What is the total amount you expect to earn in compensation?'
   question.fr: Quel montant total pensez-vous dégager pour votre rémunération ?
-  résumé.en: '[automatic] Total paid by the company for executive compensation'
-  résumé.fr: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé.en: "[automatic] Total paid by the company for the executive's
+    remuneration, including contributions"
+  résumé.fr: Total payé par l'entreprise pour la rémunération du dirigeant,
+    cotisations et contributions incluses
   titre.en: '[automatic] Total compensation'
   titre.fr: Rémunération totale
 durée légale du travail:

--- a/site/source/locales/rules-ti-en.yaml
+++ b/site/source/locales/rules-ti-en.yaml
@@ -4975,8 +4975,10 @@ indépendant . rémunération . totale:
     Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
 
     On peut aussi considérer que c’est la valeur monétaire du travail du dirigeant.
-  résumé.en: '[automatic] Total paid by the company for executive compensation'
-  résumé.fr: Total payé par l’entreprise pour la rémunération du dirigeant
+  résumé.en: "[automatic] Total paid by the company for the executive's
+    remuneration, including contributions"
+  résumé.fr: Total payé par l'entreprise pour la rémunération du dirigeant,
+    cotisations et contributions incluses
   titre.en: '[automatic] Total compensation'
   titre.fr: Rémunération totale
 paramètres:


### PR DESCRIPTION
Applique la même modification que la PR #4262 sur la branche de refactoring feature/decoupage-modele-social.

- Précise dans le résumé de `rémunération . totale` que les cotisations et contributions sont incluses
- Modification appliquée aux 3 modèles du découpage :
  - dirigeant . rémunération . totale (modele-social)
  - indépendant . rémunération . totale (modele-ti)
  - assimilé salarié . rémunération . totale (modele-as)

Résout le commentaire de @liliced sur #4262

Closes #3989