### PR TITLE
fix(questions): accepte les centimes dans les montants saisis

### DIFF
--- a/site/source/components/conversation/RuleInput.test.ts
+++ b/site/source/components/conversation/RuleInput.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { accepteLesCentimes } from './RuleInput'
+
+describe('accepteLesCentimes', () => {
+	it('accepte les centimes quand personne n’a demandé d’arrondi', () => {
+		expect(accepteLesCentimes(undefined)).toBe(true)
+		expect(accepteLesCentimes({})).toBe(true)
+		expect(accepteLesCentimes({ style: 'currency', currency: 'EUR' })).toBe(
+			true
+		)
+	})
+
+	it('arrondit quand l’appelant le demande explicitement', () => {
+		expect(accepteLesCentimes({ maximumFractionDigits: 0 })).toBe(false)
+	})
+
+	it('garde les centimes quand l’appelant en demande', () => {
+		expect(accepteLesCentimes({ maximumFractionDigits: 2 })).toBe(true)
+	})
+})

--- a/site/source/components/conversation/RuleInput.tsx
+++ b/site/source/components/conversation/RuleInput.tsx
@@ -157,6 +157,14 @@ interface RuleInputProps {
 	'aria-describedby'?: string
 }
 
+/**
+ * Un montant saisi à une question a des centimes, sauf quand l’appelant demande
+ * explicitement de l’arrondir.
+ */
+export const accepteLesCentimes = (
+	formatOptions?: Intl.NumberFormatOptions
+): boolean => formatOptions?.maximumFractionDigits !== 0
+
 export default function RuleInput({
 	dottedName,
 	onChange,
@@ -407,7 +415,7 @@ export default function RuleInput({
 					labelledby: accessibilityProps['aria-labelledby'],
 					describedby: accessibilityProps['aria-describedby'],
 				}}
-				avecCentimes={!!accessibilityProps.formatOptions?.maximumFractionDigits}
+				avecCentimes={accepteLesCentimes(accessibilityProps.formatOptions)}
 			/>
 		)
 	}

--- a/site/source/design-system/molecules/field/MontantField.test.tsx
+++ b/site/source/design-system/molecules/field/MontantField.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ComponentProps } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { TestProvider } from '@/test/TestProvider'
+
+import { MontantField } from './MontantField'
+
+const monterChampMontant = (
+	props: Partial<ComponentProps<typeof MontantField>> = {}
+) => {
+	const user = userEvent.setup()
+	render(
+		<TestProvider>
+			<MontantField
+				unité="€/titre-restaurant"
+				value={undefined}
+				label="Valeur du titre"
+				{...props}
+			/>
+		</TestProvider>
+	)
+
+	return { user, champ: screen.getByRole<HTMLInputElement>('textbox') }
+}
+
+describe('MontantField', () => {
+	it('garde les centimes quand on les accepte', async () => {
+		const { user, champ } = monterChampMontant({ avecCentimes: true })
+
+		await user.type(champ, '10,50')
+
+		expect(champ.value).toContain('10,5')
+	})
+})


### PR DESCRIPTION
Corrige #4649.

## Le défaut

Une question ne passe aucun `formatOptions` à `RuleInput`, et l'absence de format était lue comme « sans centimes » : `avecCentimes={!!formatOptions?.maximumFractionDigits}` valait `false`, le champ était formaté à zéro décimale, et la virgule tapée était alors avalée puis les chiffres recollés.

Mesuré sur `MontantField` monté seul, en tapant `10,50` :

| champ | ce qui s'affiche |
|---|---|
| sans centimes (le cas des questions) | **110 €** |
| avec centimes | 10,5 € |

Ce n'est donc pas seulement un refus de saisie : la valeur devient **dix fois trop grande**, sans que rien ne le signale. Sur une valeur unitaire de titre-restaurant, qui se compte en centimes, c'est exactement ce qu'a remonté l'usagère citée dans l'issue.

## Le correctif

Un montant a des centimes sauf quand l'appelant demande explicitement de l'arrondir, ce que fait déjà `ObjectifDeSimulation` avec `round`. La décision passe par une fonction nommée et testée plutôt que par une double négation dans le JSX.

Le défaut de `MontantField` reste `avecCentimes = false` : j'ai d'abord essayé de le passer à `true`, et le comparateur, qui l'utilise directement, s'est mis à afficher `4 166,67 €` là où ses tests attendent `4 167 €`. Les appelants directs gardent donc leur affichage à l'euro près, et seules les questions changent.

## Vérifications

- `RuleInput.test.ts` : les trois cas de la décision (aucun format, arrondi demandé, centimes demandés)
- `MontantField.test.tsx` : la saisie de `10,50` ressort bien en `10,5` quand les centimes sont acceptés
- le test des centimes échoue avant le correctif et passe après
- `test/regressions/salarié.test.ts`, la suite qui calcule de vraies simulations, titres-restaurant compris, **passe** : aucune valeur calculée ne bouge
- suite complète : les échecs restants sont préexistants. Vérifié un par un en isolant chaque test sur `main` sans le correctif : « permet de recharger la simulation depuis l'URL produite », « ne doit PAS demander la part des recettes de courte durée » et « affiche la période d'affiliation complète dans la liste des précisions » échouent à l'identique des deux côtés ; le reste est de l'expiration de délai sur les suites de régression
- `yarn lint` : aucune erreur sur les fichiers touchés

## Un point hors périmètre

Quand les centimes sont explicitement refusés, la saisie `10,50` donne toujours `110`. Les questions n'y sont plus exposées, mais un appelant qui demande un arrondi l'est encore. Ça relève de `NumericInput` et d'une correction séparée ; je peux ouvrir l'issue si ça vous intéresse.
