### PR TITLE
fix(modele-social): corrige le calcul de l'IR auto-entrepreneur (#4105)

### DIFF
--- a/modele-social/règles/dirigeant/auto-entrepreneur/impôt.publicodes
+++ b/modele-social/règles/dirigeant/auto-entrepreneur/impôt.publicodes
@@ -1,9 +1,10 @@
 dirigeant . auto-entrepreneur . impôt: oui
 
-dirigeant . auto-entrepreneur . impôt . revenu imposable: entreprise . imposition . régime . micro-entreprise . revenu abattu
+dirigeant . auto-entrepreneur . impôt . revenu imposable:
+  non applicable si: versement libératoire
+  valeur: entreprise . imposition . régime . micro-entreprise . revenu abattu
 
 dirigeant . auto-entrepreneur . impôt . versement libératoire:
-  rend non applicable: revenu imposable
   description: |
     Avec l’option pour le versement libératoire, l’impôt sur le revenu est payé
     en même temps que vos cotisations (par mois ou par trimestre) avec


### PR DESCRIPTION
Le revenu imposable AE était évalué à une valeur erronée (divisée par 3 dans certains contextes, ex : CA 300k vente → IR 1 883 € au lieu de 19 470 €) à cause du `rend non applicable: revenu imposable` posé par `versement libératoire` : cet effet à distance perturbait la chaîne d'évaluation `dirigeant . rémunération . net . imposable → auto-entrepreneur . impôt . revenu imposable`.

On déplace la condition d'applicabilité localement sur `revenu imposable` (`non applicable si: versement libératoire`), ce qui élimine l'effet à distance tout en préservant la sémantique : le revenu imposable n'est pas calculé quand l'AE a opté pour le versement libératoire.

Closes #4105 