### PR TITLE
Bouton de partage dès la première saisie sur simulateur TFS

### DIFF
--- a/site/source/pages/simulateurs/cotisation-maladie-frontalier-suisse/CotisationMaladieFrontalierSuisse.test.tsx
+++ b/site/source/pages/simulateurs/cotisation-maladie-frontalier-suisse/CotisationMaladieFrontalierSuisse.test.tsx
@@ -159,7 +159,7 @@ describe('Simulateur cotisation maladie frontalier suisse', () => {
 		).toBeInTheDocument()
 	})
 
-	it("ne propose de partager la simulation qu'une fois la situation minimale saisie", async () => {
+	it('propose le partage dès que la simulation est commencée', async () => {
 		const user = userEvent.setup()
 		render(
 			<TestProvider>
@@ -175,11 +175,6 @@ describe('Simulateur cotisation maladie frontalier suisse', () => {
 		).not.toBeInTheDocument()
 
 		await saisirDateAffiliation(user, '15/01/2026')
-		expect(
-			screen.queryByRole('button', { name: /lien de partage/i })
-		).not.toBeInTheDocument()
-
-		await user.type(screen.getByLabelText(/Salaires perçus en/i), '50000')
 
 		expect(
 			await screen.findByRole('button', { name: /lien de partage/i })


### PR DESCRIPTION
Aligne le test du frontalier suisse sur la sémantique de partage [discutée](https://github.com/betagouv/mon-entreprise/pull/4635#issuecomment-5354327311) : le lien de partage est proposé dès que la simulation est commencée — y compris pour une situation partielle.
