### PR TITLE
[Mayotte] Cotisations conjoint collaborateur

### DIFF
--- a/modele-ti/règles/indépendant/conjoint-collaborateur.publicodes
+++ b/modele-ti/règles/indépendant/conjoint-collaborateur.publicodes
@@ -50,6 +50,10 @@ indépendant . conjoint collaborateur . choix assiette:
     Article R662-1 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038785217
 
   question: Sur quelle base le conjoint cotise-t-il ?
+  non applicable si:
+    toutes ces conditions:
+      - établissement . commune . département . outre-mer . Mayotte
+      - profession libérale . CNAVPL = non
   une possibilité:
     - forfaitaire:
         valeur: choix assiette = 'forfaitaire'
@@ -102,10 +106,15 @@ indépendant . conjoint collaborateur . choix assiette:
 
 indépendant . conjoint collaborateur . assiette retraite et invalidité-décès:
   variations:
+    - si:
+        toutes ces conditions:
+          - établissement . commune . département . outre-mer . Mayotte
+          - profession libérale . CNAVPL = non
+      alors: 450 heure/an * SMIC . horaire . début d'année
     - si: choix assiette . forfaitaire
       alors:
         produit:
-          - plafond sécurité sociale
+          - plafond sécurité sociale . métropole
           - variations:
               - si: profession libérale . CNAVPL
                 alors: 1 / 2

--- a/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/exonérations.publicodes
+++ b/modele-ti/règles/indépendant/cotisations-et-contributions/cotisations/exonérations/exonérations.publicodes
@@ -17,24 +17,22 @@ indépendant . cotisations et contributions . cotisations . exonérations . Mayo
   sévérité: avertissement
   titre: Recouvrement Mayotte
   résumé: |
-    Ce simulateur applique bien les assiettes et taux de cotisations et contributions
-    **spécifiques à Mayotte**.
+    Ce simulateur applique bien les assiettes et taux de cotisations et
+    contributions **spécifiques à Mayotte**.
 
-    En revanche, l’**exonération 24 mois Mayotte** et les cotisations de
-    conjoint collaborateur/conjointe collaboratrice ne sont pas encore prises
+    En revanche, l’**exonération 24 mois Mayotte** n’est pas encore prise
     en compte.
   description: |
-    Depuis le 1er janvier 2025, l’Urssaf a repris la collecte des cotisations et
-    contributions sociales des travailleurs et travailleuses indépendantes qui
-    exercent leur activité à Mayotte.
+    Depuis le 1er janvier 2025, l’Urssaf a repris la collecte des
+    cotisations et contributions sociales des travailleurs et
+    travailleuses indépendantes qui exercent leur activité à Mayotte.
 
     Ce simulateur applique bien les assiettes et taux de cotisations et
     contributions spécifiques à Mayotte, y compris l’abattement de 50 %
     sur les assiettes de la cotisation allocations familiales et de la
     cotisation additionnelle d’assurance maladie-maternité et autonomie.
 
-    En revanche, l’**exonération 24 mois Mayotte** et les cotisations de
-    conjoint collaborateur/conjointe collaboratrice ne sont pas encore prises
+    En revanche, l’**exonération 24 mois Mayotte** n’est pas encore prise
     en compte.
   références:
     Reprise du recouvrement des cotisations pour les travailleurs indépendants à Mayotte: https://www.cssm.fr/uploads//Formulaires/6584-Depl-TI-Mayotte%2006_08_2024%20web.pdf

--- a/site/source/locales/rules-ti-en.yaml
+++ b/site/source/locales/rules-ti-en.yaml
@@ -2780,66 +2780,45 @@ indépendant . cotisations et contributions . cotisations . exonérations . DROM
   titre.en: '[automatic] DROM exemption'
   titre.fr: exonération DROM
 indépendant . cotisations et contributions . cotisations . exonérations . Mayotte:
-  description.en: >
-    [automatic] As of January 1, 2025, Urssaf has taken over the collection of
-    social contributions
+  description.en: |
+    [automatic] Since January 1, 2025, Urssaf has taken over the collection of
+    social security contributions from self-employed men and
+    self-employed men and women working in Mayotte.
 
-    contributions for self-employed workers in Mayotte.
-
-    working in Mayotte.
-
-
-    This simulator correctly applies the bases and rates of contributions and
-
+    This simulator correctly applies the contribution bases and rates
     specific to Mayotte, including the 50% deduction
-
     on the bases for the family allowance contribution and the additional
-
     additional sickness, maternity and autonomy insurance contributions.
 
