### PR TITLE
fix: découple MonthOptions des composants internes de TextField via CSS custom properties

### DIFF
--- a/site/source/design-system/molecules/field/TextField.tsx
+++ b/site/source/design-system/molecules/field/TextField.tsx
@@ -153,23 +153,27 @@ export const StyledInputContainer = styled.div.withConfig({
 				? theme.colors.extended.grey[100]
 				: theme.colors.extended.grey[700]
 		}`};
+	border-color: var(--field-border-color, ${({ theme }) =>
+		theme.darkMode
+			? theme.colors.extended.grey[100]
+			: theme.colors.extended.grey[700]}) !important;
 	outline: transparent solid 1px;
 	position: relative;
 	display: flex;
-	background-color: ${({ theme }) =>
+	background-color: var(--field-background-color, ${({ theme }) =>
 		theme.darkMode
 			? 'rgba(255, 255, 255, 10%)'
-			: theme.colors.extended.grey[100]};
+			: theme.colors.extended.grey[100]});
 	align-items: center;
 	transition: all 0.2s;
 
 	&:focus-within {
-		outline-color: ${({ theme, hasError }) =>
+		outline-color: var(--field-focus-outline-color, ${({ theme, hasError }) =>
 			hasError
 				? theme.colors.extended.error[400]
 				: theme.darkMode
 				? theme.colors.bases.primary[100]
-				: theme.colors.bases.primary[700]};
+				: theme.colors.bases.primary[700]}) !important;
 		outline-offset: ${({ theme }) => theme.spacings.xxs};
 		outline-width: ${({ theme }) => theme.spacings.xxs};
 	}
@@ -228,10 +232,10 @@ export const StyledInputContainer = styled.div.withConfig({
 				: css`calc(${hasLabel ? LABEL_HEIGHT : '0rem'} + ${
 						theme.spacings.xs
 				  }) ${theme.spacings.sm} ${theme.spacings.xs}`};
-		color: ${({ theme }) =>
+		color:  var(--field-text-color, ${({ theme }) =>
 			theme.darkMode
 				? theme.colors.extended.grey[100]
-				: theme.colors.extended.grey[800]};
+				: theme.colors.extended.grey[800]}) !important;
 	}
 
 	${({ small }) =>

--- a/site/source/pages/simulateurs/lodeom/components/MonthOptions.tsx
+++ b/site/source/pages/simulateurs/lodeom/components/MonthOptions.tsx
@@ -13,9 +13,6 @@ import {
 	QuantitéField,
 	SmallBody,
 	Strong,
-	StyledInput,
-	StyledInputContainer,
-	StyledSuffix,
 	Ul,
 } from '@/design-system'
 import { euros } from '@/domaine/Montant'
@@ -89,7 +86,7 @@ export default function MonthOptions({
 		}
 		onOptionsChange(index, newOptions)
 	}
-
+	
 	return (
 		<Appear>
 			<GridContainer container columnSpacing={4}>
@@ -270,26 +267,13 @@ const StyledLabel = styled(SmallBody)`
 	margin: 0;
 	color: ${({ theme }) => theme.colors.bases.primary[800]};
 `
-// FIXME: Ce composant utilise des styled components internes de TextField
-// (StyledInputContainer, StyledInput, StyledSuffix) qui ne devraient pas être
-// exposés publiquement car ils créent un couplage fort avec l'implémentation
-// interne. Il faudrait refactorer ce code pour soit :
-// - Utiliser des props de style sur les composants de field
-// - Créer un composant dédié dans le design-system
-// - Utiliser des sélecteurs CSS génériques
 const NumberFieldContainer = styled.div`
 	max-width: 120px;
-	${StyledInputContainer} {
-		border-color: ${({ theme }) => theme.colors.bases.primary[800]};
-		background-color: 'rgba(255, 255, 255, 10%)';
-		&:focus-within {
-			outline-color: ${({ theme }) => theme.colors.bases.primary[700]};
-		}
-		${StyledInput}, ${StyledSuffix} {
-			color: ${({ theme }) => theme.colors.bases.primary[800]}!important;
-		}
-	}
+	--field-border-color: ${({ theme }) => theme.colors.bases.primary[800]};
+	--field-focus-outline-color: ${({ theme }) => theme.colors.bases.primary[700]};
+	--field-text-color: ${({ theme }) => theme.colors.bases.primary[800]};
 `
+
 const StyledSmallBody = styled(SmallBody)`
 	font-weight: bold;
 	color: ${({ theme }) => theme.colors.bases.primary[800]};


### PR DESCRIPTION
Première PR sur l'issue #3686 (Éviter l'utilisation des composants styled-components internes d'autres modules), scopée à MonthOptions.tsx, le cas le plus isolé (un seul fichier consommateur, hors design-system).

## Solution
Ajout de CSS custom properties (`--field-border-color`, `--field-focus-outline-color`, `--field-text-color`) sur StyledInputContainer/StyledInput dans TextField.tsx, avec valeur de repli identique au style actuel. MonthOptions.tsx définit ces variables au lieu d'importer et de surcharger directement les composants internes de TextField.

## Validation
- yarn lint / yarn test:type / yarn test : aucune erreur
- Aucun changement visuel constaté en mode clair et sombre
- Le `!important` original a été conservé sur border-color, outline-color et color (nécessaire pour primer sur une règle de dark mode existante dans TextField.tsx) ; retiré sur background-color, dont l'ancienne valeur était en fait invalide et donc déjà sans effet

## Suite
Si l'approche est validée, j'appliquerai le même pattern à SearchableSelectField et ToggleGroup dans des PRs séparées.