### PR TITLE
Fix: En cas de déduction tabac, il faut d'abord appliquer la déduction tabac et seulement ensuite appliquer l'option de cotisation du conjoint collaborateur

### DIFF
--- a/modele-ti/règles/indépendant/conjoint-collaborateur.publicodes
+++ b/modele-ti/règles/indépendant/conjoint-collaborateur.publicodes
@@ -96,7 +96,7 @@ indépendant . conjoint collaborateur . choix assiette:
             valeur: proportion = 'moitié'
             titre: '1/2'
 
-indépendant . conjoint collaborateur . assiette de cotisations:
+indépendant . conjoint collaborateur . assiette retraite et invalidité-décès:
   variations:
     - si: choix assiette . forfaitaire
       alors:
@@ -109,19 +109,26 @@ indépendant . conjoint collaborateur . assiette de cotisations:
     - si: choix assiette . proportion . quart
       alors:
         produit:
-          - cotisations et contributions . assiette sociale
+          - assiette chef d'entreprise
           - 25%
     - si: choix assiette . proportion . tiers
       alors:
         produit:
-          - cotisations et contributions . assiette sociale
+          - assiette chef d'entreprise
           - 1 / 3
     - sinon:
         produit:
-          - cotisations et contributions . assiette sociale
+          - assiette chef d'entreprise
           - 50%
   arrondi: oui
   unité: €/an
+
+  avec:
+    assiette chef d'entreprise:
+      variations:
+        - si: entreprise . activité . commerciale . débit de tabac
+          alors: cotisations et contributions . assiette sociale après déduction tabac
+        - sinon: cotisations et contributions . assiette sociale
 
 indépendant . conjoint collaborateur . cotisations:
   somme:
@@ -141,7 +148,7 @@ indépendant . conjoint collaborateur . cotisations . indemnités journalières:
 indépendant . conjoint collaborateur . cotisations . retraite de base:
   valeur: cotisations et contributions . cotisations . retraite de base
   contexte:
-    cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette de cotisations
+    cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette retraite et invalidité-décès
     profession libérale . CNAVPL . exonération incapacité: non
   unité: €/an
 
@@ -173,7 +180,7 @@ indépendant . conjoint collaborateur . cotisations . retraite complémentaire:
     - sinon:
         valeur: cotisations et contributions . cotisations . retraite complémentaire
         contexte:
-          cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette de cotisations
+          cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette retraite et invalidité-décès
           profession libérale . CNAVPL . exonération incapacité: non
   unité: €/an
 
@@ -205,7 +212,7 @@ indépendant . conjoint collaborateur . cotisations . invalidité et décès:
     - sinon:
         valeur: cotisations et contributions . cotisations . invalidité et décès
         contexte:
-          cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette de cotisations
+          cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette retraite et invalidité-décès
           cotisations et contributions . cotisations . exonérations . âge: non
   unité: €/an
 

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations-et-contributions.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations-et-contributions.publicodes
@@ -165,3 +165,9 @@ indépendant . cotisations et contributions . assiette sociale:
     Article L3312-4 du Code du travail: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037075048
     Article L3324-5 du Code du travail: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038589722
     Article L3332-27 du Code du travail: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037075039
+
+indépendant . cotisations et contributions . assiette sociale après déduction tabac:
+  valeur: assiette sociale
+  abattement:
+    applicable si: entreprise . activité . commerciale . débit de tabac
+    valeur: déduction tabac

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/cotisations.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/cotisations.publicodes
@@ -215,10 +215,13 @@ indépendant . cotisations et contributions . cotisations . allocations familial
                   taux: 3.10%
 
 indépendant . cotisations et contributions . cotisations . assiette retraite et invalidité-décès:
-  valeur: assiette sociale
+  variations:
+    - si: entreprise . activité . commerciale . débit de tabac
+      alors: assiette sociale après déduction tabac
+    - sinon: assiette sociale
   abattement:
     applicable si: conjoint collaborateur . choix assiette . revenu avec partage
-    valeur: conjoint collaborateur . assiette de cotisations
+    valeur: conjoint collaborateur . assiette retraite et invalidité-décès
 
 indépendant . cotisations et contributions . cotisations . retraite de base:
   description: |
