### PR TITLE
Fix : Corrige la formule de l'Acre

### DIFF
--- a/modele-ti/règles/indépendant/conjoint-collaborateur.publicodes
+++ b/modele-ti/règles/indépendant/conjoint-collaborateur.publicodes
@@ -82,7 +82,11 @@ indépendant . conjoint collaborateur . choix assiette:
       titre: Proportion revenu
       non applicable si: choix assiette . forfaitaire
       question: À quelle proportion du revenu la conjointe ou le conjoint cotise-t-elle/il ?
-      par défaut: "'tiers'"
+      par défaut:
+        variations:
+          - si: profession libérale . CNAVPL
+            alors: "'quart'"
+          - sinon: "'tiers'"
       une possibilité:
         - quart:
             applicable si: profession libérale . CNAVPL
@@ -104,13 +108,13 @@ indépendant . conjoint collaborateur . assiette retraite et invalidité-décès
           - plafond sécurité sociale
           - variations:
               - si: profession libérale . CNAVPL
-                alors: 50%
+                alors: 1 / 2
               - sinon: 1 / 3
     - si: choix assiette . proportion . quart
       alors:
         produit:
           - assiette chef d'entreprise
-          - 25%
+          - 1 / 4
     - si: choix assiette . proportion . tiers
       alors:
         produit:
@@ -119,7 +123,7 @@ indépendant . conjoint collaborateur . assiette retraite et invalidité-décès
     - sinon:
         produit:
           - assiette chef d'entreprise
-          - 50%
+          - 1 / 2
   arrondi: oui
   unité: €/an
 
@@ -129,104 +133,3 @@ indépendant . conjoint collaborateur . assiette retraite et invalidité-décès
         - si: entreprise . activité . commerciale . débit de tabac
           alors: cotisations et contributions . assiette sociale après déduction tabac
         - sinon: cotisations et contributions . assiette sociale
-
-indépendant . conjoint collaborateur . cotisations:
-  somme:
-    - indemnités journalières
-    - retraite de base
-    - retraite complémentaire
-    - invalidité et décès
-  abattement: exonération Acre
-  unité: €/an
-
-indépendant . conjoint collaborateur . cotisations . indemnités journalières:
-  valeur: cotisations et contributions . cotisations . indemnités journalières
-  contexte:
-    cotisations et contributions . cotisations . indemnités journalières . assiette: assiette minimale . indemnités journalières
-  unité: €/an
-
-indépendant . conjoint collaborateur . cotisations . retraite de base:
-  valeur: cotisations et contributions . cotisations . retraite de base
-  contexte:
-    cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette retraite et invalidité-décès
-    profession libérale . CNAVPL . exonération incapacité: non
-  unité: €/an
-
-indépendant . conjoint collaborateur . cotisations . retraite complémentaire:
-  description: |
-    ### Pour les artisans, commerçants et professions libérales non réglementées
-
-    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
-    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
-    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
-    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
-
-    ### Pour les professions libérales réglementées
-
-    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
-    conjoint collaborateur est égale à une proportion de la cotisation de la cheffe
-    ou du chef d’entreprise. Cette proportion est de 50 % dans le cas d’un choix
-    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
-    (quart du revenu professionnel ou assiette forfaitaire).
-  variations:
-    - si: profession libérale . CNAVPL
-      alors:
-        produit:
-          - cotisations et contributions . cotisations . retraite complémentaire
-          - variations:
-              - si: choix assiette . proportion . moitié
-                alors: 50%
-              - sinon: 25%
-    - sinon:
-        valeur: cotisations et contributions . cotisations . retraite complémentaire
-        contexte:
-          cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette retraite et invalidité-décès
-          profession libérale . CNAVPL . exonération incapacité: non
-  unité: €/an
-
-indépendant . conjoint collaborateur . cotisations . invalidité et décès:
-  description: |
-    ### Pour les artisans, commerçants et professions libérales non réglementées
-
-    La cotisation invalidité-décès de la conjointe collaboratrice ou du
-    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
-    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
-    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
-
-    ### Pour les professions libérales réglementées
-
-    La cotisation invalidité-décès de la conjointe collaboratrice ou du
-    conjoint collaborateur est égale à une proportion de la professionnelle libérale
-    ou du professionnel libéral. Cette proportion est de 50 % dans le cas d’un choix
-    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
-    (quart du revenu professionnel ou assiette forfaitaire).
-  variations:
-    - si: profession libérale . CNAVPL
-      alors:
-        produit:
-          - cotisations et contributions . cotisations . invalidité et décès
-          - variations:
-              - si: choix assiette . proportion . moitié
-                alors: 50%
-              - sinon: 25%
-    - sinon:
-        valeur: cotisations et contributions . cotisations . invalidité et décès
-        contexte:
-          cotisations et contributions . cotisations . assiette retraite et invalidité-décès: assiette retraite et invalidité-décès
-          cotisations et contributions . cotisations . exonérations . âge: non
-  unité: €/an
-
-indépendant . conjoint collaborateur . cotisations . exonération Acre:
-  description: |
-    L'Acre s’applique aux cotisations de la conjointe collaboratrice ou du
-    conjoint collaborateur uniquement lorsque celle/celui-ci cotise sur une base
-    de **revenu avec partage**.
-  applicable si: choix assiette . revenu avec partage
-  produit:
-    - somme:
-        - indemnités journalières
-        - retraite de base
-        - invalidité et décès
-    - cotisations et contributions . cotisations . exonérations . Acre . taux proratisé
-  arrondi: oui
-  unité: €/an

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations-et-contributions.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations-et-contributions.publicodes
@@ -8,7 +8,7 @@ indépendant . cotisations et contributions:
     - CSG-CRDS
     - formation professionnelle
     - cotisations facultatives . montant
-    - conjoint collaborateur . cotisations
+    - cotisations . conjoint collaborateur
     - contributions spéciales
 
   avec:
@@ -105,7 +105,7 @@ indépendant . cotisations et contributions . assiette CSG-CRDS:
         somme:
           - assiette sociale . sans plancher
           - cotisations
-          - conjoint collaborateur . cotisations
+          - cotisations . conjoint collaborateur
         abattement:
           somme:
             - revenus étrangers . montant

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/conjoint-collaborateur.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/conjoint-collaborateur.publicodes
@@ -1,0 +1,107 @@
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur:
+  applicable si: conjoint collaborateur
+  somme:
+    - indemnités journalières
+    - retraite de base
+    - retraite complémentaire
+    - invalidité et décès
+  arrondi: oui
+  unité: €/an
+
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . indemnités journalières:
+  valeur: cotisations . indemnités journalières
+  contexte:
+    cotisations . indemnités journalières . assiette: assiette minimale . indemnités journalières
+    exonérations . Acre:
+      toutes ces conditions:
+        - exonérations . Acre
+        - conjoint collaborateur . choix assiette . revenu avec partage
+    exonérations . invalidité: non
+  unité: €/an
+
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite de base:
+  valeur: cotisations . retraite de base
+  contexte:
+    cotisations . assiette retraite et invalidité-décès: conjoint collaborateur . assiette retraite et invalidité-décès
+    exonérations . Acre:
+      toutes ces conditions:
+        - exonérations . Acre
+        - conjoint collaborateur . choix assiette . revenu avec partage
+    exonérations . invalidité: non
+    profession libérale . CNAVPL . exonération incapacité: non
+  unité: €/an
+
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire:
+  description: |
+    ### Pour les artisans, commerçants et professions libérales non réglementées
+
+    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
+    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
+    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
+    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
+
+    ### Pour les professions libérales réglementées
+
+    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
+    conjoint collaborateur est égale à une proportion de la cotisation de la cheffe
+    ou du chef d’entreprise. Cette proportion est de 50 % dans le cas d’un choix
+    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
+    (quart du revenu professionnel ou assiette forfaitaire).
+  variations:
+    - si: profession libérale . CNAVPL
+      alors:
+        produit:
+          - valeur: cotisations . retraite complémentaire
+            contexte:
+              profession libérale . CNAVPL . exonération incapacité: non
+          - variations:
+              - si: conjoint collaborateur . choix assiette . proportion . moitié
+                alors: 50%
+              - sinon: 25%
+    - sinon:
+        valeur: cotisations . retraite complémentaire
+        contexte:
+          cotisations . assiette retraite et invalidité-décès: conjoint collaborateur . assiette retraite et invalidité-décès
+          exonérations . invalidité: non
+  unité: €/an
+
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès:
+  description: |
+    ### Pour les artisans, commerçants et professions libérales non réglementées
+
+    La cotisation invalidité-décès de la conjointe collaboratrice ou du
+    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
+    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
+    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
+
+    ### Pour les professions libérales réglementées
+
+    La cotisation invalidité-décès de la conjointe collaboratrice ou du
+    conjoint collaborateur est égale à une proportion de la professionnelle libérale
+    ou du professionnel libéral. Cette proportion est de 50 % dans le cas d’un choix
+    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
+    (quart du revenu professionnel ou assiette forfaitaire).
+  variations:
+    - si: profession libérale . CNAVPL
+      alors:
+        produit:
+          - valeur: cotisations . invalidité et décès
+            contexte:
+              exonérations . Acre:
+                toutes ces conditions:
+                  - exonérations . Acre
+                  - conjoint collaborateur . choix assiette . revenu avec partage
+          - variations:
+              - si: conjoint collaborateur . choix assiette . proportion . moitié
+                alors: 50%
+              - sinon: 25%
+    - sinon:
+        valeur: cotisations . invalidité et décès
+        contexte:
+          cotisations . assiette retraite et invalidité-décès: conjoint collaborateur . assiette retraite et invalidité-décès
+          exonérations . Acre:
+            toutes ces conditions:
+              - exonérations . Acre
+              - conjoint collaborateur . choix assiette . revenu avec partage
+          exonérations . âge: non
+  unité: €/an

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/cotisations.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/cotisations.publicodes
@@ -7,12 +7,6 @@ indépendant . cotisations et contributions . cotisations:
     - retraite complémentaire
     - PCV
     - invalidité et décès
-  abattement:
-    le maximum de:
-      - exonérations . Acre . montant
-      - exonérations . invalidité . montant
-  arrondi: oui
-  unité: €/an
   références:
     Taux de cotisations - Artisan, commerçant et profession libérale non réglementée: https://www.urssaf.fr/accueil/outils-documentation/taux-baremes/taux-cotisations-ac-plnr.html
     Taux de cotisations - Professions libérales réglementées hors Cipav: https://www.urssaf.fr/accueil/outils-documentation/taux-baremes/taux-cotisations-plr-hors-cipav.html
@@ -46,6 +40,10 @@ indépendant . cotisations et contributions . cotisations . maladie-maternité:
             - taux: taux 1
               plafond: plafond taux 1
             - taux: taux 2
+  abattement:
+    le maximum de:
+      - exonérations . Acre . exonération . montant maladie-maternité
+      - exonérations . invalidité . exonération . montant maladie-maternité
   arrondi: oui
   unité: €/an
   références:
@@ -146,6 +144,10 @@ indépendant . cotisations et contributions . cotisations . indemnités journali
   produit:
     - assiette
     - taux
+  abattement:
+    le maximum de:
+      - exonérations . Acre . exonération . taux indemnités journalières
+      - exonérations . invalidité . exonération . taux indemnités journalières
   arrondi: oui
   unité: €/an
   références:
@@ -192,6 +194,7 @@ indépendant . cotisations et contributions . cotisations . allocations familial
   produit:
     - assiette sociale
     - taux
+  abattement: exonérations . Acre . exonération . taux allocations familiales
   arrondi: oui
   unité: €/an
   références:
@@ -268,8 +271,13 @@ indépendant . cotisations et contributions . cotisations . retraite de base:
               plafond: 1
             - taux: taux T2
   abattement:
-    applicable si: profession libérale . CNAVPL . exonération incapacité
-    valeur: 100%
+    variations:
+      - si: profession libérale . CNAVPL . exonération incapacité
+        alors: 100%
+      - sinon:
+          le maximum de:
+            - exonérations . Acre . exonération . taux retraite de base et invalidité-décès
+            - exonérations . invalidité . exonération . taux retraite de base
   arrondi: oui
   unité: €/an
   références:
@@ -343,6 +351,7 @@ indépendant . cotisations et contributions . cotisations . retraite complément
                   - taux: taux tranche 2
                     plafond: 4 * PSS proratisé
               arrondi: oui
+  abattement: exonérations . invalidité . exonération . taux retraite complémentaire
   arrondi: oui
   unité: €/an
   références:
@@ -410,7 +419,11 @@ indépendant . cotisations et contributions . cotisations . invalidité et déc�
           - assiette
           - 1.3%
         arrondi: oui
-  abattement: exonérations . âge . montant
+  abattement:
+    variations:
+      - si: exonérations . âge
+        alors: 100%
+      - sinon: exonérations . Acre . exonération . taux retraite de base et invalidité-décès
   arrondi: oui
   unité: €/an
   références:

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/Acre.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/Acre.publicodes
@@ -3,58 +3,211 @@ indépendant . cotisations et contributions . cotisations . exonérations . Acre
   applicable si: entreprise . durée d'activité . en début d'année < 1 an
   question: Bénéficiez-vous de l’Acre ?
   par défaut: non
-  description: >-
+  description: |
     L’aide à la création ou à la reprise d’une entreprise (Acre) consiste en une
-    exonération partielle de charges sociales, dite exonération de début
-    d’activité pendant 12 mois.
+    **exonération partielle** de charges sociales pendant 12 mois, dite exonération
+    de début d’activité.
 
