### PR TITLE
fix(salarié): ajout de la CET dans la base de l'exonération des heures supplémentaires

### DIFF
--- a/modele-social/règles/salarié/exonérations/exonérations.publicodes
+++ b/modele-social/règles/salarié/exonérations/exonérations.publicodes
@@ -81,8 +81,7 @@ salarié . cotisations . exonérations . heures supplémentaires:
       produit:
         - somme:
             - vieillesse . salarié
-            - retraite complémentaire . salarié
-            - CEG . salarié
+            - retraite complémentaire-CEG-CET . salarié
         - 1 / assiette
       plafond: 11.31%
 


### PR DESCRIPTION
A priori cet oubli est présent depuis toujours alors que la CET fait bien partie de l'ensemble des cotisations servant au calcul du taux moyen de cotisation. Ce sont quelques euros d'exonération de perdus :)