### PR TITLE
fix(ci): relit la bonne PR quand son commit de tête appartient aussi à une PR stackée

### DIFF
--- a/.github/workflows/pr-ai-review.yaml
+++ b/.github/workflows/pr-ai-review.yaml
@@ -58,7 +58,7 @@ jobs:
             number="$REQUESTED_PR_NUMBER"
           else
             number="$(gh api "repos/$GITHUB_REPOSITORY/commits/$RUN_HEAD_SHA/pulls" \
-              --jq '([.[] | select(.state == "open")] + .) | .[0].number // empty')"
+              --jq "([.[] | select(.head.sha == \"$RUN_HEAD_SHA\")] + [.[] | select(.state == \"open\")] + .) | .[0].number // empty")"
           fi
           if [ -z "$number" ]; then
             echo "::error::Aucune PR ne correspond au commit $RUN_HEAD_SHA"


### PR DESCRIPTION
Quand deux PR sont stackées la revue IA relit la mauvaise et ignore l'autre.

Par exemple #4663 avait pour base la branche de #4667. 
Un rebase a relancé « Vérification PR » sur les deux en même temps. Pour retrouver la PR à relire à partir du commit de tête du run, le job `context` interroge l'API des PR associées à un commit. Or le commit de tête de #4667 appartient aussi à l'historique de #4663 : l'API renvoie les deux, #4663 en premier, et l'expression `jq` prenait la première.
Les deux runs ont résolu #4663, se sont retrouvés dans le même groupe de concurrence, le second a annulé le premier, et #4667 n'a jamais été relue.

L'expression préfère désormais, dans l'ordre : la PR dont le commit de tête est exactement celui du run, puis une PR ouverte, puis n'importe laquelle.