+    Pour pouvoir en bénéficier vous devez **déposer une demande auprès de l’Urssaf**
+    dans un délai de 60 jours après la création de votre entreprise.
 
-    Elle est **automatique** pour les **sociétés et les entreprises individuelles**
-    (sous certaines conditions, comme par exemple ne pas en avoir bénéficié les trois
-    dernières années).
+    Vous ne pouvez bénéficier de l’Acre que si vous êtes dans l’
+    **une des situations suivantes** au moment de la création de votre entreprise :
+    - personne demandeuse d’emploi indemnisée ;
+    - personne demandeuse d’emploi non indemnisée mais inscrite à France Travail
+    6 mois au cours des 18 derniers mois ;
+    - bénéficiaire du revenu de solidarité active (RSA) ou de l’allocation de
+    solidarité spécifique (ASS) ;
+    - jeune de 18 à 25 ans révolus ;
+    - personne de moins de 30 ans non indemnisée (durée d’activité insuffisante pour
+    l’ouverture de droits) ;
+    - personne de moins de 30 ans reconnue handicapée ;
+    - personne salariée ou licenciée d’une entreprise en sauvegarde, en redressement
+    ou en liquidation judiciaire et qui reprend l’activité de cette entreprise ;
+    - personne ayant conclu un Cape (contrat d’appui au projet d’entreprise), sous
+    réserve qu’elle remplisse l’une des sept conditions ci-dessus à la date
+    de signature de ce contrat ;
+    - personne créant une entreprise implantée au sein d’un quartier prioritaire de
+    la politique de la ville (QPV) ;
+    - bénéficiaire de la prestation partagée d’éducation de l’enfant (PrePare) ;
+    - personne exerçant l’activité au sein d’une zone France ruralités revitalisation
+    (ZFRR) ou d’une zone France ruralités revitalisation « plus » (ZFRR+).
+
+    Pour les **sociétés**, vous devez respecter au moins une des conditions
+    suivantes :
+    - vous détenez avec votre famille plus de 50 % du capital dont au moins 35 % à
+    titre personnel ;
+    - vous dirigez la société et vous détenez avec votre famille au moins 1/3 du
+    capital dont au moins 25 % à titre personnel (sous réserve que personne d’autre
+    ne détienne plus de 50 % du capital) ;
+    - vous détenez, avec les autres personnes demandant l’Acre, plus de 50 % du
+    capital, à condition qu’au moins l’une de ces personnes soit dirigeant/dirigeante,
+    et que chacune d’elle détienne une part du capital au moins égal à 10 % de
+    la part détenue par la principale associée ou le principal associé.
+
+    Avant 2026, l'attribution de l’Acre était automatique et concernait tous les
+    créateurs et créatrices d’entreprise.
+
+    Par ailleurs, pour bénéficier de l’Acre, vous ne devez pas en avoir déjà
+    bénéficié au cours des trois années précédentes.
   références:
+    'Acre : nouvelles règles et démarches à partir du 1er janvier 2026': https://www.urssaf.fr/accueil/actualites/acre-nouvelles-regles-demarches.html
     'L’Acre : une aide pour favoriser les créations et reprises d’entreprises': https://www.urssaf.fr/accueil/exoneration-acre-createur.html
-    Aide à la création ou à la reprise d’une entreprise: https://www.service-public.fr/particuliers/vosdroits/F11677
+    Aide à la création ou à la reprise d’une entreprise: https://www.service-public.gouv.fr/particuliers/vosdroits/F11677
     # BPI ONLY
-    'Acre : aide aux créateurs et repreneurs d’entreprise': https://bpifrance-creation.fr/encyclopedie/aides-a-creation-a-reprise-dentreprise/aides-sociales-financieres/acre-aide-aux
+    'Acre : aide aux créateurs et repreneurs d’entreprise (ex Accre)': https://bpifrance-creation.fr/encyclopedie/aides-a-creation-a-reprise-dentreprise/aides-sociales-financieres/acre-aide-aux
 
 indépendant . cotisations et contributions . cotisations . exonérations . Acre . prorata sur l'année:
   description: |
-    Comme le calcul des cotisations indépendants s'effectue sur l'année entière,
-    l'exonération est proratisée en fonction de la durée effective de l'Acre sur
-    l'année courante.
+    Comme le calcul des cotisations indépendants s’effectue sur l’année entière,
+    l’exonération est proratisée en fonction de la durée effective de l’Acre sur
+    l’année courante.
 
-    Par exemple, pour une entreprise crée le 1er février 2024, le calcul du prorata
-    pour les cotisations 2025 sera le suivant :
-
-    `31 jour d'Acre restant en 2025 / 365 jour = 8,5%`
+    > Par exemple, pour une entreprise crée le 1er février 2025, le calcul du prorata
+    > pour les cotisations 2026 sera le suivant :
+    >
+    > `31 jours d’Acre restant en 2026 / 365 jours = 8,5 %`
   unité: '%'
   valeur: (1 an - entreprise . durée d'activité . en début d'année) / 1 an
 
-indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux:
-  taux progressif:
-    assiette: assiette sociale
-    multiplicateur: PSS proratisé
-    tranches:
-      - taux: 100%
-        plafond: 75%
-      - taux: 0%
-        plafond: 100%
+indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération maximale:
+  variations:
+    - si: date < 01/2026
+      alors: 100%
+    - sinon: 25%
 
-indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux proratisé:
-  produit:
-    - taux
-    - prorata sur l'année
-  unité: '%'
+indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération:
+  description: |
+    L’exonération concerne :
+    - la cotisation maladie-maternité ;
+    - la cotisation indemnités journalières ;
+    - la cotisation allocations familiales ;
+    - la cotisation retraite de base ;
+    - la cotisation invalidité et décès.
 
