### PR TITLE
Fix/saisie sans effet sur simulation

### DIFF
--- a/site/source/domaine/Entreprise.ts
+++ b/site/source/domaine/Entreprise.ts
@@ -1,6 +1,7 @@
 import { CodeActivite } from '@/domaine/CodeActivite'
 import { CodeCatégorieJuridique } from '@/domaine/CodeCatégorieJuridique'
 import { Établissement } from '@/domaine/Établissement'
+import { DottedName } from '@/domaine/publicodes/DottedName'
 import { Siren } from '@/domaine/Siren'
 
 export interface Entreprise {
@@ -12,6 +13,18 @@ export interface Entreprise {
 	siège?: Établissement
 	établissement: Établissement
 }
+
+export const RÈGLES_IDENTITÉ_ENTREPRISE = [
+	'entreprise . date de création',
+	'entreprise . code catégorie juridique',
+	'entreprise . catégorie juridique',
+	'entreprise . SIREN',
+	'entreprise . nom',
+	'établissement . SIRET',
+] as const satisfies ReadonlyArray<DottedName>
+
+export type RègleIdentitéEntreprise =
+	(typeof RÈGLES_IDENTITÉ_ENTREPRISE)[number]
 
 const établissementEstLeSiège = (entreprise: Entreprise): boolean =>
 	!!entreprise.siège &&

--- a/site/source/hooks/useSetupSafeSituation.tsx
+++ b/site/source/hooks/useSetupSafeSituation.tsx
@@ -3,6 +3,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { setEngineSituation } from '@/domaine/engine/engineCache'
 import { NomModèle } from '@/domaine/SimulationConfig'
 import { supprimeLaRègleDeLaSituation } from '@/store/actions/actions'
+import { resetCompany } from '@/store/actions/companyActions'
+import { RÈGLES_IDENTITÉ_ENTREPRISE } from '@/store/reducers/companySituationReducer'
 import { companySituationSelector } from '@/store/selectors/company/companySituation.selector'
 import { completeSituationSelector } from '@/store/selectors/completeSituation.selector'
 import { configSituationSelector } from '@/store/selectors/simulation/config/configSituation.selector'
@@ -35,9 +37,13 @@ export const useSetupSafeSituation = (nomModèle?: NomModèle) => {
 					situationDuSimulateur: simulatorSituation,
 					situationDeLEntreprise: companySituation,
 					situationDeConfiguration: configSituation,
+					règlesIdentitéEntreprise: RÈGLES_IDENTITÉ_ENTREPRISE,
 				})
 
 				switch (action.kind) {
+					case 'réinitialiser-entreprise':
+						dispatch(resetCompany())
+						break
 					case 'omettre-et-marquer-obsolète':
 						dispatch(supprimeLaRègleDeLaSituation(action.règle))
 						dispatch(règleObsolèteDétectée(action.règle))

--- a/site/source/hooks/useSetupSafeSituation.tsx
+++ b/site/source/hooks/useSetupSafeSituation.tsx
@@ -8,6 +8,7 @@ import { completeSituationSelector } from '@/store/selectors/completeSituation.s
 import { configSituationSelector } from '@/store/selectors/simulation/config/configSituation.selector'
 import { situationSelector } from '@/store/selectors/simulation/situation/situation.selector'
 import { règleObsolèteDétectée } from '@/store/slices/simulationSource.slice'
+import { décideActionRègleInvalide } from '@/utils/publicodes/décideActionRègleInvalide'
 import { safeSetSituation } from '@/utils/publicodes/safeSetSituation'
 
 export const useSetupSafeSituation = (nomModèle?: NomModèle) => {
@@ -30,20 +31,24 @@ export const useSetupSafeSituation = (nomModèle?: NomModèle) => {
 					throw new Error('Bad empty faultyDottedName')
 				}
 
-				if (faultyDottedName in simulatorSituation) {
-					dispatch(supprimeLaRègleDeLaSituation(faultyDottedName))
-					dispatch(règleObsolèteDétectée(faultyDottedName))
-				} else {
-					const dottedName = JSON.stringify(faultyDottedName)
-					let errorMessage = `Bad unknow situation : ${dottedName}`
+				const action = décideActionRègleInvalide(faultyDottedName, {
+					situationDuSimulateur: simulatorSituation,
+					situationDeLEntreprise: companySituation,
+					situationDeConfiguration: configSituation,
+				})
 
-					if (faultyDottedName in configSituation) {
-						errorMessage = `Bad config situation : ${dottedName}`
-					} else if (faultyDottedName in companySituation) {
-						errorMessage = `Bad company situation : ${dottedName}`
-					}
-
-					throw new Error(errorMessage)
+				switch (action.kind) {
+					case 'omettre-et-marquer-obsolète':
+						dispatch(supprimeLaRègleDeLaSituation(action.règle))
+						dispatch(règleObsolèteDétectée(action.règle))
+						break
+					case 'omettre':
+						dispatch(supprimeLaRègleDeLaSituation(action.règle))
+						break
+					case 'erreur-inconnue':
+						throw new Error(
+							`Bad unknown situation : ${JSON.stringify(action.règle)}`
+						)
 				}
 			}
 		)

--- a/site/source/hooks/useSetupSafeSituation.tsx
+++ b/site/source/hooks/useSetupSafeSituation.tsx
@@ -56,6 +56,7 @@ export const useSetupSafeSituation = (nomModèle?: NomModèle) => {
 								action.règle
 							)}`
 						)
+						dispatch(supprimeLaRègleDeLaSituation(action.règle))
 						break
 				}
 			}

--- a/site/source/hooks/useSetupSafeSituation.tsx
+++ b/site/source/hooks/useSetupSafeSituation.tsx
@@ -50,9 +50,13 @@ export const useSetupSafeSituation = (nomModèle?: NomModèle) => {
 						dispatch(supprimeLaRègleDeLaSituation(action.règle))
 						break
 					case 'erreur-inconnue':
-						throw new Error(
-							`Bad unknown situation : ${JSON.stringify(action.règle)}`
+						// eslint-disable-next-line no-console
+						console.error(
+							`Règle invalide hors des situations connues : ${JSON.stringify(
+								action.règle
+							)}`
 						)
+						break
 				}
 			}
 		)

--- a/site/source/hooks/useSetupSafeSituation.tsx
+++ b/site/source/hooks/useSetupSafeSituation.tsx
@@ -4,7 +4,6 @@ import { setEngineSituation } from '@/domaine/engine/engineCache'
 import { NomModèle } from '@/domaine/SimulationConfig'
 import { supprimeLaRègleDeLaSituation } from '@/store/actions/actions'
 import { resetCompany } from '@/store/actions/companyActions'
-import { RÈGLES_IDENTITÉ_ENTREPRISE } from '@/store/reducers/companySituationReducer'
 import { companySituationSelector } from '@/store/selectors/company/companySituation.selector'
 import { completeSituationSelector } from '@/store/selectors/completeSituation.selector'
 import { configSituationSelector } from '@/store/selectors/simulation/config/configSituation.selector'
@@ -37,7 +36,6 @@ export const useSetupSafeSituation = (nomModèle?: NomModèle) => {
 					situationDuSimulateur: simulatorSituation,
 					situationDeLEntreprise: companySituation,
 					situationDeConfiguration: configSituation,
-					règlesIdentitéEntreprise: RÈGLES_IDENTITÉ_ENTREPRISE,
 				})
 
 				switch (action.kind) {

--- a/site/source/store/reducers/companySituationReducer.ts
+++ b/site/source/store/reducers/companySituationReducer.ts
@@ -4,24 +4,13 @@ import { PublicodesExpression } from 'publicodes'
 import { CodeCatégorieJuridique } from '@/domaine/CodeCatégorieJuridique'
 import { toPublicodeDate } from '@/domaine/Date'
 import { PublicodesAdapter } from '@/domaine/engine/PublicodesAdapter'
-import { Entreprise } from '@/domaine/Entreprise'
+import { Entreprise, RègleIdentitéEntreprise } from '@/domaine/Entreprise'
 import { DottedName } from '@/domaine/publicodes/DottedName'
 import { Action } from '@/store/actions/actions'
 import { omit } from '@/utils'
 import { buildSituationFromObject } from '@/utils/publicodes/publicodes'
 
 import { SituationPublicodes } from './rootReducer'
-
-export const RÈGLES_IDENTITÉ_ENTREPRISE = [
-	'entreprise . date de création',
-	'entreprise . code catégorie juridique',
-	'entreprise . catégorie juridique',
-	'entreprise . SIREN',
-	'entreprise . nom',
-	'établissement . SIRET',
-] as const satisfies ReadonlyArray<DottedName>
-
-type RègleIdentitéEntreprise = (typeof RÈGLES_IDENTITÉ_ENTREPRISE)[number]
 
 const SAVED_NAMESPACES = [
 	'indépendant . profession libérale . réglementée . métier',

--- a/site/source/store/reducers/companySituationReducer.ts
+++ b/site/source/store/reducers/companySituationReducer.ts
@@ -1,4 +1,5 @@
 import * as O from 'effect/Option'
+import { PublicodesExpression } from 'publicodes'
 
 import { CodeCatégorieJuridique } from '@/domaine/CodeCatégorieJuridique'
 import { toPublicodeDate } from '@/domaine/Date'
@@ -10,6 +11,17 @@ import { omit } from '@/utils'
 import { buildSituationFromObject } from '@/utils/publicodes/publicodes'
 
 import { SituationPublicodes } from './rootReducer'
+
+export const RÈGLES_IDENTITÉ_ENTREPRISE = [
+	'entreprise . date de création',
+	'entreprise . code catégorie juridique',
+	'entreprise . catégorie juridique',
+	'entreprise . SIREN',
+	'entreprise . nom',
+	'établissement . SIRET',
+] as const satisfies ReadonlyArray<DottedName>
+
+type RègleIdentitéEntreprise = (typeof RÈGLES_IDENTITÉ_ENTREPRISE)[number]
 
 const SAVED_NAMESPACES = [
 	'indépendant . profession libérale . réglementée . métier',
@@ -46,7 +58,7 @@ export function isCompanyDottedName(dottedName: DottedName) {
 export function companySituation(
 	state: SituationPublicodes = {},
 	action: Action
-) {
+): SituationPublicodes {
 	switch (action.type) {
 		case 'ENREGISTRE_LA_RÉPONSE_À_LA_QUESTION':
 			if (isCompanyDottedName(action.fieldName)) {
@@ -92,7 +104,9 @@ export function companySituation(
 	return state
 }
 
-function getCompanySituation(entreprise: Entreprise): SituationPublicodes {
+function getCompanySituation(
+	entreprise: Entreprise
+): Record<RègleIdentitéEntreprise, PublicodesExpression> {
 	return {
 		'entreprise . date de création': toPublicodeDate(entreprise.dateDeCréation),
 		'entreprise . code catégorie juridique': entreprise.codeCatégorieJuridique,

--- a/site/source/store/reducers/companySituationReducer.ts
+++ b/site/source/store/reducers/companySituationReducer.ts
@@ -142,32 +142,3 @@ const getCatégorieFromCode = (
 
 	return 'autre'
 }
-
-// // Profession Libérale
-// const inferPLSimulateurFromCompanyDetails = (
-// 	company: Company | null
-// ): DirigeantOrNull => {
-// 	if (!company) {
-// 		return null
-// 	}
-// 	const activiteToSimulator = {
-// 		'Activités comptables': 'expert-comptable',
-// 		'Activité des médecins généralistes': 'médecin',
-// 		'Activités de radiodiagnostic et de radiothérapie': 'médecin',
-// 		'Activités chirurgicales': 'médecin',
-// 		'Activité des médecins spécialistes': 'médecin',
-// 		'Activités hospitalières': 'pamc',
-// 		'Pratique dentaire': 'chirurgien-dentiste',
-// 		'Commerce de détail de produits pharmaceutiques en magasin spécialisé':
-// 			'pharmacien',
-// 		'Activités des infirmiers et des sages-femmes': 'pamc',
-// 		"Activités des professionnels de la rééducation, de l'appareillage et des pédicures-podologues":
-// 			'auxiliaire-médical',
-// 		"Laboratoires d'analyses médicales": 'pharmacien',
-// 		'Arts du spectacle vivant': 'artiste-auteur',
-// 		'Création artistique relevant des arts plastiques': 'artiste-auteur',
-// 		'Autre création artistique': 'artiste-auteur',
-// 		'Activités photographiques': 'artiste-auteur',
-// 	} as Record<string, keyof SimulatorData>
-// 	return activiteToSimulator[company.activitePrincipale] || null
-// }

--- a/site/source/utils/publicodes/décideActionRègleInvalide.ts
+++ b/site/source/utils/publicodes/décideActionRègleInvalide.ts
@@ -14,8 +14,10 @@ export type ActionRègleInvalide =
 	| { kind: 'omettre'; règle: DottedName }
 	| { kind: 'erreur-inconnue'; règle: DottedName }
 
+const règlesIdentitéEntreprise = new Set<DottedName>(RÈGLES_IDENTITÉ_ENTREPRISE)
+
 const estRègleIdentitéEntreprise = (règle: DottedName): boolean =>
-	(RÈGLES_IDENTITÉ_ENTREPRISE as ReadonlyArray<DottedName>).includes(règle)
+	règlesIdentitéEntreprise.has(règle)
 
 export function décideActionRègleInvalide(
 	règleInvalide: DottedName,

--- a/site/source/utils/publicodes/décideActionRègleInvalide.ts
+++ b/site/source/utils/publicodes/décideActionRègleInvalide.ts
@@ -1,4 +1,7 @@
-import { RÈGLES_IDENTITÉ_ENTREPRISE } from '@/domaine/Entreprise'
+import {
+	RègleIdentitéEntreprise,
+	RÈGLES_IDENTITÉ_ENTREPRISE,
+} from '@/domaine/Entreprise'
 import { DottedName } from '@/domaine/publicodes/DottedName'
 import { SituationPublicodes } from '@/store/reducers/rootReducer'
 
@@ -16,8 +19,9 @@ export type ActionRègleInvalide =
 
 const règlesIdentitéEntreprise = new Set<DottedName>(RÈGLES_IDENTITÉ_ENTREPRISE)
 
-const estRègleIdentitéEntreprise = (règle: DottedName): boolean =>
-	règlesIdentitéEntreprise.has(règle)
+const estRègleIdentitéEntreprise = (
+	règle: DottedName
+): règle is RègleIdentitéEntreprise => règlesIdentitéEntreprise.has(règle)
 
 export function décideActionRègleInvalide(
 	règleInvalide: DottedName,

--- a/site/source/utils/publicodes/décideActionRègleInvalide.ts
+++ b/site/source/utils/publicodes/décideActionRègleInvalide.ts
@@ -1,3 +1,4 @@
+import { RÈGLES_IDENTITÉ_ENTREPRISE } from '@/domaine/Entreprise'
 import { DottedName } from '@/domaine/publicodes/DottedName'
 import { SituationPublicodes } from '@/store/reducers/rootReducer'
 
@@ -5,7 +6,6 @@ export type ContexteRègleInvalide = {
 	situationDuSimulateur: SituationPublicodes
 	situationDeLEntreprise: SituationPublicodes
 	situationDeConfiguration: SituationPublicodes
-	règlesIdentitéEntreprise: ReadonlyArray<DottedName>
 }
 
 export type ActionRègleInvalide =
@@ -14,16 +14,18 @@ export type ActionRègleInvalide =
 	| { kind: 'omettre'; règle: DottedName }
 	| { kind: 'erreur-inconnue'; règle: DottedName }
 
+const estRègleIdentitéEntreprise = (règle: DottedName): boolean =>
+	(RÈGLES_IDENTITÉ_ENTREPRISE as ReadonlyArray<DottedName>).includes(règle)
+
 export function décideActionRègleInvalide(
 	règleInvalide: DottedName,
 	{
 		situationDuSimulateur,
 		situationDeLEntreprise,
 		situationDeConfiguration,
-		règlesIdentitéEntreprise,
 	}: ContexteRègleInvalide
 ): ActionRègleInvalide {
-	if (règlesIdentitéEntreprise.includes(règleInvalide)) {
+	if (estRègleIdentitéEntreprise(règleInvalide)) {
 		return { kind: 'réinitialiser-entreprise', règle: règleInvalide }
 	}
 

--- a/site/source/utils/publicodes/décideActionRègleInvalide.ts
+++ b/site/source/utils/publicodes/décideActionRègleInvalide.ts
@@ -1,0 +1,35 @@
+import { DottedName } from '@/domaine/publicodes/DottedName'
+import { SituationPublicodes } from '@/store/reducers/rootReducer'
+
+export type ContexteRègleInvalide = {
+	situationDuSimulateur: SituationPublicodes
+	situationDeLEntreprise: SituationPublicodes
+	situationDeConfiguration: SituationPublicodes
+}
+
+export type ActionRègleInvalide =
+	| { kind: 'omettre-et-marquer-obsolète'; règle: DottedName }
+	| { kind: 'omettre'; règle: DottedName }
+	| { kind: 'erreur-inconnue'; règle: DottedName }
+
+export function décideActionRègleInvalide(
+	règleInvalide: DottedName,
+	{
+		situationDuSimulateur,
+		situationDeLEntreprise,
+		situationDeConfiguration,
+	}: ContexteRègleInvalide
+): ActionRègleInvalide {
+	if (règleInvalide in situationDuSimulateur) {
+		return { kind: 'omettre-et-marquer-obsolète', règle: règleInvalide }
+	}
+
+	if (
+		règleInvalide in situationDeLEntreprise ||
+		règleInvalide in situationDeConfiguration
+	) {
+		return { kind: 'omettre', règle: règleInvalide }
+	}
+
+	return { kind: 'erreur-inconnue', règle: règleInvalide }
+}

--- a/site/source/utils/publicodes/décideActionRègleInvalide.ts
+++ b/site/source/utils/publicodes/décideActionRègleInvalide.ts
@@ -5,9 +5,11 @@ export type ContexteRègleInvalide = {
 	situationDuSimulateur: SituationPublicodes
 	situationDeLEntreprise: SituationPublicodes
 	situationDeConfiguration: SituationPublicodes
+	règlesIdentitéEntreprise: ReadonlyArray<DottedName>
 }
 
 export type ActionRègleInvalide =
+	| { kind: 'réinitialiser-entreprise'; règle: DottedName }
 	| { kind: 'omettre-et-marquer-obsolète'; règle: DottedName }
 	| { kind: 'omettre'; règle: DottedName }
 	| { kind: 'erreur-inconnue'; règle: DottedName }
@@ -18,8 +20,13 @@ export function décideActionRègleInvalide(
 		situationDuSimulateur,
 		situationDeLEntreprise,
 		situationDeConfiguration,
+		règlesIdentitéEntreprise,
 	}: ContexteRègleInvalide
 ): ActionRègleInvalide {
+	if (règlesIdentitéEntreprise.includes(règleInvalide)) {
+		return { kind: 'réinitialiser-entreprise', règle: règleInvalide }
+	}
+
 	if (règleInvalide in situationDuSimulateur) {
 		return { kind: 'omettre-et-marquer-obsolète', règle: règleInvalide }
 	}

--- a/site/test/décideActionRègleInvalide.test.ts
+++ b/site/test/décideActionRègleInvalide.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { DottedName } from '@/domaine/publicodes/DottedName'
+import { décideActionRègleInvalide } from '@/utils/publicodes/décideActionRègleInvalide'
+
+const situationsVides = {
+	situationDuSimulateur: {},
+	situationDeLEntreprise: {},
+	situationDeConfiguration: {},
+}
+
+describe('décideActionRègleInvalide', () => {
+	it('demande de retirer la règle et de la marquer obsolète si elle vient de la situation du simulateur', () => {
+		const règle = 'salarié . contrat' as DottedName
+
+		const action = décideActionRègleInvalide(règle, {
+			...situationsVides,
+			situationDuSimulateur: { [règle]: "'CDD'" },
+		})
+
+		expect(action).toEqual({ kind: 'omettre-et-marquer-obsolète', règle })
+	})
+
+	it("demande d'omettre la règle si elle vient d'une saisie utilisateur dans la situation de l’entreprise", () => {
+		const règle = 'entreprise . activité . nature' as DottedName
+
+		const action = décideActionRègleInvalide(règle, {
+			...situationsVides,
+			situationDeLEntreprise: { [règle]: "'libérale'" },
+		})
+
+		expect(action).toEqual({ kind: 'omettre', règle })
+	})
+
+	it("demande d'omettre la règle si elle vient de la situation de configuration du simulateur", () => {
+		const règle = 'entreprise . EI' as DottedName
+
+		const action = décideActionRègleInvalide(règle, {
+			...situationsVides,
+			situationDeConfiguration: { [règle]: 'oui' },
+		})
+
+		expect(action).toEqual({ kind: 'omettre', règle })
+	})
+
+	it("retourne une erreur inconnue si la règle n'est dans aucune des situations connues", () => {
+		const règle = 'règle . inattendue' as DottedName
+
+		const action = décideActionRègleInvalide(règle, situationsVides)
+
+		expect(action).toEqual({ kind: 'erreur-inconnue', règle })
+	})
+
+	it('priorise la situation du simulateur sur celle de l’entreprise si la règle est dans les deux', () => {
+		const règle = 'entreprise . salariés' as DottedName
+
+		const action = décideActionRègleInvalide(règle, {
+			...situationsVides,
+			situationDuSimulateur: { [règle]: 'oui' },
+			situationDeLEntreprise: { [règle]: 'non' },
+		})
+
+		expect(action).toEqual({ kind: 'omettre-et-marquer-obsolète', règle })
+	})
+})

--- a/site/test/décideActionRègleInvalide.test.ts
+++ b/site/test/décideActionRègleInvalide.test.ts
@@ -73,16 +73,4 @@ describe('décideActionRègleInvalide', () => {
 
 		expect(action).toEqual({ kind: 'erreur-inconnue', règle })
 	})
-
-	it('priorise la situation du simulateur sur celle de l’entreprise si la règle est dans les deux', () => {
-		const règle = 'entreprise . salariés' as DottedName
-
-		const action = décideActionRègleInvalide(règle, {
-			...situationsVides,
-			situationDuSimulateur: { [règle]: 'oui' },
-			situationDeLEntreprise: { [règle]: 'non' },
-		})
-
-		expect(action).toEqual({ kind: 'omettre-et-marquer-obsolète', règle })
-	})
 })

--- a/site/test/décideActionRègleInvalide.test.ts
+++ b/site/test/décideActionRègleInvalide.test.ts
@@ -7,6 +7,7 @@ const situationsVides = {
 	situationDuSimulateur: {},
 	situationDeLEntreprise: {},
 	situationDeConfiguration: {},
+	règlesIdentitéEntreprise: [] as ReadonlyArray<DottedName>,
 }
 
 describe('décideActionRègleInvalide', () => {
@@ -19,6 +20,31 @@ describe('décideActionRègleInvalide', () => {
 		})
 
 		expect(action).toEqual({ kind: 'omettre-et-marquer-obsolète', règle })
+	})
+
+	it("demande de réinitialiser l'entreprise si la règle fait partie de l'identité de l'entreprise", () => {
+		const règle = 'entreprise . SIREN' as DottedName
+
+		const action = décideActionRègleInvalide(règle, {
+			...situationsVides,
+			situationDeLEntreprise: { [règle]: "'TAURUS'" },
+			règlesIdentitéEntreprise: [règle],
+		})
+
+		expect(action).toEqual({ kind: 'réinitialiser-entreprise', règle })
+	})
+
+	it("priorise la réinitialisation de l'entreprise sur l'omission si la règle est aussi une saisie", () => {
+		const règle = 'entreprise . catégorie juridique' as DottedName
+
+		const action = décideActionRègleInvalide(règle, {
+			...situationsVides,
+			situationDuSimulateur: { [règle]: "'SAS'" },
+			situationDeLEntreprise: { [règle]: "'SAS'" },
+			règlesIdentitéEntreprise: [règle],
+		})
+
+		expect(action).toEqual({ kind: 'réinitialiser-entreprise', règle })
 	})
 
 	it("demande d'omettre la règle si elle vient d'une saisie utilisateur dans la situation de l’entreprise", () => {

--- a/site/test/décideActionRègleInvalide.test.ts
+++ b/site/test/décideActionRègleInvalide.test.ts
@@ -7,7 +7,6 @@ const situationsVides = {
 	situationDuSimulateur: {},
 	situationDeLEntreprise: {},
 	situationDeConfiguration: {},
-	règlesIdentitéEntreprise: [] as ReadonlyArray<DottedName>,
 }
 
 describe('décideActionRègleInvalide', () => {
@@ -28,7 +27,6 @@ describe('décideActionRègleInvalide', () => {
 		const action = décideActionRègleInvalide(règle, {
 			...situationsVides,
 			situationDeLEntreprise: { [règle]: "'TAURUS'" },
-			règlesIdentitéEntreprise: [règle],
 		})
 
 		expect(action).toEqual({ kind: 'réinitialiser-entreprise', règle })
@@ -41,7 +39,6 @@ describe('décideActionRègleInvalide', () => {
 			...situationsVides,
 			situationDuSimulateur: { [règle]: "'SAS'" },
 			situationDeLEntreprise: { [règle]: "'SAS'" },
-			règlesIdentitéEntreprise: [règle],
 		})
 
 		expect(action).toEqual({ kind: 'réinitialiser-entreprise', règle })


### PR DESCRIPTION
Suite remontée usager sur Crisp ([vidéo](https://www.loom.com/share/3ca9cb16ce1e4c62b8d471bc52fa5bc5)), même symptôme que  #4441. Sentry confirme : ~108k erreurs `Bad company/config situation` en 14 jours (top : `entreprise . activité . nature` à 33k, `entreprise . EI` à 11k).

En fait, dans `useSetupSafeSituation`, le callback `onError` gérait les saisies du simulateur (`omit`) mais throwait pour les saisies entreprise/config — (un `try/catch` qui vidait tout le moteur). Une seule règle persistée invalide (typiquement après un refacto de modèle) suffisait à mettre le simulateur entier en incohérence.

C'est ce qui explique le `Pas encore défini` dans le bandeau alors que `TAURUS` s'affiche en dessous : `<Value>` voyait l'engine vide, mais `EntrepriseDetails` lit Redux directement…

J’ai extrait la décision de traitement dans une fonction pure `décideActionRègleInvalide` qui retourne, selon la règle fautive :

- saisie utilisateur du simulateur → on omet et marque la règle comme obsolète (comportement existant)
- saisie entreprise/config → on omet (au lieu de throw + vider) — c'est ce qui devrait résoudre la plupart des erreurs Sentry 
- clé d'identité d'entreprise → on réinitialise toute l'entreprise, pour éviter un état incohérent
- règle vraiment inconnue → log + retrait du store Redux