### PR TITLE
chore: nouvelles versions de modele-social, modele-ti et modele-as

### DIFF
--- a/modele-as/CHANGELOG.md
+++ b/modele-as/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+## 0.0.2
+
+Modification de la configuration du paquet.
+
 ## 0.0.1
 
 Création du paquet.

--- a/modele-as/package.json
+++ b/modele-as/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "modele-as",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Les règles publicodes du système social français pour les dirigeants assimilés salariés.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -8,7 +8,7 @@
 	"types": "./index.d.ts",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/betagouv/mon-entreprise.git",
+		"url": "git+https://github.com/betagouv/mon-entreprise.git",
 		"directory": "modele-as"
 	},
 	"bugs": "https://github.com/betagouv/mon-entreprise/issues?q=is%3Aopen+is%3Aissue+label%3A%22%F0%9F%93%95+l%C3%A9gislation%22",

--- a/modele-social/CHANGELOG.md
+++ b/modele-social/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+## 11.0.0
+
 ### Breaking changes
 - Suppression des règles `salarié . cotisations . exonérations . réduction générale` (utiliser `... . RGDU` à la place)
 - Suppression des règles `déclaration revenus PAMC` et `déclaration charge sociales`

--- a/modele-social/package.json
+++ b/modele-social/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "modele-social",
-	"version": "10.0.1",
+	"version": "11.0.0",
 	"description": "Les règles publicodes du système social français",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -8,7 +8,7 @@
 	"types": "./index.d.ts",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/betagouv/mon-entreprise.git",
+		"url": "git+https://github.com/betagouv/mon-entreprise.git",
 		"directory": "modele-social"
 	},
 	"bugs": "https://github.com/betagouv/mon-entreprise/issues?q=is%3Aopen+is%3Aissue+label%3A%22%F0%9F%93%95+l%C3%A9gislation%22",

--- a/modele-ti/CHANGELOG.md
+++ b/modele-ti/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+## 0.0.2
+
+Modification de la configuration du paquet.
+
 ## 0.0.1
 
 Création du paquet.

--- a/modele-ti/package.json
+++ b/modele-ti/package.json
@@ -1,14 +1,14 @@
 {
 	"name": "modele-ti",
-	"version": "0.0.1",
-	"description": "Les règles publicodes du système social français pour les TI.",
+	"version": "0.0.2",
+	"description": "Les règles publicodes du système social français pour les TI",
 	"type": "module",
 	"main": "./dist/index.js",
 	"module": "dist/index.js",
 	"types": "./index.d.ts",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/betagouv/mon-entreprise.git",
+		"url": "git+https://github.com/betagouv/mon-entreprise.git",
 		"directory": "modele-ti"
 	},
 	"bugs": "https://github.com/betagouv/mon-entreprise/issues?q=is%3Aopen+is%3Aissue+label%3A%22%F0%9F%93%95+l%C3%A9gislation%22",


### PR DESCRIPTION
Teste la publication automatique des paquets `modele-xx`.