-indépendant . cotisations et contributions . cotisations . exonérations . Acre . montant:
-  produit:
-    - somme:
-        - maladie-maternité
-        - indemnités journalières
-        - allocations familiales
-        - retraite de base
-        - invalidité et décès
-    - taux proratisé
-  arrondi: oui
-  unité: €/an
+    L’exonération est :
+    - égale au **quart des cotisations** concernées en cas d’assiette sociale
+    **inférieure à 75 % du plafond annuel de la sécurité sociale (PASS)** ;
+    - **dégressive** en cas d’assiette comprise **entre 75 % et 100 % du PASS** ;
+    - **nulle** en cas d’assiette **supérieure au PASS**.
+
+    > La formule de calcul du montant de l’exonération dégressive est la suivante :
+    >
+    > (PASS - R) x E / PASS
+    >
+    > avec :
+    > - PASS = plafond annuel de la sécurité sociale (proratisé en cas d’année
+    > incomplète) ;
+    > - R = assiette sociale ;
+    > - E = montant des cotisations exonérées calculées pour une assiette égale à
+    > 75 % du PASS (proratisé en cas d’année incomplète).
+  note: |
+    Pour des raisons de performance, nous ne calculons pas le montant de
+    l’exonération mais son taux. C’est-à-dire, le rapport entre le montant de
+    l’exonération et le montant de la cotisation hors exonération.
+
+    Afin de faciliter les calculs, nous avons également simplifié la formule de ce
+    taux d’exonération pour les cotisations indemnités journalières, allocations
+    familiales, retraite de base et invalidité-décès. En effet, dans le cadre de
+    l’Acre, l’assiette est inférieure au PASS et dans ce cas la formule de chacune
+    de ces cotisations est du type `assiette x taux`.
+
+    En notant T ce taux, la cotisation hors exonération vaut donc `R x T` et la
+    cotisation pour une assiette valant 75 % du PASS vaut `0,75 x PASS x T`.
+
+    Le taux d’exonération devient alors **`0,75 x (PASS - R) / R`**
+
+    > Preuve :
+    >
+    > [(PASS - R) x E / PASS] / (R x T)
+    >
+    > = [(PASS - R) x (0,75 x PASS x T) / PASS] / (R x T)
+    >
+    > = [(PASS - R) x (0,75 / R)
+    >
+    > = 0,75 x (PASS - R) / R
+
+    Pour la cotisation maladie-maternité, dont le calcul est plus complexe, nous
+    calculons le montant de l’exonération en utilisant la formule officielle.
+  références:
+    Article D131-6-1 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036475110
+
+  avec:
+    montant maladie-maternité:
+      produit:
+        - variations:
+            - si: assiette sociale > PSS proratisé
+              alors: 0 €/an
+            - si: assiette sociale < 75% * PSS proratisé
+              alors:
+                produit:
+                  - valeur: cotisations . maladie-maternité
+                    contexte:
+                      Acre: non
+                  - exonération maximale
+            - sinon:
+                produit:
+                  - PSS proratisé - assiette sociale
+                  - valeur: cotisations . maladie-maternité
+                    contexte:
+                      assiette sociale: 75% * PSS proratisé
+                      Acre: non
+                  - 1 / PSS proratisé
+                  - variations:
+                      - si: date < 01/2026
+                        alors: 1 / 0.25
+                      - sinon: 1
+        - prorata sur l'année
+      arrondi: oui
+      unité: €/an
+
+    taux indemnités journalières:
+      produit:
+        - variations:
+            - si: indemnités journalières . assiette > PSS proratisé
+              alors: 0%
+            - si: indemnités journalières . assiette < 75% * PSS proratisé
+              alors: exonération maximale
+            - sinon:
+                produit:
+                  - (PSS proratisé - indemnités journalières . assiette) / indemnités journalières . assiette
+                  - variations:
+                      - si: date < 01/2026
+                        alors: 3
+                      - sinon: 0.75
+        - prorata sur l'année
+      unité: '%'
+
+    taux allocations familiales:
+      produit:
+        - variations:
+            - si: assiette sociale > PSS proratisé
+              alors: 0%
+            - si: assiette sociale < 75% * PSS proratisé
+              alors: exonération maximale
+            - sinon:
+                produit:
+                  - (PSS proratisé - assiette sociale) / assiette sociale
+                  - variations:
+                      - si: date < 01/2026
+                        alors: 3
+                      - sinon: 0.75
+        - prorata sur l'année
+      unité: '%'
+
+    taux retraite de base et invalidité-décès:
+      produit:
+        - variations:
+            - si: assiette retraite et invalidité-décès > PSS proratisé
+              alors: 0%
+            - si: assiette retraite et invalidité-décès < 75% * PSS proratisé
+              alors: exonération maximale
+            - sinon:
+                produit:
+                  - (PSS proratisé - assiette retraite et invalidité-décès) / assiette retraite et invalidité-décès
+                  - variations:
+                      - si: date < 01/2026
+                        alors: 3
+                      - sinon: 0.75
+        - prorata sur l'année
+      unité: '%'

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/invalidité.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/invalidité.publicodes
@@ -55,20 +55,28 @@ indépendant . cotisations et contributions . cotisations . exonérations . inva
   unité: '%'
   arrondi: oui
 
-indépendant . cotisations et contributions . cotisations . exonérations . invalidité . montant:
-  produit:
-    - somme:
-        - maladie-maternité
-        - indemnités journalières
-        - applicable si: profession libérale . Cipav
-          # Seules les PLR Cipav bénéficient de l'exonération invalidité sur la retraite de base.
-          # Les PLR non Cipav ne sont pas gérées par l'Urssaf et ne bénéficient donc pas de cette exonération.
-          # Les A/C/PLNR ne bénéficient pas de cette exonération.
-          valeur: retraite de base
-        - non applicable si: profession libérale . CNAVPL . hors Urssaf
-          # L'exonération invalidité est un dispositif de l'Urssaf et ne concerne donc
-          # pas les PLR non Cipav
-          valeur: retraite complémentaire
-    - prorata sur l'année
-  arrondi: oui
-  unité: €/an
+indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération:
+  avec:
+    montant maladie-maternité:
+      produit:
+        - valeur: cotisations . maladie-maternité
+          contexte:
+            invalidité: non
+        - prorata sur l'année
+      arrondi: oui
+      unité: €/an
+
+    taux indemnités journalières: prorata sur l'année
+
+    taux retraite de base:
+      # Seules les PLR Cipav bénéficient de l'exonération invalidité sur la retraitede base.
+      # Les PLR non Cipav ne sont pas gérées par l'Urssaf et ne bénéficient donc pas de cette exonération.
+      # Les A/C/PLNR ne bénéficient pas de cette exonération.
+      applicable si: profession libérale . Cipav
+      valeur: prorata sur l'année
+
+    taux retraite complémentaire:
+      # L'exonération invalidité est un dispositif de l'Urssaf et ne concerne donc
+      # pas les PLR non Cipav
+      non applicable si: profession libérale . CNAVPL . hors Urssaf
+      valeur: prorata sur l'année

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/âge.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/âge.publicodes
@@ -23,6 +23,3 @@ indépendant . cotisations et contributions . cotisations . exonérations . âge
   par défaut: non
   références:
     Article 4.6 des statuts de la Cipav: https://www.lacipav.fr/sites/default/files/2025-09/Statuts%20CIPAV_doc%20VF%20Septembre%2020250923.pdf#page=19
-
-  avec:
-    montant: invalidité et décès

--- a/site/source/locales/rules-ti-en.yaml
+++ b/site/source/locales/rules-ti-en.yaml
@@ -1956,137 +1956,6 @@ indépendant . conjoint collaborateur . choix assiette:
   question.fr: Sur quelle base le conjoint cotise-t-il ?
   titre.en: '[automatic] plate selection'
   titre.fr: choix assiette
-indépendant . conjoint collaborateur . cotisations:
-  titre.en: '[automatic] contributions'
-  titre.fr: cotisations
-indépendant . conjoint collaborateur . cotisations . exonération Acre:
-  description.en: >
-    [automatic] Acre applies to the contributions of the collaborating spouse
-    only when he/she
-
-    only when the collaborating spouse contributes on a **shared income** basis.
-
-    income-sharing basis**.
-  description.fr: |
-    L'Acre s’applique aux cotisations de la conjointe collaboratrice ou du
-    conjoint collaborateur uniquement lorsque celle/celui-ci cotise sur une base
-    de **revenu avec partage**.
-  titre.en: '[automatic] Acre exemption'
-  titre.fr: exonération Acre
-indépendant . conjoint collaborateur . cotisations . indemnités journalières:
-  titre.en: '[automatic] daily allowances'
-  titre.fr: indemnités journalières
-indépendant . conjoint collaborateur . cotisations . invalidité et décès:
-  description.en: >
-    [automatic] ### For craftsmen, shopkeepers and unregulated self-employed
-    professionals
-
-
-    The disability-death contribution for the collaborating spouse is calculated on the same
-
-    is calculated according to the same scale as for the head of the company
-
-    but using the contribution base calculated according to the option
-
-    option chosen (flat-rate or proportion of professional income).
-
-
-    ### For regulated liberal professions
-
-
-    The invalidity-death contribution of the collaborating spouse is
-
-    collaborating spouse is equal to a proportion of the professional
-
-    or the self-employed professional. This proportion is 50% in the case of a choice
-
-    half of professional income, and 25% in other cases (quarter of professional income or
-
-    (quarter of professional income or flat rate).
-  description.fr: >
-    ### Pour les artisans, commerçants et professions libérales non réglementées
-
-
-    La cotisation invalidité-décès de la conjointe collaboratrice ou du
-
-    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
-
-    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
-
-    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
-
-
-    ### Pour les professions libérales réglementées
-
-
-    La cotisation invalidité-décès de la conjointe collaboratrice ou du
-
-    conjoint collaborateur est égale à une proportion de la professionnelle libérale
-
-    ou du professionnel libéral. Cette proportion est de 50 % dans le cas d’un choix
-
-    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
-
-    (quart du revenu professionnel ou assiette forfaitaire).
-  titre.en: '[automatic] disability and death'
-  titre.fr: invalidité et décès
-indépendant . conjoint collaborateur . cotisations . retraite complémentaire:
-  description.en: >
-    [automatic] ### For craftsmen, shopkeepers and unregulated self-employed
-    professionals
-
-
-    The supplementary pension contribution for the collaborating spouse is calculated on the same
-
-    contributions are calculated according to the same scale as for the company
-
-    but using the contribution base calculated according to the option
-
-    depending on the option chosen (flat-rate or proportion of professional income).
-
-
-    ### For regulated liberal professions
-
-
-    The supplementary pension contribution for the collaborating spouse is equal to a proportion of the professional income.
-
-    spouse is equal to a proportion of the contribution made by the head
-
-    contribution. This proportion is 50% in the case of a choice
-
-    half of professional income, and 25% in other cases (quarter of professional income or
-
-    (quarter of professional income or flat rate).
-  description.fr: >
-    ### Pour les artisans, commerçants et professions libérales non réglementées
-
-
-    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
-
-    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
-
-    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
-
-    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
-
-
-    ### Pour les professions libérales réglementées
-
-
-    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
-
-    conjoint collaborateur est égale à une proportion de la cotisation de la cheffe
-
-    ou du chef d’entreprise. Cette proportion est de 50 % dans le cas d’un choix
-
-    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
-
-    (quart du revenu professionnel ou assiette forfaitaire).
-  titre.en: '[automatic] supplementary pension'
-  titre.fr: retraite complémentaire
-indépendant . conjoint collaborateur . cotisations . retraite de base:
-  titre.en: '[automatic] basic retirement'
-  titre.fr: retraite de base
 indépendant . cotisations et contributions:
   avec:
     Urssaf:
@@ -2337,31 +2206,512 @@ indépendant . cotisations et contributions . cotisations . allocations familial
 indépendant . cotisations et contributions . cotisations . assiette retraite et invalidité-décès:
   titre.en: '[automatic] pension and disability-death base'
   titre.fr: assiette retraite et invalidité-décès
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur:
+  titre.en: '[automatic] collaborating spouse'
+  titre.fr: conjoint collaborateur
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . indemnités journalières:
+  titre.en: '[automatic] daily allowances'
+  titre.fr: indemnités journalières
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès:
+  description.en: >
+    [automatic] ### For craftsmen, shopkeepers and unregulated self-employed
+    professionals
+
+
+    The disability-death contribution for the collaborating spouse is calculated on the same
+
+    is calculated according to the same scale as for the head of the company
+
+    but using the contribution base calculated according to the option
+
+    option chosen (flat-rate or proportion of professional income).
+
+
+    ### For regulated liberal professions
+
+
+    The invalidity-death contribution of the collaborating spouse is
+
+    spouse is equal to a proportion of the self-employed professional's
+
+    or the self-employed professional. This proportion is 50% in the case of a choice
+
+    half of professional income, and 25% in other cases (quarter of professional income or
+
+    (quarter of professional income or flat rate).
+  description.fr: >
+    ### Pour les artisans, commerçants et professions libérales non réglementées
+
+
+    La cotisation invalidité-décès de la conjointe collaboratrice ou du
+
+    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
+
+    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
+
+    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
+
+
+    ### Pour les professions libérales réglementées
+
+
+    La cotisation invalidité-décès de la conjointe collaboratrice ou du
+
+    conjoint collaborateur est égale à une proportion de la professionnelle libérale
+
+    ou du professionnel libéral. Cette proportion est de 50 % dans le cas d’un choix
+
+    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
+
+    (quart du revenu professionnel ou assiette forfaitaire).
+  titre.en: '[automatic] disability and death'
+  titre.fr: invalidité et décès
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire:
+  description.en: >
+    [automatic] ### For craftsmen, shopkeepers and unregulated self-employed
+    professionals
+
+
+    The supplementary pension contribution for the collaborating spouse is calculated on the same
+
+    contributions are calculated according to the same scale as for the company
+
+    but using the contribution base calculated according to the option
+
+    depending on the option chosen (flat-rate or proportion of professional income).
+
+
+    ### For regulated liberal professions
+
+
+    The supplementary pension contribution for the collaborating spouse is equal to a proportion of the professional income.
+
+    spouse is equal to a proportion of the contribution made by the head
+
+    contribution. This proportion is 50% in the case of a choice
+
+    half of professional income, and 25% in other cases (quarter of professional income or
+
+    (quarter of professional income or flat rate).
+  description.fr: >
+    ### Pour les artisans, commerçants et professions libérales non réglementées
+
+
+    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
+
+    conjoint collaborateur est calculée selon le même barème que la cheffe ou le
+
+    chef d’entreprise mais en utilisant l’assiette de cotisations calculée en
+
+    fonction de l’option choisie (forfaitaire ou proportion du revenu professionnel).
+
+
+    ### Pour les professions libérales réglementées
+
+
+    La cotisation retraite complémentaire de la conjointe collaboratrice ou du
+
+    conjoint collaborateur est égale à une proportion de la cotisation de la cheffe
+
+    ou du chef d’entreprise. Cette proportion est de 50 % dans le cas d’un choix
+
+    d’assiette de la moitié du revenu professionnel, et de 25 % dans les autres cas
+
+    (quart du revenu professionnel ou assiette forfaitaire).
+  titre.en: '[automatic] supplementary pension'
+  titre.fr: retraite complémentaire
+indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite de base:
+  titre.en: '[automatic] basic retirement'
+  titre.fr: retraite de base
 indépendant . cotisations et contributions . cotisations . exonérations:
   titre.en: '[automatic] exemptions'
   titre.fr: exonérations
 indépendant . cotisations et contributions . cotisations . exonérations . Acre:
-  description.en: >-
-    [automatic] Assistance for setting up or taking over a business (Acre)
-    consists of a partial exemption from social security contributions, known as
-    the "start-up exemption", for a period of 12 months.
+  description.en: >
+    [automatic] Assistance with setting up or taking over a business (Acre)
+    consists of a
+
+    **partial** exemption from social security charges for 12 months, known as the
+
+    exemption.
 
 
-    It is **automatic** for **companies and sole proprietorships** (subject to certain conditions, such as not having benefited from it in the last three years).
-  description.fr: >-
+    To qualify, you must **apply to Urssaf** within
+
+    within 60 days of setting up your business.
+
+
+    You can only benefit from Acre if you are in one of the following situations
+
+    **one of the following situations** at the time of setting up your business:
+
+    - a job-seeker receiving compensation ;
+
+    - a job-seeker who is not receiving compensation but is registered with France Travail
+
+    6 months in the last 18 months;
+
+    - beneficiary of the revenu de solidarité active (RSA) or the allocation de
+
+    solidarité spécifique (ASS) ;
+
+    - young people aged 18 to 25;
+
+    - person under 30 not receiving benefit (duration of activity insufficient to
+
+    for entitlement);
+
+    - disabled persons under 30;
+
+    - salaried employees or those made redundant by a company in receivership or liquidation
+
+    or liquidation and who takes over the business;
+
+    - a person who has signed a Cape (contrat d'appui au projet d'entreprise), provided that
+
+    provided they meet one of the above seven conditions on the date of signing
+
+    on the date the contract is signed;
+
+    - a person setting up a business in a priority district of the
+
+    (QPV);
+
+    - beneficiary of the "prestation partagée d'éducation de l'enfant" (PrePare) ;
+
+    - person carrying on business in a France ruralités revitalization zone
+
+    (ZFRR) or a France ruralités revitalization "plus" zone (ZFRR+).
+
+
+    For **companies**, you must meet at least one of the following conditions
+
+    conditions:
+
+    - you and your family own more than 50% of the capital, of which at least 35% is held personally
+
+    personally;
+
+    - you manage the company and hold at least 1/3 of the capital with your family
+
+    capital, of which at least 25% is held by you personally (provided that no other person
+
+    owns more than 50% of the capital) ;
+
+    - you and the other persons requesting Acre hold more than 50% of the capital, provided that
+
+    capital, provided that at least one of these persons is a director,
+
+    and that each of them holds a share of the capital at least equal to 10% of the share held by the main partner.
+
+    the share held by the main partner.
+
+
+    Prior to 2026, the Acre was granted automatically to all business
+
+    business creators.
+
+
+    In addition, to benefit from Acre, you must not have already received it
+
+    in the previous three years.
+  description.fr: >
     L’aide à la création ou à la reprise d’une entreprise (Acre) consiste en une
-    exonération partielle de charges sociales, dite exonération de début
-    d’activité pendant 12 mois.
+
+    **exonération partielle** de charges sociales pendant 12 mois, dite exonération
+
+    de début d’activité.
 
 
-    Elle est **automatique** pour les **sociétés et les entreprises individuelles** (sous certaines conditions, comme par exemple ne pas en avoir bénéficié les trois dernières années).
+    Pour pouvoir en bénéficier vous devez **déposer une demande auprès de l’Urssaf**
+
+    dans un délai de 60 jours après la création de votre entreprise.
+
+
+    Vous ne pouvez bénéficier de l’Acre que si vous êtes dans l’
+
+    **une des situations suivantes** au moment de la création de votre entreprise :
+
+    - personne demandeuse d’emploi indemnisée ;
+
+    - personne demandeuse d’emploi non indemnisée mais inscrite à France Travail
+
+    6 mois au cours des 18 derniers mois ;
+
+    - bénéficiaire du revenu de solidarité active (RSA) ou de l’allocation de
+
+    solidarité spécifique (ASS) ;
+
+    - jeune de 18 à 25 ans révolus ;
+
+    - personne de moins de 30 ans non indemnisée (durée d’activité insuffisante pour
+
+    l’ouverture de droits) ;
+
+    - personne de moins de 30 ans reconnue handicapée ;
+
+    - personne salariée ou licenciée d’une entreprise en sauvegarde, en redressement
+
+    ou en liquidation judiciaire et qui reprend l’activité de cette entreprise ;
+
+    - personne ayant conclu un Cape (contrat d’appui au projet d’entreprise), sous
+
+    réserve qu’elle remplisse l’une des sept conditions ci-dessus à la date
+
+    de signature de ce contrat ;
+
+    - personne créant une entreprise implantée au sein d’un quartier prioritaire de
+
+    la politique de la ville (QPV) ;
+
+    - bénéficiaire de la prestation partagée d’éducation de l’enfant (PrePare) ;
+
+    - personne exerçant l’activité au sein d’une zone France ruralités revitalisation
+
+    (ZFRR) ou d’une zone France ruralités revitalisation « plus » (ZFRR+).
+
+
+    Pour les **sociétés**, vous devez respecter au moins une des conditions
+
+    suivantes :
+
+    - vous détenez avec votre famille plus de 50 % du capital dont au moins 35 % à
+
+    titre personnel ;
+
+    - vous dirigez la société et vous détenez avec votre famille au moins 1/3 du
+
+    capital dont au moins 25 % à titre personnel (sous réserve que personne d’autre
+
+    ne détienne plus de 50 % du capital) ;
+
+    - vous détenez, avec les autres personnes demandant l’Acre, plus de 50 % du
+
+    capital, à condition qu’au moins l’une de ces personnes soit dirigeant/dirigeante,
+
+    et que chacune d’elle détienne une part du capital au moins égal à 10 % de
+
+    la part détenue par la principale associée ou le principal associé.
+
+
+    Avant 2026, l'attribution de l’Acre était automatique et concernait tous les
+
+    créateurs et créatrices d’entreprise.
+
+
+    Par ailleurs, pour bénéficier de l’Acre, vous ne devez pas en avoir déjà
+
+    bénéficié au cours des trois années précédentes.
   question.en: '[automatic] Did you benefit from Acre?'
   question.fr: Bénéficiez-vous de l’Acre ?
   titre.en: '[automatic] Acre'
   titre.fr: Acre
-indépendant . cotisations et contributions . cotisations . exonérations . Acre . montant:
-  titre.en: '[automatic] amount'
-  titre.fr: montant
+indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération:
+  avec:
+    montant maladie-maternité:
+      titre.en: '[automatic] sickness and maternity amount'
+      titre.fr: montant maladie-maternité
+    taux allocations familiales:
+      titre.en: '[automatic] family allowance rates'
+      titre.fr: taux allocations familiales
+    taux indemnités journalières:
+      titre.en: '[automatic] daily allowance rates'
+      titre.fr: taux indemnités journalières
+    taux retraite de base et invalidité-décès:
+      titre.en: '[automatic] basic pension and disability-death rates'
+      titre.fr: taux retraite de base et invalidité-décès
+  description.en: >
+    [automatic] The exemption applies to :
+
+    - sickness and maternity contributions ;
+
+    - daily allowance contributions;
+
+    - family allowance contributions;
+
+    - basic pension contributions;
+
+    - disability and death contributions.
+
+
+    The exemption is :
+
+    - equal to **one-quarter of the contributions** concerned if the social security base
+
+    **less than 75% of the annual social security ceiling (PASS)** ;
+
+    - degressive** for contributions **between 75% and 100% of the PASS**;
+
+    - nil** in the case of a base **above the PASS**.
+
+
+    > The formula for calculating the degressive exemption is as follows:
+
+    &gt;
+
+    > (PASS - R) x E / PASS
+
+    &gt;
+
+    > where :
+
+    > - PASS = annual social security ceiling (prorated in the case of an incomplete year)
+
+    > incomplete year) ;
+
+    > - R = social security base ;
+
+    > - E = amount of exempt contributions calculated for a base equal to
+
+    > 75% of PASS (prorated in the case of an incomplete year).
+  description.fr: >
+    L’exonération concerne :
+
+    - la cotisation maladie-maternité ;
+
+    - la cotisation indemnités journalières ;
+
+    - la cotisation allocations familiales ;
+
+    - la cotisation retraite de base ;
+
+    - la cotisation invalidité et décès.
+
+
+    L’exonération est :
+
+    - égale au **quart des cotisations** concernées en cas d’assiette sociale
+
+    **inférieure à 75 % du plafond annuel de la sécurité sociale (PASS)** ;
+
+    - **dégressive** en cas d’assiette comprise **entre 75 % et 100 % du PASS** ;
+
+    - **nulle** en cas d’assiette **supérieure au PASS**.
+
+
+    > La formule de calcul du montant de l’exonération dégressive est la suivante :
+
+    >
+
+    > (PASS - R) x E / PASS
+
+    >
+
+    > avec :
+
+    > - PASS = plafond annuel de la sécurité sociale (proratisé en cas d’année
+
+    > incomplète) ;
+
+    > - R = assiette sociale ;
+
+    > - E = montant des cotisations exonérées calculées pour une assiette égale à
+
+    > 75 % du PASS (proratisé en cas d’année incomplète).
+  note.en: >
+    [automatic] For performance reasons, we do not calculate the amount of the
+    exemption
+
+    but its rate. In other words, the ratio between the amount of the exemption and the amount of the contribution excluding the exemption.
+
+    the amount of the contribution excluding the exemption.
+
+
+    To simplify calculations, we have also simplified the formula for this
+
+    exemption rate for contributions to daily allowances, family allowances
+
+    basic pension and disability-death contributions. Indeed, under the
+
+    Acre, the base is less than the PASS and in this case the formula for each of these
+
+    of each of these contributions is of the "base x rate" type.
+
+
+    If we denote this rate as T, the contribution excluding the exemption is therefore `R x T` and the contribution for a base of `R x T` is `R x T`.
+
+    contribution for a base equal to 75% of PASS is `0.75 x PASS x T`.
+
+
+    The exemption rate then becomes **`0.75 x (PASS - R) / R`**.
+
+
+    > Proof :
+
+    &gt;
+
+    > [(PASS - R) x E / PASS] / (R x T)
+
+    &gt;
+
+    > = [(PASS - R) x (0.75 x PASS x T) / PASS] / (R x T)
+
+    &gt;
+
+    > = [(PASS - R) x (0.75 / R)
+
+    &gt;
+
+    > = 0.75 x (PASS - R) / R
+
+
+    For sickness and maternity contributions, the calculation of which is more complex, we calculate the amount of the exemption using the official formula.
+
+    calculate the amount of the exemption using the official formula.
+  note.fr: >
+    Pour des raisons de performance, nous ne calculons pas le montant de
+
+    l’exonération mais son taux. C’est-à-dire, le rapport entre le montant de
+
+    l’exonération et le montant de la cotisation hors exonération.
+
+
+    Afin de faciliter les calculs, nous avons également simplifié la formule de ce
+
+    taux d’exonération pour les cotisations indemnités journalières, allocations
+
+    familiales, retraite de base et invalidité-décès. En effet, dans le cadre de
+
+    l’Acre, l’assiette est inférieure au PASS et dans ce cas la formule de chacune
+
+    de ces cotisations est du type `assiette x taux`.
+
+
+    En notant T ce taux, la cotisation hors exonération vaut donc `R x T` et la
+
+    cotisation pour une assiette valant 75 % du PASS vaut `0,75 x PASS x T`.
+
+
+    Le taux d’exonération devient alors **`0,75 x (PASS - R) / R`**
+
+
+    > Preuve :
+
+    >
+
+    > [(PASS - R) x E / PASS] / (R x T)
+
+    >
+
+    > = [(PASS - R) x (0,75 x PASS x T) / PASS] / (R x T)
+
+    >
+
+    > = [(PASS - R) x (0,75 / R)
+
+    >
+
+    > = 0,75 x (PASS - R) / R
+
+
+    Pour la cotisation maladie-maternité, dont le calcul est plus complexe, nous
+
+    calculons le montant de l’exonération en utilisant la formule officielle.
+  titre.en: '[automatic] exemption'
+  titre.fr: exonération
+indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération maximale:
+  titre.en: '[automatic] maximum exemption'
+  titre.fr: exonération maximale
 indépendant . cotisations et contributions . cotisations . exonérations . Acre . prorata sur l'année:
   description.en: >
     [automatic] As self-employed contributions are calculated on a full-year
@@ -2372,34 +2722,30 @@ indépendant . cotisations et contributions . cotisations . exonérations . Acre
     current year.
 
 
-    For example, for a company created on February 1, 2024, the prorata calculation for
+    > For example, for a company created on February 1, 2025, the prorata calculation for
 
-    for 2025 contributions will be as follows :
+    > for 2026 contributions will be as follows :
 
+    &gt;
 
-    31 days of Acre remaining in 2025 / 365 days = 8.5%`.
+    > 31 days of Acre remaining in 2026 / 365 days = 8.5%`.
   description.fr: >
-    Comme le calcul des cotisations indépendants s'effectue sur l'année entière,
+    Comme le calcul des cotisations indépendants s’effectue sur l’année entière,
 
-    l'exonération est proratisée en fonction de la durée effective de l'Acre sur
+    l’exonération est proratisée en fonction de la durée effective de l’Acre sur
 
-    l'année courante.
-
-
-    Par exemple, pour une entreprise crée le 1er février 2024, le calcul du prorata
-
-    pour les cotisations 2025 sera le suivant :
+    l’année courante.
 
 
-    `31 jour d'Acre restant en 2025 / 365 jour = 8,5%`
+    > Par exemple, pour une entreprise crée le 1er février 2025, le calcul du prorata
+
+    > pour les cotisations 2026 sera le suivant :
+
+    >
+
+    > `31 jours d’Acre restant en 2026 / 365 jours = 8,5 %`
   titre.en: '[automatic] pro rata over the year'
   titre.fr: prorata sur l'année
-indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux:
-  titre.en: '[automatic] rate'
-  titre.fr: taux
-indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux proratisé:
-  titre.en: '[automatic] prorated rate'
-  titre.fr: taux proratisé
 indépendant . cotisations et contributions . cotisations . exonérations . DROM:
   description.en: >
     [automatic] At the start of their activity, for a period of 24 months,
@@ -2530,17 +2876,26 @@ indépendant . cotisations et contributions . cotisations . exonérations . inva
   question.fr: Pendant combien de mois dans l'année bénéficiez-vous de cette pension ?
   titre.en: '[automatic] duration'
   titre.fr: durée
-indépendant . cotisations et contributions . cotisations . exonérations . invalidité . montant:
-  titre.en: '[automatic] amount'
-  titre.fr: montant
+indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération:
+  avec:
+    montant maladie-maternité:
+      titre.en: '[automatic] sickness and maternity amount'
+      titre.fr: montant maladie-maternité
+    taux indemnités journalières:
+      titre.en: '[automatic] daily allowance rates'
+      titre.fr: taux indemnités journalières
+    taux retraite complémentaire:
+      titre.en: '[automatic] supplementary pension rate'
+      titre.fr: taux retraite complémentaire
+    taux retraite de base:
+      titre.en: '[automatic] basic retirement rate'
+      titre.fr: taux retraite de base
+  titre.en: '[automatic] exemption'
+  titre.fr: exonération
 indépendant . cotisations et contributions . cotisations . exonérations . invalidité . prorata sur l'année:
   titre.en: '[automatic] pro rata over the year'
   titre.fr: prorata sur l'année
 indépendant . cotisations et contributions . cotisations . exonérations . âge:
-  avec:
-    montant:
-      titre.en: '[automatic] amount'
-      titre.fr: montant
   description.en: >
     [automatic] ### Craftsmen, shopkeepers and self-employed professionals
     outside Cipav

--- a/site/test/modele-ti/cotisations-et-contributions/conjoint-collaborateur.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/conjoint-collaborateur.test.ts
@@ -2,6 +2,9 @@ import rules from 'modele-ti'
 import Engine from 'publicodes'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+const COTISATIONS =
+	'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
+
 const defaultSituation = {
 	'indépendant . conjoint collaborateur': 'oui',
 }
@@ -18,7 +21,7 @@ const situationRevenuSansPartage = {
 		"'moitié'",
 }
 const situationAcre = {
-	'entreprise . date de création': '18/02/2026',
+	'entreprise . date de création': '01/01/2026',
 	'indépendant . cotisations et contributions . cotisations . exonérations . Acre':
 		'oui',
 }
@@ -29,13 +32,11 @@ describe('Conjoint collaborateur', () => {
 	beforeEach(() => {
 		engine = new Engine(rules)
 		engine = new Engine(rules)
-		PASS = engine.evaluate({
-			valeur: 'plafond sécurité sociale',
-			unité: '€/an',
-		}).nodeValue as number
+		PASS = engine.evaluate('plafond sécurité sociale . annuel')
+			.nodeValue as number
 	})
 
-	describe('pour les artisans, commerçants et PLNR', () => {
+	describe('pour les A/C/PLNR', () => {
 		describe('l’assiette de cotisations retraite et invalidité-décès', () => {
 			it('est égale au tiers du PASS avec l’option assiette forfaitaire', () => {
 				const e = engine.setSituation({
@@ -129,7 +130,7 @@ describe('Conjoint collaborateur', () => {
 				expect(assietteMinimale).toEqual(Math.round((PASS * 40) / 100))
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations . indemnités journalières',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . indemnités journalières',
 					Math.round((assietteMinimale * 0.5) / 100)
 				)
 			})
@@ -145,7 +146,7 @@ describe('Conjoint collaborateur', () => {
 				// > pour les artisans, commerçants et PLNR
 				// > applique le taux T1 uniquement en cas d’assiette sociale comprise entre l’assiette minimale et 1 PASS
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations . retraite de base',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite de base',
 					Math.round((30_000 * 17.87) / 100)
 				)
 			})
@@ -161,7 +162,7 @@ describe('Conjoint collaborateur', () => {
 				// > pour les artisans, commerçants et PLNR
 				// > applique le taux tranche 1 au PASS et le taux tranche 2 au reste de l’assiette sociale en cas d’assiette sociale comprise entre 1 et 4 PASS
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations . retraite complémentaire',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire',
 					Math.round((PASS * 8.1) / 100 + ((100_000 - PASS) * 9.1) / 100)
 				)
 			})
@@ -177,7 +178,7 @@ describe('Conjoint collaborateur', () => {
 				// > pour les artisans, commerçants et PLNR
 				// > applique le taux de 1,3% à l’assiette sociale lorsqu’elle est comprise entre 11,5% du PASS et 1 PASS
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations . invalidité et décès',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès',
 					Math.round((30_000 * 1.3) / 100)
 				)
 			})
@@ -189,69 +190,94 @@ describe('Conjoint collaborateur', () => {
 					...defaultSituation,
 					...situationRevenuAvecPartage,
 					'indépendant . cotisations et contributions . assiette sociale':
-						'30000 €/an',
+						'60000 €/an',
 				})
 
-				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
-				).nodeValue as number
-				const IJ = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations . indemnités journalières'
-				).nodeValue as number
-				const RB = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations . retraite de base'
-				).nodeValue as number
-				const ID = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
-				).nodeValue as number
+				const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+					.nodeValue as number
+				const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+					.nodeValue as number
+				const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+					.nodeValue as number
 
 				const e2 = engine.setSituation({
 					...defaultSituation,
 					...situationAcre,
 					...situationRevenuAvecPartage,
 					'indépendant . cotisations et contributions . assiette sociale':
-						'30000 €/an',
+						'60000 €/an',
 				})
 
-				expect(e2).toBeApplicable(
-					'indépendant . conjoint collaborateur . cotisations . exonération Acre'
+				expect(e2).toEvaluate(
+					`${COTISATIONS} . indemnités journalières`,
+					IJ - Math.round(IJ / 4)
 				)
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
-					cotisations - (IJ + RB + ID)
+					`${COTISATIONS} . retraite de base`,
+					RB - Math.round(RB / 4)
+				)
+				expect(e2).toEvaluate(
+					`${COTISATIONS} . invalidité et décès`,
+					ID - Math.round(ID / 4) + 1
 				)
 			})
 
-			// TODO: mettre à jour une fois le calcul de l'Acre corrigé
-			it.skip('applique l’Acre sur la cotisation IJ même en cas de revenus supérieurs au plafond d’exonération', () => {
+			it('applique l’Acre sur la cotisation IJ même en cas de revenus supérieurs au plafond d’exonération', () => {
 				const e1 = engine.setSituation({
 					...defaultSituation,
 					...situationRevenuAvecPartage,
 					'indépendant . cotisations et contributions . assiette sociale':
-						'50000 €/an',
+						'100000 €/an',
 				})
 
-				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
-				).nodeValue as number
-				const IJ = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations . indemnités journalières'
-				).nodeValue as number
+				const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+					.nodeValue as number
+				const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+					.nodeValue as number
+				const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+					.nodeValue as number
 
 				const e2 = engine.setSituation({
 					...defaultSituation,
 					...situationAcre,
 					...situationRevenuAvecPartage,
 					'indépendant . cotisations et contributions . assiette sociale':
-						'50000 €/an',
+						'100000 €/an',
 				})
 
-				expect(e2).toBeApplicable(
-					'indépendant . conjoint collaborateur . cotisations . exonération Acre'
-				)
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
-					cotisations - IJ
+					`${COTISATIONS} . indemnités journalières`,
+					IJ - Math.round(IJ / 4)
+				)
+				expect(e2).toEvaluate(`${COTISATIONS} . retraite de base`, RB)
+				expect(e2).toEvaluate(`${COTISATIONS} . invalidité et décès`, ID)
+			})
+
+			it('n’applique pas l’Acre si le/la dirigeant⋅e n’en bénéficie pas', () => {
+				const e1 = engine.setSituation({
+					...defaultSituation,
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'60000 €/an',
+				})
+
+				const cotisations = e1.evaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
+				).nodeValue as number
+
+				const e2 = engine.setSituation({
+					...defaultSituation,
+					'entreprise . date de création': '01/01/2026',
+					'indépendant . cotisations et contributions . cotisations . exonérations . Acre':
+						'non',
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'60000 €/an',
+				})
+
+				expect(e2).toEvaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
+					cotisations
 				)
 			})
 
@@ -263,7 +289,7 @@ describe('Conjoint collaborateur', () => {
 						'30000 €/an',
 				})
 				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
 				).nodeValue as number
 
 				const e2 = engine.setSituation({
@@ -274,11 +300,8 @@ describe('Conjoint collaborateur', () => {
 						'30000 €/an',
 				})
 
-				expect(e2).not.toBeApplicable(
-					'indépendant . conjoint collaborateur . cotisations . exonération Acre'
-				)
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
 					cotisations
 				)
 			})
@@ -290,7 +313,7 @@ describe('Conjoint collaborateur', () => {
 						'30000 €/an',
 				})
 				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
 				).nodeValue as number
 
 				const e2 = engine.setSituation({
@@ -300,11 +323,8 @@ describe('Conjoint collaborateur', () => {
 						'30000 €/an',
 				})
 
-				expect(e2).not.toBeApplicable(
-					'indépendant . conjoint collaborateur . cotisations . exonération Acre'
-				)
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
 					cotisations
 				)
 			})
@@ -316,7 +336,7 @@ describe('Conjoint collaborateur', () => {
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
 				).nodeValue as number
 
 				const e2 = engine.setSituation({
@@ -330,7 +350,33 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
+					cotisations
+				)
+			})
+
+			it('n’applique pas l’exonération âge', () => {
+				const e1 = engine.setSituation({
+					...defaultSituation,
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
+						'100000 €/an',
+					'entreprise . date de création': '01/01/2006',
+				})
+				const cotisations = e1.evaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
+				).nodeValue as number
+
+				const e2 = engine.setSituation({
+					...defaultSituation,
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès':
+						'100000 €/an',
+					'indépendant . cotisations et contributions . cotisations . exonérations . âge':
+						'oui',
+					'entreprise . date de création': '01/01/2006',
+				})
+
+				expect(e2).toEvaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
 					cotisations
 				)
 			})
