### PR TITLE
Documentation des paquets `modele-as` et `modele-ti`

### DIFF
--- a/site/source/locales/ui-en.yaml
+++ b/site/source/locales/ui-en.yaml
@@ -978,47 +978,87 @@ pages:
       section.<7></7></1></7><8></8><9>Example</9><10>Here's an example of how
       to use the various routes. You can explore their code in the
       <1>example</1> folder</10><11><0></0></11>"
-    bibliothèque: "<0><0>You can reuse the mon-entreprise calculations on your site
-      or service very easily thanks to the open-source JavaScript library
-      available on npm.</0></0><1>How to use this
-      library</1><2>Installation</2><3><0>npm install --save publicodes
-      modele-social</0></3><4>To run your own calculations, you need to install
-      the <2><0>publicodes</0></2> package, containing the publicodes
-      interpreter, and the <6><0>modele-social</0></6>package, which contains
-      the rules for the mon-entreprise simulators.</4><5><0>What is
-      publicodes?</0><1>Publicodes is a declarative language developed by
-      beta.gouv.fr and Urssaf to encode algorithms of public interest. It is the
-      language that powers all the calculations in the mon-entreprise
-      simulators.</1><2><0>Find out more about publicodes</0></2></5><6>Launch
-      the calculation</6><7>To launch the calculation, you need to parameterize
-      the engine with the rules in the <1>modele-social</1> package and call the
-      <4>evaluate</4> function with the rule whose value you wish to calculate.
-      Here's an example of a gross/net calculation</7><8><0></0></8><9>Setting
-      up the calculation</9><10>As you will have seen from the previous example,
-      the recipe for a calculation is simple: input variables (gross salary),
-      one or more output variables (net salary).</10><11>However, the
-      calculation can be parameterized using all the possibilities offered by
-      mon-entreprise's simulators!</11><12>All available rules are listed and
-      explained in the <2>online documentation</2>. This documentation is
-      auto-generated from the publicodes rule files, and fed by the current
-      simulation.</12><13>How do I reproduce a simulator calculation?</13><14>To
-      replicate a calculation from a mon-entreprise simulator in the library,
-      follow these steps: </14><15><0></0><1><0>Copy the customized code snippet
-      and integrate it into your application</0><1></1>You'll find it by
-      clicking on the \"Reuse this calculation\"
-      section.<3></3></1><2><0>(optional) Modify the situation values to tailor
-      the calculation to your needs</0><1></1> You can modify the situation
-      values without hesitation. They accept any <4>expression or publicodes
-      object.</4></2></15><16>Here's how the calculation works with the above
-      example:</16><17><0></0></17><18><0>The situation contains the data from
-      your simulation (executive with a salary of €3,400 gross), but also data
-      relating to the simulator settings.</0></18><19></19><20>Creating economic
-      graphs <1></1></20><21>You can also use the library for economic or
-      political analysis calculations. Here, we plot the price of labor and the
-      net wage as a function of the gross wage.</21><22>You can see how
-      progressive the total wage is, being lower in percentage terms for a
-      minimum wage than for a high income. In other words, high earners pay part
-      of the social contributions of low earners.</22><23><0></0></23>"
+    bibliothèque:
+      aria-label:
+        documentation: online documentation, new window
+        modele-as: modele-as, see the npm page, new window
+        modele-social: social model, see the npm page (opens in a new window)
+        modele-ti: modele-ti, see the npm page, new window
+        publicodes:
+          expression: publicodes expression or object, learn more, new window
+          npm: publicodes, see the npm page (opens in a new window)
+          site: Learn more about publicodes (opens in a new window)
+      exemples:
+        association: "Integration example on codesandbox.io: integration with other
+          libraries"
+        lancement: "Integration example on codesandbox.io: running a calculation"
+        paramétrage: "Integration example on codesandbox.io: configuring the calculation"
+      texte: "<0><0>You can easily reuse the calculations from mon-entreprise on your
+        website or service using the open-source JavaScript libraries available
+        on npm.</0></0><1>Which library should you choose?</1><3>modele-as This
+        library contains the rules and calculations for executives
+        <2>assimilated-employees&lt;/2> and female executives treated as
+        employees, such as the executives of SAS and SASU companies. This is the
+        library used in the <5>income simulator for SAS(U)
+        executives</5>.</3><4>modele-ti</4><5>This library contains the rules
+        and calculations for <2>self-employed individuals&lt;/2> , including
+        self-employed women, such as the owners of sole proprietorships
+        (excluding “auto-entreprise” entities) and EURLs, as well as members of
+        the liberal professions. This is the library used in the <5>income
+        simulator for self-employed individuals&lt;/5> and its
+        variants.</5><7>modele-socialThis is the historical library, which still
+        contains the rules for employees and employers (including Lodeom),
+        auto-entrepreneurs, dividend recipients, corporate income tax
+        calculations, and the costs of starting a business. It is used in all
+        mon-entreprise simulators and wizards except those for SAS(U) and
+        self-employed individuals</7><8>. Please note: although they are still
+        present, the rules in this library concerning employees by analogy and
+        self-employed individuals are no longer maintained.</8><9>How to use
+        these libraries?</9><10>Installation</10><11><0>npm install --save
+        publicodes modele-xx</0></11><12>Replace <1>modele-xx&lt;/1> with
+        <3>modele-as</3>,<5>modele-ti&lt;/5> or <7>modele-social&lt;/7>
+        depending on the calculations you wish to perform.</12><13>To run your
+        own calculations, you must install the package
+        <2><0>publicodes</0>&lt;/2> containing the publicodes interpreter, as
+        well as the package of your choice— <6><0>modele-as</0></6>,
+        <9><0>modele-ti</0>&lt;/9> or <13><0>modele-social</0></13>—which
+        contain the rules for the mon-entreprise simulators.</13><14><0>What is
+        Publicodes?</0><1>Publicodes is a declarative language developed by
+        beta.gouv.fr and Urssaf to implement algorithms of public interest. It
+        is the language that powers the calculations in most of the
+        “mon-entreprise” simulators.</1><2><0>Learn more about
+        Publicodes</0></2></14><16>Usage: To run a calculation, you must
+        configure the engine with the rules from the package
+        <1>modele-social&lt;/1> and call the function <4>evaluate&lt;/4> with
+        the rule whose value you wish to calculate. Here is an example for
+        gross/net pay calculation using the package <7>modele-social&lt;/7>
+        :</16><17><0></0></17><18>Configuring the</18><19>Calculation As you saw
+        in the previous example, the structure of a calculation is simple: input
+        variables (gross pay) and one or more output variables (net
+        pay).</19><20>However, the calculation can be configured using all the
+        options available in the mon-entreprise simulators!</20><21>All
+        available rules are listed and explained in the <2>online
+        documentation</2>. This documentation is auto-generated from the public
+        rule files and populated by the current simulation.</21><22>How to
+        Reproduce a Simulator’s Calculation?</22><23>To replicate the
+        calculation of a “mon-entreprise” simulator in the library, follow these
+        steps: </23><24><0></0><1><0>Copy the custom code snippet and integrate
+        it into your application</0><1></1>You’ll find it by clicking on the
+        “Reuse this calculation” section.<3></3></1><2><0>(optional) Modify the
+        scenario values to configure the calculation according to your
+        needs</0><1> &lt;/1> Feel free to modify the scenario values. They
+        accept any <4>Publicodes expression or object</4>.</2></24><25>Here is
+        the result of the calculation using the example cited
+        above:</25><26><0></0></26><27><0>The scenario contains your simulation
+        data (manager with a gross salary of €3,400), as well as data related to
+        the simulator’s settings.</0></27><28></28><29>Creating Economic Charts
+        <1></1></29><30>It is also possible to use the library for economic or
+        political analysis calculations. Here, we plot the cost of labor and net
+        pay as a function of gross pay.</30><31>We can see the progressive
+        nature of total pay, which is a smaller percentage for someone earning
+        the minimum wage than for someone with a high income. In other words,
+        high earners pay a portion of the social security contributions for
+        low-wage earners.</31><32><0></0></32>"
     choice:
       github:
         body: All our tools are open and publicly developed on GitHub.

