### PR TITLE
fix(SSR): corrige le FOUC causé par navigator global de Node 24

### DIFF
--- a/site/source/design-system/root.tsx
+++ b/site/source/design-system/root.tsx
@@ -18,8 +18,14 @@ type SystemRootProps = {
 	forceDarkMode?: boolean
 }
 
+const isBrowser = typeof document !== 'undefined'
+
+const getBrowserUserAgent = (): string | false =>
+	isBrowser && typeof navigator !== 'undefined' && navigator.userAgent
+
+const shouldDisableCSSOM = isbot(getBrowserUserAgent())
+
 const SystemRoot = ({ children, forceDarkMode }: SystemRootProps) => {
-	const userAgent = typeof navigator !== 'undefined' && navigator.userAgent
 	const [contextDarkMode] = useDarkMode()
 	const isInIframe = useIsEmbedded()
 
@@ -27,7 +33,7 @@ const SystemRoot = ({ children, forceDarkMode }: SystemRootProps) => {
 		typeof forceDarkMode === 'boolean' ? forceDarkMode : contextDarkMode
 
 	return (
-		<StyleSheetManager disableCSSOMInjection={isbot(userAgent)}>
+		<StyleSheetManager disableCSSOMInjection={shouldDisableCSSOM}>
 			<ThemeProvider theme={{ ...urssafTheme, darkMode, isInIframe }}>
 				<BackgroundStyle $darkMode={darkMode}>
 					<GlobalStyle />


### PR DESCRIPTION
Closes #4477 

Depuis le passage à Node 24, le site affiche un flash de contenu non stylé (FOUC) d'environ 1 seconde au chargement : le HTML pré-rendu apparaît sans aucun CSS, puis les styles s'appliquent à l'hydratation React.

En fait, Node 21+ expose `navigator` comme global avec `navigator.userAgent = 'Node.js/24'`. Dans `root.tsx`, le code détectait le user agent via `typeof navigator !== 'undefined' && navigator.userAgent`, ce qui retournait `false` sous Node 18 mais `'Node.js/24'` sous Node 24.

`isbot('Node.js/24')` retournait `true`, ce qui activait `disableCSSOMInjection={true}` pendant le SSR. Résultat : le tag `<style data-styled>` dans le HTML pré-rendu était vide.

J’ai modifié cette détection : On vérifie maintenant qu'on est dans un navigateur (via `document`) avant de lire `navigator.userAgent`. Pendant le SSR, `document` n'existe pas, donc `isbot()` reçoit `false` et `disableCSSOMInjection` reste désactivé.