### PR TITLE
Minuscules améliorations pour la traduction

### DIFF
--- a/site/scripts/i18n/parser.config.js
+++ b/site/scripts/i18n/parser.config.js
@@ -12,7 +12,7 @@ export default {
 
 	// Default value to give to empty keys
 	defaultValue(locale, namespace, key, value) {
-		return key === value || (key && value === '') ? 'NO_TRANSLATION' : value
+		return key === value || (key && value === '') ? key : value
 	},
 
 	indentation: 2,

--- a/site/scripts/i18n/translate-ui.js
+++ b/site/scripts/i18n/translate-ui.js
@@ -19,7 +19,6 @@ let originalKeys = yaml.parse(readFileSync(UiOriginalTranslationPath, 'utf-8'))
 let translatedKeys = yaml.parse(readFileSync(UiTranslationPath, 'utf-8'))
 await Promise.all(
 	Object.entries(missingTranslations)
-		.map(([key, value]) => [key, value === 'NO_TRANSLATION' ? key : value])
 		.map(async ([key, originalTranslation], i) => {
 			try {
 				await sleep(i * 50)

--- a/site/scripts/i18n/translate-ui.js
+++ b/site/scripts/i18n/translate-ui.js
@@ -18,8 +18,8 @@ const missingTranslations = getUiMissingTranslations()
 let originalKeys = yaml.parse(readFileSync(UiOriginalTranslationPath, 'utf-8'))
 let translatedKeys = yaml.parse(readFileSync(UiTranslationPath, 'utf-8'))
 await Promise.all(
-	Object.entries(missingTranslations)
-		.map(async ([key, originalTranslation], i) => {
+	Object.entries(missingTranslations).map(
+		async ([key, originalTranslation], i) => {
 			try {
 				await sleep(i * 50)
 				const translation = await fetchTranslation(originalTranslation)
@@ -30,7 +30,8 @@ await Promise.all(
 				console.error(e)
 				console.log(originalTranslation)
 			}
-		})
+		}
+	)
 )
 
 const { originalTranslations, translatedTranslations } =

--- a/site/scripts/i18n/utils.js
+++ b/site/scripts/i18n/utils.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 
 import dotenv from 'dotenv'
+import { Record } from 'effect'
 import rulesAS from 'modele-as'
 import rules from 'modele-social'
 import rulesTI from 'modele-ti'
@@ -11,11 +12,11 @@ dotenv.config()
 export const localesPath = new URL('../../source/locales/', import.meta.url)
 	.pathname
 export const UiStaticAnalysisPath = localesPath + 'static-analysis-fr.json'
-export const rulesTranslationFile = 'rules-en.yaml'
-export const rulesTranslationFileTI = 'rules-ti-en.yaml'
-export const rulesTranslationFileAS = 'rules-as-en.yaml'
 export const UiTranslationPath = localesPath + 'ui-en.yaml'
 export const UiOriginalTranslationPath = localesPath + 'ui-fr.yaml'
+const rulesTranslationFile = 'rules-en.yaml'
+const rulesTranslationFileTI = 'rules-ti-en.yaml'
+const rulesTranslationFileAS = 'rules-as-en.yaml'
 
 let attributesToTranslate = [
 	'titre',
@@ -133,28 +134,19 @@ export const getUiMissingTranslations = () => {
 		readFileSync(UiOriginalTranslationPath, 'utf-8')
 	)
 
-	const missingTranslations = Object.entries(staticKeys)
-		.filter(([key, valueInSource]) => {
-			if (key.match(/^\{.*\}$/) || key.includes('NO_AUTO_TRANSLATION')) {
-				return false
-			}
-			const keys = key.split(/(?<=[A-zÀ-ü0-9])\.(?=[A-zÀ-ü0-9])/)
-			const pathReducer = (currentSelection, subPath) =>
-				currentSelection?.[subPath]
-			const isNewKey = !keys.reduce(pathReducer, translatedKeys)
-			const isInvalidatedKey =
-				keys.reduce(pathReducer, originalKeys) !==
-				(valueInSource === 'NO_TRANSLATION' ? key : valueInSource)
+	const pathReducer = (currentSelection, subPath) => currentSelection?.[subPath]
 
-			return isNewKey || isInvalidatedKey
-		}, staticKeys)
-		.map(([key]) => key)
+	return Record.filter(staticKeys, (valueInSource, key) => {
+		if (key.match(/^\{.*\}$/) || key.includes('NO_AUTO_TRANSLATION')) {
+			return false
+		}
 
-	return Object.fromEntries(
-		Object.entries(staticKeys).filter(([key]) =>
-			missingTranslations.includes(key)
-		)
-	)
+		const keys = key.split(/(?<=[A-zÀ-ü0-9])\.(?=[A-zÀ-ü0-9])/)
+		const isNewKey = !keys.reduce(pathReducer, translatedKeys)
+		const isNewValue = keys.reduce(pathReducer, originalKeys) !== valueInSource
+
+		return isNewKey || isNewValue
+	})
 }
 
 const getInObject = (keys, object) =>
@@ -175,33 +167,35 @@ export function assocPath(path, val, obj) {
 export const filterUnusedTranslations = (original, translated) => {
 	const staticKeys = JSON.parse(readFileSync(UiStaticAnalysisPath, 'utf-8'))
 
-	const ret = Object.keys(staticKeys).reduce(
-		(obj, key) => {
+	return Object.keys(staticKeys).reduce(
+		({ originalTranslations, translatedTranslations }, key) => {
 			const keys = key.split(/(?<=[A-zÀ-ü0-9])\.(?=[A-zÀ-ü0-9])/)
 
-			obj.originalTranslations = assocPath(
+			originalTranslations = assocPath(
 				keys,
 				getInObject(keys, original),
-				obj.originalTranslations
+				originalTranslations
 			)
-			obj.translatedTranslations = assocPath(
+			translatedTranslations = assocPath(
 				keys,
 				getInObject(keys, translated),
-				obj.translatedTranslations
+				translatedTranslations
 			)
 
-			return obj
+			return {
+				originalTranslations,
+				translatedTranslations,
+			}
 		},
 		{ originalTranslations: {}, translatedTranslations: {} }
 	)
-
-	return ret
 }
 
 export const fetchTranslation = async (text) => {
 	if (typeof text !== 'string') {
 		throw new Error("❌ Can't translate anything other than a string")
 	}
+
 	const response = await fetch(`https://api.deepl.com/v2/translate`, {
 		method: 'POST',
 		headers: {
@@ -219,11 +213,13 @@ export const fetchTranslation = async (text) => {
 			target_lang: 'EN',
 		}),
 	})
+
 	if (response.status !== 200) {
 		const msg = JSON.stringify(text, null, 2)
 		console.error(`❌ Deepl return status ${response.status} for:\n\t${msg}\n`)
 		return ''
 	}
+
 	try {
 		const { translations } = await response.json()
 		const translation = translations[0].text

--- a/site/source/components/ConseillersEntreprisesButton.tsx
+++ b/site/source/components/ConseillersEntreprisesButton.tsx
@@ -94,8 +94,12 @@ export const ConseillersEntreprisesButton = ({
 						</Suspense>
 
 						<Body style={{ textAlign: 'right' }}>
-							<Button aria-label={t('Fermer')} size="XS" onPress={close}>
-								{t('Fermer')}
+							<Button
+								aria-label={t('global.fermer', 'Fermer')}
+								size="XS"
+								onPress={close}
+							>
+								{t('global.fermer', 'Fermer')}
 							</Button>
 						</Body>
 					</>

--- a/site/source/components/JeDonneMonAvis.tsx
+++ b/site/source/components/JeDonneMonAvis.tsx
@@ -12,6 +12,7 @@ export const JeDonneMonAvis = ({ light }: { light?: boolean }) => {
 		<Link
 			href={href}
 			aria-label={t(
+				'feedback.jedonnemonavis.aria-label',
 				'Je donne mon avis, donner mon avis sur jedonnemonavis.numerique.gouv.fr, nouvelle fenêtre'
 			)}
 		>

--- a/site/source/components/ServiceWorker.tsx
+++ b/site/source/components/ServiceWorker.tsx
@@ -119,7 +119,7 @@ export const ServiceWorker = () => {
 
 					<StyledClosedButton
 						onPress={() => setNeedRefresh(false)}
-						aria-label={t('Fermer')}
+						aria-label={t('global.fermer', 'Fermer')}
 					/>
 				</StyledMessage>
 			)}

--- a/site/source/components/layout/Footer/Footer.tsx
+++ b/site/source/components/layout/Footer/Footer.tsx
@@ -88,6 +88,7 @@ export default function Footer() {
 							<Link
 								href="https://www.urssaf.fr"
 								aria-label={t(
+									'footer.urssaf.aria-label',
 									'Urssaf, voir le site urssaf.fr, nouvelle fenêtre'
 								)}
 							>
@@ -144,7 +145,7 @@ export default function Footer() {
 											href="https://github.com/betagouv/mon-entreprise"
 											noUnderline
 											aria-label={t(
-												'footer.github.new-window',
+												'footer.github.aria-label',
 												'Voir le code source sur Github, nouvelle fenêtre'
 											)}
 										>

--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -54,7 +54,6 @@ EntrepriseSearchField:
   placeholder: "Example: Café de la gare or 40123778000127"
 ExportSimulation:
   Banner: Print or save as PDF
-Fermer: Close
 Fiche de paie: Pay slip
 Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section):
   Graph detailing the number of visits per simulator (alternative accessible via
@@ -70,11 +69,6 @@ Impôts: Taxes
 Insérer dans le champ la valeur du {{text}}: Insert the value of the {{text}}
 Intégrer le module Web: Integrating the Web module
 Intégrer nos simulateurs: Integrate our simulators
-Je donne mon avis, donner mon avis sur jedonnemonavis:
-  numerique:
-    gouv:
-      fr, nouvelle fenêtre: I give my opinion, give my opinion on
-        jedonnemonavis.numerique.gouv.fr, new window
 Jours: Days
 Le montant demandé n'est <2>pas calculable…</2>: The amount requested <2>cannot be calculated...</2>
 Les données de simulations se mettront automatiquement à jour après la modification d'un champ. <2>Un panneau s'ouvrira pour vous permettre d'apporter des précisions à la simulation, des résultats détaillés s'afficheront en dessous du formulaire et seront mis à jour quand vous modifierez ce dernier.</2>:
@@ -89,20 +83,15 @@ Message à caractère informatif: Informative message
 Modifier mes réponses: Modify my answers
 Mois: Month
 Mon entreprise: My company
-Mon entreprise recrute ! Voir les offres d'emplois de mon-entreprise:
-  urssaf:
-    fr: My company is recruiting! See job offers on mon-entreprise.urssaf.fr
 Montant annuel: Annual amount
 Montant mensuel: Monthly amount
 Mots-clés définissants l'activité: Keywords defining the activity
 Nombres: Numbers
-Non: No
 Nous n’avons pas trouvé de résultat pour cette entreprise.: No results were found for this company.
 Nouveau contenu disponible, cliquez sur recharger pour mettre à jour la page.: New content available, click reload to update page.
 Nouveautés: News
 Option ACRE non activée: ACRE option not activated
 Options: Options
-Oui: Yes
 Outils pour les développeurs: Tools for developers
 PFU (<1>"flat tax"</1>): PFU (<1>"flat tax"</1>)
 Page d'accueil: Home page
@@ -155,8 +144,6 @@ Tout réinitialiser: Reset all
 Trimestre: Quarter
 URL de votre simulation: URL of your simulation
 Un avis sur cette page ?: What do you think of this page?
-Urssaf, voir le site urssaf:
-  fr, nouvelle fenêtre: Urssaf, see the urssaf.fr website, new window
 Utiliser avec un tableur: Using a spreadsheet
 Utiliser les calculs des simulateurs dans votre application: Use simulator calculations in your application
 Version bêta: Beta version
@@ -180,7 +167,6 @@ accessibility:
     Accessibility Improvement Reference System)
   title: Accessibility
 aides différées, voir le détail du calcul pour aides différées: deferred aid, see detailed calculation for deferred aid
-août: August
 api:
   description: Tools for developers
   title: Use our REST API
@@ -204,15 +190,9 @@ aria-label:
   service-public: service-public.fr, new window
   urssaf: Urssaf, access to urssaf.fr, new window
   équipe: team, access our team presentation page, new window
-avril: April
 cards:
   simulator-resource:
     cta: Access the simulator
-certains critères, en savoir plus sur entreprendre:
-  service-public:
-    gouv:
-      fr, nouvelle fenêtre: certain criteria, find out more at
-        entreprendre.service-public.gouv.fr, new window
 checklist:
   showmore:
     closed: Read more
@@ -355,7 +335,6 @@ design-system:
     open-selector: Open date selector
     prev-month: Previous month
     year: Year
-décembre: December
 entreprise:
   détails: Company created on <1> </1> and domiciled at <3></3>.
 error:
@@ -384,6 +363,9 @@ feedback:
       try again or contact us by e-mail at
       <4>contact@mon-entreprise.beta.gouv.fr</4>.
     title: <0>An error has occurred while sending the message</0>
+  jedonnemonavis:
+    aria-label: I'm giving my opinion, give my opinion on
+      jedonnemonavis.numerique.gouv.fr, new window
   reportError: Make a suggestion
   success:
     body1: Our team will take care of your return.
@@ -393,15 +375,28 @@ feedback:
   thanks: Thank you for your feedback!
 footer:
   github:
-    new-window: View source code on Github, new window
+    aria-label: View the source code on GitHub (opens in a new window)
     text: View source code on Github
-février: February
+  urssaf:
+    aria-label: Urssaf, visit the urssaf.fr website (opens in a new window)
 gestion sémantique de version, en savoir plus, nouvelle fenêtre: semantic version management, learn more, new window
 global:
   fermer: Close
-  oui-non:
-    non: No
-    oui: Yes
+  mois:
+    août: August
+    avril: April
+    décembre: December
+    février: February
+    janvier: January
+    juillet: July
+    juin: June
+    mai: May
+    mars: March
+    novembre: November
+    octobre: October
+    septembre: September
+  non: No
+  oui: Yes
 gérer:
   ressources:
     annuaire-entreprises:
@@ -423,10 +418,7 @@ iframe:
 intégration:
   description: Tools for developers
   title: Integration
-janvier: January
 jours: days
-juillet: July
-juin: June
 l'annuaire des entreprises, nouvelle fenêtre: business directory, new window
 landing:
   aboutUs: "<0>Who are we?</0><1>We are a small <2>team</2> autonomous and
@@ -448,8 +440,6 @@ landing:
   subtitle: Wizards and simulators for <2>personalized answers</2> to your
     questions about <5>setting up and running</5> your business.
   title: Official tools for entrepreneurs
-le portail officiel, accéder à aides-entreprises:
-  fr, nouvelle fenêtre: the official portal, access to aides-entreprises.fr, new window
 legalNotice:
   accessibility:
     content: The platform is <2>partially compliant</2> with digital accessibility
@@ -479,9 +469,7 @@ legalNotice:
 library:
   description: Tools for developers
   title: Calculation library
-mai: May
 main-menu: Main menu
-mars: March
 messages:
   loading: Loading in progress...
   masquer-message: Hide message
@@ -505,8 +493,6 @@ nextSteps:
     cta: See the documentation
     title: Integrate the web module
 nombres de votes: number of votes
-novembre: November
-octobre: October
 pages:
   "404":
     action: Back to safety
@@ -1154,6 +1140,8 @@ pages:
           aria-label: Urssaf, see integration, new window
           cta-label: See integration
     module: Which module?
+    recrutement:
+      aria-label: My company is hiring! View job openings at mon-entreprise.urssaf.fr
     spreadsheet: <0>Using a spreadsheet</0><1>Would you like to use a simulator in a
       Google Sheets or Excel spreadsheet? Our <2>REST API</2> makes it
       possible!</1><2>Integrate a simulator in Excel/Sheets</2><3>Eventually,
@@ -1763,23 +1751,30 @@ pages:
         cotisations: Contributions
         impôt: Tax
         revenu: Net dividends
-      seo: <0>Dividends and distributions</0><1>At the end of a company's financial
-        year, the previous year's earnings can be held in reserve (for future
-        investment) or paid out as dividends. From the beneficiaries' point of
-        view, this is income from movable capital, subject to specific
-        contributions and taxation.</1><2>This simulator only takes into account
-        the case of an individual beneficiary and dividends decided by the
-        company.</2><3>How are dividend withholdings calculated?</3><4>Dividends
-        may be subject to a flat-rate withholding tax of 30%, including tax and
-        social security contributions (also known as<1> flat tax</1>).
-        Alternatively, you can opt for the tax scale. This simulator can be used
-        to compare the two systems.</4><5>A 12.8% advance payment is made at the
-        time of dividend payment, unless the beneficiary meets <2>certain
-        criteria</2>.</5><6>Special case of self-employed executives</6><7>For
-        the self-employed worker, the portion of dividends exceeding 10% of the
-        share capital will be subject to contributions and levies in the same
-        way as his or her executive remuneration.</7><8>In this case, please use
-        the <2>income simulator for self-employed workers</2>.</8>
+      seo:
+        aria-label: certain criteria; learn more at entreprendre.service-public.gouv.fr
+          (opens in a new window)
+        text: <0>Dividends and Distributions</0><1>At the end of a company’s fiscal
+          year, the net income from the previous fiscal year may be retained as
+          retained earnings (for future investments) or paid out as dividends.
+          From the beneficiaries’ perspective, these are investment income,
+          subject to specific social security contributions and
+          taxation.</1><2>This simulator only takes into account scenarios
+          involving individual recipients and dividends declared by the
+          company.</2><3>How are withholding taxes on dividends
+          calculated?</3><4>Dividends may be subject to a single flat-rate
+          withholding tax of 30%, which includes both income tax and social
+          security contributions (also known as the &lt;1> flat tax</1>).
+          Alternatively, the standard tax schedule may be chosen. This simulator
+          can be used to compare the two systems.</4><5>An advance tax payment
+          (12.8%) is withheld at the time the dividends are paid, unless the
+          recipient meets <2>certain criteria</2>.</5><6>Special Case for
+          Non-Salaried Executives</6><7>For self-employed individuals, the
+          portion of dividends exceeding 10% of the share capital will be
+          subject to social security contributions and other taxes under the
+          same terms as their compensation as a director.</7><8>For this
+          scenario, please use the <2>income simulator for self-employed
+          individuals</2>.</8>
       shortName: Dividends
       title: Dividend payment simulator
       warning:
@@ -2210,38 +2205,41 @@ pages:
         ogTitle: "Gross salary, net salary, net salary after tax, total cost: the
           all-in-one simulator for employees and employers"
         titre: "Gross/net salary: the Urssaf converter"
-      seo: "<0><0>How to calculate take-home pay</0><1>During the job interview, the
-        employer generally proposes a gross salary. This amount includes
-        employee contributions, which are used to finance the employee's social
-        protection and are deducted from the \"net\" salary received by the
-        employee.</1><2>You can use our simulator to convert the <2>gross salary
-        into a net salary</2> : simply enter the advertised salary in the gross
-        salary box. The simulation can be refined by answering the various
-        questions (fixed-term contract, executive status, overtime, part-time
-        work, meal vouchers, etc.).</2><3></3><4>In addition, since
-        2019,<1>impôt sur le revenu</1> has been deducted at source. To do this,
-        the Direction Générale des Finances Publiques (DGFiP) sends the employer
-        the tax rate calculated on the basis of the employee's tax return. If
-        the employee's tax rate is unknown, for example in the first year of
-        employment, the employer uses the <4>neutral rate</4>.</4></0><1><0>How
-        do I calculate the cost of hiring?</0><1>If you're looking to hire, you
-        can calculate the total cost of remunerating your employee, as well as
-        the corresponding employer and employee contributions. This will enable
-        you to define the level of remuneration, knowing the overall cost to
-        your company.</1><2>In addition to salary, our simulator takes into
-        account the calculation of benefits in kind (telephone, company car,
-        etc.), as well as compulsory health insurance.</2><3>There are also
-        <2>aides différées</2> for new hires, not all of which are taken into
-        account by our simulator. You can find them on <6>the official
-        portal</6>.</3></1><2><0>Talk to an advisor about your recruitment
-        project</0><1>You would like to :</1><2><0>be advised on the hiring aids
-        available for your recruitment project</0><1>Find out about
-        apprenticeships, professionalization contracts, \"emplois francs\" in
-        priority neighborhoods, <1>VTE</1>, etc.</1><2>Find
-        candidates</2><3>Recruiting a disabled person</3></2><3><0>Fast, simple
-        public service: you'll be called back by the advisor who can help
-        you.</0></3><4>Partners: France Travail, Apec, Cap Emploi, local
-        missions...</4><5></5></2>"
+      seo:
+        aria-label: the official portal; visit aides-entreprises.fr (opens in a new window)
+        text: "<0><0>How do you calculate take-home pay?</0><1>During a job interview,
+          the employer generally offers a salary expressed as a “gross” amount.
+          The amount quoted includes employee contributions, which are used to
+          fund the employee’s social security benefits and are deducted from the
+          “net” pay received by the employee.</1><2>You can use our calculator
+          to convert <2>gross pay to net pay&lt;/2> : simply enter the offered
+          salary in the “gross pay” field. You can refine the calculation by
+          answering various questions (fixed-term contract, executive status,
+          overtime, part-time work, meal vouchers,
+          etc.).</2><3></3><4>Furthermore, since 2019, the<1>income tax&lt;/1>
+          has been withheld at source. To facilitate this, the Directorate
+          General of Public Finances (DGFiP) provides the employer with the tax
+          rate calculated based on the employee’s tax return. If this rate is
+          unknown—for example, during an employee’s first year of employment—the
+          employer uses the <4>default rate</4>.</4></0><1><0>How do you
+          calculate the total cost of hiring?</0><1>If you’re looking to hire,
+          you can calculate the total cost of your employee’s compensation, as
+          well as the corresponding employer and employee contributions. This
+          allows you to set the compensation level while knowing the overall
+          cost to your company.</1><2>In addition to salary, our simulator
+          factors in benefits in kind (cell phone, company car, etc.), as well
+          as mandatory health insurance.</2><3>There are <2>deferred
+          incentives&lt;/2> available for hiring that are not all included in
+          our simulator; you can find them on <6>the official
+          portal</6>.</3></1><2><0>Talk to an advisor about your hiring
+          plan</0><1>You would like to:</1><2><0>Receive advice on the hiring
+          incentives available for your recruitment</0><1>Learn about
+          apprenticeships, professional training contracts, “emplois francs” in
+          priority neighborhoods, the <1>VTE program, and more…</1></1><2>Find
+          candidates</2><3>Hire a person with a disability</3></2><3><0>A simple
+          and fast public service: an advisor who can help you will call you
+          back.</0></3><4>Partner organizations involved: France Travail, APEC,
+          Cap Emploi, local employment missions…</4><5></5></2>"
       shortname: Employee
       title: Income simulator for employees
       titres-restaurant: in meal vouchers
@@ -2282,6 +2280,8 @@ pages:
   statistiques:
     a11y-switch: Enable accessibility mode on this section
     anonymous: The data collected is anonymized.
+    demandes:
+      aria-label: "{{title}}, see the request on github.com (opens in a new window)"
     explanation: <0><0>The simulators and wizards on this site are designed to
       <2>answer a specific question</2> (e.g. "How much should my company pay to
       hire a new employee?" or "What is the best legal status for starting my
@@ -2313,7 +2313,6 @@ salarié, accéder au simulateur salarié: employee, access the employee simulat
 select:
   value:
     default: Choose an option
-septembre: September
 shareSimulation:
   banner: Generate a share link
   button:
@@ -2367,8 +2366,8 @@ simulateurs:
   précision:
     défaut: "Improve your simulation by answering the questions below:"
   warning:
-    beta: "<0>This tool is in beta</0> : We are working to validate the
-      information and calculations, but <3>errors may still be present</3>."
+    beta: "<0>This tool is in beta</0> : We are working to validate the information
+      and calculations, but <3>errors may still be present</3>."
     fermer:
       aria-label: I get it, close the condensed message.
       texte: I understand
@@ -2493,8 +2492,6 @@ vos retours, accéder aux statistiques d'utilisation: your feedback, access to u
 warning:
   overwrite:
     situation: Do you want to crush your situation?
-"{{title}}, voir la demande sur github":
-  com, nouvelle fenêtre: "{{title}}view request on github.com, new window"
 À quoi servent mes cotisations ?: What are my contributions used for?
 Échanger avec un conseiller: Talk to an advisor
 "Établissement recherché :": "Establishment sought:"

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -56,7 +56,6 @@ EntrepriseSearchField:
   placeholder: "Exemple : Café de la gare ou 40123778000127"
 ExportSimulation:
   Banner: Imprimer ou sauvegarder en PDF
-Fermer: Fermer
 Fiche de paie: Fiche de paie
 Graphique détaillant la part des visites par simulateur (alternative accessible avec l'interrupteur en début de section):
   Graphique détaillant la part des visites par simulateur (alternative
@@ -72,11 +71,6 @@ Impôts: Impôts
 Insérer dans le champ la valeur du {{text}}: Insérer dans le champ la valeur du {{text}}
 Intégrer le module Web: Intégrer le module Web
 Intégrer nos simulateurs: Intégrer nos simulateurs
-Je donne mon avis, donner mon avis sur jedonnemonavis:
-  numerique:
-    gouv:
-      fr, nouvelle fenêtre: Je donne mon avis, donner mon avis sur
-        jedonnemonavis.numerique.gouv.fr, nouvelle fenêtre
 Jours: Jours
 Le montant demandé n'est <2>pas calculable…</2>: Le montant demandé n'est <2>pas calculable…</2>
 Les données de simulations se mettront automatiquement à jour après la modification d'un champ. <2>Un panneau s'ouvrira pour vous permettre d'apporter des précisions à la simulation, des résultats détaillés s'afficheront en dessous du formulaire et seront mis à jour quand vous modifierez ce dernier.</2>:
@@ -93,21 +87,15 @@ Message à caractère informatif: Message à caractère informatif
 Modifier mes réponses: Modifier mes réponses
 Mois: Mois
 Mon entreprise: Mon entreprise
-Mon entreprise recrute ! Voir les offres d'emplois de mon-entreprise:
-  urssaf:
-    fr: Mon entreprise recrute ! Voir les offres d'emplois de
-      mon-entreprise.urssaf.fr
 Montant annuel: Montant annuel
 Montant mensuel: Montant mensuel
 Mots-clés définissants l'activité: Mots-clés définissants l'activité
 Nombres: Nombres
-Non: Non
 Nous n’avons pas trouvé de résultat pour cette entreprise.: Nous n’avons pas trouvé de résultat pour cette entreprise.
 Nouveau contenu disponible, cliquez sur recharger pour mettre à jour la page.: Nouveau contenu disponible, cliquez sur recharger pour mettre à jour la page.
 Nouveautés: Nouveautés
 Option ACRE non activée: Option ACRE non activée
 Options: Options
-Oui: Oui
 Outils pour les développeurs: Outils pour les développeurs
 PFU (<1>"flat tax"</1>): PFU (<1>"flat tax"</1>)
 Page d'accueil: Page d'accueil
@@ -161,8 +149,6 @@ Tout réinitialiser: Tout réinitialiser
 Trimestre: Trimestre
 URL de votre simulation: URL de votre simulation
 Un avis sur cette page ?: Un avis sur cette page ?
-Urssaf, voir le site urssaf:
-  fr, nouvelle fenêtre: Urssaf, voir le site urssaf.fr, nouvelle fenêtre
 Utiliser avec un tableur: Utiliser avec un tableur
 Utiliser les calculs des simulateurs dans votre application: Utiliser les calculs des simulateurs dans votre application
 Version bêta: Version bêta
@@ -191,7 +177,6 @@ accessibility:
   description: Référentiel Général d’Amélioration de l’Accessibilité
   title: Accessibilité
 aides différées, voir le détail du calcul pour aides différées: aides différées, voir le détail du calcul pour aides différées
-août: août
 api:
   description: Outils pour les développeurs
   title: Utiliser notre API REST
@@ -216,15 +201,9 @@ aria-label:
   service-public: service-public.fr, nouvelle fenêtre
   urssaf: Urssaf, accéder à urssaf.fr, nouvelle fenêtre
   équipe: équipe, accéder à notre page de présentation d’équipe, nouvelle fenêtre
-avril: avril
 cards:
   simulator-resource:
     cta: Accéder au simulateur
-certains critères, en savoir plus sur entreprendre:
-  service-public:
-    gouv:
-      fr, nouvelle fenêtre: certains critères, en savoir plus sur
-        entreprendre.service-public.gouv.fr, nouvelle fenêtre
 checklist:
   showmore:
     closed: En savoir plus
@@ -372,7 +351,6 @@ design-system:
     open-selector: Ouvrir le sélecteur de date
     prev-month: Mois précédent
     year: Année
-décembre: décembre
 entreprise:
   détails: Entreprise créée le <1></1> et domiciliée à <3></3>.
 error:
@@ -402,6 +380,9 @@ feedback:
       Veuillez réessayer ou nous contacter par mail à l’adresse
       <4>contact@mon-entreprise.beta.gouv.fr</4>.
     title: <0>Une erreur est survenue pendant l’envoi du message</0>
+  jedonnemonavis:
+    aria-label: Je donne mon avis, donner mon avis sur
+      jedonnemonavis.numerique.gouv.fr, nouvelle fenêtre
   reportError: Faire une suggestion
   success:
     body1: Notre équipe prend en charge votre retour.
@@ -411,15 +392,28 @@ feedback:
   thanks: Merci de votre retour !
 footer:
   github:
-    new-window: Voir le code source sur Github, nouvelle fenêtre
+    aria-label: Voir le code source sur Github, nouvelle fenêtre
     text: Voir le code source sur Github
-février: février
+  urssaf:
+    aria-label: Urssaf, voir le site urssaf.fr, nouvelle fenêtre
 gestion sémantique de version, en savoir plus, nouvelle fenêtre: gestion sémantique de version, en savoir plus, nouvelle fenêtre
 global:
   fermer: Fermer
-  oui-non:
-    non: Non
-    oui: Oui
+  mois:
+    août: août
+    avril: avril
+    décembre: décembre
+    février: février
+    janvier: janvier
+    juillet: juillet
+    juin: juin
+    mai: mai
+    mars: mars
+    novembre: novembre
+    octobre: octobre
+    septembre: septembre
+  non: Non
+  oui: Oui
 gérer:
   ressources:
     annuaire-entreprises:
@@ -442,10 +436,7 @@ iframe:
 intégration:
   description: Outils pour les développeurs
   title: Intégration
-janvier: janvier
 jours: jours
-juillet: juillet
-juin: juin
 l'annuaire des entreprises, nouvelle fenêtre: l'annuaire des entreprises, nouvelle fenêtre
 landing:
   aboutUs: "<0>Qui sommes-nous ?</0><1>Nous sommes une petite <2>équipe</2>
@@ -469,8 +460,6 @@ landing:
     personnalisées</2> à vos questions sur la <5>création et la gestion</5> de
     votre entreprise.
   title: L'assistant officiel des entrepreneurs
-le portail officiel, accéder à aides-entreprises:
-  fr, nouvelle fenêtre: le portail officiel, accéder à aides-entreprises.fr, nouvelle fenêtre
 legalNotice:
   accessibility:
     content: La plateforme est <2>partiellement conforme</2> aux normes
@@ -501,9 +490,7 @@ legalNotice:
 library:
   description: Outils pour les développeurs
   title: Librairie de calcul
-mai: mai
 main-menu: Menu principal
-mars: mars
 messages:
   loading: Chargement en cours…
   masquer-message: Cacher le message
@@ -527,8 +514,6 @@ nextSteps:
     cta: Voir la documentation
     title: Intégrer le module web
 nombres de votes: nombres de votes
-novembre: novembre
-octobre: octobre
 pages:
   "404":
     action: Revenir en lieu sûr
@@ -1225,6 +1210,9 @@ pages:
           aria-label: Urssaf, voir l’intégration, nouvelle fenêtre
           cta-label: Voir l’intégration
     module: Quel module ?
+    recrutement:
+      aria-label: Mon entreprise recrute ! Voir les offres d'emplois de
+        mon-entreprise.urssaf.fr
     spreadsheet: <0>Utiliser avec un tableur</0><1>Vous souhaitez utiliser un
       simulateur dans une feuille Google Sheets ou Excel ? C'est possible grâce
       à notre <2>API REST</2> !</1><2>Intégrer un simulateur dans
@@ -1864,26 +1852,29 @@ pages:
         cotisations: Cotisations
         impôt: Impôt
         revenu: Dividendes nets
-      seo: <0>Les dividendes et distributions</0><1>À la fin de l'exercice d'une
-        société, le résultat de l'exercice précédent peut être conservé en
-        réserve (pour de futurs investissements) ou bien être versé en
-        dividendes. Du point de vue des bénéficiaires, ce sont des revenus de
-        capitaux mobiliers, soumis à cotisations et à une imposition
-        spécifiques.</1><2>Ne sont pris en compte dans ce simulateur que les cas
-        de figure du bénéficiaire personne physique et des dividendes décidés
-        par la société.</2><3>Comment sont calculés les prélèvements sur les
-        dividendes ?</3><4>Les dividendes peuvent être soumis au prélèvement
-        forfaitaire unique de 30% incluant imposition et contributions sociales
-        (aussi appelé<1> flat tax</1>). Par option, le barème de l'impôt peut
-        être choisi. Ce simulateur peut être utilisé pour comparer les deux
-        régimes.</4><5>Un acompte du montant de l'impôt (12,8%) est prélevé au
-        moment du versement des dividendes, sauf si le bénéficiaire remplit
-        <2>certains critères</2>.</5><6>Cas particulier du dirigeant non
-        salarié</6><7>Pour le travailleur indépendant non salarié, la part des
-        dividendes dépassant 10% du capital social sera soumise aux cotisations
-        et contributions suivant les mêmes modalités que sa rémunération de
-        dirigeant.</7><8>Pour ce cas de figure veuillez utiliser le
-        <2>simulateur de revenus pour indépendant</2>.</8>
+      seo:
+        aria-label: certains critères, en savoir plus sur
+          entreprendre.service-public.gouv.fr, nouvelle fenêtre
+        text: <0>Les dividendes et distributions</0><1>À la fin de l'exercice d'une
+          société, le résultat de l'exercice précédent peut être conservé en
+          réserve (pour de futurs investissements) ou bien être versé en
+          dividendes. Du point de vue des bénéficiaires, ce sont des revenus de
+          capitaux mobiliers, soumis à cotisations et à une imposition
+          spécifiques.</1><2>Ne sont pris en compte dans ce simulateur que les
+          cas de figure du bénéficiaire personne physique et des dividendes
+          décidés par la société.</2><3>Comment sont calculés les prélèvements
+          sur les dividendes ?</3><4>Les dividendes peuvent être soumis au
+          prélèvement forfaitaire unique de 30% incluant imposition et
+          contributions sociales (aussi appelé<1> flat tax</1>). Par option, le
+          barème de l'impôt peut être choisi. Ce simulateur peut être utilisé
+          pour comparer les deux régimes.</4><5>Un acompte du montant de l'impôt
+          (12,8%) est prélevé au moment du versement des dividendes, sauf si le
+          bénéficiaire remplit <2>certains critères</2>.</5><6>Cas particulier
+          du dirigeant non salarié</6><7>Pour le travailleur indépendant non
+          salarié, la part des dividendes dépassant 10% du capital social sera
+          soumise aux cotisations et contributions suivant les mêmes modalités
+          que sa rémunération de dirigeant.</7><8>Pour ce cas de figure veuillez
+          utiliser le <2>simulateur de revenus pour indépendant</2>.</8>
       shortName: Dividendes
       title: Simulateur de versement de dividendes
       warning:
@@ -2340,41 +2331,44 @@ pages:
         ogTitle: "Salaire brut, net, net après impôt, coût total : le simulateur
           tout-en-un pour salariés et employeurs"
         titre: "Salaire brut / net : le convertisseur Urssaf"
-      seo: "<0><0>Comment calculer le salaire net ?</0><1>Lors de l'entretien
-        d'embauche l'employeur propose en général une rémunération exprimée en «
-        brut ». Le montant annoncé inclut ainsi les cotisations salariales, qui
-        servent à financer la protection sociale du salarié et qui sont
-        retranchées du salaire « net » perçu par le salarié.</1><2>Vous pouvez
-        utiliser notre simulateur pour convertir le <2>salaire brut en net</2> :
-        il vous suffit pour cela saisir la rémunération annoncée dans la case
-        salaire brut. La simulation peut-être affinée en répondant aux
-        différentes questions (CDD, statut cadre, heures supplémentaires, temps
-        partiel, titre-restaurants, etc.).</2><3></3><4>Par ailleurs depuis
-        2019, l'<1>impôt sur le revenu</1> est prélevé à la source. Pour ce
-        faire, la direction générale des finances publiques (DGFiP) transmet à
-        l'employeur le taux d'imposition calculé à partir de la déclaration de
-        revenus du salarié. Si ce taux est inconnu, par exemple lors d'une
-        première année d'activité, l'employeur utilise le <4>taux
-        neutre</4>.</4></0><1><0>Comment calculer le coût d'embauche ?</0><1>Si
-        vous cherchez à embaucher, vous pouvez calculer le coût total de la
-        rémunération de votre salarié, ainsi que les montants de cotisations
-        patronales et salariales correspondant. Cela vous permet de définir le
-        niveau de rémunération en connaissant le montant global de charge que
-        cela représente pour votre entreprise.</1><2>En plus du salaire, notre
-        simulateur prend en compte le calcul des avantages en nature (téléphone,
-        véhicule de fonction, etc.), ainsi que la mutuelle santé
-        obligatoire.</2><3>Il existe des <2>aides différées</2> à l'embauche qui
-        ne sont pas toutes prises en compte par notre simulateur, vous pouvez
-        les retrouver sur <6>le portail officiel</6>.</3></1><2><0>Échanger avec
-        un conseiller pour votre projet de recrutement</0><1>Vous souhaitez
-        :</1><2><0>Être conseillé(e) sur les aides à l'embauche mobilisables
-        pour votre recrutement</0><1>Vous informer sur l'apprentissage, le
-        contrat de professionnalisation, les emplois francs en quartiers
-        prioritaires, le <1>VTE</1>…</1><2>Trouver des candidats</2><3>Recruter
-        une personne en situation de handicap</3></2><3><0>Service public simple
-        et rapide : vous êtes rappelé(e) par le conseiller qui peut vous
-        aider.</0></3><4>Partenaires mobilisés : France Travail, Apec, Cap
-        Emploi, missions locales…</4><5></5></2>"
+      seo:
+        aria-label: le portail officiel, accéder à aides-entreprises.fr, nouvelle fenêtre
+        text: "<0><0>Comment calculer le salaire net ?</0><1>Lors de l'entretien
+          d'embauche l'employeur propose en général une rémunération exprimée en
+          « brut ». Le montant annoncé inclut ainsi les cotisations salariales,
+          qui servent à financer la protection sociale du salarié et qui sont
+          retranchées du salaire « net » perçu par le salarié.</1><2>Vous pouvez
+          utiliser notre simulateur pour convertir le <2>salaire brut en net</2>
+          : il vous suffit pour cela saisir la rémunération annoncée dans la
+          case salaire brut. La simulation peut-être affinée en répondant aux
+          différentes questions (CDD, statut cadre, heures supplémentaires,
+          temps partiel, titre-restaurants, etc.).</2><3></3><4>Par ailleurs
+          depuis 2019, l'<1>impôt sur le revenu</1> est prélevé à la source.
+          Pour ce faire, la direction générale des finances publiques (DGFiP)
+          transmet à l'employeur le taux d'imposition calculé à partir de la
+          déclaration de revenus du salarié. Si ce taux est inconnu, par exemple
+          lors d'une première année d'activité, l'employeur utilise le <4>taux
+          neutre</4>.</4></0><1><0>Comment calculer le coût d'embauche
+          ?</0><1>Si vous cherchez à embaucher, vous pouvez calculer le coût
+          total de la rémunération de votre salarié, ainsi que les montants de
+          cotisations patronales et salariales correspondant. Cela vous permet
+          de définir le niveau de rémunération en connaissant le montant global
+          de charge que cela représente pour votre entreprise.</1><2>En plus du
+          salaire, notre simulateur prend en compte le calcul des avantages en
+          nature (téléphone, véhicule de fonction, etc.), ainsi que la mutuelle
+          santé obligatoire.</2><3>Il existe des <2>aides différées</2> à
+          l'embauche qui ne sont pas toutes prises en compte par notre
+          simulateur, vous pouvez les retrouver sur <6>le portail
+          officiel</6>.</3></1><2><0>Échanger avec un conseiller pour votre
+          projet de recrutement</0><1>Vous souhaitez :</1><2><0>Être
+          conseillé(e) sur les aides à l'embauche mobilisables pour votre
+          recrutement</0><1>Vous informer sur l'apprentissage, le contrat de
+          professionnalisation, les emplois francs en quartiers prioritaires, le
+          <1>VTE</1>…</1><2>Trouver des candidats</2><3>Recruter une personne en
+          situation de handicap</3></2><3><0>Service public simple et rapide :
+          vous êtes rappelé(e) par le conseiller qui peut vous
+          aider.</0></3><4>Partenaires mobilisés : France Travail, Apec, Cap
+          Emploi, missions locales…</4><5></5></2>"
       shortname: Salarié
       title: Simulateur de revenus pour salarié
       titres-restaurant: en titres-restaurant
@@ -2419,6 +2413,8 @@ pages:
   statistiques:
     a11y-switch: Activer le mode accessibilité sur cette section
     anonymous: Les données recueillies sont anonymisées.
+    demandes:
+      aria-label: "{{title}}, voir la demande sur github.com, nouvelle fenêtre"
     explanation: <0><0>Les simulateurs et assistants de ce site ont pour but de
       <2>répondre à une question</2> (par exemple « combien mon entreprise
       doit-elle payer pour embaucher une personne ? » ou « Quel est le meilleur
@@ -2452,7 +2448,6 @@ salarié, accéder au simulateur salarié: salarié, accéder au simulateur sala
 select:
   value:
     default: Choisissez une option
-septembre: septembre
 shareSimulation:
   banner: Générer un lien de partage
   button:
@@ -2646,8 +2641,6 @@ vos retours, accéder aux statistiques d'utilisation: vos retours, accéder aux 
 warning:
   overwrite:
     situation: Voulez-vous écraser votre situation ?
-"{{title}}, voir la demande sur github":
-  com, nouvelle fenêtre: "{{title}}, voir la demande sur github.com, nouvelle fenêtre"
 À quoi servent mes cotisations ?: À quoi servent mes cotisations ?
 Échanger avec un conseiller: Échanger avec un conseiller
 "Établissement recherché :": "Établissement recherché :"

--- a/site/source/pages/assistants/choix-du-statut/associé.tsx
+++ b/site/source/pages/assistants/choix-du-statut/associé.tsx
@@ -106,10 +106,10 @@ export default function Associés() {
 								value={question2}
 							>
 								<Radio id="question-2-oui" value={'oui'}>
-									{t('global.oui-non.oui', 'Oui')}
+									{t('global.oui', 'Oui')}
 								</Radio>
 								<Radio id="question-2-non" value={'non'}>
-									{t('global.oui-non.non', 'Non')}
+									{t('global.non', 'Non')}
 								</Radio>
 							</ToggleGroup>
 							<Spacing md />
@@ -188,10 +188,10 @@ export default function Associés() {
 								value={question3}
 							>
 								<Radio id="question-3-oui" value={'oui'}>
-									{t('global.oui-non.oui', 'Oui')}
+									{t('global.oui', 'Oui')}
 								</Radio>
 								<Radio id="question-3-non" value={'non'}>
-									{t('global.oui-non.non', 'Non')}
+									{t('global.non', 'Non')}
 								</Radio>
 							</ToggleGroup>
 							<Spacing md />

--- a/site/source/pages/assistants/cmg/components/enfants/QuestionsAeeH.tsx
+++ b/site/source/pages/assistants/cmg/components/enfants/QuestionsAeeH.tsx
@@ -51,10 +51,10 @@ export default function QuestionsAeeH() {
 				value={valeur}
 			>
 				<StyledRadio value="oui" id="input-perçoit-AeeH-oui">
-					{t('Oui')}
+					{t('global.oui', 'Oui')}
 				</StyledRadio>
 				<StyledRadio value="non" id="input-perçoit-AeeH-non">
-					{t('Non')}
+					{t('global.non', 'Non')}
 				</StyledRadio>
 			</ToggleGroup>
 

--- a/site/source/pages/assistants/cmg/components/informations-générales/QuestionCMGPerçu.tsx
+++ b/site/source/pages/assistants/cmg/components/informations-générales/QuestionCMGPerçu.tsx
@@ -49,10 +49,10 @@ export default function QuestionCMGPerçu() {
 				value={valeur}
 			>
 				<StyledRadio value="oui" id="input-CMG-perçu-oui">
-					{t('Oui')}
+					{t('global.oui', 'Oui')}
 				</StyledRadio>
 				<StyledRadio value="non" id="input-CMG-perçu-non">
-					{t('Non')}
+					{t('global.non', 'Non')}
 				</StyledRadio>
 			</ToggleGroup>
 		</>

--- a/site/source/pages/assistants/cmg/components/informations-générales/QuestionNombreMoisDéclarationsSuffisant.tsx
+++ b/site/source/pages/assistants/cmg/components/informations-générales/QuestionNombreMoisDéclarationsSuffisant.tsx
@@ -49,10 +49,10 @@ export default function QuestionNombreMoisDéclarationsSuffisant() {
 				value={valeur}
 			>
 				<StyledRadio value="oui" id="input-mois-déclarations-oui">
-					{t('Oui')}
+					{t('global.oui', 'Oui')}
 				</StyledRadio>
 				<StyledRadio value="non" id="input-mois-déclarations-non">
-					{t('Non')}
+					{t('global.non', 'Non')}
 				</StyledRadio>
 			</ToggleGroup>
 		</>

--- a/site/source/pages/integration/index.tsx
+++ b/site/source/pages/integration/index.tsx
@@ -47,6 +47,7 @@ export default function Integration() {
 								<a
 									href={openJobOffer.link}
 									aria-label={t(
+										'pages.développeur.recrutement.aria-label',
 										"Mon entreprise recrute ! Voir les offres d'emplois de mon-entreprise.urssaf.fr"
 									)}
 								>

--- a/site/source/pages/simulateurs/dividendes/SeoExplanations.tsx
+++ b/site/source/pages/simulateurs/dividendes/SeoExplanations.tsx
@@ -8,7 +8,7 @@ export const SeoExplanations = () => {
 	const { t } = useTranslation()
 
 	return (
-		<Trans i18nKey="pages.simulateurs.dividendes.seo">
+		<Trans i18nKey="pages.simulateurs.dividendes.seo.text">
 			<H2>Les dividendes et distributions</H2>
 			<Body>
 				À la fin de l'exercice d'une société, le résultat de l'exercice
@@ -34,6 +34,7 @@ export const SeoExplanations = () => {
 				<Link
 					rel="noreferrer"
 					aria-label={t(
+						'pages.simulateurs.dividendes.seo.aria-label',
 						'certains critères, en savoir plus sur entreprendre.service-public.gouv.fr, nouvelle fenêtre'
 					)}
 					href="https://entreprendre.service-public.gouv.fr/vosdroits/F32963"

--- a/site/source/pages/simulateurs/lodeom/components/RéductionMoisParMois.tsx
+++ b/site/source/pages/simulateurs/lodeom/components/RéductionMoisParMois.tsx
@@ -47,18 +47,18 @@ export default function RéductionMoisParMois({
 	)
 
 	const months = [
-		t('janvier'),
-		t('février'),
-		t('mars'),
-		t('avril'),
-		t('mai'),
-		t('juin'),
-		t('juillet'),
-		t('août'),
-		t('septembre'),
-		t('octobre'),
-		t('novembre'),
-		t('décembre'),
+		t('global.mois.janvier', 'janvier'),
+		t('global.mois.février', 'février'),
+		t('global.mois.mars', 'mars'),
+		t('global.mois.avril', 'avril'),
+		t('global.mois.mai', 'mai'),
+		t('global.mois.juin', 'juin'),
+		t('global.mois.juillet', 'juillet'),
+		t('global.mois.août', 'août'),
+		t('global.mois.septembre', 'septembre'),
+		t('global.mois.octobre', 'octobre'),
+		t('global.mois.novembre', 'novembre'),
+		t('global.mois.décembre', 'décembre'),
 	]
 
 	const quarters = {

--- a/site/source/pages/simulateurs/salarié/components/SeoExplanations.tsx
+++ b/site/source/pages/simulateurs/salarié/components/SeoExplanations.tsx
@@ -12,7 +12,7 @@ export const SeoExplanations = () => {
 	const { t, i18n } = useTranslation()
 
 	return (
-		<Trans i18nKey="pages.simulateurs.salarié.seo">
+		<Trans i18nKey="pages.simulateurs.salarié.seo.text">
 			<section>
 				<H2>Comment calculer le salaire net ?</H2>
 				<Body>
@@ -85,6 +85,7 @@ export const SeoExplanations = () => {
 					<Link
 						href="http://www.aides-entreprises.fr"
 						aria-label={t(
+							'pages.simulateurs.salarié.seo.aria-label',
 							'le portail officiel, accéder à aides-entreprises.fr, nouvelle fenêtre'
 						)}
 					>

--- a/site/source/pages/statistiques/DemandesUtilisateurs.tsx
+++ b/site/source/pages/statistiques/DemandesUtilisateurs.tsx
@@ -129,6 +129,7 @@ function Issue({ title, number, count, closedAt }: IssueProps) {
 			<Link
 				href={`https://github.com/betagouv/mon-entreprise/issues/${number}`}
 				aria-label={t(
+					'pages.statistiques.demandes.aria-label',
 					'{{title}}, voir la demande sur github.com, nouvelle fenêtre',
 					{ title }
 				)}


### PR DESCRIPTION
- Suppression de `NO_TRANSLATION` qui ne change rien mais ajoute de la gymnastique autour des traductions sans clef (comme `t('Texte à traduire sans clef')` VS `t('clef.de.traduction', 'Texte à traduire avec clef')`)
- Ajout de clef de traduction aux textes contenant des URLs (ce qui causait un problème de parsing dans le fichier de traduction, même si la traduction était fonctionnelle)
- Ajout de clefs de traduction pour quelques éléments simples et transverses (il y en a bien sûr moultes autres à ajouter mais c'est un début)
- Léger réusinage du code de `scripts/i18n/utils` pour notamment simplifier `getUiMissingTranslations`
 
J'aurais aimé aller plus loin mais c'est encore toute une pelote à déméler donc je me suis arrêté là.