### PR TITLE
ci: ajoute environment: master au job npm-publish pour OIDC

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -12,6 +12,7 @@ jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-22.04
+    environment: master
     strategy:
       matrix:
         package: ['modele-social', 'exoneration-covid']


### PR DESCRIPTION
Le Trusted Publisher npm de modele-social est configuré avec l'environment 'master'. Sans cette déclaration côté workflow, l'authentification OIDC échoue avec ENEEDAUTH.