### PR TITLE
fix(salarié): déduction forfaitaire pour heures supplémentaires non liée à la RGDU

### DIFF
--- a/modele-social/règles/salarié/exonérations/exonérations.publicodes
+++ b/modele-social/règles/salarié/exonérations/exonérations.publicodes
@@ -38,10 +38,7 @@ salarié . cotisations . exonérations . heures supplémentaires:
 
   avec:
     employeur:
-      applicable si:
-        toutes ces conditions:
-          - temps de travail . heures supplémentaires > 0
-          - exonérations . RGDU > 0
+      applicable si: temps de travail . heures supplémentaires > 0
       titre: déduction forfaitaire pour heures supplémentaires
       produit:
         - temps de travail . heures supplémentaires


### PR DESCRIPTION
cf https://www.urssaf.fr/accueil/employeur/beneficier-exonerations/exonerations-heures/deduction-forfaitaire-patronale.html

> Vous pouvez cumuler la déduction forfaitaire patronale avec :
soit la réduction générale ;
soit une autre exonération de cotisations et contributions patronales.

C'est la société qui doit être éligible à la RGDU, mais pas forcément chaque bulletin. La condition d’applicabilité est en trop.