@@ -280,9 +283,6 @@ indépendant . cotisations et contributions . cotisations . retraite de base:
     assiette:
       valeur: assiette retraite et invalidité-décès
       plancher: assiette minimale . retraite
-      abattement:
-        applicable si: déduction tabac
-        valeur: déduction tabac
       références:
         Cotisations minimales: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
         Article D633-2 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048838330
@@ -322,7 +322,7 @@ indépendant . cotisations et contributions . cotisations . retraite complément
           - si: profession libérale . non réglementée . taux spécifique retraite complémentaire
             alors:
               barème:
-                assiette: assiette
+                assiette: assiette retraite et invalidité-décès
                 multiplicateur: PSS proratisé
                 tranches:
                   - taux: 0%
@@ -332,7 +332,7 @@ indépendant . cotisations et contributions . cotisations . retraite complément
               arrondi: oui
           - sinon:
               barème:
-                assiette: assiette
+                assiette: assiette retraite et invalidité-décès
                 tranches:
                   - taux: taux tranche 1
                     plafond:
@@ -350,12 +350,6 @@ indépendant . cotisations et contributions . cotisations . retraite complément
     Article D635-7 du Code de la sécurité sociale: www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041966498
 
   avec:
-    assiette:
-      valeur: assiette retraite et invalidité-décès
-      abattement:
-        applicable si: déduction tabac
-        valeur: déduction tabac
-
     taux tranche 1:
       variations:
         - si: après réforme
@@ -430,6 +424,3 @@ indépendant . cotisations et contributions . cotisations . invalidité et déc�
       valeur: assiette retraite et invalidité-décès
       plancher: assiette minimale . invalidité et décès
       plafond: PSS proratisé
-      abattement:
-        applicable si: déduction tabac
-        valeur: déduction tabac

--- a/site/source/locales/rules-ti-en.yaml
+++ b/site/source/locales/rules-ti-en.yaml
@@ -1908,9 +1908,13 @@ indépendant . conjoint collaborateur:
   question.fr: Avez-vous un conjoint collaborateur ?
   titre.en: '[automatic] collaborating spouse'
   titre.fr: conjoint collaborateur
-indépendant . conjoint collaborateur . assiette de cotisations:
-  titre.en: '[automatic] contribution base'
-  titre.fr: assiette de cotisations
+indépendant . conjoint collaborateur . assiette retraite et invalidité-décès:
+  avec:
+    assiette chef d'entreprise:
+      titre.en: "[automatic] business manager's base"
+      titre.fr: assiette chef d'entreprise
+  titre.en: '[automatic] pension and disability-death base'
+  titre.fr: assiette retraite et invalidité-décès
 indépendant . conjoint collaborateur . choix assiette:
   avec:
     proportion:
@@ -2217,6 +2221,9 @@ indépendant . cotisations et contributions . assiette sociale:
     - et en soustraire la participation, l’intéressement et l’abondement au PER.
   titre.en: '[automatic] social base'
   titre.fr: assiette sociale
+indépendant . cotisations et contributions . assiette sociale après déduction tabac:
+  titre.en: '[automatic] social base after tobacco deduction'
+  titre.fr: assiette sociale après déduction tabac
 indépendant . cotisations et contributions . avec dividendes:
   description.en: >
     [automatic] This is the total amount owed by the self-employed person for
@@ -2723,9 +2730,6 @@ indépendant . cotisations et contributions . cotisations . retraite complément
     PRCI:
       titre.en: '[automatic] supplementary pension ceiling for self-employed workers'
       titre.fr: plafond retraite complémentaire des indépendants
-    assiette:
-      titre.en: '[automatic] plate'
-      titre.fr: assiette
     taux tranche 1:
       titre.en: '[automatic] rate tranche 1'
       titre.fr: taux tranche 1

--- a/site/test/modele-ti/cotisations-et-contributions/conjoint-collaborateur.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/conjoint-collaborateur.test.ts
@@ -36,7 +36,7 @@ describe('Conjoint collaborateur', () => {
 	})
 
 	describe('pour les artisans, commerçants et PLNR', () => {
-		describe('l’assiette de cotisations', () => {
+		describe('l’assiette de cotisations retraite et invalidité-décès', () => {
 			it('est égale au tiers du PASS avec l’option assiette forfaitaire', () => {
 				const e = engine.setSituation({
 					...defaultSituation,
@@ -45,7 +45,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					Math.round(PASS / 3)
 				)
 			})
@@ -62,7 +62,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					20_000
 				)
 			})
@@ -79,7 +79,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					30_000
 				)
 			})
@@ -96,7 +96,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					20_000
 				)
 			})
