### PR TITLE
fix: corrige l'affichage mobile du montant des cotisations (#4290)

### DIFF
--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -58,10 +58,7 @@ export function ObjectifDeSimulation({
 					spacing={2}
 				>
 					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
-						<TitreObjectif id={`${id}-label`} noWrap={true}>
-							{titre}
-						</TitreObjectif>
-
+						<TitreObjectif id={`${id}-label`}>{titre}</TitreObjectif>
 						{explication && (
 							<ForceThemeProvider forceTheme="default">
 								{explication}
@@ -98,9 +95,19 @@ const GridCentered = styled(Grid)`
 	grid-template-columns: 1.25fr 1fr;
 	gap: ${({ theme }) => theme.spacings.md};
 
-	& > div:first-of-type {
+	& > div {
+		padding: 0;
 		max-width: 100%;
 		text-align: right;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpointsWidth.sm}) {
+		grid-template-columns: 1fr;
+		gap: ${({ theme }) => theme.spacings.xs};
+
+		& > div {
+			text-align: left;
+		}
 	}
 `
 
@@ -120,4 +127,7 @@ const StyledBody = styled(Body)`
 
 const StyledValue = styled(Body)`
 	margin: 1.2rem 0;
+	font-size: ${({ theme }) => theme.fontSizes.lg};
+	text-align: right;
+	padding-right: ${({ theme }) => theme.spacings.sm};
 `

--- a/site/source/design-system/typography/TitreObjectif.tsx
+++ b/site/source/design-system/typography/TitreObjectif.tsx
@@ -19,6 +19,7 @@ export const TitreObjectif = ({ id, children, noWrap = false }: Props) => {
 }
 
 const StyledBody = styled(Body)<{ $noWrap?: boolean }>`
+	display: inline;
 	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	margin: 0;
 	${({ $noWrap }) =>


### PR DESCRIPTION
Le composant ObjectifDeSimulation n'avait pas de layout responsive, contrairement à ObjectifSaisissableDeSimulation. Sur mobile, le montant était coupé car la grille restait en deux colonnes avec un titre en noWrap.

Closes #4290 