--- a/site/source/locales/ui-fr.yaml
+++ b/site/source/locales/ui-fr.yaml
@@ -1037,50 +1037,91 @@ pages:
       ».<7></7></1></7><8></8><9>Exemple</9><10>Voici un exemple d'utilisation
       des différentes routes, vous pouvez explorer leur code dans le dossier
       <1>example</1></10><11><0></0></11>"
-    bibliothèque: "<0><0>Vous pouvez réutiliser les calculs de mon-entreprise sur
-      votre site ou service très facilement grâce à la bibliothèque JavaScript
-      open-source disponible sur npm.</0></0><1>Comment utiliser cette librairie
-      ?</1><2>Installation</2><3><0>npm install --save publicodes
-      modele-social</0></3><4>Pour lancer vos propres calculs, vous devez
-      installer le paquet <2><0>publicodes</0></2> contenant l'interpréteur
-      publicodes, ainsi que le paquet <6><0>modele-social</0></6>, qui contient
-      les règles des simulateurs mon-entreprise.</4><5><0>Qu'est-ce que
-      publicodes ?</0><1>Publicodes est un langage déclaratif développé par
-      beta.gouv.fr et l'Urssaf pour encoder des algorithmes d'intérêt public.
-      C'est le langage qui propulse tous les calculs des simulateurs de
-      mon-entreprise.</1><2><0>En savoir plus sur
-      publicodes</0></2></5><6>Lancer le calcul</6><7>Pour lancer le calcul, il
-      vous faut paramétrer le moteur avec les règles du paquet
-      <1>modele-social</1> et à appeler la fonction <4>evaluate</4> avec la
-      règle dont vous souhaitez calculer la valeur. Voici un exemple pour le
-      calcul brut / net</7><8><0></0></8><9>Paramétrer le calcul</9><10>Vous
-      l'aurez constaté dans l'exemple précédent, la recette d'un calcul est
-      simple : des variables d'entrée (le salaire brut), une ou plusieurs
-      variables de sorties (le salaire net).</10><11>Le calcul est cependant
-      paramétrable avec toutes les possibilités permises dans les simulateurs de
-      mon-entreprise !</11><12>Toutes les règles disponibles sont listées et
-      expliquées sur la <2>documentation en ligne</2>. Cette documentation est
-      auto-générée depuis les fichiers de règles publicodes, et alimentée par la
-      simulation en cours.</12><13>Comment reproduire un calcul d'un simulateur
-      ?</13><14>Pour répliquer un calcul d'un simulateur de mon-entreprise dans
-      la bibliothèque, voici la marche à suivre : </14><15><0></0><1><0>Copiez
-      l'extrait de code personnalisé et intégrez-le dans votre
-      application</0><1></1>Vous le trouverez en cliquant sur la section «
-      Réutiliser ce calcul ».<3></3></1><2><0>(facultatif) Modifiez les valeurs
-      de la situation pour paramétrer le calcul selon vos besoins</0><1></1>
-      Vous pouvez modifier sans hésiter les valeurs de la situation. Ces
-      dernières acceptent n'importe quelle <4>expression ou objet
-      publicodes.</4></2></15><16>Voici ce que donne le calcul avec l'exemple
-      cité ci-dessus :</16><17><0></0></17><18><0>La situation contient les
-      données de votre simulation (cadre avec salaire à 3400 € brut), mais
-      également les données relatives au paramétrage du
-      simulateur.</0></18><19></19><20>Faire des graphiques économiques
-      <1></1></20><21>Il est aussi possible d'utiliser la bibliothèque pour des
-      calculs d'analyse économique ou politique. Ici, on trace le prix du
-      travail et le salaire net en fonction du brut.</21><22>On peut constater
-      la progressivité du salaire total, qui est en pourcent plus faible pour un
-      SMIC que pour un haut revenu. Autrement dit, les hauts salaires paient une
-      partie des cotisations sociales des bas salaires.</22><23><0></0></23>"
+    bibliothèque:
+      aria-label:
+        documentation: documentation en ligne, nouvelle fenêtre
+        modele-as: modele-as, voir la page npm, nouvelle fenêtre
+        modele-social: modele-social, voir la page npm, nouvelle fenêtre
+        modele-ti: modele-ti, voir la page npm, nouvelle fenêtre
+        publicodes:
+          expression: expression ou objet publicodes, en savoir plus, nouvelle fenêtre
+          npm: publicodes, voir la page npm, nouvelle fenêtre
+          site: En savoir plus sur publicodes, nouvelle fenêtre
+      exemples:
+        association: "Exemple d’intégration sur codesandbox.io : association avec
+          d’autres librairies"
+        lancement: "Exemple d’intégration sur codesandbox.io : lancement d’un calcul"
+        paramétrage: "Exemple d’intégration sur codesandbox.io : paramétrage du calcul"
+      texte: "<0><0>Vous pouvez réutiliser les calculs de mon-entreprise sur votre
+        site ou service très facilement grâce aux bibliothèques JavaScript open
+        source disponibles sur npm.</0></0><1>Quelle librairie choisir
+        ?</1><2>modele-as</2><3>Cette librairie contient les règles et calculs
+        pour les dirigeants <2>assimilés salariés</2> et dirigeantes assimilées
+        salariées, comme les dirigeantes et dirigeants de SAS et de SASU. C’est
+        la librairie utilisée dans le <5>simulateur de revenus pour dirigeant de
+        SAS(U)</5>.</3><4>modele-ti</4><5>Cette librairie contient les règles et
+        calculs pour les <2>travailleurs indépendants</2> et travailleuses
+        indépendantes, comme les dirigeantes et dirigeants d'entreprise
+        individuelle (hors auto-entreprise) et d’EURL et les professions
+        libérales. C’est la librairie utilisée dans le <5>simulateur de revenus
+        pour indépendant</5> et ses variantes.</5><6>modele-social</6><7>C’est
+        la librairie historique, qui contient encore les règles pour les
+        salariées/salariés et employeurs/employeuses (dont Lodeom), les
+        auto-entrepreneurs/auto-entrepreneuses, les bénéficiaires de dividendes,
+        le calcul de l’impôt sur les sociétés et les coûts de création d’une
+        entreprise. Elle est utilisée dans les autres simulateurs et assistants
+        de mon-entreprise que ceux pour SAS(U) et travailleurs
+        indépendants.</7><8>Attention, bien qu’elles soient toujours présentes,
+        les règles de cette librairie qui concernent les assimilés salariés et
+        les travailleurs indépendants ne sont plus maintenues.</8><9>Comment
+        utiliser ces librairies ?</9><10>Installation</10><11><0>npm install
+        --save publicodes modele-xx</0></11><12>Remplacez <1>modele-xx</1> par
+        <3>modele-as</3>,<5>modele-ti</5> ou <7>modele-social</7> selon les
+        calculs que vous souhaitez effectuer.</12><13>Pour lancer vos propres
+        calculs, vous devez installer le paquet <2><0>publicodes</0></2>
+        contenant l'interpréteur publicodes, ainsi que le paquet de votre choix
+        <6><0>modele-as</0></6>, <9><0>modele-ti</0></9> ou
+        <13><0>modele-social</0></13>, qui contiennent les règles des
+        simulateurs de mon-entreprise.</13><14><0>Qu’est-ce que publicodes
+        ?</0><1>Publicodes est un langage déclaratif développé par beta.gouv.fr
+        et l’Urssaf pour encoder des algorithmes d'intérêt public. C’est le
+        langage qui propulse les calculs de la plupart des simulateurs de
+        mon-entreprise.</1><2><0>En savoir plus sur
+        publicodes</0></2></14><15>Utilisation</15><16>Pour lancer le calcul, il
+        vous faut paramétrer le moteur avec les règles du paquet
+        <1>modele-social</1> et à appeler la fonction <4>evaluate</4> avec la
+        règle dont vous souhaitez calculer la valeur. Voici un exemple pour le
+        calcul brut / net avec le paquet <7>modele-social</7>
+        :</16><17><0></0></17><18>Paramétrer le calcul</18><19>Vous l'aurez
+        constaté dans l'exemple précédent, la recette d'un calcul est simple :
+        des variables d'entrée (le salaire brut), une ou plusieurs variables de
+        sorties (le salaire net).</19><20>Le calcul est cependant paramétrable
+        avec toutes les possibilités permises dans les simulateurs de
+        mon-entreprise !</20><21>Toutes les règles disponibles sont listées et
+        expliquées sur la <2>documentation en ligne</2>. Cette documentation est
+        auto-générée depuis les fichiers de règles publicodes, et alimentée par
+        la simulation en cours.</21><22>Comment reproduire le calcul d’un
+        simulateur ?</22><23>Pour répliquer le calcul d’un simulateur de
+        mon-entreprise dans la bibliothèque, voici la marche à suivre :
+        </23><24><0></0><1><0>Copiez l'extrait de code personnalisé et
+        intégrez-le dans votre application</0><1></1>Vous le trouverez en
+        cliquant sur la section « Réutiliser ce calcul
+        ».<3></3></1><2><0>(facultatif) Modifiez les valeurs de la situation
+        pour paramétrer le calcul selon vos besoins</0><1></1> Vous pouvez
+        modifier sans hésiter les valeurs de la situation. Ces dernières
+        acceptent n'importe quelle <4>expression ou objet
+        publicodes</4>.</2></24><25>Voici ce que donne le calcul avec l'exemple
+        cité ci-dessus :</25><26><0></0></26><27><0>La situation contient les
+        données de votre simulation (cadre avec salaire à 3400 € brut), mais
+        également les données relatives au paramétrage du
+        simulateur.</0></27><28></28><29>Faire des graphiques économiques
+        <1></1></29><30>Il est aussi possible d'utiliser la bibliothèque pour
+        des calculs d'analyse économique ou politique. Ici, on trace le prix du
+        travail et le salaire net en fonction du brut.</30><31>On peut constater
+        la progressivité du salaire total, qui est en pourcent plus faible pour
+        un SMIC que pour un haut revenu. Autrement dit, les hauts salaires
+        paient une partie des cotisations sociales des bas
+        salaires.</31><32><0></0></32>"
     choice:
       github:
         body: Tous nos outils sont ouverts et développés publiquement sur GitHub.

