### PR TITLE
Déclaration d'accessibilité : retrait du doublon concernant la date de mise à jour

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -588,7 +588,7 @@ pages:
     a letter by post (free of charge, do not use a stamp) to:<1></1>Défenseur
     des droits<3></3>Libre réponse 71120<5></5>75342 Paris CEDEX
     07</2><3>Contact the D&eacute;fenseur des droits by telephone: <2>+33 9 69
-    39 00 00</2></3></43><44>Updated on May 27, 2025</44>"
+    39 00 00</2></3></43>"
   assistants:
     activité-détails:
       next1: Continue with this activity

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -620,8 +620,7 @@ pages:
     courrier par la poste (gratuit, ne pas mettre de timbre) à :<1></1>Défenseur
     des droits<3></3>Libre réponse 71120<5></5>75342 Paris CEDEX
     07</2><3>Contacter le D&eacute;fenseur des droits par
-    t&eacute;l&eacute;phone : <2>+33 9 69 39 00 00</2></3></43><44>Mis à jour le
-    27 mai 2025</44>"
+    t&eacute;l&eacute;phone : <2>+33 9 69 39 00 00</2></3></43>"
   assistants:
     activité-détails:
       next1: Continuer avec cette activité

--- a/site/source/pages/Accessibilité.tsx
+++ b/site/source/pages/Accessibilité.tsx
@@ -6,7 +6,7 @@ import { typography } from '@/design-system'
 
 import Meta from '../components/utils/Meta'
 
-const { H1, Body, H2, H3, H4, Li, Link, SmallBody, Ul } = typography
+const { H1, Body, H2, H3, H4, Li, Link, Ul } = typography
 
 export default function Accessibilité() {
 	const { t } = useTranslation()
@@ -311,7 +311,6 @@ export default function Accessibilité() {
 					</Link>
 				</Li>
 			</Ul>
-			<SmallBody>Mis à jour le 27 mai 2025</SmallBody>
 		</Trans>
 	)
 }


### PR DESCRIPTION
Cette PR express retire la ligne finale de la déclaration d'accessibilité, indiquant sa date de mise à jour :

<img width="541" height="106" alt="image" src="https://github.com/user-attachments/assets/45814f17-17db-48ea-a122-e5c6ec5ca4f0" />

Celle-ci n'est pas à jour (c'est dommage pour une date de mise à jour 😁 ) et fait doublon avec l'information dans le corps de la déclaration : 

<img width="1107" height="147" alt="image" src="https://github.com/user-attachments/assets/9a1fed10-cfe1-47ad-a4dc-875c27d3abb8" />

Il me semble préférable de ne pas doublonner l'info et de ne conserver que la seconde.