### PR TITLE
fix: désactive le scope hoisting de Turbopack

### DIFF
--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -17,6 +17,10 @@ const nextConfig = {
 		'@publicodes/react-ui',
 	],
 
+	experimental: {
+		turbopackScopeHoisting: false,
+	},
+
 	turbopack: {
 		rules: {
 			'*.yaml': {


### PR DESCRIPTION
Le scope hoisting de Turbopack (activé par défaut en build de prod) évalue deux fois certains modules fusionnés, dupliquant les singletons de module : sur #4642, le NavigationContext est dédoublé (useNavigation must be used within a NavigationProvider à chaque chargement)

Reproduit sur Next 16.2.6, 16.3.4 et 16.4.0-canary.15 — Des bugs similaires ont déjà été corrigés (vercel/next.js#96697) mais pas exactement notre cas. Je suis en train de préparer une issue à remonter à Next.js.

Bug similaire également décrit ici : https://yceffort.kr/en/2026/08/turbopack-scope-hoisting-singleton-split