--- a/site/source/pages/integration/Library.tsx
+++ b/site/source/pages/integration/Library.tsx
@@ -17,6 +17,7 @@ import {
 	SmallBody,
 	Strong,
 } from '@/design-system'
+import { useSitePaths } from '@/sitePaths'
 
 import Meta from '../../components/utils/Meta'
 import { StyledExempleIframe } from './API'
@@ -25,6 +26,7 @@ import StepByStep from './components/StepByStep'
 import illustration from './images/illustration_library.svg'
 
 export default function Library() {
+	const { absoluteSitePaths } = useSitePaths()
 	const { t } = useTranslation()
 
 	return (
@@ -34,64 +36,153 @@ export default function Library() {
 				description={t('library.description', 'Outils pour les développeurs')}
 			/>
 			<ScrollToTop />
-			<Trans i18nKey="pages.développeur.bibliothèque">
+			<Trans i18nKey="pages.développeur.bibliothèque.texte">
 				<PageHeader
 					titre="Utilisez les calculs des simulateurs dans votre application"
 					picture={illustration}
 				>
 					<Intro>
 						Vous pouvez réutiliser les calculs de mon-entreprise sur votre site
-						ou service très facilement grâce à la bibliothèque JavaScript
-						open-source disponible sur npm.
+						ou service très facilement grâce aux bibliothèques JavaScript open
+						source disponibles sur npm.
 					</Intro>
 				</PageHeader>
 
-				<H2>Comment utiliser cette librairie ?</H2>
+				<H2>Quelle librairie choisir ?</H2>
+
+				<H3>modele-as</H3>
+
+				<Body>
+					Cette librairie contient les règles et calculs pour les dirigeants{' '}
+					<Strong>assimilés salariés</Strong> et dirigeantes assimilées
+					salariées, comme les dirigeantes et dirigeants de SAS et de SASU.
+					C’est la librairie utilisée dans le{' '}
+					<Link to={absoluteSitePaths.simulateurs.sasu}>
+						simulateur de revenus pour dirigeant de SAS(U)
+					</Link>
+					.
+				</Body>
+
+				<H3>modele-ti</H3>
+
+				<Body>
+					Cette librairie contient les règles et calculs pour les{' '}
+					<Strong>travailleurs indépendants</Strong> et travailleuses
+					indépendantes, comme les dirigeantes et dirigeants d'entreprise
+					individuelle (hors auto-entreprise) et d’EURL et les professions
+					libérales. C’est la librairie utilisée dans le{' '}
+					<Link to={absoluteSitePaths.simulateurs.indépendant}>
+						simulateur de revenus pour indépendant
+					</Link>{' '}
+					et ses variantes.
+				</Body>
+
+				<H3>modele-social</H3>
+
+				<Body>
+					C’est la librairie historique, qui contient encore les règles pour les
+					salariées/salariés et employeurs/employeuses (dont Lodeom), les
+					auto-entrepreneurs/auto-entrepreneuses, les bénéficiaires de
+					dividendes, le calcul de l’impôt sur les sociétés et les coûts de
+					création d’une entreprise. Elle est utilisée dans les autres
+					simulateurs et assistants de mon-entreprise que ceux pour SAS(U) et
+					travailleurs indépendants.
+				</Body>
+
+				<Message type="error" icon>
+					Attention, bien qu’elles soient toujours présentes, les règles de
+					cette librairie qui concernent les assimilés salariés et les
+					travailleurs indépendants ne sont plus maintenues.
+				</Message>
+
+				<H2>Comment utiliser ces librairies ?</H2>
 
 				<H3>Installation</H3>
+
 				<pre>
-					<Code>npm install --save publicodes modele-social</Code>
+					<Code>npm install --save publicodes modele-xx</Code>
 				</pre>
+
+				<SmallBody>
+					Remplacez <Code>modele-xx</Code> par <Code>modele-as</Code>,
+					<Code>modele-ti</Code> ou <Code>modele-social</Code> selon les calculs
+					que vous souhaitez effectuer.
+				</SmallBody>
+
 				<Body>
 					Pour lancer vos propres calculs, vous devez installer le paquet{' '}
 					<Link
 						href="https://www.npmjs.com/package/publicodes"
-						aria-label="publicodes, voir la page npm de la librairie publicodes, nouvelle fenêtre"
+						aria-label={t(
+							'pages.développeur.bibliothèque.aria-label.publicodes.npm',
+							'publicodes, voir la page npm, nouvelle fenêtre'
+						)}
 					>
 						<Code>publicodes</Code>
 					</Link>{' '}
-					contenant l'interpréteur publicodes, ainsi que le paquet{' '}
+					contenant l'interpréteur publicodes, ainsi que le paquet de votre
+					choix{' '}
+					<Link
+						href="https://www.npmjs.com/package/modele-as"
+						aria-label={t(
+							'pages.développeur.bibliothèque.aria-label.modele-as',
+							'modele-as, voir la page npm, nouvelle fenêtre'
+						)}
+					>
+						<Code>modele-as</Code>
+					</Link>
+					,{' '}
+					<Link
+						href="https://www.npmjs.com/package/modele-ti"
+						aria-label={t(
+							'pages.développeur.bibliothèque.aria-label.modele-ti',
+							'modele-ti, voir la page npm, nouvelle fenêtre'
+						)}
+					>
+						<Code>modele-ti</Code>
+					</Link>{' '}
+					ou{' '}
 					<Link
 						href="https://www.npmjs.com/package/modele-social"
-						aria-label="modèle-social, voir la page npm de la librairie modèle-social, nouvelle fenêtre"
+						aria-label={t(
+							'pages.développeur.bibliothèque.aria-label.modele-social',
+							'modele-social, voir la page npm, nouvelle fenêtre'
+						)}
 					>
 						<Code>modele-social</Code>
 					</Link>
-					, qui contient les règles des simulateurs mon-entreprise.
+					, qui contiennent les règles des simulateurs de mon-entreprise.
 				</Body>
+
 				<Message icon>
-					<H4>Qu'est-ce que publicodes ?</H4>
+					<H4>Qu’est-ce que publicodes ?</H4>
 					<Body>
 						Publicodes est un langage déclaratif développé par beta.gouv.fr et
-						l'Urssaf pour encoder des algorithmes d'intérêt public. C'est le
-						langage qui propulse tous les calculs des simulateurs de
+						l’Urssaf pour encoder des algorithmes d'intérêt public. C’est le
+						langage qui propulse les calculs de la plupart des simulateurs de
 						mon-entreprise.
 					</Body>
 					<Body>
 						<Link
 							href="https://publi.codes"
-							aria-label="En savoir plus sur publicodes, nouvelle fenêtre"
+							aria-label={t(
+								'pages.développeur.bibliothèque.aria-label.publicodes.site',
+								'En savoir plus sur publicodes, nouvelle fenêtre'
+							)}
 						>
 							En savoir plus sur publicodes
 						</Link>
 					</Body>
 				</Message>
-				<H3>Lancer le calcul</H3>
+
+				<H3>Utilisation</H3>
+
 				<Body>
 					Pour lancer le calcul, il vous faut paramétrer le moteur avec les
 					règles du paquet <Code>modele-social</Code> et à appeler la fonction{' '}
 					<Code>evaluate</Code> avec la règle dont vous souhaitez calculer la
-					valeur. Voici un exemple pour le calcul brut / net
+					valeur. Voici un exemple pour le calcul brut / net avec le paquet{' '}
+					<Code>modele-social</Code> :
 				</Body>
 				<div
 					style={{
@@ -100,10 +191,15 @@ export default function Library() {
 				>
 					<StyledExempleIframe
 						src="https://codesandbox.io/embed/zen-keller-2dpct?fontsize=14&hidenavigation=1&theme=dark"
-						title="Exemple d'intégration sur codesandbox.io : lancement d'un calcul"
+						title={t(
+							'pages.développeur.bibliothèque.exemples.lancement',
+							'Exemple d’intégration sur codesandbox.io : lancement d’un calcul'
+						)}
 					/>
 				</div>
+
 				<H2>Paramétrer le calcul</H2>
+
 				<Body>
 					Vous l'aurez constaté dans l'exemple précédent, la recette d'un calcul
 					est simple : des variables d'entrée (le salaire brut), une ou
@@ -119,7 +215,10 @@ export default function Library() {
 						target="_blank"
 						rel="noreferrer"
 						href="/documentation"
-						aria-label="documentation en ligne, voir la documentation en ligne, nouvelle fenêtre"
+						aria-label={t(
+							'pages.développeur.bibliothèque.aria-label.documentation',
+							'documentation en ligne, nouvelle fenêtre'
+						)}
 					>
 						documentation en ligne
 					</Link>
@@ -127,9 +226,9 @@ export default function Library() {
 					publicodes, et alimentée par la simulation en cours.
 				</Body>
 
-				<H3>Comment reproduire un calcul d'un simulateur ?</H3>
+				<H3>Comment reproduire le calcul d’un simulateur ?</H3>
 				<Body>
-					Pour répliquer un calcul d'un simulateur de mon-entreprise dans la
+					Pour répliquer le calcul d’un simulateur de mon-entreprise dans la
 					bibliothèque, voici la marche à suivre :{' '}
 				</Body>
 				<Ol>
@@ -153,10 +252,14 @@ export default function Library() {
 						situation. Ces dernières acceptent n'importe quelle{' '}
 						<Link
 							href="https://publi.codes/docs/manuel/principe-de-base"
-							aria-label="expression ou objet publicodes, en savoir plus sur publi.codes, nouvelle fenêtre"
+							aria-label={t(
+								'pages.développeur.bibliothèque.aria-label.publicodes.expression',
+								'expression ou objet publicodes, en savoir plus, nouvelle fenêtre'
+							)}
 						>
-							expression ou objet publicodes.
+							expression ou objet publicodes
 						</Link>
+						.
 					</Li>
 				</Ol>
 
@@ -166,7 +269,10 @@ export default function Library() {
 				<div>
 					<StyledExempleIframe
 						src="https://codesandbox.io/embed/mon-entreprise-exemple-2-cev02?fontsize=14&hidenavigation=1&theme=dark"
-						title="Exemple d'intégration sur codesandbox.io : paramétrage du calcul"
+						title={t(
+							'pages.développeur.bibliothèque.exemples.paramétrage',
+							'Exemple d’intégration sur codesandbox.io : paramétrage du calcul'
+						)}
 					/>
 				</div>
 				<Message type="info" icon>
@@ -176,6 +282,7 @@ export default function Library() {
 						paramétrage du simulateur.
 					</Body>
 				</Message>
+
 				<CasParticuliers />
 
 				<H2>
@@ -199,7 +306,10 @@ export default function Library() {
 				>
 					<StyledExempleIframe
 						src="https://codesandbox.io/embed/mon-entreprise-exemple-3-4j11c?fontsize=14&hidenavigation=1&theme=dark"
-						title="Exemple d'intégration sur codesandbox.io : association avec d'autres librairies"
+						title={t(
+							'pages.développeur.bibliothèque.exemples.association',
+							'Exemple d’intégration sur codesandbox.io : association avec d’autres librairies'
+						)}
 					/>
 				</div>
 			</Trans>


### PR DESCRIPTION
Closes #4481 (again)

Met à jour la page documentation sur les paquets NPM : Footer > Intégrer nos simulateurs > Librairie de calcul

Les exemples de code dans la documentation des règles sont à jour.