### PR TITLE
Use new <YesOrNoToggleGroup /> in <RuleField />

### DIFF
--- a/site/source/components/conversation/RuleField.tsx
+++ b/site/source/components/conversation/RuleField.tsx
@@ -107,6 +107,7 @@ export function RuleField({
 			<StylingContainer>
 				<YesOrNoToggleGroup
 					legend={labelOrLegend ?? ''}
+					ruleToExplain={dottedName}
 					value={value as 'oui' | 'non' | undefined}
 					onChange={(value) => onChange(value, dottedName)}
 				/>
@@ -156,8 +157,8 @@ const StylingContainer = styled.div`
 	.react-aria-Label {
 		${H3Style}
 
-		margin: ${({ theme }) => `${theme.spacings.lg} 0 ${theme.spacings.xxs}`};
-}
+		margin: ${({ theme }) => `${theme.spacings.sm} 0 0`};
+	}
 `
 
 const StyledFieldset = styled.fieldset`

--- a/site/source/components/conversation/RuleField.tsx
+++ b/site/source/components/conversation/RuleField.tsx
@@ -104,11 +104,13 @@ export function RuleField({
 
 	if (ruleFieldNature === YES_OR_NO_TOGGLE_GROUP) {
 		return (
-			<YesOrNoToggleGroup
-				legend={labelOrLegend ?? ''}
-				value={value as 'oui' | 'non' | undefined}
-				onChange={(value) => onChange(value, dottedName)}
-			/>
+			<StylingContainer>
+				<YesOrNoToggleGroup
+					legend={labelOrLegend ?? ''}
+					value={value as 'oui' | 'non' | undefined}
+					onChange={(value) => onChange(value, dottedName)}
+				/>
+			</StylingContainer>
 		)
 	}
 
@@ -149,6 +151,14 @@ export function RuleField({
 		</>
 	)
 }
+
+const StylingContainer = styled.div`
+	.react-aria-Label {
+		${H3Style}
+
+		margin: ${({ theme }) => `${theme.spacings.lg} 0 ${theme.spacings.xxs}`};
+}
+`
 
 const StyledFieldset = styled.fieldset`
 	display: contents;

--- a/site/source/components/conversation/RuleField.tsx
+++ b/site/source/components/conversation/RuleField.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components'
 
 import { ExplicableRule } from '@/components/conversation/Explicable'
 import { H3, H3Style } from '@/design-system'
+import { YesOrNoToggleGroup } from '@/design-system/molecules/fields/Radiogroup'
 import {
 	PublicodesAdapter,
 	ValeurPublicodes,
@@ -101,7 +102,17 @@ export function RuleField({
 		value
 	)
 
-	if ([RADIO_GROUP, YES_OR_NO_TOGGLE_GROUP].includes(ruleFieldNature)) {
+	if (ruleFieldNature === YES_OR_NO_TOGGLE_GROUP) {
+		return (
+			<YesOrNoToggleGroup
+				legend={labelOrLegend ?? ''}
+				value={value as 'oui' | 'non' | undefined}
+				onChange={(value) => onChange(value, dottedName)}
+			/>
+		)
+	}
+
+	if (ruleFieldNature === RADIO_GROUP) {
 		return (
 			<StyledFieldset>
 				<StyledLegend>

--- a/site/source/design-system/molecules/fields/Radiogroup/ToggleGroup.tsx
+++ b/site/source/design-system/molecules/fields/Radiogroup/ToggleGroup.tsx
@@ -98,19 +98,20 @@ const StyledRadioContainer = styled.div`
 const StyledRARadio = styled(RARadio)`
 	${radioFieldsSharedStyles}
 
-	&:hover {
-		background: ${({ theme }) => theme.colors.bases.primary[200]};
-	}
-
 	&::before {
 		transition: none;
 	}
 
-	&:hover::before {
-		border-color: ${({ theme }) => theme.colors.bases.primary[200]};
+	&:hover {
+		background: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.grey[600]
+				: theme.colors.bases.primary[200]};
 	}
 
-	&[data-selected='true']::before {
-		background: ${({ theme }) => theme.colors.bases.primary[700]};
-	}
+	&:hover::before {
+		border-color: ${({ theme }) =>
+			theme.darkMode
+				? theme.colors.extended.grey[600]
+				: theme.colors.bases.primary[200]};
 `

--- a/site/source/design-system/molecules/fields/Radiogroup/ToggleGroup.tsx
+++ b/site/source/design-system/molecules/fields/Radiogroup/ToggleGroup.tsx
@@ -6,6 +6,9 @@ import {
 } from 'react-aria-components'
 import { styled } from 'styled-components'
 
+import { ExplicableRule } from '@/components/conversation/Explicable'
+import { DottedName } from '@/domaine/publicodes/DottedName'
+
 import { fieldContainerStyles, radioFieldsSharedStyles } from '../fieldsStyles'
 
 export type ToggleOption = {
@@ -19,12 +22,14 @@ type ToggleGroupProps = Pick<
 > & {
 	legend: string
 	options: ToggleOption[]
+	ruleToExplain?: DottedName
 }
 
 export function ToggleGroup({
 	defaultValue = null,
 	legend,
 	options,
+	ruleToExplain,
 	value,
 	onChange,
 }: ToggleGroupProps) {
@@ -35,7 +40,11 @@ export function ToggleGroup({
 			onChange={onChange}
 			orientation="horizontal"
 		>
-			<RALabel>{legend}</RALabel>
+			<StyledLegendAndExplicableRuleContainer>
+				<RALabel>{legend}</RALabel>
+
+				{ruleToExplain && <ExplicableRule dottedName={ruleToExplain} />}
+			</StyledLegendAndExplicableRuleContainer>
 
 			<StyledGroupContainer>
 				{options.map((option) => (
@@ -52,6 +61,12 @@ const StyledRARadioGroup = styled(RARadioGroup)`
 	${fieldContainerStyles}
 
 	gap: ${({ theme }) => theme.spacings.xs};
+`
+
+const StyledLegendAndExplicableRuleContainer = styled.div`
+	display: flex;
+	align-items: baseline;
+	gap: ${({ theme }) => theme.spacings.xxs};
 `
 
 const StyledGroupContainer = styled.div`

--- a/site/source/design-system/molecules/fields/Radiogroup/YesOrNoToggleGroup.tsx
+++ b/site/source/design-system/molecules/fields/Radiogroup/YesOrNoToggleGroup.tsx
@@ -2,18 +2,21 @@ import { RadioGroupProps as RARadioGroupProps } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 
 import { OuiNon } from '@/domaine/OuiNon'
+import { DottedName } from '@/domaine/publicodes/DottedName'
 
 import { ToggleGroup } from './ToggleGroup'
 
 type YesOrNoToggleGroupProps = Pick<RARadioGroupProps, 'onChange'> & {
 	defaultValue?: OuiNon
 	legend: string
+	ruleToExplain?: DottedName
 	value?: OuiNon
 }
 
 export function YesOrNoToggleGroup({
 	defaultValue,
 	legend,
+	ruleToExplain,
 	value,
 	onChange,
 }: YesOrNoToggleGroupProps) {
@@ -27,6 +30,7 @@ export function YesOrNoToggleGroup({
 				{ label: t('conversation.yes', 'Oui'), value: 'oui' },
 				{ label: t('conversation.no', 'Non'), value: 'non' },
 			]}
+			ruleToExplain={ruleToExplain}
 			value={value}
 			onChange={onChange}
 		/>

--- a/site/source/design-system/molecules/fields/fieldsStyles.tsx
+++ b/site/source/design-system/molecules/fields/fieldsStyles.tsx
@@ -83,7 +83,7 @@ export const fieldInputStyles = css`
 	}
 
 	@media not print {
-		color: ${({ theme }) =>
+		${({ theme }) =>
 			theme.darkMode
 				? `color: ${theme.colors.extended.grey[100]}`
 				: 'color: inherit'};
@@ -132,7 +132,9 @@ export const radioFieldsSharedStyles = css`
 
 	&::before {
 		padding: ${({ theme }) => theme.spacings.xxs};
-		border: ${({ theme }) => theme.spacings.sm} solid white;
+		border: ${({ theme }) => theme.spacings.sm} solid;
+		border-color: ${({ theme }) =>
+			theme.darkMode ? theme.colors.extended.grey[700] : 'white'};
 
 		background: transparent;
 	}
@@ -144,8 +146,9 @@ export const radioFieldsSharedStyles = css`
 
 		width: ${({ theme }) => theme.spacings.md};
 		height: ${({ theme }) => theme.spacings.md};
-		border: ${({ theme }) => theme.spacings.xxxs} solid
-			${({ theme }) => theme.colors.extended.grey[600]};
+		border: ${({ theme }) => theme.spacings.xxxs} solid;
+		border-color: ${({ theme }) =>
+			theme.darkMode ? 'white' : theme.colors.extended.grey[600]};
 	}
 
 	&[data-focused='true'] {
@@ -154,7 +157,13 @@ export const radioFieldsSharedStyles = css`
 		}
 	}
 
+	&[data-selected='true']::before {
+		background: ${({ theme }) =>
+			theme.darkMode ? 'white' : theme.colors.bases.primary[700]};
+	}
+
 	&[data-selected='true']::after {
-		border-color: ${({ theme }) => theme.colors.bases.primary[700]};
+		border-color: ${({ theme }) =>
+			theme.darkMode ? 'white' : theme.colors.bases.primary[700]};
 	}
 `


### PR DESCRIPTION
Cette PR utilise pour la première fois l'un des nouveaux composants construits avec `react-aria-components`. 🎉

J'ai voulu commencé avec `<RadioGroup />` (car c'est lui qui doit intervenir dans la première question du simulateur salarié) mais ce n'est pas le plus simple : il faut suivre le cheminement `<RuleInput />` appellant `<UnePossibilité />` qui appelle le composant-factory `<ChoixUnique />` et c'est une belle pelote de sous-cas à démêler pour atteindre celui des boutons radio. 😕

Du coup j'ai préféré commencé par des composants "plus faciles à brancher", pour qu'ils permettent déjà de résoudre certains des problèmes qui se poseront de manière récurrente.

En l'occurrence, le branchement du nouveau `<YesOrNoToggleGroup />` a lui été assez facile, les résultats du simulateur m'ayant l'air bien prendre en compte les changements de valeur (Oui / Non).

Il n'y a pas eu besoin de beaucoup le retoucher, et le plus long a probablement été de rectifier les styles pour le dark mode. 🙂

<img width="395" height="102" alt="image" src="https://github.com/user-attachments/assets/03800d63-4be5-457a-9801-8e355dbc818f" />