### PR TITLE
fix(comparateur): corrige l'unité du revenu cotisé retraite de base

### DIFF
--- a/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Détails.tsx
@@ -304,7 +304,8 @@ const Détails = ({
 						<DetailsRowCards
 							dottedName="protection sociale . retraite . base . cotisée"
 							namedEngines={namedEngines}
-							unit="€ cotisés par an"
+							unit="€/an"
+							displayedUnit="€ cotisés par an"
 						/>
 					</Condition>
 


### PR DESCRIPTION
L'unité "€ cotisés par an" n'est pas reconnue par publicodes, ce qui empêchait la conversion €/mois → €/an pour la SASU. Résultat : la valeur mensuelle était affichée comme annuelle.

Closes #4361