-
-    On the other hand, the 24-month Mayotte exemption** and the contributions
-    for
-
-    contributions are not yet taken into account.
-
+    However, the 24-month Mayotte exemption has not yet been taken into account.
     taken into account.
   description.fr: |
-    Depuis le 1er janvier 2025, l’Urssaf a repris la collecte des cotisations et
-    contributions sociales des travailleurs et travailleuses indépendantes qui
-    exercent leur activité à Mayotte.
+    Depuis le 1er janvier 2025, l’Urssaf a repris la collecte des
+    cotisations et contributions sociales des travailleurs et
+    travailleuses indépendantes qui exercent leur activité à Mayotte.
 
     Ce simulateur applique bien les assiettes et taux de cotisations et
     contributions spécifiques à Mayotte, y compris l’abattement de 50 %
     sur les assiettes de la cotisation allocations familiales et de la
     cotisation additionnelle d’assurance maladie-maternité et autonomie.
 
-    En revanche, l’**exonération 24 mois Mayotte** et les cotisations de
-    conjoint collaborateur/conjointe collaboratrice ne sont pas encore prises
+    En revanche, l’**exonération 24 mois Mayotte** n’est pas encore prise
     en compte.
   résumé.en: >
-    [automatic] This simulator correctly applies the bases and rates of
-    contributions and levies
-
-    **specific to Mayotte**.
-
-
-    However, the **Mayotte 24-month exemption** and contributions for
-
-    contributions are not yet taken into account.
-
-    taken into account.
-  résumé.fr: >
-    Ce simulateur applique bien les assiettes et taux de cotisations et
+    [automatic] This simulator applies the bases and rates of contributions and
     contributions
 
-    **spécifiques à Mayotte**.
+    specific to Mayotte**.
 
 
-    En revanche, l’**exonération 24 mois Mayotte** et les cotisations de
+    However, the **Mayotte 24-month exemption** is not yet taken into account.
 
-    conjoint collaborateur/conjointe collaboratrice ne sont pas encore prises
+    taken into account.
+  résumé.fr: |
+    Ce simulateur applique bien les assiettes et taux de cotisations et
+    contributions **spécifiques à Mayotte**.
 
+    En revanche, l’**exonération 24 mois Mayotte** n’est pas encore prise
     en compte.
   titre.en: '[automatic] Mayotte collection'
   titre.fr: Recouvrement Mayotte

--- a/site/test/modele-ti/cotisations-et-contributions/conjoint-collaborateur.test.ts
+++ b/site/test/modele-ti/cotisations-et-contributions/conjoint-collaborateur.test.ts
@@ -118,6 +118,21 @@ describe('Conjoint collaborateur', () => {
 					30_000
 				)
 			})
+
+			it('est égale à 450 Smic horaire mahorais à Mayotte', () => {
+				const e = engine.setSituation({
+					...defaultSituation,
+					'établissement . commune . département': "'Mayotte'",
+				})
+
+				const Smic = e.evaluate("SMIC . horaire . début d'année")
+					.nodeValue as number
+
+				expect(e).toEvaluate(
+					'indépendant . conjoint collaborateur . assiette retraite et invalidité-décès',
+					Math.round(450 * Smic)
+				)
+			})
 		})
 
 		describe('montant des cotisations', () => {


### PR DESCRIPTION
Closes #4412

> Pour rappel :
> - Le conjoint collaborateur d’un artisan, commerçant ou PL NR Mahorais n’est redevable que de la cotisation de retraite de base 
> - Le conjoint collaborateur d’un PL Cipav Mahorais n’est redevable que des cotisations de retraite de base, de retraite  complémentaire et d’invalidité-décès
> - Le conjoint collaborateur d’un PL hors Cipav Mahorais n’est redevable d’aucune cotisation auprès de l’Urssaf (compétence CNAVPL et sections PL).
>
> Les tranches et taux applicables aux cotisations retraite, et invalidité-décès le cas échéant, des conjoints sont les mêmes que pour les chefs d’entreprise.
> La différence se situe au niveau de l’assiette prise en compte qui dépend de l’option de cotisation choisie par le conjoint. 
> - Conjoint collaborateur d’un artisan, commerçant ou PL NR : Option forfaitaire 450/fois le SMIC Mahorais
> - Conjoint collaborateur d’un PL Cipav : les options de cotisation sont les mêmes que pour les conjoints collaborateur d’un PL Cipav de métropole.
>
> La cotisation retraite dont sont redevables les conjoints collaborateurs A/C est forfaitaire soit 450/fois le SMIC Mahorais