### PR TITLE
feat(comparateur): affiche la valeur du point dans la section retraite complémentaire

### DIFF
--- a/modele-social/règles/protection-sociale.publicodes
+++ b/modele-social/règles/protection-sociale.publicodes
@@ -262,6 +262,23 @@ protection sociale . retraite . complémentaire:
         - CIPAV
     - 10 ans
 
+protection sociale . retraite . complémentaire . valeur du point:
+  titre: Valeur de service du point
+  description: |
+    La valeur de service du point permet de convertir les points de retraite
+    complémentaire acquis en pension annuelle. Cette valeur est revalorisée
+    régulièrement par les caisses de retraite.
+  unité: €/an/point
+  variations:
+    - si: salarié
+      alors: AGIRC ARRCO . valeur du point
+    - si:
+        une de ces conditions:
+          - dirigeant . indépendant . PL . CIPAV
+          - dirigeant . auto-entrepreneur . Cipav
+      alors: CIPAV . valeur de service du point
+    - sinon: RCI . valeur du point
+
 protection sociale . retraite . complémentaire . AGIRC ARRCO:
   titre: Agirc-Arrco
   applicable si: salarié

--- a/site/source/locales/rules-en.yaml
+++ b/site/source/locales/rules-en.yaml
@@ -8694,6 +8694,20 @@ protection sociale . retraite . complémentaire . RCI:
       titre.fr: valeur du point
   titre.en: '[automatic] supplementary pension for the self-employed'
   titre.fr: retraite complémentaire des indépendants
+protection sociale . retraite . complémentaire . valeur du point:
+  description.en: >
+    [automatic] The service value of the point is used to convert acquired
+    supplementary retirement
+
+    points into an annual pension. This value is regularly
+
+    by the pension funds.
+  description.fr: |
+    La valeur de service du point permet de convertir les points de retraite
+    complémentaire acquis en pension annuelle. Cette valeur est revalorisée
+    régulièrement par les caisses de retraite.
+  titre.en: '[automatic] Point service value'
+  titre.fr: Valeur de service du point
 protection sociale . retraite . trimestres:
   avec:
     exonération invalidité indépendant:

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -1446,6 +1446,7 @@ pages:
               into a monthly pension, which is added to your basic pension.
             h4: Supplementary pension
             unit: point(s) acquired per year
+            valeur-du-point: "Point value : <2><0></0></2>"
           lien-assurance-retraite:
             aria-label: Access the Retirement Insurance simulator, new window
             message: To estimate the amount of your future retirement pension, use the

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -1531,6 +1531,7 @@ pages:
               base.
             h4: Retraite complémentaire
             unit: point(s) acquis par an
+            valeur-du-point: "Valeur du point : <2><0></0></2>"
           lien-assurance-retraite:
             aria-label: Accéder au simulateur de l'Assurance retraite, nouvelle fenêtre
             message: Pour estimer le montant de votre future pension de retraite, utilisez

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -337,6 +337,21 @@ const Détails = ({
 							'pages.simulateurs.comparaison-statuts.items.retraite.complémentaire.unit',
 							'point(s) acquis par an'
 						)}
+						footer={(engine) => (
+							<Body style={{ margin: 0 }}>
+								<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.retraite.complémentaire.valeur-du-point">
+									Valeur du point&nbsp;:{' '}
+									<Strong>
+										<Value
+											engine={engine}
+											expression="protection sociale . retraite . complémentaire . valeur du point"
+											displayedUnit="€ par an"
+											linkToRule={false}
+										/>
+									</Strong>
+								</Trans>
+							</Body>
+						)}
 					/>
 
 					<Message type="info" border={false}>


### PR DESCRIPTION
Ajoute une règle publicodes consolidée 'protection sociale . retraite . complémentaire . valeur du point' qui sélectionne la valeur selon le régime applicable (AGIRC-ARRCO, RCI ou CIPAV). Affiche cette valeur sous chaque carte du comparateur pour contextualiser les points acquis.