@@ -113,7 +113,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					30_000
 				)
 			})
@@ -137,7 +137,7 @@ describe('Conjoint collaborateur', () => {
 			it('utilise le même barème pour la retraite de base', () => {
 				const e = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'30000 €/an',
 				})
 
@@ -153,7 +153,7 @@ describe('Conjoint collaborateur', () => {
 			it('utilise le même barème pour la retraite complémentaire', () => {
 				const e = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 				})
 
@@ -169,7 +169,7 @@ describe('Conjoint collaborateur', () => {
 			it('utilise le même barème pour l’invalidité-décès', () => {
 				const e = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'30000 €/an',
 				})
 
@@ -312,7 +312,7 @@ describe('Conjoint collaborateur', () => {
 			it('n’applique pas l’exonération invalidité', () => {
 				const e1 = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
@@ -321,7 +321,7 @@ describe('Conjoint collaborateur', () => {
 
 				const e2 = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 					'indépendant . cotisations et contributions . cotisations . exonérations . invalidité':
 						'oui',
@@ -353,7 +353,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					Math.round(PASS / 2)
 				)
 			})
@@ -370,7 +370,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					15_000
 				)
 			})
@@ -387,7 +387,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					30_000
 				)
 			})
@@ -404,7 +404,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					15_000
 				)
 			})
@@ -421,7 +421,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . assiette de cotisations',
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
 					30_000
 				)
 			})
@@ -446,7 +446,7 @@ describe('Conjoint collaborateur', () => {
 				it('utilise le même barème', () => {
 					const e = engine.setSituation({
 						...defaultSituationPLR,
-						'indépendant . conjoint collaborateur . assiette de cotisations':
+						'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 							'30000 €/an',
 					})
 
@@ -763,7 +763,7 @@ describe('Conjoint collaborateur', () => {
 			it('n’applique pas l’exonération invalidité', () => {
 				const e1 = engine.setSituation({
 					...defaultSituationPLR,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
@@ -772,7 +772,7 @@ describe('Conjoint collaborateur', () => {
 
 				const e2 = engine.setSituation({
 					...defaultSituationPLR,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 					'indépendant . cotisations et contributions . cotisations . exonérations . invalidité':
 						'oui',
@@ -789,7 +789,7 @@ describe('Conjoint collaborateur', () => {
 			it('n’applique pas l’exonération âge', () => {
 				const e1 = engine.setSituation({
 					...defaultSituationPLR,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
@@ -798,7 +798,7 @@ describe('Conjoint collaborateur', () => {
 
 				const e2 = engine.setSituation({
 					...defaultSituationPLR,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 					'indépendant . cotisations et contributions . cotisations . exonérations . âge':
 						'oui',
@@ -813,7 +813,7 @@ describe('Conjoint collaborateur', () => {
 			it('n’applique pas l’exonération incapacité CNAVPL', () => {
 				const e1 = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
@@ -822,7 +822,7 @@ describe('Conjoint collaborateur', () => {
 
 				const e2 = engine.setSituation({
 					...defaultSituation,
-					'indépendant . conjoint collaborateur . assiette de cotisations':
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
 						'100000 €/an',
 					'indépendant . profession libérale . CNAVPL . exonération incapacité':
 						'oui',

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-complémentaire.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-complémentaire.test.ts
@@ -138,22 +138,6 @@ describe('Cotisation retraite complémentaire', () => {
 			})
 		})
 
-		it('applique la déduction tabac à l’assiette sociale', () => {
-			const e = engine.setSituation({
-				...defaultSituation,
-				'indépendant . cotisations et contributions . assiette sociale':
-					'30000 €/an',
-				'entreprise . activité . commerciale . débit de tabac': 'oui',
-				'indépendant . cotisations et contributions . déduction tabac':
-					'10000 €/an',
-			})
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite complémentaire . assiette',
-				30_000 - 10_000
-			)
-		})
-
 		describe('en cas de taux spécifiques PLNR', () => {
 			const TAUX_SPÉCIFIQUE = 14 / 100
 


### PR DESCRIPTION
#4294 