### PR TITLE
Remplace un tableau par une liste

### DIFF
--- a/site/source/pages/budget/budget.yaml
+++ b/site/source/pages/budget/budget.yaml
@@ -7,33 +7,13 @@
 
     [➡ Voir la convention](https://static.data.gouv.fr/resources/conventions-de-partenariat/20190423-181035/convention-du-15-avril-2019.pdf)
 
-    <table style="text-align: left">
-      <caption class="sr-only">Montants des financements répartis par financeurs et le total des financements</caption>
-      <tr>
-        <th scope="col"></th>
-        <th scope="col"></th>
-      </tr>
-      <tr>
-        <th scope="row" style="font-weight: 400;">Financement DINSIC</th>
-        <td style="text-align: right;">150 000 € HT</td>
-      </tr>
-      <tr>
-        <th scope="row" style="font-weight: 400;">Financement Acoss initial</th>
-        <td style="text-align: right;">100 000 € HT</td>
-      </tr>
-      <tr>
-        <th scope="row" style="font-weight: 400;">Rallonge Acoss fin d’année</th>
-        <td style="text-align: right;">12 500 € HT</td>
-      </tr>
-      <tr>
-        <th scope="row" style="font-weight: 700;">Total HT</th>
-        <td style="text-align: right; font-weight: 700;">262 500 € HT</td>
-      </tr>
-      <tr>
-        <th scope="row" style="font-weight: 700;">Total TTC</th>
-        <td style="text-align: right; font-weight: 700;">315 000 € TTC</td>
-      </tr>
-    </table>
+    <ul>
+      <li>Financement DINSIC : 150 000 € HT</li>
+      <li>Financement Acoss initial : 100 000 € HT</li>
+      <li>Rallonge Acoss fin d’année : 12 500 € HT</li>
+      <li><b>Total HT</b> : 262 500 € HT</li>
+      <li><b>Total TTC</b> : 315 000 € HT</li>
+    </ul>
 
     En fin d’année une rallonge est attribuée pour la réalisation d’un nouveau
     simulateur et une expérimentation sur la paie.


### PR DESCRIPTION
Dans la page budget de 2019, il y avait un tableau avec les différents financeurs 

<img width="317" height="150" alt="image" src="https://github.com/user-attachments/assets/3c340312-bf7b-4749-acb9-ed0b3f961867" />

Le format tableau n'allait pas, il fallait que ça soit une liste car il n'y avait pas d'entête ni autre intérêt de visuel.

J'ai donc mis une liste et un critère de réglé.
<img width="368" height="163" alt="image" src="https://github.com/user-attachments/assets/e27e0d83-928b-4ac2-a0ca-d3760c3d2630" />

Closes #3964