@@ -437,7 +483,7 @@ describe('Conjoint collaborateur', () => {
 				expect(assietteMinimale).toEqual(Math.round((40 / 100) * PASS))
 
 				expect(e).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations . indemnités journalières',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . indemnités journalières',
 					Math.round((assietteMinimale * 0.3) / 100)
 				)
 			})
@@ -454,7 +500,7 @@ describe('Conjoint collaborateur', () => {
 					// > pour les PLR
 					// > applique les taux des tranches 1 et 2 en cas d’assiette sociale comprise entre l’assiette minimale et 1 PASS
 					expect(e).toEvaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite de base',
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite de base',
 						Math.round((30_000 * 8.73) / 100 + (30_000 * 1.87) / 100)
 					)
 				})
@@ -472,7 +518,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite complémentaire'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 4)
@@ -493,7 +539,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite complémentaire'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 4)
@@ -514,7 +560,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite complémentaire'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 4)
@@ -535,7 +581,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite complémentaire'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 2)
@@ -556,7 +602,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite complémentaire'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . retraite complémentaire'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 2)
@@ -575,7 +621,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . invalidité et décès'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 4)
@@ -596,7 +642,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . invalidité et décès'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 4)
@@ -617,7 +663,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . invalidité et décès'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 4)
@@ -638,7 +684,7 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . invalidité et décès'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 2)
@@ -659,105 +705,157 @@ describe('Conjoint collaborateur', () => {
 						'indépendant . cotisations et contributions . cotisations . invalidité et décès'
 					).nodeValue as number
 					const cotisationConjoint = e.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
+						'indépendant . cotisations et contributions . cotisations . conjoint collaborateur . invalidité et décès'
 					).nodeValue
 
 					expect(cotisationConjoint).toEqual(cotisation / 2)
 				})
 			})
