### PR TITLE
[Refonte UX] Correctifs divers

### DIFF
--- a/site/source/components/PeriodSwitch.tsx
+++ b/site/source/components/PeriodSwitch.tsx
@@ -70,7 +70,7 @@ export default function PeriodSwitch({ periods }: Props) {
 
 const GridCentered = styled.fieldset`
 	display: grid;
-	grid-template-columns: 1.25fr 1fr;
+	grid-template-columns: 1.15fr 1fr;
 	gap: ${({ theme }) => theme.spacings.md};
 
 	& > div {

--- a/site/source/components/PeriodSwitch.tsx
+++ b/site/source/components/PeriodSwitch.tsx
@@ -69,6 +69,8 @@ export default function PeriodSwitch({ periods }: Props) {
 }
 
 const GridCentered = styled.fieldset`
+	position: relative;
+	z-index: 1;
 	display: grid;
 	grid-template-columns: 1.15fr 1fr;
 	gap: ${({ theme }) => theme.spacings.md};

--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -74,7 +74,7 @@ export function ObjectifDeSimulation({
 
 const GridCentered = styled(Grid)`
 	display: grid;
-	grid-template-columns: 1.25fr 1fr;
+	grid-template-columns: 1.15fr 1fr;
 	gap: ${({ theme }) => theme.spacings.md};
 
 	& > div {

--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -2,7 +2,6 @@ import { Option } from 'effect'
 import React from 'react'
 import { styled } from 'styled-components'
 
-import { ForceThemeProvider } from '@/components/utils/DarkModeContext'
 import { Body, Grid, InfoBulle, TitreObjectif } from '@/design-system'
 import { Montant, montantToString } from '@/domaine/Montant'
 import { useInitialRender } from '@/hooks/useInitialRender'
@@ -55,11 +54,7 @@ export function ObjectifDeSimulation({
 				>
 					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
 						<TitreObjectif id={`${id}-label`}>{titre}</TitreObjectif>
-						{explication && (
-							<ForceThemeProvider forceTheme="default">
-								{explication}
-							</ForceThemeProvider>
-						)}
+						{explication}
 
 						{description && <InfoBulle description={description} />}
 					</Grid>

--- a/site/source/components/Simulation/ObjectifDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifDeSimulation.tsx
@@ -13,7 +13,6 @@ export type ObjectifDeSimulationProps = {
 	id: string
 	titre: React.ReactNode
 	description?: React.ReactNode
-	explication?: React.ReactNode
 	valeur: Option.Option<Montant> | string
 	small?: boolean
 	appear?: boolean
@@ -25,7 +24,6 @@ export function ObjectifDeSimulation({
 	id,
 	titre,
 	description,
-	explication,
 	valeur,
 	displayedUnit,
 	small = false,
@@ -44,17 +42,9 @@ export function ObjectifDeSimulation({
 	return (
 		<Appear unless={!appear || initialRender}>
 			<StyledGoal $small={small}>
-				<GridCentered
-					container
-					style={{
-						alignItems: 'baseline',
-						justifyContent: 'space-between',
-					}}
-					spacing={2}
-				>
+				<GridCentered container spacing={2}>
 					<Grid item md="auto" sm={small ? 9 : 8} xs={8}>
 						<TitreObjectif id={`${id}-label`}>{titre}</TitreObjectif>
-						{explication}
 
 						{description && <InfoBulle description={description} />}
 					</Grid>
@@ -76,6 +66,8 @@ const GridCentered = styled(Grid)`
 	display: grid;
 	grid-template-columns: 1.15fr 1fr;
 	gap: ${({ theme }) => theme.spacings.md};
+	align-items: baseline;
+	justify-content: space-between;
 
 	& > div {
 		padding: 0;

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -92,7 +92,7 @@ export function ObjectifSaisissableDeSimulation({
 
 const GridCentered = styled(Grid)`
 	display: grid;
-	grid-template-columns: 1.25fr 1fr;
+	grid-template-columns: 1.15fr 1fr;
 	gap: ${({ theme }) => theme.spacings.md};
 
 	& > div {

--- a/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
+++ b/site/source/components/Simulation/ObjectifSaisissableDeSimulation.tsx
@@ -1,6 +1,6 @@
 import * as O from 'effect/Option'
 import React, { useState } from 'react'
-import { css, styled } from 'styled-components'
+import { styled } from 'styled-components'
 
 import { Grid, InfoBulle, TitreObjectifSaisissable } from '@/design-system'
 import { Montant } from '@/domaine/Montant'
@@ -59,7 +59,7 @@ export function ObjectifSaisissableDeSimulation({
 		<Appear unless={!appear || initialRender}>
 			<StyledGoal>
 				<GridCentered container spacing={2}>
-					<StyledGridItem item $avecDescription={!!description}>
+					<Grid item>
 						<TitreObjectifSaisissable
 							id={`${id}-label`}
 							htmlFor={`${id}-input`}
@@ -69,7 +69,7 @@ export function ObjectifSaisissableDeSimulation({
 						</TitreObjectifSaisissable>
 
 						{description && <InfoBulle description={description} />}
-					</StyledGridItem>
+					</Grid>
 
 					<Grid item>
 						{!isFocused && montantAnimation !== undefined && (
@@ -140,16 +140,6 @@ const StyledGoal = styled.div`
 	@media print {
 		padding: 0;
 	}
-`
-
-const StyledGridItem = styled(Grid)<{ $avecDescription: boolean }>`
-	${({ $avecDescription }) =>
-		!$avecDescription &&
-		css`
-			display: flex;
-			justify-content: end;
-			align-items: center;
-		`}
 `
 
 const LargeInputContainer = styled.div`

--- a/site/source/components/Simulation/SimulationGoal.tsx
+++ b/site/source/components/Simulation/SimulationGoal.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { styled } from 'styled-components'
 
-import { ExplicableRule } from '@/components/conversation/Explicable'
 import RuleInput from '@/components/conversation/RuleInput'
 import RuleLink from '@/components/RuleLink'
 import { ObjectifDeSimulation } from '@/components/Simulation/ObjectifDeSimulation'
@@ -176,7 +175,6 @@ export function SimulationGoal({
 			isInfoMode={isInfoMode}
 			small={small}
 			appear={appear}
-			explication={<ExplicableRule dottedName={dottedName} />}
 		/>
 	)
 }

--- a/site/source/components/search/SimulatorHits.tsx
+++ b/site/source/components/search/SimulatorHits.tsx
@@ -13,7 +13,6 @@ import {
 } from '@/design-system'
 import { MergedSimulatorDataValues } from '@/hooks/useCurrentSimulatorData'
 import { useNavigationOrigin } from '@/hooks/useNavigationOrigin'
-import { useSitePaths } from '@/sitePaths'
 
 import { FromTop } from '../ui/animate'
 import { Highlight } from './Hightlight'
@@ -21,33 +20,27 @@ import { Highlight } from './Hightlight'
 type AlgoliaSimulatorHit = Hit<{
 	icône: string
 	title: string
+	path: MergedSimulatorDataValues['path']
 	pathId: MergedSimulatorDataValues['pathId']
+	tooltip?: MergedSimulatorDataValues['tooltip']
 }>
 
 type SimulatorHitsProps = {
 	hits: Array<AlgoliaSimulatorHit>
 }
 
-const SimulateurCardHit = ({
-	hit,
-	path,
-	tooltip,
-}: {
-	path: MergedSimulatorDataValues['path'] | '/'
-	tooltip?: MergedSimulatorDataValues['tooltip']
-	hit: AlgoliaSimulatorHit
-}) => {
+const SimulateurCardHit = ({ hit }: { hit: AlgoliaSimulatorHit }) => {
 	const [, setNavigationOrigin] = useNavigationOrigin()
 
 	return (
 		<StyledSmallCard
 			icon={<Emoji emoji={hit.icône} />}
-			to={{ pathname: path }}
+			to={{ pathname: hit.path ?? '/' }}
 			onPress={() => setNavigationOrigin({ fromSimulateurs: true })}
 			title={
 				<p>
 					<Highlight hit={hit} attribute="title" />{' '}
-					{tooltip && <InfoBulle description={tooltip} />}
+					{hit.tooltip && <InfoBulle description={hit.tooltip} />}
 				</p>
 			}
 		/>
@@ -61,51 +54,37 @@ const StyledSmallCard = styled(SmallCard)`
 export const SimulatorHits = connectHits<
 	{ hits: AlgoliaSimulatorHit[] },
 	AlgoliaSimulatorHit
->(({ hits }: SimulatorHitsProps) => {
-	const { absoluteSitePaths } = useSitePaths()
-
-	const getPath = (hit: AlgoliaSimulatorHit) =>
-		hit.pathId
-			.split('.')
-			.reduce<Record<string, unknown> | null>(
-				(acc, curr) =>
-					(acc && curr in acc && (acc[curr] as Record<string, unknown>)) ||
-					null,
-				absoluteSitePaths
-			) as MergedSimulatorDataValues['path'] | null
-
-	return (
-		<>
-			<H3 as="h2">
-				<Trans>Simulateurs</Trans>
-			</H3>
-			{!hits.length && (
-				<FromTop>
-					<SmallBody $grey>
-						<Trans>
-							Aucun résultat ne correspond à votre recherche. Essayez avec
-							d'autres mots-clés.
-						</Trans>
-					</SmallBody>
-				</FromTop>
+>(({ hits }: SimulatorHitsProps) => (
+	<>
+		<H3 as="h2">
+			<Trans>Simulateurs</Trans>
+		</H3>
+		{!hits.length && (
+			<FromTop>
+				<SmallBody $grey>
+					<Trans>
+						Aucun résultat ne correspond à votre recherche. Essayez avec
+						d'autres mots-clés.
+					</Trans>
+				</SmallBody>
+			</FromTop>
+		)}
+		<Grid container spacing={2} as="ul" style={{ padding: 0 }}>
+			{hits.map(
+				(hit) =>
+					hit.pathId && (
+						<Grid
+							item
+							key={hit.objectID}
+							xs={12}
+							lg={6}
+							as="li"
+							style={{ listStyle: 'none' }}
+						>
+							<SimulateurCardHit hit={hit} />
+						</Grid>
+					)
 			)}
-			<Grid container spacing={2} as="ul" style={{ padding: 0 }}>
-				{hits.map(
-					(hit) =>
-						hit.pathId && (
-							<Grid
-								item
-								key={hit.objectID}
-								xs={12}
-								lg={6}
-								as="li"
-								style={{ listStyle: 'none' }}
-							>
-								<SimulateurCardHit hit={hit} path={getPath(hit) ?? '/'} />
-							</Grid>
-						)
-				)}
-			</Grid>
-		</>
-	)
-})
+		</Grid>
+	</>
+))

--- a/site/source/design-system/global-style.ts
+++ b/site/source/design-system/global-style.ts
@@ -13,7 +13,11 @@ export const SROnly = css`
 `
 
 export const FocusStyle = css`
-	outline: 3px solid ${({ theme }) => theme.colors.bases.primary[700]};
+	outline: 3px solid
+		${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.grey[100]
+				: theme.colors.bases.primary[700]};
 	outline-offset: 2px;
 	box-shadow: 0 0 0 2px #ffffff;
 `

--- a/site/source/design-system/icons/index.tsx
+++ b/site/source/design-system/icons/index.tsx
@@ -5,7 +5,13 @@ export const SvgIcon = styled.svg`
 	fill: ${({ theme }) =>
 		theme.darkMode
 			? theme.colors.extended.grey[100]
-			: theme.colors.bases.primary[800]};
+			: theme.colors.bases.primary[700]};
+	path.inner-icon {
+		fill: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.bases.primary[700]
+				: theme.colors.extended.grey[100]};
+	}
 `
 
 export const ArrowCircleIcon = (props: HTMLAttributes<SVGElement>) => (
@@ -135,7 +141,6 @@ export const CircledArrowIcon = (props: HTMLAttributes<SVGElement>) => (
 		width="40"
 		height="40"
 		viewBox="0 0 45 45"
-		fill="#1D458C"
 		xmlns="http://www.w3.org/2000/svg"
 		aria-hidden
 	>
@@ -145,16 +150,16 @@ export const CircledArrowIcon = (props: HTMLAttributes<SVGElement>) => (
 			d="M20 40C31.0457 40 40 31.0457 40 20C40 8.95431 31.0457 0 20 0C8.95431 0 0 8.95431 0 20C0 31.0457 8.95431 40 20 40Z"
 		/>
 		<path
+			className="inner-icon"
 			fillRule="evenodd"
 			clipRule="evenodd"
 			d="M23.1195 13.6676C23.5243 13.2918 24.157 13.3152 24.5328 13.7199L29.7328 19.3199C30.0891 19.7036 30.0891 20.2972 29.7328 20.6808L24.5328 26.2808C24.157 26.6856 23.5243 26.709 23.1195 26.3332C22.7148 25.9574 22.6914 25.3247 23.0672 24.9199L27.6354 20.0004L23.0672 15.0808C22.6914 14.6761 22.7148 14.0434 23.1195 13.6676Z"
-			fill="white"
 		/>
 		<path
+			className="inner-icon"
 			fillRule="evenodd"
 			clipRule="evenodd"
 			d="M10 20.0004C10 19.4481 10.4477 19.0004 11 19.0004L29 19.0004C29.5523 19.0004 30 19.4481 30 20.0004C30 20.5527 29.5523 21.0004 29 21.0004L11 21.0004C10.4477 21.0004 10 20.5527 10 20.0004Z"
-			fill="white"
 		/>
 	</SvgIcon>
 )

--- a/site/source/design-system/molecules/field/Checkbox.tsx
+++ b/site/source/design-system/molecules/field/Checkbox.tsx
@@ -128,7 +128,7 @@ const VisibleContainer = styled.span<{
 	z-index: 1;
 	border-radius: ${({ theme }) => theme.box.borderRadius};
 	padding: 0 ${({ theme }) => theme.spacings.sm};
-	margin: 0 calc(-1 * ${({ theme }) => theme.spacings.sm});
+	margin: 0 ${({ theme }) => theme.spacings.xxs};
 	align-items: ${({ $alignItems }) => $alignItems};
 `
 const LabelBody = styled(Body)`

--- a/site/source/design-system/molecules/field/Radio/Radio.tsx
+++ b/site/source/design-system/molecules/field/Radio/Radio.tsx
@@ -161,7 +161,7 @@ export const VisibleRadio = styled.span<{ $inert?: boolean }>`
 	align-items: center;
 	text-align: initial;
 	padding: 0 ${({ theme }) => theme.spacings.sm};
-	margin: 0 calc(-1 * ${({ theme }) => theme.spacings.sm});
+	margin: 0 ${({ theme }) => theme.spacings.xxs};
 	border-radius: ${({ theme }) => theme.box.borderRadius};
 	z-index: 1;
 	${({ theme, $inert }) =>

--- a/site/source/design-system/switch/Switch.tsx
+++ b/site/source/design-system/switch/Switch.tsx
@@ -19,7 +19,7 @@ const sizeDico = {
 	XL: '4rem',
 } as { [K in Size]: string }
 
-const StyledSpan = styled.span<{ checked: boolean }>`
+const StyledSpan = styled.span<{ checked: boolean; $light: boolean }>`
 	position: relative;
 	left: ${({ checked }) =>
 		checked ? 'calc(100% - 2 * (var(--switch-size) / 5))' : '0'};
@@ -32,6 +32,10 @@ const StyledSpan = styled.span<{ checked: boolean }>`
 		0px 3px 1px 0px #0000000f,
 		0px 3px 8px 0px #00000026;
 	background-color: #ffffff;
+	background-color: ${({ theme, checked, $light }) =>
+		checked && theme.darkMode && !$light
+			? theme.colors.bases.primary[700]
+			: theme.colors.extended.grey[100]};
 	color: inherit;
 `
 interface StyledSwitchProps {
@@ -45,9 +49,11 @@ const StyledSwitch = styled.span<StyledSwitchProps>`
 	--switch-size: ${({ $size }) => sizeDico[$size]};
 	display: inline-flex;
 	transition: all 0.15s ease-in-out;
-	background-color: ${({ theme, checked }) =>
+	background-color: ${({ theme, checked, $light }) =>
 		checked
-			? theme.colors.bases.primary[700]
+			? theme.darkMode && !$light
+				? theme.colors.extended.grey[100]
+				: theme.colors.bases.primary[700]
 			: theme.colors.extended.grey[600]};
 	color: inherit;
 	font-family: ${({ theme }) => theme.fonts.main};
@@ -136,7 +142,7 @@ export const Switch = (props: SwitchProps) => {
 					tabIndex={0}
 					ref={ref}
 				/>
-				<StyledSpan aria-hidden checked={isSelected} />
+				<StyledSpan aria-hidden checked={isSelected} $light={light} />
 			</StyledSwitch>
 
 			{srOnlyLabel ? (

--- a/site/source/design-system/tooltip/Tooltip.tsx
+++ b/site/source/design-system/tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@ import {
 	flip,
 	offset,
 	shift,
+	Strategy,
 	useFloating,
 } from '@floating-ui/react-dom'
 import { ReactNode, useId, useState } from 'react'
@@ -60,12 +61,9 @@ export const Tooltip = ({
 					id={id}
 					ref={refs.setFloating}
 					role="tooltip"
-					style={{
-						position: strategy,
-						top: y ?? 0,
-						left: x ?? 0,
-						width: 'max-content',
-					}}
+					position={strategy}
+					top={y ?? 0}
+					left={x ?? 0}
 				>
 					{tooltip}
 				</StyledTooltip>
@@ -74,21 +72,30 @@ export const Tooltip = ({
 	)
 }
 
-const StyledTooltip = styled.span`
+const StyledTooltip = styled.span.withConfig({
+	shouldForwardProp: (prop) => !['position', 'top', 'left'].includes(prop),
+})<{
+	position: Strategy
+	top: number
+	left: number
+}>`
+	position: ${({ position }) => position};
+	top: ${({ top }) => `${top}px`};
+	left: ${({ left }) => `${left}px`};
+	width: max-content;
 	max-width: 20rem;
-
 	opacity: 1 !important;
+	z-index: 100;
+	padding: ${({ theme }) => `${theme.spacings.xs} ${theme.spacings.sm}`};
 	font-family: ${({ theme }) => theme.fonts.main};
 	font-size: ${({ theme }) => theme.fontSizes.min};
 	line-height: ${({ theme }) => theme.lineHeights.sm};
+	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	background: ${({ theme }) => theme.colors.extended.grey[800]};
-	padding: ${({ theme }) => `${theme.spacings.xs} ${theme.spacings.sm}`};
 	border: 1px solid
 		${({ theme }) =>
 			theme.darkMode ? theme.colors.extended.dark[500] : 'transparent'};
-	color: ${({ theme }) => theme.colors.extended.grey[100]};
 	border-radius: ${({ theme }) => theme.box.borderRadius};
-	z-index: 100;
 	pointer-events: none;
 	* {
 		color: ${({ theme }) => theme.colors.extended.grey[100]};

--- a/site/source/design-system/tooltip/Tooltip.tsx
+++ b/site/source/design-system/tooltip/Tooltip.tsx
@@ -5,7 +5,7 @@ import {
 	shift,
 	useFloating,
 } from '@floating-ui/react-dom'
-import { CSSProperties, ReactNode, useId, useState } from 'react'
+import { ReactNode, useId, useState } from 'react'
 import { styled } from 'styled-components'
 
 import { useOnKeyDown } from '@/hooks/useOnKeyDown'
@@ -14,12 +14,10 @@ export const Tooltip = ({
 	children,
 	tooltip,
 	className,
-	style,
 }: {
 	children: ReactNode
 	tooltip: ReactNode
 	className?: string
-	style?: CSSProperties
 }) => {
 	const [isOpen, setIsOpen] = useState(false)
 
@@ -47,7 +45,6 @@ export const Tooltip = ({
 		<>
 			<StyledButtonAsText
 				className={className}
-				style={style}
 				ref={refs.setReference}
 				onMouseEnter={() => setIsOpen(true)}
 				onMouseLeave={() => setIsOpen(false)}

--- a/site/source/design-system/typography/list.tsx
+++ b/site/source/design-system/typography/list.tsx
@@ -72,7 +72,10 @@ export const UlStyle = css<ListProps>`
 	}
 	> ${Li} ${Li}::before {
 		font-size: 60%;
-		color: ${({ theme }) => theme.colors.bases.primary[700]};
+		color: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.grey[100]
+				: theme.colors.bases.primary[700]};
 	}
 `
 export const Ul = styled.ul<ListProps>`

--- a/site/source/pages/simulateurs/SimulateurPageLayout.tsx
+++ b/site/source/pages/simulateurs/SimulateurPageLayout.tsx
@@ -85,7 +85,7 @@ export default function SimulateurPageLayout({
 
 			{beta && <BetaBanner />}
 
-			{children}
+			{inIframe ? <Conteneur>{children}</Conteneur> : children}
 
 			{!inIframe && (
 				<>
@@ -106,6 +106,9 @@ export default function SimulateurPageLayout({
 	)
 }
 
+const Conteneur = styled.div`
+	padding: 0 ${({ theme }) => theme.spacings.xxxs};
+`
 const StyledSpan = styled.span`
 	margin-right: ${({ theme }) => theme.spacings.sm};
 `

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Comparaison.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Comparaison.tsx
@@ -343,7 +343,7 @@ export const Comparaison = ({
 							'point(s) acquis par an'
 						)}
 						footer={(engine) => (
-							<Body style={{ margin: 0 }}>
+							<BodyNoMargin>
 								<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.retraite.complémentaire.valeur-du-point">
 									Valeur du point&nbsp;:{' '}
 									<Strong>
@@ -355,7 +355,7 @@ export const Comparaison = ({
 										/>
 									</Strong>
 								</Trans>
-							</Body>
+							</BodyNoMargin>
 						)}
 					/>
 
@@ -455,16 +455,8 @@ export const Comparaison = ({
 								expression="protection sociale . maladie . arrêt maladie != 0"
 							>
 								<StyledDiv>
-									<CircledPlusIcon
-										style={{
-											marginTop: '0 !important',
-										}}
-									/>
-									<Body
-										style={{
-											margin: '0',
-										}}
-									>
+									<CircledPlusIcon />
+									<BodyNoMargin>
 										<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.santé.arrêt.footer">
 											Pour y prétendre, vous devez avoir cotisé au moins{' '}
 											<Strong>
@@ -474,7 +466,7 @@ export const Comparaison = ({
 												/>
 											</Strong>
 										</Trans>
-									</Body>
+									</BodyNoMargin>
 								</StyledDiv>
 							</Condition>
 						)}
@@ -642,11 +634,7 @@ export const Comparaison = ({
 							</Strong>
 							.
 						</BodyNoMargin>
-						<BodyNoTopMargin
-							style={{
-								marginBottom: '1rem',
-							}}
-						>
+						<BodyNoTopMargin>
 							Pour y prétendre, vous devez respecter{' '}
 							<BlackColoredLink href="https://www.service-public.fr/particuliers/vosdroits/F672">
 								certaines règles
@@ -669,7 +657,7 @@ export const Comparaison = ({
 							</span>
 						}
 						evolutionLabel={
-							<span style={{ fontSize: '0.75rem' }}>
+							<span style={{ fontSize: '0.875rem' }}>
 								{t(
 									'pages.simulateurs.comparaison-statuts.items.prévoyance.invalidité.evolution-label',
 									'(invalidité totale)'
@@ -862,11 +850,11 @@ const StyledMessage = styled(Message)`
 
 const StyledDiv = styled.div`
 	display: flex;
+	align-items: center;
+	column-gap: ${({ theme }) => theme.spacings.md};
 
 	svg {
 		width: 2.5rem;
-		margin-right: 1rem;
-		margin-top: 1rem;
 	}
 `
 

--- a/site/source/pages/simulateurs/comparaison-statuts/components/Comparaison.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/Comparaison.tsx
@@ -103,7 +103,7 @@ export const Comparaison = ({
 						'Vos revenus'
 					)}
 				>
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.revenus.h4',
 							'Revenu net mensuel après impôts'
@@ -121,7 +121,7 @@ export const Comparaison = ({
 						>
 							<RevenuTable namedEngines={namedEngines} />
 						</InfoButton>
-					</StyledH4>
+					</H4>
 					<DetailsRowCards
 						dottedName="dirigeant . rémunération . net . après impôt"
 						namedEngines={namedEngines}
@@ -270,13 +270,13 @@ export const Comparaison = ({
 						'Vos droits pour la retraite'
 					)}
 				>
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.retraite.base.h4',
 							'Retraite de base'
 						)}
 						<ExplicableRule dottedName="protection sociale . retraite . trimestres" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.retraite.base.body">
 							Chaque année, selon votre rémunération, vous validez{' '}
@@ -319,13 +319,13 @@ export const Comparaison = ({
 						/>
 					</Condition>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.retraite.complémentaire.h4',
 							'Retraite complémentaire'
 						)}
 						<ExplicableRule dottedName="protection sociale . retraite . complémentaire" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.retraite.complémentaire.body">
 							Tous les ans, selon votre rémunération,{' '}
@@ -409,13 +409,13 @@ export const Comparaison = ({
 						</BodyNoMargin>
 					</Trans>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.santé.arrêt.h4',
 							'Arrêt maladie'
 						)}
 						<ExplicableRule dottedName="protection sociale . maladie . arrêt maladie" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.santé.arrêt.body">
 							Pour tous les statuts, vous aurez un{' '}
@@ -480,13 +480,13 @@ export const Comparaison = ({
 						)}
 					/>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.santé.atmp.h4',
 							'Accident du travail et maladie professionnelle'
 						)}
 						<ExplicableRule dottedName="protection sociale . maladie . accidents du travail et maladies professionnelles . indemmnités" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.santé.atmp.body">
 							En cas d’<Strong>accident du travail</Strong>, de{' '}
@@ -543,13 +543,13 @@ export const Comparaison = ({
 						unit="€/jour"
 					/>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.parentalité.maternité.h4',
 							'Maternité'
 						)}
 						<ExplicableRule dottedName="protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos maternel" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.parentalité.maternité.body">
 							En plus des indemnités journalières, vous pouvez aussi prétendre à
@@ -569,13 +569,13 @@ export const Comparaison = ({
 						)}
 					/>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.parentalité.adoption.h4',
 							'Adoption'
 						)}
 						<ExplicableRule dottedName="protection sociale . maladie . maternité paternité adoption . allocation forfaitaire de repos adoption" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.parentalité.adoption.body">
 							En plus des indemnités journalières, vous pouvez aussi prétendre à
@@ -626,13 +626,13 @@ export const Comparaison = ({
 							.
 						</Trans>
 					</Body>
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.prévoyance.invalidité.h4',
 							'Invalidité'
 						)}
 						<ExplicableRule dottedName="protection sociale . invalidité et décès" />
-					</StyledH4>
+					</H4>
 					<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.prévoyance.invalidité.body.1">
 						<BodyNoMargin>
 							Vous pouvez bénéficier d’une pension invalidité{' '}
@@ -690,13 +690,13 @@ export const Comparaison = ({
 						unit="€/mois"
 					/>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.prévoyance.décès.h4',
 							'Décès'
 						)}
 						<ExplicableRule dottedName="protection sociale . invalidité et décès . capital décès" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.prévoyance.décès.body.1">
 							La Sécurité Sociale garantit un{' '}
@@ -781,13 +781,13 @@ export const Comparaison = ({
 						'La gestion juridique et comptable'
 					)}
 				>
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.gestion.création.h4',
 							'Coût de création'
 						)}
 						<ExplicableRule dottedName="entreprise . coût formalités . création" />
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.gestion.création.body">
 							Les formalités de création d’une entreprise diffèrent selon les
@@ -803,12 +803,12 @@ export const Comparaison = ({
 						displayedUnit="€ HT"
 					/>
 
-					<StyledH4>
+					<H4>
 						{t(
 							'pages.simulateurs.comparaison-statuts.items.gestion.conjoint.h4',
 							'Statut du conjoint / de la conjointe'
 						)}
-					</StyledH4>
+					</H4>
 					<Body>
 						<Trans i18nKey="pages.simulateurs.comparaison-statuts.items.gestion.conjoint.body">
 							Vous êtes marié/mariée, pacsé/pacsée ou en union libre&nbsp;: il
@@ -858,9 +858,6 @@ export const Comparaison = ({
 const StyledMessage = styled(Message)`
 	margin-top: ${({ theme }) => theme.spacings.xl};
 	margin-bottom: -${({ theme }) => theme.spacings.md};
-`
-const StyledH4 = styled(H4)`
-	color: ${({ theme }) => theme.colors.bases.primary[600]};
 `
 
 const StyledDiv = styled.div`

--- a/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
+++ b/site/source/pages/simulateurs/comparaison-statuts/components/DetailsRowCards.tsx
@@ -175,7 +175,7 @@ const DetailsRowCards = ({
 									)}
 								</StatusCard.Titre>
 							)}
-							{evolutionDottedName && (
+							{isDefinedAndApplicable && evolutionDottedName && (
 								<StatusCard.ValeurSecondaire>
 									<Value
 										linkToRule={false}


### PR DESCRIPTION
Diverses petites corrections :
- mode sombre de certains éléments
  - les switch "CA mixte" et "mode clair/sombre"
  - les icônes (notamment celle avec flèche dans le titre de chaque catégorie du comparateur)
  -  l'explication de règle quand elle est dans le bloc objectifs (par ex : montant des cotisations sur les simulateurs indépendant)
  - le focus des éléments (boutons, option dans une question radio, ...)
- code de l'affichage des résultats de recherche Algolia (normalement aucun impact fonctionnel)
- affichage des valeurs secondaires dans le comparateur en cas d'absence de résultat (pension d'invalidité totale et IJ à partir du 29ème jour en cas de revenus trop faibles)
- alignement en version mobile des objectifs sans description (ex: rémunération brute en SASU)
- suppression du bouton "info" du bloc des objectifs
- correction du troncage de la nouvelle disposition en iframe