### PR TITLE
ci: corrige la syntaxe invalide secrets: inherit dans workflow_call

### DIFF
--- a/.github/workflows/_build-and-deploy-prod.yaml
+++ b/.github/workflows/_build-and-deploy-prod.yaml
@@ -5,7 +5,6 @@ name: Build et déploiement production
 # (release, push master, schedule).
 on:
   workflow_call:
-    secrets: inherit
 
 permissions:
   contents: read


### PR DESCRIPTION
secrets: inherit n'est valide que dans l'appel d'un workflow réutilisable (côté caller), pas dans sa définition (côté workflow_call). Le retirer permet au workflow réutilisable d'accéder aux secrets du repo via le mécanisme par défaut quand il est appelé avec secrets: inherit.