### PR TITLE
fix(modele-ti): taux 2026 de la retraite complémentaire CARMF et CARCDSF

### DIFF
--- a/modele-ti/règles/indépendant/professions-libérales/CARCDSF.publicodes
+++ b/modele-ti/règles/indépendant/professions-libérales/CARCDSF.publicodes
@@ -49,8 +49,16 @@ indépendant . profession libérale . réglementée . CARCDSF . retraite complé
         multiplicateur: plafond sécurité sociale . métropole
         tranches:
           - taux: 0%
-            plafond: 0.85
-          - taux: 10.80%
+            plafond:
+              variations:
+                - si: date < 01/2026
+                  alors: 0.85
+                - sinon: 0.65
+          - taux:
+              variations:
+                - si: date < 01/2026
+                  alors: 10.80%
+                - sinon: 11.35%
             plafond: 5
         arrondi: oui
 

--- a/modele-ti/règles/indépendant/professions-libérales/CARMF.publicodes
+++ b/modele-ti/règles/indépendant/professions-libérales/CARMF.publicodes
@@ -61,7 +61,9 @@ indépendant . profession libérale . réglementée . CARMF . retraite compléme
           - variations:
             - si: date < 01/2024
               alors: 10%
-            - sinon: 10.2%
+            - si: date < 01/2026
+              alors: 10.2%
+            - sinon: 11.8%
   abattement:
     applicable si: CNAVPL . exonération incapacité
     valeur: 100%
@@ -70,6 +72,7 @@ indépendant . profession libérale . réglementée . CARMF . retraite compléme
   références:
     Montant des cotisations: http://www.carmf.fr/page.php?page=cdrom/coti/coti-cours.htm
     Guide de l’assurance vieillesse des professions libérales (2025): https://www.cnavpl.fr/wp-content/uploads/2025/07/Guide-2025.pdf#page=45
+    Taux 2026: https://www.carmf.fr/page.php?page=chiffrescles/stats/2026/taux2026.htm
     Taux 2025: https://www.carmf.fr/page.php?page=chiffrescles/stats/2025/taux2025.htm
     Taux 2024: https://www.carmf.fr/page.php?page=chiffrescles/stats/2024/taux2024.htm
     Taux 2023: https://www.carmf.fr/page.php?page=chiffrescles/stats/2023/taux2023.htm


### PR DESCRIPTION
## Contexte

Le taux de la retraite complémentaire n'a pas été repris pour 2026 dans deux caisses, alors que leurs autres régimes l'ont bien été (invalidité-décès et ASV de la CARMF, cotisation forfaitaire de la CARCDSF portent déjà leurs valeurs 2026). Le modèle sous-estime donc la cotisation de retraite complémentaire de ces deux professions pour l'exercice 2026.

Un indice le confirme côté CARMF : la règle `retraite complémentaire` référence `Taux 2025`, `Taux 2024` et `Taux 2023`, mais pas `Taux 2026`, contrairement à la règle `invalidité et décès` voisine.

## Corrections

### CARMF — taux de la retraite complémentaire

Le taux passe de **10,2 % à 11,80 %** au 1ᵉʳ janvier 2026. Le plafond de 3,5 PASS est inchangé.

> Régime complémentaire : **11,80 %** des revenus nets d'activité indépendante 2024 dans la limite de 168 210 €
> — <https://www.carmf.fr/page.php?page=chiffrescles/stats/2026/taux2026.htm>

(168 210 € = 3,5 × 48 060 €, le plafond déjà en place.)

### CARCDSF — cotisation proportionnelle de la retraite complémentaire

Le taux passe de **10,80 % à 11,35 %**, et la borne basse de la bande d'assiette de **0,85 à 0,65 PASS**. La borne haute reste à 5 PASS.

> Cotisation proportionnelle : **11,35 %** des revenus 2025, entre **0,65 fois et 5 fois le PASS**, soit entre 31 239 € et 240 300 € pour 2026
> — <https://www.carcdsf.fr/cotisations-du-praticien/montant-des-cotisations>

La cotisation forfaitaire (3 210,60 € en 2026) est déjà correcte et n'est pas touchée.

## Vérification

Les valeurs ont été confrontées à des appels de cotisations 2026 réellement émis par les deux caisses, qui impriment leur détail ligne à ligne (assiette, taux, montant).

**CARCDSF, appel 2026 d'un chirurgien-dentiste** (revenus 2025 : 416 865 €) :

|  | montant |
| --- | --- |
| cotisation forfaitaire imprimée | 3 210,60 € |
| assiette proportionnelle imprimée | 209 061 € (= 4,35 PASS, soit 5 − 0,65) |
| taux imprimé | 11,350 % |
| **régime complémentaire imprimé** | **26 938,60 €** |
| modèle actuel | 24 751 € (−2 188) |
| **modèle corrigé** | **26 939 €** (écart nul) |

**CARMF, appel 2026 d'un médecin de secteur 1** (revenus nets 2024 : 71 193 €) :

|  | montant |
| --- | --- |
| **complémentaire vieillesse imprimée** | **8 401 €** |
| 71 193 × 11,80 % | 8 400,77 € |
| modèle actuel | 7 262 € (−1 139) |
| **modèle corrigé** | **8 401 €** (écart nul) |

Non-régression vérifiée : les évaluations de 2024 et 2025 sont inchangées pour les deux caisses.

L'écriture retenue (`variations` sous un `plafond` et sous un `taux` de barème) suit des précédents déjà présents dans le dépôt : `CARPIMKO.publicodes` pour un `plafond`, `CARMF.publicodes` pour un `montant` de grille.

## Note de périmètre

La règle CARCDSF `retraite complémentaire . cotisation forfaitaire . réduction applicable` conserve son seuil de 85 % du PASS : c'est un mécanisme distinct (réduction du forfait pour les faibles revenus), et je n'ai pas trouvé de source indiquant qu'il ait changé en 2026. Il n'est donc pas modifié ici.

La suite de tests a été lancée : **796 tests passent, 6 ignorés, aucun échec, et aucun instantané n'est modifié** — ces valeurs ne déplacent donc pas de snapshot. Le détail, ainsi que les quatre obstacles rencontrés sous Windows avant d'y parvenir, figurent [en commentaire](https://github.com/betagouv/mon-entreprise/pull/4613#issuecomment-5113822742).