+		})
 
-			describe('exonérations', () => {
-				it('applique l’Acre en cas de revenus avec partage', () => {
-					const e1 = engine.setSituation({
-						...defaultSituationPLR,
-						...situationRevenuAvecPartage,
-						'indépendant . cotisations et contributions . assiette sociale':
-							'30000 €/an',
-					})
-
-					const cotisations = e1.evaluate(
-						'indépendant . conjoint collaborateur . cotisations'
-					).nodeValue as number
-					const IJ = e1.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . indemnités journalières'
-					).nodeValue as number
-					const RB = e1.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . retraite de base'
-					).nodeValue as number
-					const ID = e1.evaluate(
-						'indépendant . conjoint collaborateur . cotisations . invalidité et décès'
-					).nodeValue as number
-
-					const e2 = engine.setSituation({
-						...defaultSituationPLR,
-						...situationAcre,
-						...situationRevenuAvecPartage,
-						'indépendant . cotisations et contributions . assiette sociale':
-							'30000 €/an',
-					})
-
-					expect(e2).toBeApplicable(
-						'indépendant . conjoint collaborateur . cotisations . exonération Acre'
-					)
-					expect(e2).toEvaluate(
-						'indépendant . conjoint collaborateur . cotisations',
-						cotisations - (IJ + RB + ID)
-					)
+		describe('exonérations', () => {
+			it('applique l’Acre en cas de revenus avec partage', () => {
+				const e1 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'60000 €/an',
 				})
 
-				it('n’applique pas l’Acre en cas de revenus sans partage', () => {
-					const e1 = engine.setSituation({
-						...defaultSituationPLR,
-						...situationRevenuSansPartage,
-						'indépendant . cotisations et contributions . assiette sociale':
-							'30000 €/an',
-					})
-					const cotisations = e1.evaluate(
-						'indépendant . conjoint collaborateur . cotisations'
-					).nodeValue as number
+				const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+					.nodeValue as number
+				const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+					.nodeValue as number
+				const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+					.nodeValue as number
 
-					const e2 = engine.setSituation({
-						...defaultSituationPLR,
-						...situationAcre,
-						...situationRevenuSansPartage,
-						'indépendant . cotisations et contributions . assiette sociale':
-							'30000 €/an',
-					})
-
-					expect(e2).not.toBeApplicable(
-						'indépendant . conjoint collaborateur . cotisations . exonération Acre'
-					)
-					expect(e2).toEvaluate(
-						'indépendant . conjoint collaborateur . cotisations',
-						cotisations
-					)
+				const e2 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationAcre,
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'60000 €/an',
 				})
 
-				it('n’applique pas l’Acre en cas d’assiette forfaitaire', () => {
-					const e1 = engine.setSituation({
-						...defaultSituationPLR,
-						'indépendant . cotisations et contributions . assiette sociale':
-							'30000 €/an',
-					})
-					const cotisations = e1.evaluate(
-						'indépendant . conjoint collaborateur . cotisations'
-					).nodeValue as number
+				expect(e2).toEvaluate(
+					`${COTISATIONS} . indemnités journalières`,
+					IJ - Math.round(IJ / 4)
+				)
+				expect(e2).toEvaluate(
+					`${COTISATIONS} . retraite de base`,
+					RB - Math.round(RB / 4)
+				)
+				expect(e2).toEvaluate(
+					`${COTISATIONS} . invalidité et décès`,
+					ID - ID / 4
+				)
+			})
 
-					const e2 = engine.setSituation({
-						...defaultSituationPLR,
-						...situationAcre,
-						'indépendant . cotisations et contributions . assiette sociale':
-							'30000 €/an',
-					})
-
-					expect(e2).not.toBeApplicable(
-						'indépendant . conjoint collaborateur . cotisations . exonération Acre'
-					)
-					expect(e2).toEvaluate(
-						'indépendant . conjoint collaborateur . cotisations',
-						cotisations
-					)
+			it('applique l’Acre sur la cotisation IJ même en cas de revenus supérieurs au plafond d’exonération', () => {
+				const e1 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'100000 €/an',
 				})
+
+				const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+					.nodeValue as number
+				const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+					.nodeValue as number
+				const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+					.nodeValue as number
+
+				const e2 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationAcre,
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'100000 €/an',
+				})
+
+				expect(e2).toEvaluate(
+					`${COTISATIONS} . indemnités journalières`,
+					IJ - Math.round(IJ / 4)
+				)
+				expect(e2).toEvaluate(`${COTISATIONS} . retraite de base`, RB)
+				expect(e2).toEvaluate(`${COTISATIONS} . invalidité et décès`, ID)
+			})
+
+			it('n’applique pas l’Acre si le/la dirigeant⋅e n’en bénéficie pas', () => {
+				const e1 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'60000 €/an',
+				})
+
+				const cotisations = e1.evaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
+				).nodeValue as number
+
+				const e2 = engine.setSituation({
+					...defaultSituationPLR,
+					'entreprise . date de création': '01/01/2026',
+					'indépendant . cotisations et contributions . cotisations . exonérations . Acre':
+						'non',
+					...situationRevenuAvecPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'60000 €/an',
+				})
+
+				expect(e2).toEvaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
+					cotisations
+				)
+			})
+
+			it('n’applique pas l’Acre en cas de revenus sans partage', () => {
+				const e1 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationRevenuSansPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'30000 €/an',
+				})
+				const cotisations = e1.evaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
+				).nodeValue as number
+
+				const e2 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationAcre,
+					...situationRevenuSansPartage,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'30000 €/an',
+				})
+
+				expect(e2).toEvaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
+					cotisations
+				)
+			})
+
+			it('n’applique pas l’Acre en cas d’assiette forfaitaire', () => {
+				const e1 = engine.setSituation({
+					...defaultSituationPLR,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'30000 €/an',
+				})
+				const cotisations = e1.evaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
+				).nodeValue as number
+
+				const e2 = engine.setSituation({
+					...defaultSituationPLR,
+					...situationAcre,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'30000 €/an',
+				})
+
+				expect(e2).toEvaluate(
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
+					cotisations
+				)
 			})
 
 			it('n’applique pas l’exonération invalidité', () => {
@@ -767,7 +865,7 @@ describe('Conjoint collaborateur', () => {
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
 				).nodeValue as number
 
 				const e2 = engine.setSituation({
@@ -781,7 +879,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
 					cotisations
 				)
 			})
@@ -793,7 +891,7 @@ describe('Conjoint collaborateur', () => {
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
 				).nodeValue as number
 
 				const e2 = engine.setSituation({
@@ -805,7 +903,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
 					cotisations
 				)
 			})
@@ -817,7 +915,7 @@ describe('Conjoint collaborateur', () => {
 						'100000 €/an',
 				})
 				const cotisations = e1.evaluate(
-					'indépendant . conjoint collaborateur . cotisations'
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur'
 				).nodeValue as number
 
 				const e2 = engine.setSituation({
@@ -829,7 +927,7 @@ describe('Conjoint collaborateur', () => {
 				})
 
 				expect(e2).toEvaluate(
-					'indépendant . conjoint collaborateur . cotisations',
+					'indépendant . cotisations et contributions . cotisations . conjoint collaborateur',
 					cotisations
 				)
 			})

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/début-activité.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/début-activité.test.ts
@@ -13,10 +13,8 @@ describe('Cotisations de début d’activité', () => {
 	let PASS: number
 	beforeEach(() => {
 		engine = new Engine(rules)
-		PASS = engine.evaluate({
-			valeur: 'plafond sécurité sociale',
-			unité: '€/an',
-		}).nodeValue as number
+		PASS = engine.evaluate('plafond sécurité sociale . annuel')
+			.nodeValue as number
 	})
 
 	describe('Pour les A/C/PLNR', () => {

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/invalidité-décès.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/invalidité-décès.test.ts
@@ -11,10 +11,8 @@ describe('Cotisation invalidité et décès', () => {
 	let PASS: number
 	beforeEach(() => {
 		engine = new Engine(rules)
-		PASS = engine.evaluate({
-			valeur: 'plafond sécurité sociale',
-			unité: '€/an',
-		}).nodeValue as number
+		PASS = engine.evaluate('plafond sécurité sociale . annuel')
+			.nodeValue as number
 	})
 
 	describe('pour les artisans, commerçants et PLNR', () => {
@@ -109,7 +107,6 @@ describe('Cotisation invalidité et décès', () => {
 			})
 		})
 
-		// Exemples issus de la doc Urssaf
 		describe('en cas d’année incomplète', () => {
 			it('applique une assiette minimale proratisée', () => {
 				const e = engine.setSituation({

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-base.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-base.test.ts
@@ -11,10 +11,8 @@ describe('Cotisation retraite de base', () => {
 	let PASS: number
 	beforeEach(() => {
 		engine = new Engine(rules)
-		PASS = engine.evaluate({
-			valeur: 'plafond sécurité sociale',
-			unité: '€/an',
-		}).nodeValue as number
+		PASS = engine.evaluate('plafond sécurité sociale . annuel')
+			.nodeValue as number
 	})
 
 	describe('pour les artisans, commerçants et PLNR', () => {

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-complémentaire.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-complémentaire.test.ts
@@ -11,10 +11,8 @@ describe('Cotisation retraite complémentaire', () => {
 	let PASS: number
 	beforeEach(() => {
 		engine = new Engine(rules)
-		PASS = engine.evaluate({
-			valeur: 'plafond sécurité sociale',
-			unité: '€/an',
-		}).nodeValue as number
+		PASS = engine.evaluate('plafond sécurité sociale . annuel')
+			.nodeValue as number
 	})
 
 	describe('pour les artisans, commerçants et PLNR', () => {

--- a/site/test/modele-ti/cotisations-et-contributions/exonérations/Acre.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/exonérations/Acre.test.ts
@@ -2,278 +2,360 @@ import rules from 'modele-ti'
 import Engine from 'publicodes'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+const COTISATIONS = 'indépendant . cotisations et contributions . cotisations'
+
 const defaultSituation = {
-	'plafond sécurité sociale': '47100 €/an',
 	'entreprise . imposition': "'IR'",
-	'entreprise . date de création': '18/02/2026',
+	'entreprise . date de création': '01/01/2026',
+}
+const defaultSituationAcre = {
+	...defaultSituation,
 	'indépendant . cotisations et contributions . cotisations . exonérations . Acre':
 		'oui',
-	'indépendant . cotisations et contributions . assiette sociale': '30000 €/an',
 }
 
-// TODO: mettre à jour une fois le calcul de l'Acre corrigé
-describe.skip('L’exonération Acre', () => {
+describe('L’exonération Acre', () => {
 	let engine: Engine
 	beforeEach(() => {
 		engine = new Engine(rules)
 	})
 
-	it('est complète lorsque l’assiette sociale est inférieure à 75% du PASS', () => {
-		const e = engine.setSituation(defaultSituation)
-
-		expect(e).toEvaluate(
-			'indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux',
-			100
-		)
-	})
-
-	it('est partielle lorsque l’assiette sociale est comprise entre 75% du PASS et le PASS', () => {
-		const e = engine.setSituation({
+	describe('avant 2026', () => {
+		const defaultSituationAvant2026 = {
 			...defaultSituation,
-			'indépendant . cotisations et contributions . assiette sociale':
-				'40000 €/an',
-		})
-		const taux = Math.round(
-			e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux'
-			).nodeValue as number
-		)
-
-		expect(taux).toBeLessThan(100)
-		expect(taux).toBeGreaterThan(0)
-	})
-
-	it('est nulle lorsque l’assiette sociale est supérieure au PASS', () => {
-		const e = engine.setSituation({
-			...defaultSituation,
-			'indépendant . cotisations et contributions . assiette sociale':
-				'50000 €/an',
-		})
-
-		expect(e).toEvaluate(
-			'indépendant . cotisations et contributions . cotisations . exonérations . Acre . taux',
-			0
-		)
-	})
-
-	it('est proratisée en fonction de la durée d’application sur l’année en cours', () => {
-		const e = engine.setSituation({
-			...defaultSituation,
-			'entreprise . date de création': '18/02/2025',
-		})
-
-		const prorata = e.evaluate(
-			"indépendant . cotisations et contributions . cotisations . exonérations . Acre . prorata sur l'année"
-		).nodeValue as number
-
-		expect(e).toEvaluate(
-			'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération',
-			Math.round(prorata)
-		)
-	})
-
-	describe('pour les A/C/PLNR', () => {
-		it('s’applique à la cotisation maladie-maternité', () => {
-			const e = engine.setSituation(defaultSituation)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation indemnités journalières', () => {
-			const e = engine.setSituation(defaultSituation)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation allocations familiales', () => {
-			const e = engine.setSituation(defaultSituation)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . allocations familiales',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation retraite de base', () => {
-			const e = engine.setSituation(defaultSituation)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation invalidité et décès', () => {
-			const e = engine.setSituation(defaultSituation)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . invalidité et décès',
-				0
-			)
-		})
-	})
-
-	describe('pour les PLR Cipav', () => {
-		const defaultSituationCipav = {
-			...defaultSituation,
-			'entreprise . activité': "'libérale'",
-			'entreprise . activité . libérale . réglementée': 'oui',
+			date: '01/01/2025',
+			'entreprise . date de création': '01/01/2025',
 		}
-		it('s’applique à la cotisation maladie-maternité', () => {
-			const e = engine.setSituation(defaultSituationCipav)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation indemnités journalières', () => {
-			const e = engine.setSituation(defaultSituationCipav)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation allocations familiales', () => {
-			const e = engine.setSituation(defaultSituationCipav)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . allocations familiales',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation retraite de base', () => {
-			const e = engine.setSituation(defaultSituationCipav)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation invalidité et décès', () => {
-			const e = engine.setSituation(defaultSituationCipav)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . invalidité et décès',
-				0
-			)
-		})
-	})
-
-	describe('pour les PLR non Cipav', () => {
-		const defaultSituationPLR = {
-			...defaultSituation,
-			'entreprise . activité': "'libérale'",
-			'entreprise . activité . libérale . réglementée': 'oui',
-			'indépendant . profession libérale . réglementée . métier':
-				"'expert-comptable'",
+		const defaultSituationAvecAcreAvant2026 = {
+			...defaultSituationAcre,
+			date: '01/01/2025',
+			'entreprise . date de création': '01/01/2025',
 		}
 
-		it('s’applique à la cotisation maladie-maternité', () => {
-			const e = engine.setSituation(defaultSituationPLR)
+		it('est totale lorsque l’assiette sociale est inférieure à 75% du PASS', () => {
+			const e = engine.setSituation({
+				...defaultSituationAvecAcreAvant2026,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
 
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité',
-				0
-			)
+			expect(e).toEvaluate(`${COTISATIONS} . maladie-maternité`, 0)
+			expect(e).toEvaluate(`${COTISATIONS} . indemnités journalières`, 0)
+			expect(e).toEvaluate(`${COTISATIONS} . allocations familiales`, 0)
+			expect(e).toEvaluate(`${COTISATIONS} . retraite de base`, 0)
+			expect(e).toEvaluate(`${COTISATIONS} . invalidité et décès`, 0)
 		})
 
-		it('s’applique à la cotisation indemnités journalières', () => {
-			const e = engine.setSituation(defaultSituationPLR)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation allocations familiales', () => {
-			const e = engine.setSituation(defaultSituationPLR)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . allocations familiales',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation retraite de base', () => {
-			const e = engine.setSituation(defaultSituationPLR)
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base',
-				0
-			)
-		})
-
-		it('s’applique à la cotisation retraite de base après la participation CPAM pour les médecins', () => {
+		it('est partielle lorsque l’assiette sociale est comprise entre 75% du PASS et le PASS', () => {
 			const e1 = engine.setSituation({
-				'plafond sécurité sociale': '47100 €/an',
-				'entreprise . imposition': "'IR'",
+				...defaultSituationAvant2026,
 				'indépendant . cotisations et contributions . assiette sociale':
 					'40000 €/an',
-				'entreprise . activité': "'libérale'",
-				'entreprise . activité . libérale . réglementée': 'oui',
 			})
-			const retraitePLR = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
-			).nodeValue as number
+
+			const AM = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF = e1.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
+
+			const PASS = engine
+				.setSituation({ date: '01/01/2025' })
+				.evaluate('plafond sécurité sociale . annuel').nodeValue as number
+			const TroisQuartDuPASS = Math.round(0.75 * PASS)
 
 			const e2 = engine.setSituation({
-				'plafond sécurité sociale': '47100 €/an',
-				'entreprise . imposition': "'IR'",
-				'indépendant . cotisations et contributions . assiette sociale':
-					'40000 €/an',
-				'entreprise . activité': "'libérale'",
-				'entreprise . activité . libérale . réglementée': 'oui',
-				'indépendant . profession libérale . réglementée . métier':
-					"'santé . médecin'",
+				...defaultSituationAvant2026,
+				'indépendant . cotisations et contributions . assiette sociale': `${TroisQuartDuPASS} €/an`,
 			})
-			const retraiteMédecin = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
-			).nodeValue as number
 
-			expect(retraiteMédecin).toBeLessThan(retraitePLR)
+			const AM75Pass = e2.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ75Pass = e2.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF75Pass = e2.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB75Pass = e2.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID75Pass = e2.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
 
 			const e3 = engine.setSituation({
-				'plafond sécurité sociale': '47100 €/an',
-				'entreprise . imposition': "'IR'",
+				...defaultSituationAvecAcreAvant2026,
 				'indépendant . cotisations et contributions . assiette sociale':
 					'40000 €/an',
-				'entreprise . activité': "'libérale'",
-				'entreprise . activité . libérale . réglementée': 'oui',
-				'indépendant . profession libérale . réglementée . métier':
-					"'santé . médecin'",
-				'entreprise . date de création': '18/02/2025',
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre':
-					'oui',
 			})
-			const exonération = e3.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
 
 			expect(e3).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base',
-				Math.round(retraiteMédecin * (1 - exonération / 100))
+				`${COTISATIONS} . maladie-maternité`,
+				AM - Math.round(((PASS - 40_000) * AM75Pass) / (0.25 * PASS))
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . indemnités journalières`,
+				IJ - Math.round(((PASS - 40_000) * IJ75Pass) / (0.25 * PASS)) + 1
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . allocations familiales`,
+				AF - Math.round(((PASS - 40_000) * AF75Pass) / (0.25 * PASS))
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . retraite de base`,
+				RB - Math.round(((PASS - 40_000) * RB75Pass) / (0.25 * PASS)) + 1
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . invalidité et décès`,
+				ID - Math.round(((PASS - 40_000) * ID75Pass) / (0.25 * PASS))
 			)
 		})
 
-		it('s’applique à la cotisation invalidité et décès', () => {
-			const e = engine.setSituation(defaultSituationPLR)
+		it('est nulle lorsque l’assiette sociale est supérieure au PASS', () => {
+			const e1 = engine.setSituation({
+				...defaultSituationAvant2026,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'50000 €/an',
+			})
+			const cotisations = e1.evaluate(COTISATIONS).nodeValue
 
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . invalidité et décès',
-				0
+			const e2 = engine.setSituation({
+				...defaultSituationAvecAcreAvant2026,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'50000 €/an',
+			})
+
+			expect(e2).toEvaluate(COTISATIONS, cotisations)
+		})
+
+		it('est proratisée en fonction de la durée d’application sur l’année en cours', () => {
+			const e1 = engine.setSituation({
+				...defaultSituationAvant2026,
+				'entreprise . date de création': '18/02/2024',
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
+
+			const AM = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF = e1.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
+
+			const e2 = engine.setSituation({
+				...defaultSituationAvecAcreAvant2026,
+				'entreprise . date de création': '18/02/2024', // = 47 jours d'Acre restant en 2025
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
+
+			// Avant prorata, l'exonération totale car assiette sociale < 75% du PASS proratisé
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . maladie-maternité`,
+				AM - Math.round((AM * 47) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . indemnités journalières`,
+				IJ - Math.round((IJ * 47) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . allocations familiales`,
+				AF - Math.round((AF * 47) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . retraite de base`,
+				RB - Math.round((RB * 47) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . invalidité et décès`,
+				ID - Math.round((ID * 47) / 365)
+			)
+		})
+	})
+
+	describe('après 2026', () => {
+		it('est égale au quart des cotisations exonérées lorsque l’assiette sociale est inférieure à 75% du PASS', () => {
+			const e1 = engine.setSituation({
+				...defaultSituation,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
+
+			const AM = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF = e1.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
+
+			const e2 = engine.setSituation({
+				...defaultSituationAcre,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
+
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . maladie-maternité`,
+				AM - Math.round(AM / 4)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . indemnités journalières`,
+				IJ - Math.round(IJ / 4) + 1
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . allocations familiales`,
+				AF - Math.round(AF / 4)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . retraite de base`,
+				RB - Math.round(RB / 4)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . invalidité et décès`,
+				ID - Math.round(ID / 4) + 1
+			)
+		})
+
+		it('est dégressive lorsque l’assiette sociale est comprise entre 75% du PASS et le PASS', () => {
+			const e1 = engine.setSituation({
+				...defaultSituation,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'40000 €/an',
+			})
+
+			const AM = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF = e1.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
+
+			const PASS = engine.evaluate('plafond sécurité sociale . annuel')
+				.nodeValue as number
+			const TroisQuartDuPASS = Math.round(0.75 * PASS)
+
+			const e2 = engine.setSituation({
+				...defaultSituation,
+				'indépendant . cotisations et contributions . assiette sociale': `${TroisQuartDuPASS} €/an`,
+			})
+
+			const AM75Pass = e2.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ75Pass = e2.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF75Pass = e2.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB75Pass = e2.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID75Pass = e2.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
+
+			const e3 = engine.setSituation({
+				...defaultSituationAcre,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'40000 €/an',
+			})
+
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . maladie-maternité`,
+				AM - Math.round(((PASS - 40_000) * AM75Pass) / PASS)
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . indemnités journalières`,
+				IJ - Math.round(((PASS - 40_000) * IJ75Pass) / PASS)
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . allocations familiales`,
+				AF - Math.round(((PASS - 40_000) * AF75Pass) / PASS)
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . retraite de base`,
+				RB - Math.round(((PASS - 40_000) * RB75Pass) / PASS)
+			)
+			expect(e3).toEvaluate(
+				`${COTISATIONS} . invalidité et décès`,
+				ID - Math.round(((PASS - 40_000) * ID75Pass) / PASS)
+			)
+		})
+
+		it('est nulle lorsque l’assiette sociale est supérieure au PASS', () => {
+			const e1 = engine.setSituation({
+				...defaultSituation,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'50000 €/an',
+			})
+			const cotisations = e1.evaluate(COTISATIONS).nodeValue
+
+			const e2 = engine.setSituation({
+				...defaultSituationAcre,
+				'indépendant . cotisations et contributions . assiette sociale':
+					'50000 €/an',
+			})
+
+			expect(e2).toEvaluate(COTISATIONS, cotisations)
+		})
+
+		it('est proratisée en fonction de la durée d’application sur l’année en cours', () => {
+			const e1 = engine.setSituation({
+				...defaultSituation,
+				'entreprise . date de création': '18/02/2025',
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
+
+			const AM = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
+			const IJ = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
+			const AF = e1.evaluate(`${COTISATIONS} . allocations familiales`)
+				.nodeValue as number
+			const RB = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
+			const ID = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
+
+			const e2 = engine.setSituation({
+				...defaultSituationAcre,
+				'entreprise . date de création': '18/02/2025', // = 48 jours d'Acre restant en 2026
+				'indépendant . cotisations et contributions . assiette sociale':
+					'30000 €/an',
+			})
+
+			// Aant prorata, l'exonération est maximale (25%) car assiette sociale < 75% du PASS proratisé
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . maladie-maternité`,
+				AM - Math.round(((AM / 4) * 48) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . indemnités journalières`,
+				IJ - Math.round(((IJ / 4) * 48) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . allocations familiales`,
+				AF - Math.round(((AF / 4) * 48) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . retraite de base`,
+				RB - Math.round(((RB / 4) * 48) / 365)
+			)
+			expect(e2).toEvaluate(
+				`${COTISATIONS} . invalidité et décès`,
+				ID - Math.round(((ID / 4) * 48) / 365)
 			)
 		})
 	})

--- a/site/test/modele-ti/cotisations-et-contributions/exonérations/exonérations.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/exonérations/exonérations.test.ts
@@ -2,6 +2,8 @@ import rules from 'modele-ti'
 import Engine from 'publicodes'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+const COTISATIONS = 'indépendant . cotisations et contributions . cotisations'
+
 const defaultSituation = {
 	'plafond sécurité sociale': '47100 €/an',
 	'entreprise . imposition': "'IR'",
@@ -19,7 +21,7 @@ const defaultSituationAvecExonérations = {
 }
 
 // TODO: mettre à jour une fois le calcul de l'Acre corrigé
-describe.skip('L’exonération appliquée', () => {
+describe('L’exonération appliquée', () => {
 	let engine: Engine
 	beforeEach(() => {
 		engine = new Engine(rules)
@@ -28,119 +30,87 @@ describe.skip('L’exonération appliquée', () => {
 	describe('à la cotisation maladie-maternité', () => {
 		it('est l’Acre lorsqu’elle est plus avantageuse que l’exonération invalidité', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'1 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . montant maladie-maternité':
+					'100 €/an',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . montant maladie-maternité':
+					'200 €/an',
 			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
+				`${COTISATIONS} . maladie-maternité`
 			).nodeValue
 
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
-
-			expect(acre).toBeGreaterThan(invalidité)
-
-			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - acre / 100))
-			)
+			expect(cotisationExonérée).toEqual(cotisation - 200)
 		})
 
 		it('est l’exonération invalidité lorsqu’elle est plus avantageuse que l’Acre', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . maladie-maternité`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'11 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . montant maladie-maternité':
+					'200 €/an',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . montant maladie-maternité':
+					'100 €/an',
 			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
+				`${COTISATIONS} . maladie-maternité`
 			).nodeValue
 
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
-
-			expect(invalidité).toBeGreaterThan(acre)
-
-			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - invalidité / 100))
-			)
+			expect(cotisationExonérée).toEqual(cotisation - 200)
 		})
 	})
 
 	describe('à la cotisation indemnités journalières', () => {
 		it('est l’Acre lorsqu’elle est plus avantageuse que l’exonération invalidité', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'1 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux indemnités journalières':
+					'10 %',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux indemnités journalières':
+					'20 %',
 			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
+				`${COTISATIONS} . indemnités journalières`
 			).nodeValue
 
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
-
-			expect(acre).toBeGreaterThan(invalidité)
-
 			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - acre / 100))
+				cotisation - Math.round(0.2 * cotisation)
 			)
 		})
 
 		it('est l’exonération invalidité lorsqu’elle est plus avantageuse que l’Acre', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . indemnités journalières`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'11 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux indemnités journalières':
+					'20 %',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux indemnités journalières':
+					'10 %',
 			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
+				`${COTISATIONS} . indemnités journalières`
 			).nodeValue
 
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
-
-			expect(invalidité).toBeGreaterThan(acre)
-
 			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - invalidité / 100))
+				cotisation - Math.round(0.2 * cotisation)
 			)
 		})
 	})
@@ -148,151 +118,128 @@ describe.skip('L’exonération appliquée', () => {
 	describe('à la cotisation retraite de base', () => {
 		it('est l’Acre lorsqu’elle est plus avantageuse que l’exonération invalidité', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'1 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux retraite de base':
+					'10 %',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux retraite de base et invalidité-décès':
+					'20 %',
 			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
+				`${COTISATIONS} . retraite de base`
 			).nodeValue
 
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
-
-			expect(acre).toBeGreaterThan(invalidité)
-
 			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - acre / 100))
+				cotisation - Math.round(0.2 * cotisation)
 			)
 		})
 
 		it('est l’exonération invalidité lorsqu’elle est plus avantageuse que l’Acre', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . retraite de base`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'11 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux retraite de base':
+					'20 %',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux retraite de base et invalidité-décès':
+					'10 %',
 			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
+				`${COTISATIONS} . retraite de base`
 			).nodeValue
 
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
-
-			expect(invalidité).toBeGreaterThan(acre)
-
 			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - invalidité / 100))
+				cotisation - Math.round(0.2 * cotisation)
 			)
 		})
 
 		it('est l’exonération incapacité lorsqu’elle est présente', () => {
 			const e = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'11 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux retraite de base':
+					'10 %',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux retraite de base et invalidité-décès':
+					'20 %',
 				'indépendant . profession libérale . CNAVPL . exonération incapacité':
 					'oui',
 			})
 
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base',
-				0
-			)
+			expect(e).toEvaluate(`${COTISATIONS} . retraite de base`, 0)
 		})
 	})
 
 	describe('à la cotisation retraite complémentaire', () => {
 		it('est l’exonération invalidité lorsqu’il n’y a pas d’exonération incapacité', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . retraite complémentaire`)
+				.nodeValue as number
 
 			const e2 = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'11 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux retraite complémentaire':
+					'20 %',
 			})
-			const invalidité = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération'
-			).nodeValue as number
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
+				`${COTISATIONS} . retraite complémentaire`
 			).nodeValue
 
 			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - invalidité / 100))
+				cotisation - Math.round(0.2 * cotisation)
 			)
 		})
 
 		it('est l’exonération incapacité lorsqu’elle est présente', () => {
 			const e = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'1 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . exonération . taux retraite complémentaire':
+					'20 %',
 				'indépendant . profession libérale . CNAVPL . exonération incapacité':
 					'oui',
 			})
 
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite complémentaire',
-				0
-			)
+			expect(e).toEvaluate(`${COTISATIONS} . retraite complémentaire`, 0)
 		})
 	})
 
 	describe('à la cotisation invalidité-décès', () => {
 		it('est l’Acre lorsqu’il n’y a pas d’exonération incapacité', () => {
 			const e1 = engine.setSituation(defaultSituation)
-			const cotisation = e1.evaluate(
-				'indépendant . cotisations et contributions . cotisations . invalidité et décès'
-			).nodeValue as number
+			const cotisation = e1.evaluate(`${COTISATIONS} . invalidité et décès`)
+				.nodeValue as number
 
-			const e2 = engine.setSituation(defaultSituationAvecExonérations)
-			const acre = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération'
-			).nodeValue as number
+			const e2 = engine.setSituation({
+				...defaultSituationAvecExonérations,
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux retraite de base et invalidité-décès':
+					'20 %',
+			})
+
 			const cotisationExonérée = e2.evaluate(
-				'indépendant . cotisations et contributions . cotisations . invalidité et décès'
+				`${COTISATIONS} . invalidité et décès`
 			).nodeValue
 
 			expect(cotisationExonérée).toEqual(
-				Math.round(cotisation * (1 - acre / 100))
+				cotisation - Math.round(0.2 * cotisation)
 			)
 		})
 
 		it('est l’exonération âge lorsqu’elle est présente', () => {
 			const e = engine.setSituation({
 				...defaultSituationAvecExonérations,
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-					'11 mois',
+				'indépendant . cotisations et contributions . cotisations . exonérations . Acre . exonération . taux retraite de base et invalidité-décès':
+					'20 %',
 				'indépendant . cotisations et contributions . cotisations . exonérations . âge':
 					'oui',
 			})
 
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . invalidité et décès',
-				0
-			)
+			expect(e).toEvaluate(`${COTISATIONS} . invalidité et décès`, 0)
 		})
 	})
 })

--- a/site/test/modele-ti/cotisations-et-contributions/exonérations/invalidité.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/exonérations/invalidité.test.ts
@@ -2,13 +2,16 @@ import rules from 'modele-ti'
 import Engine from 'publicodes'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+const COTISATIONS = 'indépendant . cotisations et contributions . cotisations'
+
 const defaultSituation = {
 	'entreprise . imposition': "'IR'",
 	'indépendant . cotisations et contributions . assiette sociale': '50000 €/an',
+}
+const defaultSituationInvalidité = {
+	...defaultSituation,
 	'indépendant . cotisations et contributions . cotisations . exonérations . invalidité':
 		'oui',
-	'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
-		'9 mois',
 }
 
 describe('L’exonération invalidité', () => {
@@ -17,69 +20,42 @@ describe('L’exonération invalidité', () => {
 		engine = new Engine(rules)
 	})
 
-	it('applique un taux égal au prorata de la durée d’invalidité', () => {
-		const e = engine.setSituation(defaultSituation)
+	it('s’applique aux cotisations maladie-maternité, indemnités journalières et retraite complémentaire pour les A/C/PLNR', () => {
+		const e1 = engine.setSituation(defaultSituation)
 
-		expect(e).toEvaluate(
-			"indépendant . cotisations et contributions . cotisations . exonérations . invalidité . prorata sur l'année",
-			75
+		expect(e1).not.toBeApplicable(
+			`${COTISATIONS} . exonérations . invalidité . exonération`
 		)
+
+		const retraiteDeBase = e1.evaluate(`${COTISATIONS} . retraite de base`)
+			.nodeValue as number
+
+		const e2 = engine.setSituation(defaultSituationInvalidité)
+
+		expect(e2).toEvaluate(`${COTISATIONS} . maladie-maternité`, 0)
+		expect(e2).toEvaluate(`${COTISATIONS} . indemnités journalières`, 0)
+		expect(e2).toEvaluate(`${COTISATIONS} . retraite de base`, retraiteDeBase)
+		expect(e2).toEvaluate(`${COTISATIONS} . retraite complémentaire`, 0)
 	})
 
-	describe('pour les A/C/PLNR', () => {
-		it('s’applique aux cotisations maladie-maternité, indemnités journalières et retraite complémentaire', () => {
-			const e = engine.setSituation(defaultSituation)
-			const maladie = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
-			).nodeValue as number
-			const IJ = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
-			).nodeValue as number
-			const retraiteComplémentaire = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
-			).nodeValue as number
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . montant',
-				Math.round(0.75 * (maladie + IJ + retraiteComplémentaire))
-			)
-		})
-	})
-
-	describe('pour les PLR Cipav', () => {
+	it('s’applique aux cotisations maladie-maternité, indemnités journalières, retraite de base et retraite complémentaire pour les PLR Cipav', () => {
 		const situationCipav = {
 			'entreprise . activité': "'libérale'",
 			'entreprise . activité . libérale . réglementée': 'oui',
 		}
 
-		it('s’applique aux cotisations maladie-maternité, indemnités journalières, retraite de base et retraite complémentaire', () => {
-			const e = engine.setSituation({
-				...defaultSituation,
-				...situationCipav,
-			})
-			const maladie = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
-			).nodeValue as number
-			const IJ = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
-			).nodeValue as number
-			const retraiteDeBase = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite de base'
-			).nodeValue as number
-			const retraiteComplémentaire = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . retraite complémentaire'
-			).nodeValue as number
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . montant',
-				Math.round(
-					0.75 * (maladie + IJ + retraiteDeBase + retraiteComplémentaire)
-				)
-			)
+		const e = engine.setSituation({
+			...defaultSituationInvalidité,
+			...situationCipav,
 		})
+
+		expect(e).toEvaluate(`${COTISATIONS} . maladie-maternité`, 0)
+		expect(e).toEvaluate(`${COTISATIONS} . indemnités journalières`, 0)
+		expect(e).toEvaluate(`${COTISATIONS} . retraite de base`, 0)
+		expect(e).toEvaluate(`${COTISATIONS} . retraite complémentaire`, 0)
 	})
 
-	describe('pour les PLR non Cipav', () => {
+	it('s’applique aux cotisations maladie-maternité et indemnités journalières pour les PLR non Cipav', () => {
 		const situationPLRNonCipav = {
 			'entreprise . activité': "'libérale'",
 			'entreprise . activité . libérale . réglementée': 'oui',
@@ -87,22 +63,41 @@ describe('L’exonération invalidité', () => {
 				"'expert-comptable'",
 		}
 
-		it('s’applique aux cotisations maladie-maternité et indemnités journalières', () => {
-			const e = engine.setSituation({
-				...defaultSituation,
-				...situationPLRNonCipav,
-			})
-			const maladie = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . maladie-maternité'
-			).nodeValue as number
-			const IJ = e.evaluate(
-				'indépendant . cotisations et contributions . cotisations . indemnités journalières'
-			).nodeValue as number
-
-			expect(e).toEvaluate(
-				'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . montant',
-				Math.round(0.75 * (maladie + IJ))
-			)
+		const e1 = engine.setSituation({
+			...defaultSituation,
+			...situationPLRNonCipav,
 		})
+
+		const retraiteDeBase = e1.evaluate(`${COTISATIONS} . retraite de base`)
+			.nodeValue as number
+		const retraiteComplémentaire = e1.evaluate(
+			`${COTISATIONS} . retraite complémentaire`
+		).nodeValue as number
+
+		const e2 = engine.setSituation({
+			...defaultSituationInvalidité,
+			...situationPLRNonCipav,
+		})
+
+		expect(e2).toEvaluate(`${COTISATIONS} . maladie-maternité`, 0)
+		expect(e2).toEvaluate(`${COTISATIONS} . indemnités journalières`, 0)
+		expect(e2).toEvaluate(`${COTISATIONS} . retraite de base`, retraiteDeBase)
+		expect(e2).toEvaluate(
+			`${COTISATIONS} . retraite complémentaire`,
+			retraiteComplémentaire
+		)
+	})
+
+	it('est proratisée en fonction de la durée d’invalidité', () => {
+		const e = engine.setSituation({
+			...defaultSituationInvalidité,
+			'indépendant . cotisations et contributions . cotisations . exonérations . invalidité . durée':
+				'9 mois',
+		})
+
+		expect(e).toEvaluate(
+			`${COTISATIONS} . exonérations . invalidité . prorata sur l'année`,
+			75
+		)
 	})
 })

--- a/site/test/regressions/__snapshots__/indépendant.test.ts.snap
+++ b/site/test/regressions/__snapshots__/indépendant.test.ts.snap
@@ -91,7 +91,7 @@ exports[`calculate simulations-indépendant > acre 1`] = `
 entreprise . chiffre d'affaires: 72973
 impôt . montant: undefined
 indépendant . cotisations et contributions . cotisations: 17615
-indépendant . cotisations et contributions . début activité: 1746
+indépendant . cotisations et contributions . début activité: 3131
 indépendant . revenu professionnel: 51566
 indépendant . rémunération . brute: 72973
 indépendant . rémunération . nette: 50000
@@ -379,7 +379,7 @@ exports[`calculate simulations-indépendant > exonération invalidité 3`] = `
 entreprise . chiffre d'affaires: undefined
 impôt . montant: undefined
 indépendant . cotisations et contributions . cotisations: undefined
-indépendant . cotisations et contributions . début activité: 1746
+indépendant . cotisations et contributions . début activité: 2319
 indépendant . revenu professionnel: undefined
 indépendant . rémunération . brute: 10000
 indépendant . rémunération . nette: undefined

--- a/site/test/regressions/__snapshots__/professions-libérales.test.ts.snap
+++ b/site/test/regressions/__snapshots__/professions-libérales.test.ts.snap
@@ -1,35 +1,35 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`calculate simulations-professions-libérales > CIPAV Acre 1`] = `
-"entreprise . chiffre d'affaires: 6165
-indépendant . cotisations et contributions: 1165
-indépendant . cotisations et contributions . avec dividendes: 1165
+"entreprise . chiffre d'affaires: 6713
+indépendant . cotisations et contributions: 1713
+indépendant . cotisations et contributions . avec dividendes: 1713
 indépendant . cotisations et contributions . début activité: null
-indépendant . rémunération . brute: 6165
+indépendant . rémunération . brute: 6713
 indépendant . rémunération . impôt: 0
 indépendant . rémunération . impôt . avec dividendes: 0
 indépendant . rémunération . nette: 5000
 indépendant . rémunération . nette . après impôt: 5000
 indépendant . rémunération . nette . avec dividendes: 5000
 protection sociale . retraite . base: 3
-protection sociale . retraite . base . trimestres: 3
-protection sociale . retraite . complémentaire: 26"
+protection sociale . retraite . base . trimestres: 2
+protection sociale . retraite . complémentaire: 29"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV Acre 2`] = `
-"entreprise . chiffre d'affaires: 24133
-indépendant . cotisations et contributions: 4133
-indépendant . cotisations et contributions . avec dividendes: 4133
+"entreprise . chiffre d'affaires: 26068
+indépendant . cotisations et contributions: 6060
+indépendant . cotisations et contributions . avec dividendes: 6060
 indépendant . cotisations et contributions . début activité: null
-indépendant . rémunération . brute: 24133
-indépendant . rémunération . impôt: 552
-indépendant . rémunération . impôt . avec dividendes: 552
+indépendant . rémunération . brute: 26068
+indépendant . rémunération . impôt: 560
+indépendant . rémunération . impôt . avec dividendes: 560
 indépendant . rémunération . nette: 20000
-indépendant . rémunération . nette . après impôt: 19448
+indépendant . rémunération . nette . après impôt: 19440
 indépendant . rémunération . nette . avec dividendes: 20000
-protection sociale . retraite . base: 11
+protection sociale . retraite . base: 12
 protection sociale . retraite . base . trimestres: 4
-protection sociale . retraite . complémentaire: 99"
+protection sociale . retraite . complémentaire: 108"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV Acre 3`] = `
@@ -209,67 +209,67 @@ protection sociale . retraite . complémentaire: 511"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 2`] = `
-"entreprise . chiffre d'affaires: 97495
-indépendant . cotisations et contributions: 37496
-indépendant . cotisations et contributions . avec dividendes: 37496
+"entreprise . chiffre d'affaires: 94336
+indépendant . cotisations et contributions: 34336
+indépendant . cotisations et contributions . avec dividendes: 34336
 indépendant . cotisations et contributions . début activité: null
-indépendant . rémunération . brute: 97495
-indépendant . rémunération . impôt: 4959
-indépendant . rémunération . impôt . avec dividendes: 4959
+indépendant . rémunération . brute: 94336
+indépendant . rémunération . impôt: 4938
+indépendant . rémunération . impôt . avec dividendes: 4938
 indépendant . rémunération . nette: 60000
-indépendant . rémunération . nette . après impôt: 55041
+indépendant . rémunération . nette . après impôt: 55062
 indépendant . rémunération . nette . avec dividendes: 60000
 protection sociale . retraite . base: 31
 protection sociale . retraite . base . trimestres: 4
-protection sociale . retraite . complémentaire: 525"
+protection sociale . retraite . complémentaire: 501"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 3`] = `
-"entreprise . chiffre d'affaires: 94420
-indépendant . cotisations et contributions: 34420
-indépendant . cotisations et contributions . avec dividendes: 34420
+"entreprise . chiffre d'affaires: 93803
+indépendant . cotisations et contributions: 33803
+indépendant . cotisations et contributions . avec dividendes: 33803
 indépendant . cotisations et contributions . début activité: null
-indépendant . rémunération . brute: 94420
-indépendant . rémunération . impôt: 4939
-indépendant . rémunération . impôt . avec dividendes: 4939
+indépendant . rémunération . brute: 93803
+indépendant . rémunération . impôt: 4935
+indépendant . rémunération . impôt . avec dividendes: 4935
 indépendant . rémunération . nette: 60000
-indépendant . rémunération . nette . après impôt: 55061
+indépendant . rémunération . nette . après impôt: 55065
 indépendant . rémunération . nette . avec dividendes: 60000
-protection sociale . retraite . base: 45
+protection sociale . retraite . base: 41
 protection sociale . retraite . base . trimestres: 4
-protection sociale . retraite . complémentaire: 501"
+protection sociale . retraite . complémentaire: 496"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 4`] = `
-"entreprise . chiffre d'affaires: 97495
-indépendant . cotisations et contributions: 37496
-indépendant . cotisations et contributions . avec dividendes: 37496
+"entreprise . chiffre d'affaires: 94336
+indépendant . cotisations et contributions: 34336
+indépendant . cotisations et contributions . avec dividendes: 34336
 indépendant . cotisations et contributions . début activité: null
-indépendant . rémunération . brute: 97495
-indépendant . rémunération . impôt: 4959
-indépendant . rémunération . impôt . avec dividendes: 4959
+indépendant . rémunération . brute: 94336
+indépendant . rémunération . impôt: 4938
+indépendant . rémunération . impôt . avec dividendes: 4938
 indépendant . rémunération . nette: 60000
-indépendant . rémunération . nette . après impôt: 55041
+indépendant . rémunération . nette . après impôt: 55062
 indépendant . rémunération . nette . avec dividendes: 60000
 protection sociale . retraite . base: 31
 protection sociale . retraite . base . trimestres: 4
-protection sociale . retraite . complémentaire: 525"
+protection sociale . retraite . complémentaire: 501"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 5`] = `
-"entreprise . chiffre d'affaires: 94420
-indépendant . cotisations et contributions: 34420
-indépendant . cotisations et contributions . avec dividendes: 34420
+"entreprise . chiffre d'affaires: 93803
+indépendant . cotisations et contributions: 33803
+indépendant . cotisations et contributions . avec dividendes: 33803
 indépendant . cotisations et contributions . début activité: null
-indépendant . rémunération . brute: 94420
-indépendant . rémunération . impôt: 4939
-indépendant . rémunération . impôt . avec dividendes: 4939
+indépendant . rémunération . brute: 93803
+indépendant . rémunération . impôt: 4935
+indépendant . rémunération . impôt . avec dividendes: 4935
 indépendant . rémunération . nette: 60000
-indépendant . rémunération . nette . après impôt: 55061
+indépendant . rémunération . nette . après impôt: 55065
 indépendant . rémunération . nette . avec dividendes: 60000
-protection sociale . retraite . base: 45
+protection sociale . retraite . base: 41
 protection sociale . retraite . base . trimestres: 4
-protection sociale . retraite . complémentaire: 501"
+protection sociale . retraite . complémentaire: 496"
 `;
 
 exports[`calculate simulations-professions-libérales > CIPAV conjoint collaborateur 6`] = `
@@ -283,7 +283,7 @@ indépendant . rémunération . impôt . avec dividendes: 0
 indépendant . rémunération . nette: 1000
 indépendant . rémunération . nette . après impôt: 1000
 indépendant . rémunération . nette . avec dividendes: 1000
-protection sociale . retraite . base: 7
+protection sociale . retraite . base: 5
 protection sociale . retraite . base . trimestres: 3
 protection sociale . retraite . complémentaire: 12"
 `;


### PR DESCRIPTION
#4294 

- Les exonérations Acre et invalidité sont à nouveau calculées par cotisation (et pas au total)
- Pour la cotisation maladie-maternité, on utilise la formule officielle de l'Acre et on affiche les montants des exonérations
- Pour les autres cotisations, on affiche un taux d'exonération et on utilise une formule simplifiée pour l'Acre
- Les tests unitaires comparent le montant de l'exonération Acre avec le montant attendu selon la formule officielle (i.e. la formule simplifiée est correcte)