### PR TITLE
[Mayotte] Dispenses d'assiette minimale

### DIFF
--- a/modele-ti/règles/indépendant/cotisations-et-contributions/assiette-minimale.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/assiette-minimale.publicodes
@@ -1,8 +1,14 @@
 indépendant . assiette minimale:
   non applicable si:
-    une de ces conditions:
-      - situation personnelle . RSA
-      - entreprise . activité . saisonnière
+    toutes ces conditions:
+      - une de ces conditions:
+          - situation personnelle . RSA
+          - entreprise . activité . saisonnière
+      - une de ces conditions:
+          - profession libérale . CNAVPL
+          - toutes ces conditions:
+              - profession libérale . CNAVPL = non
+              - établissement . commune . département . outre-mer . Mayotte = non
   valeur: oui
   description: |
     Si le revenu du chef d’entreprise est déficitaire ou inférieur aux bases de
@@ -46,7 +52,13 @@ indépendant . assiette minimale . retraite:
   variations:
     - si: entreprise . durée d'activité cette année < 90 jour
       alors: 0
-    - sinon: 450 heure/an * SMIC . horaire . début d'année
+    - sinon:
+        produit:
+          - 450 heure/an
+          - variations:
+              - si: profession libérale . CNAVPL
+                alors: SMIC . horaire . métropole . début d'année
+              - sinon: SMIC . horaire . début d'année
   arrondi: oui
   unité: €/an
   références:

--- a/modele-ti/règles/indépendant/professions-libérales/CNAVPL.publicodes
+++ b/modele-ti/règles/indépendant/professions-libérales/CNAVPL.publicodes
@@ -82,10 +82,7 @@ indépendant . profession libérale . CNAVPL . retraite de base:
 
     assiette:
       valeur: cotisations et contributions . cotisations . assiette retraite et invalidité-décès
-      plancher:
-        valeur: 450 heure/an * SMIC . horaire . métropole . début d'année
-        arrondi: oui
-        unité: €/an
+      plancher: assiette minimale . retraite
 
 indépendant . profession libérale . CNAVPL . retraite complémentaire:
   variations:

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/invalidité-décès.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/invalidité-décès.test.ts
@@ -455,6 +455,36 @@ describe('Cotisation invalidité et décès', () => {
 
 					expect(e).toEvaluate(COTISATION, Math.round(assietteMaximale * TAUX))
 				})
+
+				describe('n’applique pas d’assiette minimale', () => {
+					it('en cas de RSA ou de prime d’activité', () => {
+						const e = engine.setSituation({
+							...situation,
+							'indépendant . cotisations et contributions . assiette sociale':
+								'1000 €/an',
+							'situation personnelle . RSA': 'oui',
+						})
+
+						expect(e).toEvaluate(
+							'indépendant . profession libérale . Cipav . invalidité et décès . assiette',
+							1_000
+						)
+					})
+
+					it('en cas d’activité saisonnière', () => {
+						const e = engine.setSituation({
+							...situation,
+							'indépendant . cotisations et contributions . assiette sociale':
+								'1000 €/an',
+							'entreprise . activité . saisonnière': 'oui',
+						})
+
+						expect(e).toEvaluate(
+							'indépendant . profession libérale . Cipav . invalidité et décès . assiette',
+							1_000
+						)
+					})
+				})
 			})
 		})
 	})

--- a/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-base.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/cotisations/retraite-base.test.ts
@@ -199,6 +199,36 @@ describe('Cotisation retraite de base', () => {
 
 				expect(e).toEvaluate(COTISATION, Math.round(assietteMinimale * TAUX))
 			})
+
+			it('applique une assiette minimale en cas de RSA ou de prime d’activité', () => {
+				const e = engine.setSituation({
+					...situation,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'1000 €/an',
+					'situation personnelle . RSA': 'oui',
+				})
+
+				const assietteMinimale = e.evaluate(
+					'indépendant . assiette minimale . retraite'
+				).nodeValue as number
+
+				expect(e).toEvaluate(`${COTISATION} . assiette`, assietteMinimale)
+			})
+
+			it('applique une assiette minimale en cas d’activité saisonnière', () => {
+				const e = engine.setSituation({
+					...situation,
+					'indépendant . cotisations et contributions . assiette sociale':
+						'1000 €/an',
+					'entreprise . activité . saisonnière': 'oui',
+				})
+
+				const assietteMinimale = e.evaluate(
+					'indépendant . assiette minimale . retraite'
+				).nodeValue as number
+
+				expect(e).toEvaluate(`${COTISATION} . assiette`, assietteMinimale)
+			})
 		})
 	})
 
@@ -340,7 +370,7 @@ describe('Cotisation retraite de base', () => {
 					'situation personnelle . RSA': 'oui',
 				})
 
-				expect(e).toEvaluate(`${COTISATION} . assiette`, 1_000)
+				expect(e).toEvaluate(`${COTISATION_PLR} . assiette`, 1_000)
 			})
 
 			it('en cas d’activité saisonnière', () => {
@@ -351,7 +381,7 @@ describe('Cotisation retraite de base', () => {
 					'entreprise . activité . saisonnière': 'oui',
 				})
 
-				expect(e).toEvaluate(`${COTISATION} . assiette`, 1_000)
+				expect(e).toEvaluate(`${COTISATION_PLR} . assiette`, 1_000)
 			})
 		})
 
@@ -438,6 +468,30 @@ describe('Cotisation retraite de base', () => {
 					`${COTISATION_PLR} . tranche 2`,
 					Math.round(5 * PASS * TAUX_T2)
 				)
+			})
+
+			describe('n’applique pas d’assiette minimale', () => {
+				it('en cas de RSA ou de prime d’activité', () => {
+					const e = engine.setSituation({
+						...situation,
+						'indépendant . cotisations et contributions . assiette sociale':
+							'1000 €/an',
+						'situation personnelle . RSA': 'oui',
+					})
+
+					expect(e).toEvaluate(`${COTISATION_PLR} . assiette`, 1_000)
+				})
+
+				it('en cas d’activité saisonnière', () => {
+					const e = engine.setSituation({
+						...situation,
+						'indépendant . cotisations et contributions . assiette sociale':
+							'1000 €/an',
+						'entreprise . activité . saisonnière': 'oui',
+					})
+
+					expect(e).toEvaluate(`${COTISATION_PLR} . assiette`, 1_000)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Closes #4410 

Pour les **TI bénéficiaires du RSA ou en activité saisonnière**, l'assiette minimale **retraite** s'applique :
- aux A/C/PLNR **à** Mayotte

Elle ne s'applique pas :
- aux A/C/PLNR et PLR **hors** Mayotte
- aux PLR **à** Mayotte

Les règles d'application de l'assiette minimale d'**invalidité-décès** ne sont pas impactées car les A/C/PLNR à Mayotte ne sont pas redevables de cette cotisation.
L'assiette minimale s'applique aux PLR **hors et à** Mayotte mais ne s'applique pas aux PLR bénéficiaires du RSA ou en activité saisonnière **hors et à** Mayotte 